### PR TITLE
Simplify pip selectors

### DIFF
--- a/docs/source/tutorials/installation.rst
+++ b/docs/source/tutorials/installation.rst
@@ -70,8 +70,8 @@ Minimal Installation (fewer dependencies)
 To be even more selective about dependencies, you can install `minimal-client`
 and/or `minimal-server`. These do not install numpy, pandas, xarray,
 and other dependencies related to transporting them between server and client.
-This can be useful for a maximally-lean deployment that perhaps does not
-need all of these structures.
+This can be useful for a maximally-lean workflow that is only interested in
+exploring metadata.
 
 .. code:: bash
 

--- a/docs/source/tutorials/installation.rst
+++ b/docs/source/tutorials/installation.rst
@@ -7,22 +7,41 @@ This tutorial covers
 * Installation using pip
 * Installation from source
 
-Pip
----
+Standard Installation with pip
+------------------------------
 
-We strongly recommend creating a fresh environment.
+First, we strongly recommend creating a fresh software environment using venv,
+conda, or similar.
 
 .. code:: bash
 
+   # with venv...
    python3 -m venv try-tiled
    source try-tiled/bin/activate
 
-Install Tiled from PyPI. If you want to just grab everything you might need
-without worrying about keeping dependencies low:
+   # with conda...
+   conda create -n try-tiled python pip
+   conda activate try-tiled
+
+Install Tiled from PyPI using pip.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[complete]'
+   python3 -m pip install 'tiled[all]'
+
+If you are connecting to an existing to a tiled server as a client, there
+is not need to install all the server-related dependencies.
+
+.. code:: bash
+
+   python3 -m pip install 'tiled[client]'  # client only
+
+Likewise, if you are deploying a tiled server but not using the client, you can
+skip a couple client-related dependencies.
+
+.. code:: bash
+
+   python3 -m pip install 'tiled[server]'  # server only
 
 .. warning::
 
@@ -30,14 +49,14 @@ without worrying about keeping dependencies low:
 
    .. code:: bash
 
-      python3 -m pip install 'tiled[complete]'
+      python3 -m pip install 'tiled[all]'
 
    On MacOS, you MUST include the single quotes.
    On Windows, you MUST NOT include them; you should instead do:
 
    .. code:: bash
 
-      python3 -m pip install tiled[complete]
+      python3 -m pip install tiled[all]
 
    On Linux, you may include them or omit them; it works the same either way.
 
@@ -45,25 +64,21 @@ without worrying about keeping dependencies low:
    se*. It just happens that modern MacOS systems ship with zsh as the default
    shell, whereas Linux typically ships with bash.)
 
-To install dependencies more selectively, decide whether you are
-publishing data as a ``server``, reading data as a ``client`` or both.
-
-.. code:: bash
-
-   python3 -m pip install 'tiled[client]'         # client only
-   python3 -m pip install 'tiled[server]'         # server only
-   python3 -m pip install 'tiled[client,server]'  # both
+Minimal Installation (fewer dependencies)
+-----------------------------------------
 
 To be even more selective about dependencies, you can install `minimal-client`
 and/or `minimal-server`. These do not install numpy, pandas, xarray,
 and other dependencies related to transporting them between server and client.
 This can be useful for a maximally-lean deployment that perhaps does not
-need all of these.
+need all of these structures.
 
 .. code:: bash
 
    python3 -m pip install 'tiled[minimal-client]'
    python3 -m pip install 'tiled[minimal-server]'
+
+See the files named `requirements-*.txt` in the repository root for details.
 
 Source
 ------
@@ -74,4 +89,4 @@ To install an editable installation for local development:
 
    git clone https://github.com/bluesky/tiled
    cd tiled
-   pip install -e '.[complete]'
+   pip install -e '.[all]'

--- a/docs/source/tutorials/installation.rst
+++ b/docs/source/tutorials/installation.rst
@@ -51,17 +51,19 @@ publishing data as a ``server``, reading data as a ``client`` or both.
 .. code:: bash
 
    python3 -m pip install 'tiled[client]'         # client only
-   python3 -m pip install 'tiled[client,cache]'   # add support for keeping local copies
    python3 -m pip install 'tiled[server]'         # server only
    python3 -m pip install 'tiled[client,server]'  # both
 
-If you may be publishing or reading ``xarray``, pandas ``dataframe``, and numpy
-``array`` data, install them all, or a subset. With none of the above you can
-still publish and/or read *metadata* but cannot pull any actual data.
+To be even more selective about dependencies, you can install `minimal-client`
+and/or `minimal-server`. These do not install numpy, pandas, xarray,
+and other dependencies related to transporting them between server and client.
+This can be useful for a maximally-lean deployment that perhaps does not
+need all of these.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[array,dataframe,xarray]'
+   python3 -m pip install 'tiled[minimal-client]'
+   python3 -m pip install 'tiled[minimal-server]'
 
 Source
 ------

--- a/docs/source/tutorials/serving-files.md
+++ b/docs/source/tutorials/serving-files.md
@@ -4,13 +4,6 @@ In this tutorial, we will use Tiled to browse a directory of
 spreadsheets and image files from Python and read the data as pandas
 DataFrames and numpy arrays.
 
-For this tutorial, install tiffffile and openpyxl.
-
-```
-pip install tiled[complete]
-pip install tifffile openpyxl
-```
-
 Generate a directory of example files using a utility provided by Tiled.
 (Or use your own, if you have one to hand.)
 

--- a/requirements-array.txt
+++ b/requirements-array.txt
@@ -1,2 +1,3 @@
+# These are needed by the client and server to transmit/receive arrays.
 dask[array]
 numpy

--- a/requirements-cache.txt
+++ b/requirements-cache.txt
@@ -1,2 +1,0 @@
-heapdict
-locket

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,3 +1,4 @@
+# These are the requirements needed for basic client functionality.
 appdirs
 entrypoints
 heapdict

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 appdirs
 entrypoints
+heapdict
 httpx>=0.18.2
 jsonschema
 msgpack

--- a/requirements-compression.txt
+++ b/requirements-compression.txt
@@ -1,0 +1,2 @@
+blosc
+lz4

--- a/requirements-compression.txt
+++ b/requirements-compression.txt
@@ -1,2 +1,4 @@
+# These are used by the client/server to more efficiently compress.
+# They fall back to gzip (which is slower) if these are not installed.
 blosc
 lz4

--- a/requirements-dataframe.txt
+++ b/requirements-dataframe.txt
@@ -1,3 +1,4 @@
+# These are needed by the client and server to transmit/receive dataframes.
 dask[dataframe]
 pandas
 pyarrow

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -1,0 +1,4 @@
+# These are used by the server to read files in the respective formats.
+h5py
+openpyxl
+tifffile

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,3 +1,4 @@
+# These are the requirements needed for basic server functionality.
 dask
 python-dateutil
 fastapi

--- a/requirements-xarray.txt
+++ b/requirements-xarray.txt
@@ -1,3 +1,4 @@
+# These are needed by the client and server to transmit/receive xarrays.
 dask[array]
 pyarrow
 xarray

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,38 @@ def read_requirements(filename):
     return requirements
 
 
-extras_require = {
+categorized_requirements = {
     key: read_requirements(f"requirements-{key}.txt")
-    for key in ["client", "cache", "server", "array", "dataframe", "xarray"]
+    for key in ["client", "compression", "server", "array", "dataframe", "xarray"]
 }
-extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
+extras_require = {}
+extras_require["client"] = sorted(
+    set(
+        sum(
+            (
+                categorized_requirements[k]
+                for k in ["client", "array", "dataframe", "xarray", "compression"]
+            ),
+            [],
+        )
+    )
+)
+extras_require["server"] = sorted(
+    set(
+        sum(
+            (
+                categorized_requirements[k]
+                for k in ["server", "array", "dataframe", "xarray", "compression"]
+            ),
+            [],
+        )
+    )
+)
+extras_require["minimal-client"] = categorized_requirements["client"]
+extras_require["minimal-server"] = categorized_requirements["server"]
+extras_require["all"] = extras_require["complete"] = sorted(
+    set(sum(categorized_requirements.values(), []))
+)
 
 setup(
     name="tiled",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def read_requirements(filename):
 
 categorized_requirements = {
     key: read_requirements(f"requirements-{key}.txt")
-    for key in ["client", "compression", "server", "array", "dataframe", "xarray"]
+    for key in ["client", "compression", "formats", "server", "array", "dataframe", "xarray"]
 }
 extras_require = {}
 extras_require["client"] = sorted(
@@ -71,6 +71,7 @@ extras_require["server"] = sorted(
 )
 extras_require["minimal-client"] = categorized_requirements["client"]
 extras_require["minimal-server"] = categorized_requirements["server"]
+extras_require["formats"] = categorized_requirements["formats"]
 extras_require["all"] = extras_require["complete"] = sorted(
     set(sum(categorized_requirements.values(), []))
 )


### PR DESCRIPTION
The dependencies are very finely separated. If your client is only going to be access arrays and tables, it shouldn't need xarray installled.

But the pip selectors exposed these details a little too much, with verbose invocations like


```
pip install tiled[client,cache,xarray,dataframe,array]
```

I have reduced the options to:

```
[minimal-client]  # a bare-boned client _with_ caching support but only gzip compression support and no structures
[client]   # adds numpy, pandas, arrow, xarray, blosc, lz4, etc.
[minimal-server]  # basic runable server
[server]   # adds numpy, pandas, arrow, xarray, blosc, lz4, etc.
[all]  # a synonym for [client,server]
[complete]  # a synonym for [all] since about 50% of libraries I know of spell it this way
```