### PR TITLE
Support external authentications

### DIFF
--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -69,7 +69,7 @@ class PAMAuthenticator:
 
 class OIDCAuthenticator:
     handles_credentials = False
-    confirmation_message = "You have logged with ORCID as {username}"
+    confirmation_message = "You have logged with ORCID as {username}."
     configuration_schema = """
 client_id:
   type: string

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -69,6 +69,7 @@ class PAMAuthenticator:
 
 class OIDCAuthenticator:
     handles_credentials = False
+    confirmation_message = "You have logged with ORCID as {username}"
     configuration_schema = """
 client_id:
   type: string

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -343,7 +343,9 @@ Navigate web browser to this address to obtain access code:
             )
             # The proper term for this is 'refresh token' but that may be
             # confusing jargon to the end user, so we say "access code".
-            refresh_token = input("Access code: ")
+            raw_refresh_token = input("Access code: ")
+            # Remove any accidentally-included quotes.
+            refresh_token = raw_refresh_token.replace('"', '')
             tokens = {"refresh_token": refresh_token}
         if self._token_cache is not None:
             # We are using a token cache. Store the new refresh token.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -297,17 +297,14 @@ class Context:
             response = self._client.send(request, stream=stream, timeout=timeout)
         if (response.status_code == 401) and (attempts == 0):
             # Try refreshing the token.
-            # TODO Use a more targeted signal to know that refreshing the token will help.
-            # Parse the error message? Add a special header from the server?
-            if self._username is not None:
-                tokens = self.reauthenticate()
-                access_token = tokens["access_token"]
-                auth_header = f"Bearer {access_token}"
-                # Patch in the Authorization header for this request...
-                request.headers["authorization"] = auth_header
-                # And update the default headers for future requests.
-                self._client.headers["Authorization"] = auth_header
-                return self._send(request, timeout, stream=stream, attempts=1)
+            tokens = self.reauthenticate()
+            access_token = tokens["access_token"]
+            auth_header = f"Bearer {access_token}"
+            # Patch in the Authorization header for this request...
+            request.headers["authorization"] = auth_header
+            # And update the default headers for future requests.
+            self._client.headers["Authorization"] = auth_header
+            return self._send(request, timeout, stream=stream, attempts=1)
         return response
 
     def authenticate(self):
@@ -429,6 +426,10 @@ Navigate web browser to this address to obtain access code:
         # If we get this far, reauthentication worked.
         # Store the new refresh token.
         self._token_cache["refresh_token"] = tokens["refresh_token"]
+        # Update the client's Authentication header.
+        access_token = tokens["access_token"]
+        auth_header = f"Bearer {access_token}"
+        self._client.headers["authorization"] = auth_header
         return tokens
 
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -174,7 +174,7 @@ class Context:
         if (not offline) and (
             self._handshake_data["authentication"]["required"] or (username is not None)
         ):
-            if self._handshake_data["authentication"]["required"] in (
+            if self._handshake_data["authentication"]["type"] in (
                 "password",
                 "external",
             ):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -162,6 +162,7 @@ class Context:
         self._app = app
 
         # Make an initial "safe" request to let the server set the CSRF cookie.
+        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
         handshake_request = self._client.build_request("GET", self._authentication_uri)
         # If an Authorization header is set, that's for the Resource server.
         # Do not include it in the request to the Authentication server.
@@ -367,16 +368,6 @@ Navigate web browser to this address to obtain access code:
             raise
 
     def _refresh(self, refresh_token=None):
-        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
-        # Make an initial "safe" request to let the server set the CSRF cookie.
-        # TODO: Skip this if we already have a valid CSRF cookie for the authentication domain.
-        # TODO: The server should support HEAD requests so we can do this more cheaply.
-        handshake_request = self._client.build_request("GET", self._authentication_uri)
-        # If an Authorization header is set, that's for the Resource server.
-        # Do not include it in the request to the Authentication server.
-        handshake_request.headers.pop("Authorization", None)
-        handshake_response = self._client.send(handshake_request)
-        handle_error(handshake_response)
         if refresh_token is None:
             if self._token_cache is None:
                 # We are not using a token cache.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -247,6 +247,16 @@ async def login_for_access_token(
 @external_authentication_router.post(
     "/token/refresh", response_model=AccessAndRefreshTokens
 )
+@password_authentication_router.post(
+    "/auth/token/refresh",
+    response_model=AccessAndRefreshTokens,
+    include_in_schema=False,
+)  # back-compat alias
+@external_authentication_router.post(
+    "/auth/token/refresh",
+    response_model=AccessAndRefreshTokens,
+    include_in_schema=False,
+)  # back-compat alias
 async def post_token_refresh(
     refresh_token: RefreshToken,
     settings: BaseSettings = Depends(get_settings),
@@ -297,8 +307,20 @@ def slide_session(refresh_token, settings):
     }
 
 
-@external_authentication_router.post("/logout")
-@password_authentication_router.post("/logout")
+@external_authentication_router.get("/auth/whoami")
+@password_authentication_router.get("/auth/whoami")
+async def whoami(current_user: str = Depends(get_current_user)):
+    return {"username": current_user}
+
+
+@external_authentication_router.post("/auth/logout")
+@password_authentication_router.post("/auth/logout")
+@external_authentication_router.post(
+    "/logout", include_in_schema=False
+)  # back-compat alias
+@password_authentication_router.post(
+    "/logout", include_in_schema=False
+)  # back-compat alias
 async def logout(
     response: Response,
 ):

--- a/tiled/server/models.py
+++ b/tiled/server/models.py
@@ -107,4 +107,5 @@ class About(pydantic.BaseModel):
     formats: Dict[str, List[str]]
     aliases: Dict[str, Dict[str, List[str]]]
     queries: List[str]
+    authentication: dict
     meta: dict

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -62,6 +62,16 @@ async def about(
             request.state.cookies_to_set.append(
                 {"key": API_KEY_COOKIE_NAME, "value": settings.single_user_api_key}
             )
+    if authenticator is None:
+        auth_type = "api_key"
+    else:
+        if authenticator.handles_credentials:
+            auth_type = "password"
+            auth_endpoint = None
+        else:
+            auth_type = "external"
+            auth_endpoint = authenticator.authorization_endpoint
+
     return json_or_msgpack(
         request.headers,
         models.About(
@@ -82,6 +92,11 @@ async def about(
             meta={"root_path": request.scope.get("root_path") or "/"}
             if (root_path is not None)
             else {},
+            authentication={
+                "type": auth_type,
+                "required": settings.allow_anonymous_access,
+                "endpoint": auth_endpoint,
+            },
         ),
     )
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -50,7 +50,6 @@ async def about(
     authenticator=Depends(get_authenticator),
     serialization_registry=Depends(get_serialization_registry),
     query_registry=Depends(get_query_registry),
-    root_path: str = Query(None),
 ):
     # TODO The lazy import of reader modules and serializers means that the
     # lists of formats are not populated until they are first used. Not very
@@ -64,6 +63,7 @@ async def about(
             )
     if authenticator is None:
         auth_type = "api_key"
+        auth_endpoint = None
     else:
         if authenticator.handles_credentials:
             auth_type = "password"
@@ -89,9 +89,7 @@ async def about(
             },
             queries=list(query_registry.name_to_query_type),
             # documentation_url=".../docs",  # TODO How to get the base URL?
-            meta={"root_path": request.scope.get("root_path") or "/"}
-            if (root_path is not None)
-            else {},
+            meta={"root_path": request.scope.get("root_path") or "/"},
             authentication={
                 "type": auth_type,
                 "required": settings.allow_anonymous_access,

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -92,7 +92,7 @@ async def about(
             meta={"root_path": request.scope.get("root_path") or "/"},
             authentication={
                 "type": auth_type,
-                "required": settings.allow_anonymous_access,
+                "required": not settings.allow_anonymous_access,
                 "endpoint": auth_endpoint,
             },
         ),

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -94,6 +94,9 @@ async def about(
                 "type": auth_type,
                 "required": not settings.allow_anonymous_access,
                 "endpoint": auth_endpoint,
+                "confirmation_message": getattr(
+                    authenticator, "confirmation_message", None
+                ),
             },
         ),
     )


### PR DESCRIPTION
ORCID works!

```
In [1]: from tiled.client import from_uri

In [2]: c = from_uri("https://tiled-demo.blueskyproject.io")

Navigate web browser to this address to obtain access code:

https://orcid.org/oauth/authorize?client_id=APP-0ROS9DU5F717F7XN&response_type=code&scope=/authenticate&redirect_uri=https://tiled-demo.blueskyproject.io/auth/code


Access code: [redacted]

In [3]: c
Out[3]: <Node {'big_image', 'small_image', 'medium_image', ...} ~13 entries>
```