### PR TITLE
add workflow for testing container

### DIFF
--- a/.github/workflows/testing-container.yml
+++ b/.github/workflows/testing-container.yml
@@ -1,0 +1,17 @@
+name: Unit Tests in Container
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Test docker container
+      shell: bash -l {0}
+      run: docker build --target=test -t tiled -f docker/Dockerfile .


### PR DESCRIPTION
This adds a new workflow for running the unit tests inside the docker image. As discussed before this will help us to discover problems with the pinned dependencies for the container. It works by building the test target defined in the Dockerfile. It is a separate workflow from the regular unit tests because the python version matrix doesn't make sense here.