### PR TITLE
Make API key secret larger, and store/expose last 8 for identification.

### DIFF
--- a/tiled/database/migrations/versions/481830dd6c11_initialize.py
+++ b/tiled/database/migrations/versions/481830dd6c11_initialize.py
@@ -84,6 +84,7 @@ def upgrade():
             index=True,
             nullable=False,
         ),
+        Column("last_eight", Unicode(8), nullable=False),
         Column("latest_activity", DateTime(timezone=False), nullable=True),
         Column("expiration_time", DateTime(timezone=False), nullable=True),
         Column("note", Unicode(1023), nullable=True),

--- a/tiled/database/orm.py
+++ b/tiled/database/orm.py
@@ -164,6 +164,7 @@ class APIKey(Timestamped, Base):
         nullable=False,
         default=lambda: uuid_module.uuid4(),
     )
+    last_eight = Column(Unicode(8), nullable=False)
     expiration_time = Column(DateTime(timezone=False), nullable=True)
     latest_activity = Column(DateTime(timezone=False), nullable=True)
     note = Column(Unicode(1023), nullable=True)

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -209,6 +209,7 @@ class Role(pydantic.BaseModel, orm_mode=True):
 
 class APIKeyAttributes(pydantic.BaseModel):
     principal: uuid.UUID
+    last_eight: pydantic.constr(min_length=8, max_length=8)
     expiration_time: Optional[datetime]
     note: Optional[pydantic.constr(max_length=255)]
     scopes: List[str]
@@ -217,6 +218,7 @@ class APIKeyAttributes(pydantic.BaseModel):
 
 class APIKey(pydantic.BaseModel, orm_mode=True):
     uuid: uuid.UUID
+    last_eight: pydantic.constr(min_length=8, max_length=8)
     expiration_time: Optional[datetime]
     note: Optional[pydantic.constr(max_length=255)]
     scopes: List[str]


### PR DESCRIPTION
You only get the see the API key secret once. Later, it can be inconvenient to figure out what the key was. You can do:

```
http GET :8000/auth/apikey 'Authorization:Apikey SECRET
```

but it would be nice to be able to identify the key without _using_ the key. This PR stores the last 8 digits of the hex-encoded secret so that it can be cross-referenced easily.

Since this reduces the security of the secret, the PR adds 4 bytes to compensate.

I read that GitHub does this (or did this) for personal access tokens, but I can't find clear evidence that they _currently_ do. I don't feel confident that we should do this.