### PR TITLE
small doc changes

### DIFF
--- a/docs/source/tutorials/navigation.md
+++ b/docs/source/tutorials/navigation.md
@@ -13,7 +13,7 @@ Now, in a Python interpreter, connect, with the Python client.
 ```python
 from tiled.client.catalog import Catalog
 
-catalog = Catalog.from_uri("http:/localhost:8000")
+catalog = Catalog.from_uri("http://localhost:8000")
 ```
 
 A Catalog is a nested strucutre of data. Conceptually, it corresponds well to
@@ -54,8 +54,6 @@ however many fit on one line.
 ```python
 >>> catalog
 <Catalog {'arrays', 'dataframes', 'xarrays', 'nested', ...} ~5 entries>
->>> catalog['arrays']
-<Catalog {'large', 'medium', 'small', 'tiny'}>
 ```
 
 Catalogs act like (nested) mappings in Python. All the (read-only) methods

--- a/docs/source/tutorials/serving-files.md
+++ b/docs/source/tutorials/serving-files.md
@@ -7,6 +7,7 @@ DataFrames and numpy arrays.
 For this tutorial, install tiffffile and openpyxl.
 
 ```
+pip install tiled[complete]
 pip install tifffile openpyxl
 ```
 
@@ -54,7 +55,7 @@ In a Python interpreter, connect with the Python client.
 ```python
 from tiled.client.catalog import Catalog
 
-catalog = Catalog.from_uri("http:/localhost:8000")
+catalog = Catalog.from_uri("http://localhost:8000")
 ```
 
 The ``catalog`` has the same tree structure as the directory on
@@ -70,7 +71,7 @@ disk, and we can slice and access the data.
 >>> catalog['more']['d.tif']
 <ClientDaskArrayAdapter>
 
->>> catalog['more']['d.tif']
+>>> catalog['more']['d.tif'].read()
 array([[1., 1., 1., ..., 1., 1., 1.],
        [1., 1., 1., ..., 1., 1., 1.],
        [1., 1., 1., ..., 1., 1., 1.],


### PR DESCRIPTION
A couple of small changes.

I debated how to document the extras installation of tiled server. [complete] was the easiest way to get this tutorial to work...it needs arrow and dask[dataframe] and maybe more. And for a tutorial, I thought ease of installation might beat dependency isolation.