### PR TITLE
GraphQL Implementation

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,4 +1,5 @@
 # These are the requirements needed for basic server functionality.
+ariadne
 cachey
 cachetools
 dask

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -6,6 +6,7 @@ import sys
 import urllib.parse
 from functools import lru_cache, partial
 
+from ariadne.asgi import GraphQL
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
@@ -34,6 +35,7 @@ from .metrics import capture_request_metrics
 from .object_cache import NO_CACHE, ObjectCache
 from .object_cache import logger as object_cache_logger
 from .object_cache import set_object_cache
+from .graphql import schema as graphql_schema
 from .router import declare_search_router, router
 from .settings import get_settings
 
@@ -45,7 +47,7 @@ SENSITIVE_COOKIES = {
 }
 CSRF_HEADER_NAME = "x-csrf"
 CSRF_QUERY_PARAMETER = "csrf"
-
+GRAPHQL_URL = "graphql"
 
 def get_app(
     query_registry, compression_registry, include_routers=None, background_tasks=None
@@ -65,6 +67,8 @@ def get_app(
     app.include_router(router)
     for user_router in include_routers or []:
         app.include_router(user_router)
+
+    # app.add_route(GRAPHQL_URL, GraphQL(schema=schema, debug=True))
 
     @app.on_event("startup")
     async def startup_event():

--- a/tiled/server/graphql.py
+++ b/tiled/server/graphql.py
@@ -1,0 +1,28 @@
+from ariadne import ObjectType, QueryType, gql, make_executable_schema
+
+type_defs = gql("""
+
+    type Query {
+        # datasets(uris: [String], tags: [String], limit: Int, skip: Int): [Dataset]!
+        hello(msg: String!): String!
+    }
+
+
+
+
+# """)
+
+query = QueryType()
+# # I think what we want here is the root tree, and a way to register new query parts based on root tree
+
+# # entry = root_tree.authenticated_as(current_user)
+
+
+@query.field("hello")
+def resolve_datasets(self, *_, msg=""):
+    return msg
+
+
+schema = make_executable_schema(type_defs, query)
+
+# def set_root_tree(**kwarg


### PR DESCRIPTION
This draft PR represents thoughts related to creating a GraphQL search implementation in tiled. I'm creating the PR very early in development to maximize feedback.

This uses the [Ariadne](https://ariadnegraphql.org/) graphql package, which focuses on "schema first" development.

Currently, this only supports a "hello world" endpoint at `/graphql`.

The general theory is that this will always support a single endpoint into which Tree-specific schemas and code can be registered at startup. At app startup, the code in graphql.py will be notified of the `root tree` object. With that, it will interrogate top level `nodes` for registered queries. A `gqlquery` will provide:
- a query part (possibly a graphql `fragment` 
- one or more resolver iplementations

In this way, developers who register tiled a `Tree` will be able to optionally specify a graphql schema (string) and implementation (python).