### PR TITLE
Don't the entire dataset when you have a slice

### DIFF
--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -322,9 +322,7 @@ def array_full(
 
     try:
         with record_timing(request.state.metrics, "read"):
-            array = reader.read()
-        if slice:
-            array = array[slice]
+            array = reader.read(slice)
         array = numpy.asarray(array)  # Force dask or PIMS or ... to do I/O.
     except IndexError:
         raise HTTPException(status_code=400, detail="Block index out of range")


### PR DESCRIPTION
I found an issue with some h5 that tiled was crashing with out memory issues.

I believe the reason is that the array route was doing a full read of the dataset, then returning a slice. But the array readers take a slice parameter. Sending that in seems to fix this issue with my files nicely.