### PR TITLE
Added case to get shape information for macrostructure

### DIFF
--- a/tiled/readers/tiff.py
+++ b/tiled/readers/tiff.py
@@ -52,7 +52,7 @@ class TiffReader:
         if self._file.is_shaped:
             shape = tuple(self._file.shaped_metadata[0]["shape"])
         else:
-            shape=[len(self._file.asarray()), len(self._file.asarray()[0])]
+            shape = self._file.asarray().shape
         return ArrayMacroStructure(
             shape=shape,
             chunks=tuple((dim,) for dim in shape),

--- a/tiled/readers/tiff.py
+++ b/tiled/readers/tiff.py
@@ -49,7 +49,10 @@ class TiffReader:
         return MachineDataType.from_numpy_dtype(self._file.series[0].dtype)
 
     def macrostructure(self):
-        shape = tuple(self._file.shaped_metadata[0]["shape"])
+        if self._file.is_shaped:
+            shape = tuple(self._file.shaped_metadata[0]["shape"])
+        else:
+            shape=[len(self._file.asarray()), len(self._file.asarray()[0])]
         return ArrayMacroStructure(
             shape=shape,
             chunks=tuple((dim,) for dim in shape),


### PR DESCRIPTION
Some files don't contain shape information in the metadata. If this field is empty, the size of the data/array is read to build the list that contains this information.