### PR TITLE
pin httpx version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# .git
+# .gitignore
+# node_modules
+# npm-debug.log
+# Dockerfile*
+# docker-compose*
+# README.md
+# LICENSE
+# .vscode
+
+
+# # Byte-compiled / optimized / DLL files
+# __pycache__/
+# *.py[cod]
+# *$py.class
+
+# # C extensions
+# *.so
+
+# # Distribution / packaging
+# .Python
+# env/
+# build/
+# develop-eggs/
+# dist/
+# downloads/
+# eggs/
+# .eggs/
+# lib/
+# lib64/
+# parts/
+# sdist/
+# var/
+# venv/
+# *.egg-info/
+# .installed.cfg
+# *.egg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+
+COPY ./ /app
+WORKDIR /app
+RUN pip install -U pip
+RUN pip install -e .[server,xarray,dataframe,xarray]
+
+# CMD  tiled serve directory /data

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+# FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+
+# COPY ./ /app
+# WORKDIR /app
+# RUN pip install -U pip
+# RUN pip install .[server,xarray,cache,dataframe,xarray]
+
+# commented above is an attempt to use gunicorn to provide horizontal scaling
+# that solution will depend on some new features...until then, see below of single process
+# tiled
+
+FROM python:3.9
+
+COPY ./ /app
+WORKDIR /app
+RUN pip install -U pip && RUN pip install .[server,xarray,dataframe,xarray]
+
+CMD  tiled serve directory /data

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,6 +1,6 @@
 appdirs
 entrypoints
 jsonschema
-httpx
+httpx>=0.18.2
 msgpack
 pyyaml


### PR DESCRIPTION
httpx changed their api in 0.18...url.netloc used to provide a string, now it provides bytes. Tiled has calls that treat this as the newer bytes, so this PR pins httpx to 0.18.2 or greater.

https://github.com/bluesky/tiled/blob/fb7acf75373d86386206c6b1d922ff0ea1ceac30/tiled/client/utils.py#L101