### PR TITLE
read full dataframe directly in DataFrameClient

### DIFF
--- a/tiled/_tests/test_object_cache.py
+++ b/tiled/_tests/test_object_cache.py
@@ -74,19 +74,19 @@ a,b,c
     cache = get_object_cache()
     assert cache.hits == cache.misses == 0
     client["data"].read()
-    assert cache.misses == 2  # two dask objects in the cache
+    assert cache.misses == 1  # two dask objects in the cache
     assert cache.hits == 0
     client["data"].read()
-    assert cache.misses == 2
-    assert cache.hits == 2
+    assert cache.misses == 1
+    assert cache.hits == 1
     # Simulate eviction.
     cache.clear()
     client["data"].read()
-    assert cache.misses == 4
-    assert cache.hits == 2
+    assert cache.misses == 2
+    assert cache.hits == 1
     client["data"].read()
-    assert cache.misses == 4
-    assert cache.hits == 4
+    assert cache.misses == 2
+    assert cache.hits == 2
 
 
 def test_object_cache_disabled(tmpdir):

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -230,7 +230,16 @@ class DataFrameClient(DaskDataFrameClient):
         """
         Access the entire DataFrame. Optionally select a subset of the columns.
         """
-        return super().read(columns).compute()
+        content = self.context.get_content(
+            f"/dataframe/full/{'/'.join(self.context.path_parts)}/{'/'.join(self._path)}",
+            params=self._params,
+            headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
+        )
+        df = deserialization_registry("dataframe", APACHE_ARROW_FILE_MIME_TYPE, content)
+
+        if columns is not None:
+            df = df[columns]
+        return df
 
     def download(self):
         # Do not run super().download() because DaskDataFrameClient calls compute()


### PR DESCRIPTION
If we are going to get a pandas dataframe rather than a dask dataframe avoid going through the dask object as an intermediate. Avoids needing to make a separate metadata request. Improves throughput ~2x as expected. alternative to #111.