### PR TITLE
Sliding sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ target/
 
 example_files/
 *.yml
+*.json

--- a/tiled/client/__init__.py
+++ b/tiled/client/__init__.py
@@ -1,3 +1,4 @@
+from .authentication import login  # noqa: F401
 from .catalog import (  # noqa: F401
     ASCENDING,
     DESCENDING,
@@ -6,5 +7,4 @@ from .catalog import (  # noqa: F401
     from_config,
     from_profile,
     from_uri,
-    generate_token,
 )

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -6,7 +6,6 @@ import dask.array
 from ..structures.array import ArrayStructure
 from ..media_type_registration import deserialization_registry
 from .base import BaseArrayClient
-from .utils import get_content_with_cache
 
 
 class DaskArrayClient(BaseArrayClient):
@@ -35,10 +34,7 @@ class DaskArrayClient(BaseArrayClient):
             raise NotImplementedError(
                 "Slicing less than one block is not yet supported."
             )
-        content = get_content_with_cache(
-            self._cache,
-            self._offline,
-            self._client,
+        content = self._get_content_with_cache(
             self._route + "/" + "/".join(self._path),
             headers={"Accept": media_type},
             params={

--- a/tiled/client/authentication.py
+++ b/tiled/client/authentication.py
@@ -1,0 +1,150 @@
+import getpass
+import os
+from pathlib import Path
+from re import T
+import urllib.parse
+
+import appdirs
+
+from .utils import (
+    client_and_path_from_uri,
+    client_from_catalog,
+    handle_error,
+)
+
+
+DEFAULT_TOKEN_CACHE = os.getenv(
+    "TILED_TOKEN_CACHE", os.path.join(appdirs.user_config_dir("tiled"), "tokens")
+)
+
+
+def _token_directory(token_cache, netloc, username):
+    return Path(
+        token_cache,
+        urllib.parse.quote_plus(netloc),  # Make a valid filename out of hostname:port.
+        username,
+    )
+
+
+def login(catalog, username=None, *, token_cache=DEFAULT_TOKEN_CACHE):
+    client, uri = _client_and_uri_from_uri_or_profile(catalog)
+    authenticate_client(client, username, token_cache=token_cache)
+
+
+def authenticate_client(client, username, *, token_cache=DEFAULT_TOKEN_CACHE):
+    if "tiled_csrf" not in client.cookies:
+        # Make an initial "safe" request to let the server set the CSRF cookie.
+        # We could also use this to check the API version.
+        handshake_response = client.get("/")
+        handle_error(handshake_response)
+    username = username or input("Username: ")
+    password = getpass.getpass()
+    form_data = {"grant_type": "password", "username": username, "password": password}
+    token_response = client.post("/token", data=form_data)
+    handle_error(token_response)
+    data = token_response.json()
+    if token_cache:
+        # We are using a token cache. Store the new refresh token.
+        directory = _token_directory(token_cache, client.base_url.netloc, username)
+        directory.mkdir(exist_ok=True, parents=True)
+        filepath = directory / "refresh_token.json"
+        filepath.touch(mode=0o600)  # Set permissions.
+        with open(filepath, "w") as file:
+            file.write(data["refresh_token"])
+    access_token = token_response.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {access_token}"
+
+
+def reauthenticate_client(
+    client, username, *, token_cache=DEFAULT_TOKEN_CACHE, prompt_on_failure=True
+):
+    try:
+        _reauthenticate_client(client, username, token_cache=token_cache)
+    except CannotRefreshAuthentication:
+        if prompt_on_failure:
+            return authenticate_client(client, username, token_cache=token_cache)
+        else:
+            raise
+
+
+def _reauthenticate_client(client, username, *, token_cache=DEFAULT_TOKEN_CACHE):
+    # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+    if "tiled_csrf" not in client.cookies:
+        # Make an initial "safe" request to let the server set the CSRF cookie.
+        # We could also use this to check the API version.
+        handshake_response = client.get("/")
+        handle_error(handshake_response)
+    if token_cache:
+        # We are using a token_cache.
+        directory = _token_directory(token_cache, client.base_url.netloc, username)
+        filepath = directory / "refresh_token.json"
+        if filepath.is_file():
+            # There is a token file.
+            with open(filepath, "r") as file:
+                refresh_token = file.read()
+            token_response = client.post(
+                "/token/refresh",
+                json={"refresh_token": refresh_token},
+                headers={"x-csrf": client.cookies["tiled_csrf"]},
+            )
+            if token_response.status_code == 401:
+                # Refreshing the token failed.
+                # Discard the expired (or otherwise invalid) refresh_token.json file.
+                filepath.unlink(missing_ok=True)
+                raise CannotRefreshAuthentication(
+                    "Server rejected attempt to refresh token"
+                )
+        else:
+            raise CannotRefreshAuthentication(
+                "No refresh token was found in token cache"
+            )
+
+    else:
+        # We are not using a token cache.
+        raise CannotRefreshAuthentication("No token cache was given")
+    handle_error(token_response)
+    access_token = token_response.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {access_token}"
+
+
+def _client_and_uri_from_uri_or_profile(uri_or_profile):
+    if uri_or_profile.startswith("http://") or uri_or_profile.startswith("https://"):
+        # This looks like a URI.
+        uri = uri_or_profile
+        client, _ = client_and_path_from_uri(uri)
+        return client, uri
+    else:
+        from ..profiles import load_profiles
+
+        # Is this a profile name?
+        profiles = load_profiles()
+        if uri_or_profile in profiles:
+            profile_name = uri_or_profile
+            filepath, profile_content = profiles[profile_name]
+            if "uri" in profile_content:
+                uri = profile_content["uri"]
+                client, _ = client_and_path_from_uri(uri)
+                return client, uri
+            elif "direct" in profile_content:
+                # The profiles specifies that there is no server. We should create
+                # an app ourselves and use it directly via ASGI.
+                from ..config import construct_serve_catalog_kwargs
+
+                serve_catalog_kwargs = construct_serve_catalog_kwargs(
+                    profile_content.pop("direct", None), source_filepath=filepath
+                )
+                client = client_from_catalog(**serve_catalog_kwargs)
+                PLACEHOLDER = "__process_local_app__"
+                return client, PLACEHOLDER
+            else:
+                raise ValueError("Invalid profile content")
+
+    raise ValueError(
+        f"Not sure what to do with catalog {uri_or_profile!r}. "
+        "It does not look like a URI (it does not start with http[s]://) "
+        "and it does not match any profiles."
+    )
+
+
+class CannotRefreshAuthentication(Exception):
+    pass

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -175,7 +175,9 @@ class BaseClient:
             # Parse the error message? Add a special header from the server?
             if self._username is not None:
                 reauthenticate_client(
-                    self._client, self._username, token_cache=self._token_cache,
+                    self._client,
+                    self._username,
+                    token_cache=self._token_cache,
                 )
                 request.headers["authorization"] = self._client.headers["authorization"]
                 return self._send(request, timeout, attempts=1)

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -10,10 +10,10 @@ from .utils import (
     NotAvailableOffline,
     UNSET,
 )
-from ..catalogs.utils import IndexersMixin, UNCHANGED
+from ..catalogs.utils import UNCHANGED
 
 
-class BaseClient(collections.abc.Mapping, IndexersMixin):
+class BaseClient:
     def __init__(
         self,
         client,
@@ -173,11 +173,12 @@ class BaseClient(collections.abc.Mapping, IndexersMixin):
             # Try refreshing the token.
             # TODO Use a more targeted signal to know that refreshing the token will help.
             # Parse the error message? Add a special header from the server?
-            reauthenticate_client(
-                self._client, self._username, token_cache=self._token_cache
-            )
-            request.headers["authorization"] = self._client.headers["authorization"]
-            return self._send(request, timeout, attempts=1)
+            if self._username is not None:
+                reauthenticate_client(
+                    self._client, self._username, token_cache=self._token_cache,
+                )
+                request.headers["authorization"] = self._client.headers["authorization"]
+                return self._send(request, timeout, attempts=1)
         return response
 
 
@@ -214,7 +215,7 @@ class BaseStructureClient(BaseClient):
         pass
 
 
-class BaseArrayClient(BaseClient):
+class BaseArrayClient(BaseStructureClient):
     """
     Shared by Array, DataArray, Dataset
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -1,30 +1,57 @@
+import collections.abc
+
+import msgpack
+
 from ..utils import DictView, ListView
-from .utils import get_json_with_cache
-from ..catalogs.utils import UNCHANGED
+from .authentication import reauthenticate_client
+from .utils import (
+    handle_error,
+    NEEDS_INITIALIZATION,
+    NotAvailableOffline,
+    UNSET,
+)
+from ..catalogs.utils import IndexersMixin, UNCHANGED
 
 
-class BaseClient:
+class BaseClient(collections.abc.Mapping, IndexersMixin):
     def __init__(
         self,
         client,
         *,
+        item,
+        username,
+        token_cache,
         cache,
         offline,
         path,
         metadata,
         params,
-        structure=None,
     ):
         self._client = client
+        self._token_cache = token_cache
+        self._username = username
         self._offline = offline
+        if isinstance(path, str):
+            raise ValueError("path is expected to be a list of segments")
+        # Stash *immutable* copies just to be safe.
+        self._path = tuple(path or [])
+        if item is NEEDS_INITIALIZATION:
+            self._item = None
+            self._metadata = {}
+        else:
+            self._item = item
+            self._metadata = metadata
+        self._cached_len = None  # a cache just for __len__
+        self._params = params or {}
         self._cache = cache
-        self._metadata = metadata
-        self._path = path
-        self._params = params
-        self._structure = structure
 
     def __repr__(self):
         return f"<{type(self).__name__}>"
+
+    @property
+    def item(self):
+        "JSON payload describing this item. Mostly for internal use."
+        return self._item
 
     @property
     def metadata(self):
@@ -44,6 +71,10 @@ class BaseClient:
         "Direct link to this entry"
         return f"{self._client.base_url}/metadata/{'/'.join(self.path)}"
 
+    @property
+    def username(self):
+        return self._username
+
     def new_variation(
         self,
         offline=UNCHANGED,
@@ -51,7 +82,6 @@ class BaseClient:
         metadata=UNCHANGED,
         path=UNCHANGED,
         params=UNCHANGED,
-        structure=UNCHANGED,
     ):
         """
         This is intended primarily for internal use and use by subclasses.
@@ -66,17 +96,106 @@ class BaseClient:
             self._path = path
         if params is UNCHANGED:
             self._params = params
-        if structure is UNCHANGED:
-            self._structure = structure
         return type(self)(
             client=self._client,
+            item=self._item,
+            username=self._username,
             offline=offline,
             cache=cache,
             metadata=metadata,
             path=path,
             params=params,
-            structure=structure,
         )
+
+    def _get_content_with_cache(self, path, accept=None, timeout=UNSET, **kwargs):
+        request = self._client.build_request("GET", path, **kwargs)
+        if accept:
+            request.headers["Accept"] = accept
+        url = request.url.raw  # URL as tuple
+        if self._offline:
+            # We must rely on the cache alone.
+            reservation = self._cache.get_reservation(url)
+            if reservation is None:
+                raise NotAvailableOffline(url)
+            content = reservation.load_content()
+            if content is None:
+                # TODO Do we ever get here?
+                raise NotAvailableOffline(url)
+            return content
+        if self._cache is None:
+            # No cache, so we can use the client straightforwardly.
+            response = self._send(request, timeout=timeout)
+            handle_error(response)
+            return response.content
+        # If we get this far, we have an online client and a cache.
+        reservation = self._cache.get_reservation(url)
+        try:
+            if reservation is not None:
+                request.headers["If-None-Match"] = reservation.etag
+            response = self._send(request, timeout=timeout)
+            handle_error(response)
+            if response.status_code == 304:  # HTTP 304 Not Modified
+                # Read from the cache
+                content = reservation.load_content()
+            elif response.status_code == 200:
+                etag = response.headers.get("ETag")
+                content = response.content
+                # TODO Respect Cache-control headers (e.g. "no-store")
+                if etag is not None:
+                    # Write to cache.
+                    self._cache.put_etag_for_url(url, etag)
+                    self._cache.put_content(etag, content)
+            else:
+                raise NotImplementedError(
+                    f"Unexpected status_code {response.status_code}"
+                )
+        finally:
+            if reservation is not None:
+                reservation.ensure_released()
+        return content
+
+    def _get_json_with_cache(self, path, **kwargs):
+        return msgpack.unpackb(
+            self._get_content_with_cache(path, accept="application/x-msgpack", **kwargs)
+        )
+
+    def _send(self, request, timeout, attempts=0):
+        """
+        Handle httpx's timeout API, which uses a special internal sentinel to mean
+        "no timeout" and therefore must not be passed any value (including None)
+        if we want no timeout.
+        """
+        if timeout is UNSET:
+            response = self._client.send(request)
+        else:
+            response = self._client.send(request, timeout=timeout)
+        if (response.status_code == 401) and (attempts == 0):
+            # Try refreshing the token.
+            # TODO Use a more targeted signal to know that refreshing the token will help.
+            # Parse the error message? Add a special header from the server?
+            reauthenticate_client(
+                self._client, self._username, token_cache=self._token_cache
+            )
+            request.headers["authorization"] = self._client.headers["authorization"]
+            return self._send(request, timeout, attempts=1)
+        return response
+
+
+class BaseStructureClient(BaseClient):
+    def __init__(
+        self,
+        client,
+        *,
+        structure=None,
+        **kwargs,
+    ):
+        super().__init__(client, **kwargs)
+        self._structure = structure
+
+    def new_variation(self, structure=UNCHANGED, **kwargs):
+        if structure is UNCHANGED:
+            structure = self._structure
+        return super().new_variation(structure=structure, **kwargs)
 
     def touch(self):
         """
@@ -110,10 +229,7 @@ class BaseArrayClient(BaseClient):
         # our structure (as part of the some larger structure) and passed it
         # in.
         if self._structure is None:
-            content = get_json_with_cache(
-                self._cache,
-                self._offline,
-                self._client,
+            content = self._get_json_with_cache(
                 f"/metadata/{'/'.join(self._path)}",
                 params={
                     "fields": ["structure.micro", "structure.macro"],

--- a/tiled/client/catalog.py
+++ b/tiled/client/catalog.py
@@ -23,11 +23,12 @@ from .utils import (
 )
 from ..catalogs.utils import (
     catalog_repr,
+    IndexersMixin,
     UNCHANGED,
 )
 
 
-class Catalog(BaseClient):
+class Catalog(BaseClient, collections.abc.Mapping, IndexersMixin):
 
     # This maps the structure_family sent by the server to a client-side object that
     # can interpret the structure_family's structure and content. OneShotCachedMap is used to
@@ -299,6 +300,8 @@ class Catalog(BaseClient):
                 path=path,
                 metadata=metadata,
                 params=self._params,
+                username=self._username,
+                token_cache=self._token_cache,
             )
 
     def new_variation(
@@ -651,8 +654,8 @@ def from_uri(
         False by default. If True, rely on cache only.
     username : str, optional
         Username for authenticated access.
-    token_cache: str or dict, optional
-        Path to directory of tokens, or dict (for development, testing).
+    token_cache : str, optional
+        Path to directory for storing refresh tokens.
     special_clients : dict, optional
         Advanced: Map client_type_hint from the server to special client
         catalog objects. See also
@@ -681,7 +684,7 @@ def from_catalog(
     *,
     username=None,
     special_clients=None,
-    token_cache=None,
+    token_cache=DEFAULT_TOKEN_CACHE,
 ):
     """
     Connect to a Catalog directly, running the app in this same process.
@@ -713,8 +716,8 @@ def from_catalog(
         catalog objects. See also
         ``Catalog.discover_special_clients()`` and
         ``Catalog.DEFAULT_SPECIAL_CLIENT_DISPATCH``.
-    token_cache: str or dict, optional
-        Path to directory of tokens, or dict (for development, testing).
+    token_cache : str, optional
+        Path to directory for storing refresh tokens.
     """
     client = client_from_catalog(
         catalog, authenticator, allow_anonymous_access, secret_keys
@@ -742,7 +745,7 @@ def from_client(
     offline=False,
     path=None,
     special_clients=None,
-    token_cache=None,
+    token_cache=DEFAULT_TOKEN_CACHE,
 ):
     """
     Advanced: Connect to a Catalog using a custom instance of httpx.Client or httpx.AsyncClient.
@@ -768,8 +771,8 @@ def from_client(
         catalog objects. See also
         ``Catalog.discover_special_clients()`` and
         ``Catalog.DEFAULT_SPECIAL_CLIENT_DISPATCH``.
-    token_cache: str or dict, optional
-        Path to directory of tokens, or dict (for development, testing).
+    token_cache : str, optional
+        Path to directory for storing refresh tokens.
     """
     # Interpret structure_clients="numpy" and structure_clients="dask" shortcuts.
     if isinstance(structure_clients, str):

--- a/tiled/client/catalog.py
+++ b/tiled/client/catalog.py
@@ -14,7 +14,7 @@ from ..utils import (
     OneShotCachedMap,
     Sentinel,
 )
-from .authentication import authenticate_client, DEFAULT_TOKEN_CACHE
+from .authentication import DEFAULT_TOKEN_CACHE, reauthenticate_client
 from .base import BaseClient
 from .utils import (
     client_and_path_from_uri,
@@ -783,7 +783,7 @@ def from_client(
         Catalog.DEFAULT_SPECIAL_CLIENT_DISPATCH,
     )
     if username is not None:
-        authenticate_client(client, username, token_cache=token_cache)
+        reauthenticate_client(client, username, token_cache=token_cache)
     instance = Catalog(
         client,
         item=NEEDS_INITIALIZATION,

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -8,11 +8,11 @@ from ..structures.dataframe import (
     DataFrameStructure,
 )
 from ..media_type_registration import deserialization_registry
-from .base import BaseClient
+from .base import BaseStructureClient
 from .utils import get_content_with_cache, get_json_with_cache
 
 
-class DaskDataFrameClient(BaseClient):
+class DaskDataFrameClient(BaseStructureClient):
     "Client-side wrapper around an array-like that returns dask arrays"
 
     def __init__(self, *args, **kwargs):
@@ -227,6 +227,6 @@ class DataFrameClient(DaskDataFrameClient):
     def touch(self):
         # Do not run super().touch() because DaskDataFrameClient calls compute()
         # which does not apply here.
-        BaseClient.touch(self)
+        BaseStructureClient.touch(self)
         self._ipython_key_completions_()
         self.read()

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -9,7 +9,6 @@ from ..structures.dataframe import (
 )
 from ..media_type_registration import deserialization_registry
 from .base import BaseStructureClient
-from .utils import get_content_with_cache, get_json_with_cache
 
 
 class DaskDataFrameClient(BaseStructureClient):
@@ -28,10 +27,7 @@ class DaskDataFrameClient(BaseStructureClient):
         # for long.
         TIMEOUT = 0.2  # seconds
         try:
-            content = get_json_with_cache(
-                self._cache,
-                self._offline,
-                self._client,
+            content = self._get_json_with_cache(
                 f"/metadata/{'/'.join(self._path)}",
                 params={"fields": "structure.macro", **self._params},
                 timeout=TIMEOUT,
@@ -59,10 +55,7 @@ class DaskDataFrameClient(BaseStructureClient):
         See http://ipython.readthedocs.io/en/stable/config/integrating.html#tab-completion
         """
         try:
-            content = get_json_with_cache(
-                self._cache,
-                self._offline,
-                self._client,
+            content = self._get_json_with_cache(
                 f"/metadata/{'/'.join(self._path)}",
                 params={"fields": "structure.macro", **self._params},
             )
@@ -78,20 +71,14 @@ class DaskDataFrameClient(BaseStructureClient):
         self.read().compute()
 
     def structure(self):
-        meta_content = get_content_with_cache(
-            self._cache,
-            self._offline,
-            self._client,
+        meta_content = self._get_content_with_cache(
             f"/dataframe/meta/{'/'.join(self._path)}",
             params=self._params,
         )
         meta = deserialization_registry(
             "dataframe", APACHE_ARROW_FILE_MIME_TYPE, meta_content
         )
-        divisions_content = get_content_with_cache(
-            self._cache,
-            self._offline,
-            self._client,
+        divisions_content = self._get_content_with_cache(
             f"/dataframe/divisions/{'/'.join(self._path)}",
             params=self._params,
         )
@@ -119,10 +106,7 @@ class DaskDataFrameClient(BaseStructureClient):
             # Note: The singular/plural inconsistency here is due to the fact that
             # ["A", "B"] will be encoded in the URL as column=A&column=B
             params["column"] = columns
-        content = get_content_with_cache(
-            self._cache,
-            self._offline,
-            self._client,
+        content = self._get_content_with_cache(
             "/dataframe/partition/" + "/".join(self._path),
             headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
             params={**params, **self._params},

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -12,7 +12,6 @@ from ..structures.xarray import (
 
 from .array import ArrayClient, DaskArrayClient
 from .base import BaseArrayClient
-from .utils import get_json_with_cache
 
 
 class DaskVariableClient(BaseArrayClient):
@@ -217,10 +216,7 @@ class DaskDatasetClient(BaseArrayClient):
         # for long.
         TIMEOUT = 0.2  # seconds
         try:
-            content = get_json_with_cache(
-                self._cache,
-                self._offline,
-                self._client,
+            content = self._get_json_with_cache(
                 f"/metadata/{'/'.join(self._path)}",
                 params={"fields": "structure.macro", **self._params},
                 timeout=TIMEOUT,
@@ -249,10 +245,7 @@ class DaskDatasetClient(BaseArrayClient):
         See http://ipython.readthedocs.io/en/stable/config/integrating.html#tab-completion
         """
         try:
-            content = get_json_with_cache(
-                self._cache,
-                self._offline,
-                self._client,
+            content = self._get_json_with_cache(
                 f"/metadata/{'/'.join(self._path)}",
                 params={"fields": "structure.macro", **self._params},
             )

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -28,6 +28,8 @@ from ..utils import SpecialUsers
 ALGORITHM = "HS256"
 UNIT_SECOND = timedelta(seconds=1)
 API_KEY_COOKIE_NAME = "tiled_api_key"
+API_KEY_HEADER_NAME = "x-tiled-api-key"
+API_KEY_QUERY_PARAMETER = "api_key"
 CSRF_COOKIE_NAME = "tiled_csrf"
 
 
@@ -49,7 +51,7 @@ class TokenData(BaseModel):
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 api_key_query = APIKeyQuery(name="api_key", auto_error=False)
-api_key_header = APIKeyHeader(name="X-TILED-API-KEY", auto_error=False)
+api_key_header = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
 api_key_cookie = APIKeyCookie(name="tiled_api_key", auto_error=False)
 authentication_router = APIRouter()
 

--- a/tiled/server/models.py
+++ b/tiled/server/models.py
@@ -82,9 +82,16 @@ class ReaderResource(Resource):
     attributes: ReaderAttributes
 
 
-class Token(pydantic.BaseModel):
+class AccessAndRefreshTokens(pydantic.BaseModel):
     access_token: str
+    expires_in: int
+    refresh_token: str
+    refresh_token_expires_in: int
     token_type: str
+
+
+class RefreshToken(pydantic.BaseModel):
+    refresh_token: str
 
 
 class TokenData(pydantic.BaseModel):

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -1,9 +1,18 @@
+from datetime import timedelta
 from functools import lru_cache
 import os
 import secrets
-from typing import Any, List
+from typing import Any, List, Optional
 
 from pydantic import BaseSettings
+
+
+if os.getenv("TILED_SESSION_MAX_AGE"):
+    DEFAULT_SESSION_MAX_AGE = timedelta(
+        sections=int(os.getenv("TILED_SESSION_MAX_AGE"))
+    )
+else:
+    DEFAULT_SESSION_MAX_AGE = None
 
 
 class Settings(BaseSettings):
@@ -25,6 +34,15 @@ class Settings(BaseSettings):
     secret_keys: List[str] = os.getenv(
         "TILED_SERVER_SECRET_KEYS", secrets.token_hex(32)
     ).split(";")
+    access_token_max_age: timedelta = timedelta(
+        seconds=int(os.getenv("TILED_ACCESS_TOKEN_MAX_AGE", 15 * 60))  # 15 minutes
+    )
+    refresh_token_max_age: timedelta = timedelta(
+        seconds=int(
+            os.getenv("TILED_REFRESH_TOKEN_MAX_AGE", 7 * 24 * 60 * 60)
+        )  # 7 days
+    )
+    session_max_age: Optional[timedelta] = DEFAULT_SESSION_MAX_AGE  # None
 
 
 @lru_cache()


### PR DESCRIPTION
Implements refresh tokens with sliding sessions.

* All the refresh tokens for a session share a UUID4 session ID which can, in the future, be used to revoke all refresh tokens for a session in an efficient way.
* There is a configurable max session age (default none). This is when you get logged out even during active use.
* There is a configuration max refresh token age (default one week). This is when you get logged out after a period of idleness.
* There is a configurable max access token age. This does not really affect the user experience because the client will automatically get a new access token. Default is 15 minutes for now.
* [Double Submit Cookie CSRF protection](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie) is used.

TO DO:

* [ ] Figure out what to do with the in-process client.
* [ ] Implement revoking refresh tokens.

## Demo

Server:

```
$ TILED_ACCESS_TOKEN_MAX_AGE=20 ALICE_PASSWORD=foo tiled serve config example_configs/toy_authentication.yml 
```

Client:

```
$ rm session.json  # clean session

$ http --session=./session.json GET :8000/metadata/  # not allowed!
HTTP/1.1 401 Unauthorized
content-length: 30
content-type: application/json
date: Tue, 25 May 2021 16:48:29 GMT
server: uvicorn
server-timing: app;dur=2.7

{
    "detail": "Not authenticated"
}

$ http --session=./session.json --form POST http://127.0.0.1:8000/token username=alice password=foo > tokens.json

$ jq . tokens.json
{
  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsImV4cCI6MTYyMTk2MTMzNCwidHlwZSI6ImFjY2VzcyJ9.ihZRpS-dPZrMinoWMW7Ox_9mUUTN-KS05Lzcg5pFWOM",
  "expires_in": 20,  # configured artificially short (20 seconds) for this demo
  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsInR5cGUiOiJyZWZyZXNoIiwiaWF0IjoxNjIxOTc1NzE0LjUzNDEwOCwic2lkIjozNjgwMzkyMTUwMjY4NDY3ODY5NTk0ODk0MDcwNjE1MTA4NzczNiwic2N0IjoxNjIxOTc1NzE0LjUzNDEwOH0.4BzBUYGhL7fEoK8mBYP67ypB7aPTSEmmkFRiOSfzS58",
  "refresh_token_expires_in": 604800,
  "token_type": "bearer"
}

$ http --session=./session.json GET :8000/metadata/ Authorization:"Bearer $(jq -r .access_token tokens.json)"
HTTP/1.1 200 OK
content-length: 214
content-type: application/json
date: Tue, 25 May 2021 16:48:47 GMT
etag: f86de76282c7b77dd1efc28d4fe8b6fe
server: uvicorn
server-timing: app;dur=3.3

{
    "data": {
        "attributes": {
            "client_type_hint": null,
            "count": 2,
            "metadata": {},
            "sorting": null
        },
        "id": "",
        "links": {
            "self": "http://localhost:8000/metadata/"
        },
        "meta": null,
        "type": "catalog"
    },
    "error": null,
    "links": null,
    "meta": null
}

$ # later, after TILED_ACCESS_TOKEN_MAX_AGE passes...
$ http --session=./session.json GET :8000/metadata/ Authorization:"Bearer $(jq -r .access_token tokens.json)"
HTTP/1.1 401 Unauthorized
content-length: 38
content-type: application/json
date: Tue, 25 May 2021 16:49:02 GMT
server: uvicorn
server-timing: app;dur=2.6

{
    "detail": "Access token has expired."
}

$ http --session=./session.json POST http://127.0.0.1:8000/token/refresh refresh_token=$(jq -r .refresh_token tokens.json) x-tiled-csrf-token:$(jq -r .cookies.tiled_csrf_token.value session.json) > new_tokens.json

$ jq . new_tokens.json
{
  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsImV4cCI6MTYyMTk2MTM4MywidHlwZSI6ImFjY2VzcyJ9.AfwuR7sVqOEwkOpveTyKYCBaqETO2fEnWm8f-KFxuVA",
  "expires_in": 20,
  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsInR5cGUiOiJyZWZyZXNoIiwiaWF0IjoxNjIxOTc1NzYzLjU4MzQxNCwic2lkIjozNjgwMzkyMTUwMjY4NDY3ODY5NTk0ODk0MDcwNjE1MTA4NzczNiwic2N0IjoxNjIxOTc1NzE0LjUzNDEwOH0.bCfROz_j2DkkbTNgpDgYAOdOJTk1itDSPcxT17Xhl9U",
  "refresh_token_expires_in": 604800,
  "token_type": "bearer"
}

$ http --session=./session.json GET :8000/metadata/ Authorization:"Bearer $(jq -r .access_token new_tokens.json)"HTTP/1.1 200 OK
content-length: 214
content-type: application/json
date: Tue, 25 May 2021 16:49:36 GMT
etag: f86de76282c7b77dd1efc28d4fe8b6fe
server: uvicorn
server-timing: app;dur=3.3

{
    "data": {
        "attributes": {
            "client_type_hint": null,
            "count": 2,
            "metadata": {},
            "sorting": null
        },
        "id": "",
        "links": {
            "self": "http://localhost:8000/metadata/"
        },
        "meta": null,
        "type": "catalog"
    },
    "error": null,
    "links": null,
    "meta": null
}
```