### PR TITLE
moved NumpySafeJSONEncoder to utils. In the process of testing throughout other implementations in tiled

### DIFF
--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -71,16 +71,19 @@ def test_shape_with_zero():
 
 
 def test_infinity_handler():
-    data=numpy.array([0, 1, numpy.NAN, -numpy.Inf, numpy.Inf])
-    metadata={"infinity": math.inf, "-infinity": -math.inf, "nan": numpy.NAN}
-    inf_tree = Tree({"example": ArrayAdapter.from_array(data, metadata=metadata)}, metadata=metadata)
+    data = numpy.array([0, 1, numpy.NAN, -numpy.Inf, numpy.Inf])
+    metadata = {"infinity": math.inf, "-infinity": -math.inf, "nan": numpy.NAN}
+    inf_tree = Tree(
+        {"example": ArrayAdapter.from_array(data, metadata=metadata)}, metadata=metadata
+    )
     client = from_tree(inf_tree)
     print(f"Metadata: {client['example'].metadata}")
     print(f"Data: {client['example'].read()}")
-    client['example'].export('/tmp/test.json')
-    
+    client["example"].export("/tmp/test.json")
+
     import json
+
     def strict_parse_constant(c):
         raise ValueError(f"{c} is not valid JSON")
-    
-    json.load(open('/tmp/test.json', 'r'), parse_constant=strict_parse_constant)
+
+    json.load(open("/tmp/test.json", "r"), parse_constant=strict_parse_constant)

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -101,9 +101,7 @@ def entry(
         raise HTTPException(status_code=404, detail=f"No such entry: {path_parts}")
 
 
-def reader(
-    entry: Any = Depends(entry),
-):
+def reader(entry: Any = Depends(entry),):
     "Specify a path parameter and use it to look up a reader."
     if not isinstance(entry, DuckReader):
         raise HTTPException(status_code=404, detail="This is not a Reader.")
@@ -133,9 +131,7 @@ def expected_shape(
     return tuple(map(int, expected_shape.split(",")))
 
 
-def slice_(
-    slice: str = Query(None, regex="^[0-9,:]*$"),
-):
+def slice_(slice: str = Query(None, regex="^[0-9,:]*$"),):
     "Specify and parse a block index parameter."
     import numpy
 
@@ -225,16 +221,7 @@ class DuckTree(metaclass=abc.ABCMeta):
 
 
 def construct_entries_response(
-    query_registry,
-    tree,
-    route,
-    path,
-    offset,
-    limit,
-    fields,
-    filters,
-    sort,
-    base_url,
+    query_registry, tree, route, path, offset, limit, fields, filters, sort, base_url,
 ):
     path_parts = [segment for segment in path.split("/") if segment]
     if not isinstance(tree, DuckTree):

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -24,7 +24,7 @@ from starlette.responses import JSONResponse, StreamingResponse, Send
 from . import models
 from .authentication import get_current_user
 from .etag import tokenize
-from ..utils import APACHE_ARROW_FILE_MIME_TYPE, modules_available
+from ..utils import APACHE_ARROW_FILE_MIME_TYPE, modules_available, NumpySafeJSONEncoder
 from ..query_registration import query_registry as default_query_registry
 from ..queries import KeyLookup, QueryValueError
 from ..media_type_registration import (
@@ -590,7 +590,7 @@ class NumpySafeJSONResponse(JSONResponse):
             # Fast (optimistic) path
             return super().render(content)
         except Exception:
-            return json.dumps(content, cls=_NumpySafeJSONEncoder).encode()
+            return json.dumps(content, cls=NumpySafeJSONEncoder).encode()
 
 
 def _numpy_safe_msgpack_encoder(obj):

--- a/tiled/structures/array.py
+++ b/tiled/structures/array.py
@@ -10,7 +10,7 @@ from typing import Tuple
 import numpy
 
 from ..media_type_registration import serialization_registry, deserialization_registry
-from ..utils import modules_available
+from ..utils import modules_available, NumpySafeJSONEncoder
 
 
 class Endianness(str, enum.Enum):
@@ -164,7 +164,7 @@ serialization_registry.register(
 serialization_registry.register(
     "array",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist()).encode(),
+    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
 )
 
 

--- a/tiled/structures/array.py
+++ b/tiled/structures/array.py
@@ -164,7 +164,9 @@ serialization_registry.register(
 serialization_registry.register(
     "array",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
+    lambda array, metadata: json.dumps(
+        array.tolist(), cls=NumpySafeJSONEncoder
+    ).encode(),
 )
 
 
@@ -207,9 +209,7 @@ if modules_available("PIL"):
         return numpy.asarray(image).asdtype(dtype).reshape(shape)
 
     serialization_registry.register(
-        "array",
-        "image/png",
-        lambda array, metadata: save_to_buffer_PIL(array, "png"),
+        "array", "image/png", lambda array, metadata: save_to_buffer_PIL(array, "png"),
     )
     deserialization_registry.register(
         "array",
@@ -234,14 +234,10 @@ if modules_available("tifffile"):
         return file.getbuffer()
 
     serialization_registry.register(
-        "array",
-        "image/tiff",
-        save_to_buffer_tifffile,
+        "array", "image/tiff", save_to_buffer_tifffile,
     )
     deserialization_registry.register(
-        "array",
-        "image/tiff",
-        array_from_buffer_tifffile,
+        "array", "image/tiff", array_from_buffer_tifffile,
     )
 
 
@@ -265,7 +261,5 @@ def serialize_html(array, metadata):
 
 
 serialization_registry.register(
-    "array",
-    "text/html",
-    serialize_html,
+    "array", "text/html", serialize_html,
 )

--- a/tiled/structures/structured_array.py
+++ b/tiled/structures/structured_array.py
@@ -6,7 +6,7 @@ import numpy
 
 from .array import MachineDataType as BuiltinType, ArrayMacroStructure
 from ..media_type_registration import serialization_registry
-
+from ..utils import NumpySafeJSONEncoder
 
 @dataclass
 class Field:
@@ -146,7 +146,7 @@ serialization_registry.register(
 serialization_registry.register(
     "structured_array_generic",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist()).encode(),
+    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
 )
 serialization_registry.register(
     "structured_array_tabular",
@@ -156,5 +156,5 @@ serialization_registry.register(
 serialization_registry.register(
     "structured_array_tabular",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist()).encode(),
+    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
 )

--- a/tiled/structures/structured_array.py
+++ b/tiled/structures/structured_array.py
@@ -8,6 +8,7 @@ from .array import MachineDataType as BuiltinType, ArrayMacroStructure
 from ..media_type_registration import serialization_registry
 from ..utils import NumpySafeJSONEncoder
 
+
 @dataclass
 class Field:
     name: str
@@ -146,7 +147,9 @@ serialization_registry.register(
 serialization_registry.register(
     "structured_array_generic",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
+    lambda array, metadata: json.dumps(
+        array.tolist(), cls=NumpySafeJSONEncoder
+    ).encode(),
 )
 serialization_registry.register(
     "structured_array_tabular",
@@ -156,5 +159,7 @@ serialization_registry.register(
 serialization_registry.register(
     "structured_array_tabular",
     "application/json",
-    lambda array, metadata: json.dumps(array.tolist(), cls=NumpySafeJSONEncoder).encode(),
+    lambda array, metadata: json.dumps(
+        array.tolist(), cls=NumpySafeJSONEncoder
+    ).encode(),
 )

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 _LOCAL_TZINFO = dateutil.tz.gettz()
 
+
 class ListView(collections.abc.Sequence):
     "An immutable view of a list."
 
@@ -496,8 +497,7 @@ class NumpySafeJSONEncoder(json.JSONEncoder):
             else:
                 return obj.isoformat()
         return super().default(obj)
-    
-    
+
     def iterencode(self, o, _one_shot=False):
         """Encode the given object and yield each string
         representation as available.
@@ -514,8 +514,13 @@ class NumpySafeJSONEncoder(json.JSONEncoder):
         else:
             _encoder = json.encoder.encode_basestring
 
-        def floatstr(o, allow_nan=self.allow_nan,
-                _repr=float.__repr__, _inf= json.encoder.INFINITY, _neginf=-json.encoder.INFINITY):
+        def floatstr(
+            o,
+            allow_nan=self.allow_nan,
+            _repr=float.__repr__,
+            _inf=json.encoder.INFINITY,
+            _neginf=-json.encoder.INFINITY,
+        ):
             # Check for specials.  Note that this type of test is processor
             # and/or platform-specific, so do tests which don't depend on the
             # internals.
@@ -531,10 +536,11 @@ class NumpySafeJSONEncoder(json.JSONEncoder):
 
             if not allow_nan:
                 raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
+                    "Out of range float values are not JSON compliant: " + repr(o)
+                )
 
             return text
+
 
 # The MIME type vnd.apache.arrow.file is provisional. See:
 # https://lists.apache.org/thread.html/r9b462400a15296576858b52ae22e73f13c3e66f031757b2c9522f247%40%3Cdev.arrow.apache.org%3E  # noqa

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -524,7 +524,6 @@ class NumpySafeJSONEncoder(json.JSONEncoder):
             # Check for specials.  Note that this type of test is processor
             # and/or platform-specific, so do tests which don't depend on the
             # internals.
-
             if o != o:
                 text = '"NaN"'
             elif o == _inf:
@@ -540,6 +539,19 @@ class NumpySafeJSONEncoder(json.JSONEncoder):
                 )
 
             return text
+        
+        if (_one_shot and json.encoder.c_make_encoder is not None
+                and self.indent is None):
+            _iterencode = json.encoder.c_make_encoder(
+                markers, self.default, _encoder, self.indent,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, self.allow_nan)
+        else:
+            _iterencode = json.encoder._make_iterencode(
+                markers, self.default, _encoder, self.indent, floatstr,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, _one_shot)
+        return _iterencode(o, 0)
 
 
 # The MIME type vnd.apache.arrow.file is provisional. See:


### PR DESCRIPTION
Closes #95 