### PR TITLE
Add a dynamic example.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ coverage
 flake8
 pytest
 pytest-asyncio
-sphinx !=4.1.0, !=4.1.1, !=4.1.2
+sphinx !=4.1.0, !=4.1.1, !=4.1.2, !=4.2.0
 # These are dependencies of various sphinx extensions for documentation.
 h5py
 ipython

--- a/tiled/examples/generated.py
+++ b/tiled/examples/generated.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import dask.array
@@ -27,95 +28,105 @@ data = {
 }
 print("Done generating example data.", file=sys.stderr)
 
-tree = Tree(
-    {
-        "big_image": ArrayAdapter.from_array(data["big_image"]),
-        "small_image": ArrayAdapter.from_array(data["small_image"]),
-        "medium_image": ArrayAdapter.from_array(data["medium_image"]),
-        "tiny_image": ArrayAdapter.from_array(data["tiny_image"]),
-        "tiny_cube": ArrayAdapter.from_array(data["tiny_cube"]),
-        "tiny_hypercube": ArrayAdapter.from_array(data["tiny_hypercube"]),
-        "low_entropy": ArrayAdapter.from_array(data["low_entropy"]),
-        "high_entropy": ArrayAdapter.from_array(data["high_entropy"]),
-        "short_table": DataFrameAdapter.from_pandas(
-            pandas.DataFrame(
-                {
-                    "A": data["short_column"],
-                    "B": 2 * data["short_column"],
-                    "C": 3 * data["short_column"],
-                },
-                index=pandas.Index(
-                    numpy.arange(len(data["short_column"])), name="index"
-                ),
-            ),
-            npartitions=1,
-            metadata={"animal": "dog", "color": "red"},
-        ),
-        "long_table": DataFrameAdapter.from_pandas(
-            pandas.DataFrame(
-                {
-                    "A": data["long_column"],
-                    "B": 2 * data["long_column"],
-                    "C": 3 * data["long_column"],
-                },
-                index=pandas.Index(
-                    numpy.arange(len(data["long_column"])), name="index"
-                ),
-            ),
-            npartitions=5,
-            metadata={"animal": "dog", "color": "green"},
-        ),
-        "labeled_data": Tree(
+mapping = {
+    "big_image": ArrayAdapter.from_array(data["big_image"]),
+    "small_image": ArrayAdapter.from_array(data["small_image"]),
+    "medium_image": ArrayAdapter.from_array(data["medium_image"]),
+    "tiny_image": ArrayAdapter.from_array(data["tiny_image"]),
+    "tiny_cube": ArrayAdapter.from_array(data["tiny_cube"]),
+    "tiny_hypercube": ArrayAdapter.from_array(data["tiny_hypercube"]),
+    "low_entropy": ArrayAdapter.from_array(data["low_entropy"]),
+    "high_entropy": ArrayAdapter.from_array(data["high_entropy"]),
+    "short_table": DataFrameAdapter.from_pandas(
+        pandas.DataFrame(
             {
-                "image_with_dims": VariableAdapter(
+                "A": data["short_column"],
+                "B": 2 * data["short_column"],
+                "C": 3 * data["short_column"],
+            },
+            index=pandas.Index(numpy.arange(len(data["short_column"])), name="index"),
+        ),
+        npartitions=1,
+        metadata={"animal": "dog", "color": "red"},
+    ),
+    "long_table": DataFrameAdapter.from_pandas(
+        pandas.DataFrame(
+            {
+                "A": data["long_column"],
+                "B": 2 * data["long_column"],
+                "C": 3 * data["long_column"],
+            },
+            index=pandas.Index(numpy.arange(len(data["long_column"])), name="index"),
+        ),
+        npartitions=5,
+        metadata={"animal": "dog", "color": "green"},
+    ),
+    "labeled_data": Tree(
+        {
+            "image_with_dims": VariableAdapter(
+                xarray.Variable(
+                    data=dask.array.from_array(data["medium_image"]),
+                    dims=["x", "y"],
+                    attrs={"thing": "stuff"},
+                ),
+            ),
+        }
+    ),
+    "structured_data": Tree(
+        {
+            "image_with_coords": DataArrayAdapter(
+                xarray.DataArray(
                     xarray.Variable(
                         data=dask.array.from_array(data["medium_image"]),
                         dims=["x", "y"],
                         attrs={"thing": "stuff"},
                     ),
+                    coords={
+                        "x": dask.array.arange(len(data["medium_image"])) / 10,
+                        "y": dask.array.arange(len(data["medium_image"])) / 50,
+                    },
                 ),
-            }
-        ),
-        "structured_data": Tree(
-            {
-                "image_with_coords": DataArrayAdapter(
-                    xarray.DataArray(
-                        xarray.Variable(
-                            data=dask.array.from_array(data["medium_image"]),
-                            dims=["x", "y"],
-                            attrs={"thing": "stuff"},
+            ),
+            "xarray_dataset": DatasetAdapter(
+                xarray.Dataset(
+                    {
+                        "image": xarray.DataArray(
+                            xarray.Variable(
+                                data=dask.array.from_array(data["medium_image"]),
+                                dims=["x", "y"],
+                                attrs={"thing": "stuff"},
+                            ),
+                            coords={
+                                "x": dask.array.arange(len(data["medium_image"])) / 10,
+                                "y": dask.array.arange(len(data["medium_image"])) / 50,
+                            },
                         ),
-                        coords={
-                            "x": dask.array.arange(len(data["medium_image"])) / 10,
-                            "y": dask.array.arange(len(data["medium_image"])) / 50,
-                        },
-                    ),
-                ),
-                "xarray_dataset": DatasetAdapter(
-                    xarray.Dataset(
-                        {
-                            "image": xarray.DataArray(
-                                xarray.Variable(
-                                    data=dask.array.from_array(data["medium_image"]),
-                                    dims=["x", "y"],
-                                    attrs={"thing": "stuff"},
-                                ),
-                                coords={
-                                    "x": dask.array.arange(len(data["medium_image"]))
-                                    / 10,
-                                    "y": dask.array.arange(len(data["medium_image"]))
-                                    / 50,
-                                },
-                            ),
-                            "z": xarray.DataArray(
-                                data=dask.array.ones((len(data["medium_image"]),))
-                            ),
-                        },
-                        coords={"time": numpy.arange(len(data["medium_image"]))},
-                    )
-                ),
-            },
-            metadata={"animal": "cat", "color": "green"},
-        ),
-    },
-)
+                        "z": xarray.DataArray(
+                            data=dask.array.ones((len(data["medium_image"]),))
+                        ),
+                    }
+                )
+            ),
+        },
+        metadata={"animal": "cat", "color": "green"},
+    ),
+    # Below, an asynchronous task modifies this value over time.
+    "dynamic": ArrayAdapter.from_array(numpy.zeros((3, 3))),
+}
+tree = Tree(mapping)
+
+
+async def increment_dynamic():
+    """
+    Change the value of the 'dynamic' node every 3 seconds.
+    """
+    fill_value = 0
+    while True:
+        fill_value += 1
+        mapping["dynamic"] = ArrayAdapter.from_array(fill_value * numpy.ones((3, 3)))
+        await asyncio.sleep(3)
+
+
+# The server will run this on its event loop. We cannot start it *now* because
+# there is not yet a running event loop.
+tree.background_tasks.append(increment_dynamic)

--- a/tiled/trees/in_memory.py
+++ b/tiled/trees/in_memory.py
@@ -20,6 +20,7 @@ class Tree(collections.abc.Mapping, IndexersMixin):
         "_access_policy",
         "_authenticated_identity",
         "include_routers",
+        "background_tasks",
         "_mapping",
         "_metadata",
     )
@@ -56,6 +57,7 @@ class Tree(collections.abc.Mapping, IndexersMixin):
         self._access_policy = access_policy
         self._authenticated_identity = authenticated_identity
         self.include_routers = []
+        self.background_tasks = []
         super().__init__()
 
     @property


### PR DESCRIPTION
## This adds an array whose values increment every 3 seconds.

Demo:

```
tiled serve pyobject --public tiled.examples.generated:tree
```

```
08:30 dallan@pop-os:tiled [dynamic-example]$ http :8000/array/full/dynamic Accept:text/csv
HTTP/1.1 200 OK
content-length: 36
content-type: text/csv; charset=utf-8
date: Fri, 17 Sep 2021 12:35:19 GMT
etag: c083952bb933d777c683bd2a46187e42
server: uvicorn
server-timing: read;dur=1.8, pack;dur=0.2, app;dur=7.5
set-cookie: tiled_csrf=rEOsJ6R1XfMOMx57HEd-BA6l8OWbQqYxu17cRLtccps; HttpOnly; Path=/; SameSite=lax

1.0,1.0,1.0
1.0,1.0,1.0
1.0,1.0,1.0

08:35 dallan@pop-os:tiled [dynamic-example]$ http :8000/array/full/dynamic Accept:text/csv
HTTP/1.1 200 OK
content-length: 36
content-type: text/csv; charset=utf-8
date: Fri, 17 Sep 2021 12:35:22 GMT
etag: e76410d766eeafe4700231ba01d0742c
server: uvicorn
server-timing: read;dur=0.6, pack;dur=0.2, app;dur=6.4
set-cookie: tiled_csrf=D_rOpN72GTS4tleFtqrZNjRD_bKILQVvDok3uxTagL8; HttpOnly; Path=/; SameSite=lax

2.0,2.0,2.0
2.0,2.0,2.0
2.0,2.0,2.0

08:35 dallan@pop-os:tiled [dynamic-example]$ http :8000/array/full/dynamic Accept:text/csv
HTTP/1.1 200 OK
content-length: 36
content-type: text/csv; charset=utf-8
date: Fri, 17 Sep 2021 12:35:23 GMT
etag: e76410d766eeafe4700231ba01d0742c
server: uvicorn
server-timing: read;dur=0.6, pack;dur=0.2, app;dur=6.4
set-cookie: tiled_csrf=7ySiq4F0AoLq2kym2_STKdfSQDb2IXROLRcG-VI3cQo; HttpOnly; Path=/; SameSite=lax

2.0,2.0,2.0
2.0,2.0,2.0
2.0,2.0,2.0

08:35 dallan@pop-os:tiled [dynamic-example]$ http :8000/array/full/dynamic Accept:text/csv
HTTP/1.1 200 OK
content-length: 36
content-type: text/csv; charset=utf-8
date: Fri, 17 Sep 2021 12:35:26 GMT
etag: 39bf68eaf785f9681f8e7fd3d18b42ef
server: uvicorn
server-timing: read;dur=0.6, pack;dur=0.2, app;dur=6.2
set-cookie: tiled_csrf=-yD6v_7oVdKNqwQ5A0IW-zuTld6lbB5j7onr44ST4Y0; HttpOnly; Path=/; SameSite=lax

3.0,3.0,3.0
3.0,3.0,3.0
3.0,3.0,3.0
```

## Implementation Notes

FastAPI has a mechanism for running [background tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/). In the usual way for FastAPI, it uses dependency injection in API endpoint functions. The feature is designed for one-shot applications like "When someone POSTs to this endpoint, send an email." We want something that kicks off at startup and running continuously. Similar to [this example](https://github.com/tiangolo/fastapi/issues/2713#issuecomment-768949823) we use the FastAPI startup hook to create asyncio tasks.

Tiled already has a similar mechanism that trees can use to advertise custom additional routes that want to add to the API. (Databroker uses that for `/documents`.) I think it makes sense to let trees advertise tasks they want to run as well. The tasks will be run as soon as a running event loop is available.

The biggest lines-of-code change here in refactoring `generated.py` from

```
tree = Tree({...})
```

to

```
mapping = {...}
tree = Tree(mapping)
```

so that we can mutate `mapping`. The actual change is small.