### PR TITLE
Switched the 500 error for a 406 plus a more detailed message about the error

### DIFF
--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -398,9 +398,9 @@ def construct_data_response(
             f"The shape of this data {err.args[0]} is incompatible with the requested format ({media_type}). "
             f"Slice it or choose a different format.",
         )
-    except SerializationError:
+    except SerializationError as err:
         raise UnsupportedMediaTypes(
-            "This type is supported in general but there was an unknown error packing this specific data.",
+            f"This type is supported in general but there was an error packing this specific data; {err.args}",
         )
     return PatchedResponse(
         content=content,

--- a/tiled/structures/array.py
+++ b/tiled/structures/array.py
@@ -9,7 +9,12 @@ from typing import List, Optional, Tuple, Union
 import numpy
 
 from ..media_type_registration import deserialization_registry, serialization_registry
-from ..utils import UnsupportedShape, modules_available, safe_json_dump_array
+from ..utils import (
+    SerializationError,
+    UnsupportedShape,
+    modules_available,
+    safe_json_dump_array,
+)
 
 
 class Endianness(str, enum.Enum):
@@ -299,8 +304,16 @@ if modules_available("PIL"):
         high = numpy.percentile(array.ravel(), 99)
         scaled_array = numpy.clip((array - low) / (high - low), 0, 1)
         file = io.BytesIO()
-        image = Image.fromarray(img_as_ubyte(scaled_array))
-        image.save(file, format=format)
+
+        try:
+            image = Image.fromarray(img_as_ubyte(scaled_array))
+            image.save(file, format=format)
+        except (TypeError, ValueError):
+            raise SerializationError(
+                f"""The shape of the data ({scaled_array.shape}) is incompatible
+                with the requested format ({format})"""
+            )
+
         return file.getbuffer()
 
     def array_from_buffer_PIL(buffer, format, dtype, shape):

--- a/tiled/structures/array.py
+++ b/tiled/structures/array.py
@@ -310,8 +310,8 @@ if modules_available("PIL"):
             image.save(file, format=format)
         except (TypeError, ValueError):
             raise SerializationError(
-                f"""The shape of the data ({scaled_array.shape}) is incompatible
-                with the requested format ({format})"""
+                f"The shape of the data ({scaled_array.shape}) is incompatible "
+                f"with the requested format ({format})"
             )
 
         return file.getbuffer()


### PR DESCRIPTION
The error is generated while trying to save an array with more than 2 dimensions. The returned message had the wrong id and it was misleading.