### PR TITLE
Obtain base_url in a more robust and standard way

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -229,7 +229,6 @@ class Context:
             (url.scheme, url.netloc.decode(), base_path, {}, url.fragment)
         )
         client.base_url = base_url
-        client.headers["x-base-url"] = base_url
         path_parts = list(PurePosixPath(url.path).relative_to(base_path).parts)
         if path_parts:
             # Strip "/node/metadata"

--- a/tiled/schemas/service_configuration.yml
+++ b/tiled/schemas/service_configuration.yml
@@ -344,6 +344,19 @@ properties:
         description: |
           Configure the application with a root_path when it is behind a proxy
           serving it on some path prefix.
+      proxy_headers:
+        type: boolean
+        description: |
+          Enable/Disable X-Forwarded-Proto, X-Forwarded-For,
+          X-Forwarded-Port to populate remote address info. Defaults to enabled,
+          but is restricted to only trusting connecting IPs in the
+          forwarded-allow-ips configuration.
+      forwarded_allow_ips:
+        type: string
+        description: |
+          Comma separated list of IPs to trust with proxy headers. Defaults to
+          the `$FORWARDED_ALLOW_IPS` environment variable if available, or
+          '127.0.0.1'. A wildcard '*' means always trust.
       ssl_keyfile:
         type: string
         description: SSL key file

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -485,6 +485,8 @@ def _get_base_url(request):
     #   to specify a non-default port.
     #   https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
     host = request.headers.get("x-forwarded-host", request.headers["host"])
-    scheme = request.headers.get("x-forwarded-scheme", request.url.scheme)
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
     root_path = request.scope.get("root_path") or "/"
+    if not root_path.endswith("/"):
+        root_path = f"{root_path}/"
     return f"{scheme}://{host}{root_path}"


### PR DESCRIPTION
Closes #146 

To test, I deployed this on https://tiled-demo.blueskyproject.io/, which serves Tiled using gunicorn behind nginx. The scheme and the host are both correct:

```
$ http https://tiled-demo.blueskyproject.io/node/metadata/ | jq .data.links
{
  "self": "https://tiled-demo.blueskyproject.io/node/metadata/",
  "search": "https://tiled-demo.blueskyproject.io/node/search/"
}
```

We also care about the niche use case of SSH port-forwarding to access a Tiled deployment that is only available on an internal network (such as `tiled.nsls2.bnl.gov` is now). HTTPS over port-forwarding is janky (it breaks SSL) but it has been useful in the early stages. Fortunately, it is supported by the approach in this PR:

```
$ ssh -L 8000:localhost:443 tiled-demo.blueskyproject.io
...
$ http --verify false "https://localhost:8000/node/metadata/" | jq .data.links
{
  "self": "https://localhost:8000/node/metadata/",
  "search": "https://localhost:8000/node/search/"
}
```

It works because the `Host` header in the request is set to `localhost:8000` and propagated through nginx as `X-Forwarded-Host`.

I had previously supported this use case with a custom `x-base-url` header, set by the Python client and observed by the server. This is not necessary, and it is removed in this PR.