### PR TITLE
improve prometheus configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,6 @@ COPY --from=builder /app /app
 
 WORKDIR /deploy
 
-RUN mkdir /deploy/prometheus
-ENV PROMETHEUS_MULTIPROC_DIR=/deploy/prometheus
-
 EXPOSE 8000
 
 ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/tiled/adapters/files.py
+++ b/tiled/adapters/files.py
@@ -106,6 +106,8 @@ class DirectoryAdapter(MapAdapter):
         # These are unofficial but common file extensions.
         ".hdf": "application/x-hdf5",
         ".hdf5": "application/x-hdf5",
+        # on opensuse csv -> text/x-comma-separated-values
+        ".csv": "text/csv",
     }
 
     @classmethod

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -164,12 +164,12 @@ def construct_serve_tree_kwargs(
                 )
             elif not Path(prometheus_multiproc_dir).is_dir():
                 raise ValueError(
-                    "prometheus enabled but PROMETHEUS_MULTIPROC_DIR"
+                    "prometheus enabled but PROMETHEUS_MULTIPROC_DIR "
                     f"({prometheus_multiproc_dir}) is not a directory"
                 )
             elif not os.access(prometheus_multiproc_dir, os.W_OK):
                 raise ValueError(
-                    "prometheus enabled but PROMETHEUS_MULTIPROC_DIR"
+                    "prometheus enabled but PROMETHEUS_MULTIPROC_DIR "
                     f"({prometheus_multiproc_dir}) is not writable"
                 )
 

--- a/tiled/schemas/service_configuration.yml
+++ b/tiled/schemas/service_configuration.yml
@@ -384,4 +384,6 @@ properties:
       prometheus:
         type: boolean
         description: |
-          Enable/Disable prometheus metrics
+          Enable/Disable prometheus metrics. Default is false.
+          If enabled `PROMETHEUS_MULTIPROC_DIR` environment variable
+          must be set to the path of a writable directory.

--- a/tiled/schemas/service_configuration.yml
+++ b/tiled/schemas/service_configuration.yml
@@ -378,3 +378,10 @@ properties:
       ssl_ciphers:
         type: string
         description: Ciphers to use (see stdlib ssl module's). Default TLSv1.
+  metrics:
+    type: object
+    properties:
+      prometheus:
+        type: boolean
+        description: |
+          Enable/Disable prometheus metrics

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -4,7 +4,12 @@ conventions for metrics & labels. We generally prefer naming them
 `tiled_<noun>_<verb>_<type_suffix>`.
 """
 
+from functools import lru_cache
+
+from fastapi import APIRouter, Request, Response
 from prometheus_client import Histogram
+
+router = APIRouter()
 
 REQUEST_DURATION = Histogram(
     "tiled_request_duration_seconds",
@@ -124,3 +129,32 @@ def capture_request_metrics(request, response):
         COMPRESSION_RATIO.labels(
             method=method, code=code, endpoint=endpoint, encoding=encoding
         ).observe(metrics["compress"]["ratio"])
+
+
+@lru_cache()
+def prometheus_registry():
+    """
+    Configure prometheus_client.
+
+    This is run the first time the /metrics endpoint is used.
+    """
+    # The multiprocess configuration makes it compatible with gunicorn.
+    # https://github.com/prometheus/client_python/#multiprocess-mode-eg-gunicorn
+    from prometheus_client import CollectorRegistry
+    from prometheus_client.multiprocess import MultiProcessCollector
+
+    registry = CollectorRegistry()
+    MultiProcessCollector(registry)  # This has a side effect, apparently.
+    return registry
+
+
+@router.get("/metrics")
+async def metrics(request: Request):
+    """
+    Prometheus metrics
+    """
+    from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+    request.state.endpoint = "metrics"
+    data = generate_latest(prometheus_registry())
+    return Response(data, headers={"Content-Type": CONTENT_TYPE_LATEST})


### PR DESCRIPTION
Currently if `PROMETHEUS_MULTIPROC_DIR` is set but not writable we fail opaquely at initialization and if `PROMETHEUS_MULTIPROC_DIR` is unset we get an internal server error when trying to access `/metrics`.

This adds a configuration option to enable/disable prometheus. 
If prometheus is disabled nothing is initialized and `/metrics` route is not present.
If prometheus is enabled checks that `PROMETHEUS_MULTIPROC_DIR` is a writable directory and give sensible error message if not.

Closes #144.