### PR TITLE
TiffSequenceReader class

### DIFF
--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import numpy
+import pandas
+import pytest
+import tifffile as tf
+
+from ..readers.array import ArrayAdapter
+from ..readers.tiff_sequence import TiffSequenceReader
+from ..readers.dataframe import DataFrameAdapter
+from ..client import from_tree
+from ..trees.in_memory import Tree
+
+
+@pytest.fixture
+def directory(tmpdir):
+    data = numpy.random.random((100, 100))
+    for i in range(10):
+        tf.imwrite(Path(tmpdir, f"temp{i:05}.tif"), data)
+
+    return str(Path(tmpdir, "*.tif"))
+
+@pytest.mark.parametrize('slice_input, correct_shape',
+                          [(None, (10,100,100)),
+                          (0, (100,100)),
+                          (slice(0, 10, 2), (5,100,100)),
+                          ((1, slice(0,10), slice(0,10)), (10,10)),
+                          ((slice(0,10), slice(0,10), slice(0,10)), (10,10,10)),
+                          ])
+def test_tiff_sequence(directory, slice_input, correct_shape):
+    tree = Tree(
+        {
+            "A": TiffSequenceReader(tf.TiffSequence(directory))
+            }
+        )
+    client = from_tree(tree)
+    arr=client["A"].read(slice=slice_input)
+    assert arr.shape == correct_shape
+    
+
+@pytest.mark.parametrize('block_input, correct_shape',
+                          [((0,0,0), (1,100,100))
+                          ])
+def test_tiff_sequence_block(directory, block_input, correct_shape):
+    tree = Tree(
+        {
+            "A": TiffSequenceReader(tf.TiffSequence(directory))
+            }
+        )
+    client = from_tree(tree)
+    arr=client["A"].read_block(block_input)
+    assert arr.shape == correct_shape
+
+

--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -1,13 +1,10 @@
 from pathlib import Path
 
 import numpy
-import pandas
 import pytest
 import tifffile as tf
 
-from ..readers.array import ArrayAdapter
 from ..readers.tiff_sequence import TiffSequenceReader
-from ..readers.dataframe import DataFrameAdapter
 from ..client import from_tree
 from ..trees.in_memory import Tree
 
@@ -17,38 +14,29 @@ def directory(tmpdir):
     data = numpy.random.random((100, 100))
     for i in range(10):
         tf.imwrite(Path(tmpdir, f"temp{i:05}.tif"), data)
-
     return str(Path(tmpdir, "*.tif"))
 
-@pytest.mark.parametrize('slice_input, correct_shape',
-                          [(None, (10,100,100)),
-                          (0, (100,100)),
-                          (slice(0, 10, 2), (5,100,100)),
-                          ((1, slice(0,10), slice(0,10)), (10,10)),
-                          ((slice(0,10), slice(0,10), slice(0,10)), (10,10,10)),
-                          ])
+
+@pytest.mark.parametrize(
+    "slice_input, correct_shape",
+    [
+        (None, (10, 100, 100)),
+        (0, (100, 100)),
+        (slice(0, 10, 2), (5, 100, 100)),
+        ((1, slice(0, 10), slice(0, 10)), (10, 10)),
+        ((slice(0, 10), slice(0, 10), slice(0, 10)), (10, 10, 10)),
+    ],
+)
 def test_tiff_sequence(directory, slice_input, correct_shape):
-    tree = Tree(
-        {
-            "A": TiffSequenceReader(tf.TiffSequence(directory))
-            }
-        )
+    tree = Tree({"A": TiffSequenceReader(tf.TiffSequence(directory))})
     client = from_tree(tree)
-    arr=client["A"].read(slice=slice_input)
+    arr = client["A"].read(slice=slice_input)
     assert arr.shape == correct_shape
-    
 
-@pytest.mark.parametrize('block_input, correct_shape',
-                          [((0,0,0), (1,100,100))
-                          ])
+
+@pytest.mark.parametrize("block_input, correct_shape", [((0, 0, 0), (1, 100, 100))])
 def test_tiff_sequence_block(directory, block_input, correct_shape):
-    tree = Tree(
-        {
-            "A": TiffSequenceReader(tf.TiffSequence(directory))
-            }
-        )
+    tree = Tree({"A": TiffSequenceReader(tf.TiffSequence(directory))})
     client = from_tree(tree)
-    arr=client["A"].read_block(block_input)
+    arr = client["A"].read_block(block_input)
     assert arr.shape == correct_shape
-
-

--- a/tiled/readers/tiff_sequence.py
+++ b/tiled/readers/tiff_sequence.py
@@ -29,7 +29,7 @@ class TiffSequenceReader:
         of a group of images
         """
 
-        #print("Inside Reader:", slice)
+        # Print("Inside Reader:", slice)
         if slice is None:
             return self._seq.asarray()
         if isinstance(slice, int):
@@ -79,7 +79,7 @@ class TiffSequenceReader:
             return arr
 
     def read_block(self, block, slice=None):
-        #print("Block:", block)
+        # Print("Block:", block)
         if block[1:] != (0, 0):
             raise IndexError(block)
         arr = self.read(builtins.slice(block[0], block[0] + 1))

--- a/tiled/readers/tiff_sequence.py
+++ b/tiled/readers/tiff_sequence.py
@@ -6,14 +6,15 @@ from ..structures.array import (
     MachineDataType,
 )
 
+
 class TiffSequenceReader:
-    
+
     structure_family = "array"
-    
+
     def __init__(self, seq):
         self._seq = seq
         self._metadata = {}
-        
+
     @property
     def metadata(self):
         return self._metadata
@@ -26,10 +27,10 @@ class TiffSequenceReader:
         read() can receive one value or one slice to select all the data from one file or a sequence of files;
         or it can receive a tuple of up to three values (int or slice) to select a more specific sequence of pixels
         of a group of images
-        """    
-        
-        print("Inside Reader:", slice)
-        if slice is None:            
+        """
+
+        #print("Inside Reader:", slice)
+        if slice is None:
             return self._seq.asarray()
         if isinstance(slice, int):
             # e.g. read(slice=0)
@@ -78,26 +79,27 @@ class TiffSequenceReader:
             return arr
 
     def read_block(self, block, slice=None):
-        print("Block:", block)
+        #print("Block:", block)
         if block[1:] != (0, 0):
             raise IndexError(block)
-        arr = self.read(builtins.slice(block[0],block[0]+1))
+        arr = self.read(builtins.slice(block[0], block[0] + 1))
         if slice is not None:
             arr = arr[slice]
         return arr
-        
+
     def microstructure(self):
         # Assume all files have the same data type
         return MachineDataType.from_numpy_dtype(self.read(slice=0).dtype)
-        
+
     def macrostructure(self):
         shape = (len(self._seq), *self.read(slice=0).shape)
-        #print("array shape", shape)
+        # print("array shape", shape)
         return ArrayMacroStructure(
             shape=shape,
             # one chunks per underlying TIFF file
-            chunks = (
+            chunks=(
                 (1,) * shape[0],
                 (shape[1],),
                 (shape[2],),
-        ))
+            ),
+        )

--- a/tiled/readers/tiff_sequence.py
+++ b/tiled/readers/tiff_sequence.py
@@ -1,0 +1,103 @@
+import builtins
+import numpy as np
+
+from ..structures.array import (
+    ArrayMacroStructure,
+    MachineDataType,
+)
+
+class TiffSequenceReader:
+    
+    structure_family = "array"
+    
+    def __init__(self, seq):
+        self._seq = seq
+        self._metadata = {}
+        
+    @property
+    def metadata(self):
+        return self._metadata
+
+    def read(self, slice=None):
+        """Return a numpy array
+
+        Receives a sequence of values to select from a collection of tiff files that were saved in a folder
+        The input order is defined as files --> X slice --> Y slice
+        read() can receive one value or one slice to select all the data from one file or a sequence of files;
+        or it can receive a tuple of up to three values (int or slice) to select a more specific sequence of pixels
+        of a group of images
+        """    
+        
+        print("Inside Reader:", slice)
+        if slice is None:            
+            return self._seq.asarray()
+        if isinstance(slice, int):
+            # e.g. read(slice=0)
+            return self._seq.asarray(file=slice)
+        # e.g. read(slice=(...))
+        if isinstance(slice, tuple):
+            image_axis, *the_rest = slice
+            # Could be int or slice
+            # (0, slice(...)) or (0,....) are converted to a list
+            if isinstance(image_axis, int):
+                # e.g. read(slice=(0, ....))
+                arr = self._seq.asarray(file=image_axis)
+            if isinstance(image_axis, builtins.slice):
+                if image_axis.start is None:
+                    slice_start = 0
+                else:
+                    slice_start = image_axis.start
+                if image_axis.step is None:
+                    slice_step = 1
+                else:
+                    slice_step = image_axis.step
+                arr = np.stack(
+                    [
+                        self._seq.asarray(file=i)
+                        for i in range(slice_start, image_axis.stop, slice_step)
+                    ]
+                )
+            arr = arr[tuple(the_rest)]
+            return arr
+        if isinstance(slice, builtins.slice):
+            # Check for start and step which can be optional
+            if slice.start is None:
+                slice_start = 0
+            else:
+                slice_start = slice.start
+            if slice.step is None:
+                slice_step = 1
+            else:
+                slice_step = slice.step
+            arr = np.stack(
+                [
+                    self._seq.asarray(file=i)
+                    for i in range(slice_start, slice.stop, slice_step)
+                ]
+            )
+            return arr
+
+    def read_block(self, block, slice=None):
+        print("Block:", block)
+        if block[1:] != (0, 0):
+            raise IndexError(block)
+        arr = self.read(builtins.slice(block[0],block[0]+1))
+        if slice is not None:
+            arr = arr[slice]
+        return arr
+        
+    def microstructure(self):
+        # Assume all files have the same data type
+        return MachineDataType.from_numpy_dtype(self.read(slice=0).dtype)
+        
+    def macrostructure(self):
+        shape = (len(self._seq), *self.read(slice=0).shape)
+        #print("array shape", shape)
+        return ArrayMacroStructure(
+            shape=shape,
+            # one chunks per underlying TIFF file
+            chunks = (
+                (1,) * shape[0],
+                (shape[1],),
+                (shape[2],),
+        ))


### PR DESCRIPTION
Created a TiffSequenceReader class with read(), read_block(), microstructure() and macrostructure() methods.
Added method to test read() and read_block()

The read_block() method is still not covering all possible cases. It passes cases with inputs like (0,0,0), (1,0,0), (2,0,0) which are the inputs that read() uses when it has to create chunks for a request of a large data set. I need to get more familiar with the possible uses for the input variable `block`. Slices seem not to be working for this input; not sure if they are necessary though.