### PR TITLE
Rework API keys

### DIFF
--- a/docs/source/how-to/api-keys.md
+++ b/docs/source/how-to/api-keys.md
@@ -1,0 +1,217 @@
+# Create and Use API Keys
+
+This guide applies to **multi-user** Tiled deployments, i.e. deployments configured
+with an authentication provider.
+
+```{note}
+
+**Single-user** deployments run with a single API key. By default, it is
+randomly generated and printed to the console at server startup, like so:
+
+    $ tiled serve pyobject tiled.examples.generated:tree
+    Generating large example data...
+    Done generating example data.
+
+        Use the following URL to connect to Tiled:
+
+        "http://127.0.0.1:8000?api_key=8df0146c93e9add287d0e7f84a165ba4bd3517bbb3c7c6b4d963c3e1549d0311"
+
+This guide does not apply to single-user deployments like this.
+```
+
+## Why use API keys?
+
+Users can log in to Tiled with a simple username/password or through
+a third party like ORICD or Google, as demonstrated in the tutorial
+{doc}`../tutorials/login`. For interactive workflows in Python, this the most
+convenient way to authenticate.
+
+But in other situations, it can more convenient to generate and use an API key.
+An API key uses a comparatively simpler interaction, without an interactive
+prompt or the need to periodically "refresh" a session to keep it active. This
+is useful when:
+
+* The code using tiled is running in an unsupervised, automated fashion
+  or scaled across many workers, such as in an HPC job, where is it not
+  possible to provide credentials interactively.
+* You are connecting from a generic web client like a web browser or `curl`,
+  which has no built-in integration with Tiled or with OpenAPI+OAuth2.
+
+## Create an API Key
+
+To follow along, you may start a Tiled server with a simple authentication provider,
+as shown. Alternatively, you may use an existing authenticated Tiled server, such as
+`https://tiled-demo.blueskyproject.io`; if you do, replace `http://localhost:8000`
+in the examples below with that address.
+
+```
+# You can find example_configs/ in the root of the tiled source code repository.
+ALICE_PASSWORD=secret1 tiled serve config example_configs/toy_authentication.yml
+```
+
+Using the Tiled commandline interface, log in as `alice` using the password `secret1`.
+
+```
+$ tiled login http://localhost:8000
+Username: alice
+Password:
+```
+
+Create a new API key.
+
+```
+$ tiled api_key create http://localhost:8000
+48e8f8598940fa0f3e80b406def606e17e815a2c76fe21350a99d6d9935371d11533b318
+```
+
+This text is the API key. **It should be handled as a secret.**
+
+```{note}
+
+When typing out `http://localhost:8000` into each command grows tedious,
+follow {doc}`profiles` to make a convenient alias. The command accepts URL _or_
+a profile name.
+```
+
+## Use the API Key in Python
+
+We can use it in the Python client:
+
+```py
+>>> from tiled.client import from_url
+>>> API_KEY = "YOUR_KEY_HERE"
+>>> c = from_uri("http://localhost:8000", api_key=API_KEY)
+```
+
+API keys should never be placed directly in scripts or notebooks.
+Instead, set the environment variable `TILED_API_KEY`.
+
+```
+export TILED_API_KEY=YOUR_KEY_HERE
+```
+
+and then start Python (or IPython, or Jupyter, or...). The Python client will
+use that, unless it is explicitly passed different credentials.
+
+```py
+>>> from tiled.client import from_url
+>>> c = from_uri("http://localhost:8000")  # uses TILED_API_KEY, if set
+```
+
+## Use the API Key in other web clients
+
+We can use in other web clients as well. For example, using [HTTPie](https://httpie.io/)
+we can see that unauthenticated requests are refused
+
+```
+$ http http://localhost:8000/node/metadata/
+HTTP/1.1 401 Unauthorized
+content-length: 30
+content-type: application/json
+date: Mon, 31 Jan 2022 17:30:06 GMT
+server: uvicorn
+server-timing: app;dur=2.6
+set-cookie: tiled_csrf=bZLhKsXVE2VirgXQncHsHn4Y0Wwwr66U0T0hqarJyfw; HttpOnly; Path=/; SameSite=lax
+x-tiled-root: http://localhost:8000/
+
+{
+    "detail": "Not authenticated"
+}
+```
+
+but passing the API key in the `Authorization` header as `Apikey YOUR_KEY_HERE` is accepted.
+(Note the use of `'` quotes.)
+
+```
+$ http http://localhost:8000/node/metadata/ 'Authorization:Apikey 48e8f8598940fa0f3e80b406def606e17e815a2c76fe21350a99d6d9935371d11533b318'
+HTTP/1.1 200 OK
+content-length: 320
+content-type: application/json
+date: Mon, 31 Jan 2022 17:34:48 GMT
+etag: c7d94c99b0a3cd6e102a78520db84bef
+server: uvicorn
+server-timing: tok;dur=0.0, pack;dur=0.0, app;dur=15.2
+set-cookie: tiled_csrf=InE4mplUO0goPxf4V07tVuLSLUvDqhgtALTHYoC3T3s; HttpOnly; Path=/; SameSite=lax
+<etc.>
+```
+
+The API key can also be passed in the URL like
+`http://localhost:8000/node/metadata/?api_key=YOUR_KEY_HERE`. Using the
+`Authorization` header is preferred (more secure) but in some situations, as in
+pasting a link into a web browser, the URL is the only option.
+
+## Manage API Keys
+
+We can use the tiled commandline interface to examine and revoke API keys as well.
+
+```
+$ tiled api_key
+Usage: tiled api_key [OPTIONS] COMMAND [ARGS]...
+
+  Create, list, and revoke API keys.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  create
+  list
+  revoke
+```
+
+We can see the key that we made above in the list.
+
+```
+$ tiled api_key list http://localhost:8000
+First 8   Expires at (UTC)     Latest activity      Note                Scopes
+48e8f859  -                    2022-01-31T18:32:33                      inherit
+
+```
+
+By default, an API key inherits all the same access
+as the user who is for. If an API key will be used for a specific task, it is
+good security hygiene to give it only the privileges it needs for that task.  It
+is also recommended to set a limited lifetimes so that if the key is
+unknowingly leaked it will not continue to work forever. For example, this
+command creates an API key that will expire in 10 minutes (600 seconds) and can
+search/list metadata but cannot download array data.
+
+```
+$ tiled api_key create http://localhost:8000 --expires-in 600 --scopes read:metadata
+ba9af604023a829ab22edb786168d6e1b97cef68c54c6d95d7fad5e3e6347fa131263581
+```
+
+```
+$ tiled api_key list http://localhost:8000
+First 8   Expires at (UTC)     Latest activity      Note                Scopes
+48e8f859  -                    2022-01-31T18:32:33                      inherit
+ba9af604  2022-01-31T23:03:57  -                                        read:metadata
+```
+
+Finally, the `--note` option can be used to label an API key as a reminder of
+where or how it is being used.
+
+```
+$ tiled api_key create http://localhost:8000 --note="Data validation pipeline" --scopes read:metadata read:data
+573928c62e53096321fb874847bcc6a90ea636eebd8acbd7c5e9d18d2859847b3bfb4f19
+$ tiled api_key list http://localhost:8000
+First 8   Expires at (UTC)     Latest activity      Note                      Scopes
+48e8f859  -                    2022-01-31T18:32:33                            inherit
+ba9af604  2022-01-31T23:03:57  -                                              read:metadata
+573928c6  -                    -                    Data validation pipeline  read:metadata read:data
+```
+
+If an API key is no longer need or accidentally leaked, it should be revoked. It
+can be identified by its first eight characters, as shown in the the output of
+`tiled api_key list`.
+
+```
+$ tiled api_key revoke http://localhost:8000 573928c6
+$ tiled api_key list http://localhost:8000
+First 8   Expires at (UTC)     Latest activity      Note                      Scopes
+48e8f859  -                    2022-01-31T18:32:33                            inherit
+ba9af604  2022-01-31T23:03:57  -                                              read:metadata
+```
+
+Passing the full key also works, if you have it handy. There is no need to trim
+just the first eight.

--- a/docs/source/how-to/custom-export-formats.md
+++ b/docs/source/how-to/custom-export-formats.md
@@ -1,4 +1,4 @@
-# Custom Export Formats
+# Add Custom Export Formats
 
 The Tiled server can provide data---in whole or in part---in a variety of
 formats. See {doc}`../tutorials/export` for a list of the formats supported out

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,6 +21,7 @@ tutorials/plotly-integration
 how-to/configuration
 how-to/custom-export-formats
 how-to/profiles
+how-to/api-keys
 how-to/direct-client
 how-to/tune-caches
 how-to/docker
@@ -47,6 +48,7 @@ reference/service
 reference/http-api-overview
 reference/python-client
 reference/authentication
+reference/scopes
 reference/commandline
 reference/service-configuration
 reference/client-profiles

--- a/docs/source/reference/authentication.md
+++ b/docs/source/reference/authentication.md
@@ -156,7 +156,7 @@ $ http POST https://tiled-demo.blueskyproject.io/auth/session/refresh refresh_to
 
 From here, everything follows the same as in Scenario 1, above.
 
-# Configure session lifetime parameters
+## Configure session lifetime parameters
 
 The server implements "sliding sessions". The following are tunable:
 

--- a/docs/source/reference/scopes.md
+++ b/docs/source/reference/scopes.md
@@ -1,0 +1,23 @@
+# Scopes
+
+Tiled uses OAuth2 scopes to restrict the actions that users, services, and API keys can perform.
+
+## Scopes
+
+* `inherit` --- Default scope for API keys. Inherit scopes of the Principal associated with this key, resolved at access time.
+* `read:metadata` --- List and search metadata.
+* `read:data` --- Fetch (array, dataframe) data.
+* `apikeys` --- Manage API keys for the currently-authenticated user or service.
+* `metrics` --- Access Prometheus metrics.
+* `admin:apikeys` --- Manage API keys on behalf of any user or service.
+* `read:principals` --- Read list of all users and services and their attributes.
+
+An authenticated entity ("Principal") may be assigned roles:
+
+## Roles
+
+* `user` --- default role, granted scopes `["read:metadata", "read:data", "apikeys"]`
+* `admin` --- granted all scopes
+
+There is support for custom roles at the database level, but it is not yet
+exposed through the API.

--- a/docs/source/reference/scopes.md
+++ b/docs/source/reference/scopes.md
@@ -1,10 +1,13 @@
 # Scopes
 
 Tiled uses OAuth2 scopes to restrict the actions that users, services, and API keys can perform.
+See the guide {doc}`../how-to/api-keys` for instructions on generating API keys
+with restricted scopes.
 
-## Scopes
+## List of Scopes
 
-* `inherit` --- Default scope for API keys. Inherit scopes of the Principal associated with this key, resolved at access time.
+* `inherit` --- Default scope for API keys. Inherit scopes of the Principal
+  associated with this key, resolved at access time.
 * `read:metadata` --- List and search metadata.
 * `read:data` --- Fetch (array, dataframe) data.
 * `apikeys` --- Manage API keys for the currently-authenticated user or service.
@@ -12,12 +15,22 @@ Tiled uses OAuth2 scopes to restrict the actions that users, services, and API k
 * `admin:apikeys` --- Manage API keys on behalf of any user or service.
 * `read:principals` --- Read list of all users and services and their attributes.
 
-An authenticated entity ("Principal") may be assigned roles:
-
 ## Roles
+
+An authenticated entity ("Principal") may be assigned roles that confer a list
+of scopes.
 
 * `user` --- default role, granted scopes `["read:metadata", "read:data", "apikeys"]`
 * `admin` --- granted all scopes
 
-There is support for custom roles at the database level, but it is not yet
-exposed through the API.
+There is support for custom roles at the database level, but neither role
+creation/customization nor role assignment are yet exposed through the API.
+(This will come in a future release.)
+
+For now, admin role can only be assigned in the service configuration, as
+in this example.
+
+```{eval-rst}
+.. literalinclude:: ../../../example_configs/toy_authentication.yml
+   :caption: example_configs/toy_authentication.py
+```

--- a/docs/source/reference/scopes.md
+++ b/docs/source/reference/scopes.md
@@ -27,8 +27,8 @@ There is support for custom roles at the database level, but neither role
 creation/customization nor role assignment are yet exposed through the API.
 (This will come in a future release.)
 
-For now, admin role can only be assigned in the service configuration, as
-in this example.
+For now, admin role can only be assigned by setting `tiled_admins` in the
+service configuration, as in this example.
 
 ```{eval-rst}
 .. literalinclude:: ../../../example_configs/toy_authentication.yml

--- a/docs/source/tutorials/login.md
+++ b/docs/source/tutorials/login.md
@@ -1,7 +1,7 @@
 # Log into an Authenticated Tiled Server
 
 For this tutorial, we will log in to the demo Tiled server at
-`http://tiled-demo.blueskyproject.io`. This server is configured to use
+`https://tiled-demo.blueskyproject.io`. This server is configured to use
 [ORCID](https://orcid.org) for authentication, so you will need an ORCID
 account.
 

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -246,6 +246,7 @@ def test_api_keys(enter_password, config):
     user_client_from_key["A1"]
     activity1 = user_client_from_key.context.which_api_key()["latest_activity"]
     assert activity1 is not None
+    time.sleep(2)  # Ensure time resolution (1 second) has ticked up.
     user_client_from_key["A1"]
     activity2 = user_client_from_key.context.which_api_key()["latest_activity"]
     assert activity2 > activity1

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -152,13 +152,13 @@ def test_revoke_session(enter_password, config):
         client = from_config(config, username="alice", token_cache={})
     # Get the current session ID.
     info = client.context.whoami()
-    (session,) = info["attributes"]["sessions"]
+    (session,) = info["sessions"]
     assert not session["revoked"]
     # Revoke it.
     client.context.revoke_session(session["uuid"])
     # Update info and confirm it is listed as revoked.
     updated_info = client.context.whoami()
-    (updated_session,) = updated_info["attributes"]["sessions"]
+    (updated_session,) = updated_info["sessions"]
     assert updated_session["revoked"]
     # Confirm it cannot be refreshed.
     with pytest.raises(CannotRefreshAuthentication):
@@ -215,10 +215,10 @@ def test_admin(enter_password, config):
     with enter_password("secret2"):
         user_client = from_config(config, username="bob", token_cache={})
 
-    user_roles = user_client.context.whoami()["attributes"]["roles"]
+    user_roles = user_client.context.whoami()["roles"]
     assert [role["name"] for role in user_roles] == ["user"]
 
-    adming_roles = admin_client.context.whoami()["attributes"]["roles"]
+    adming_roles = admin_client.context.whoami()["roles"]
     assert "admin" in [role["name"] for role in adming_roles]
 
 
@@ -237,25 +237,19 @@ def test_api_keys(enter_password, config):
         user_client = from_config(config, username="bob", token_cache={})
 
     # Make and use an API key. Check that latest_activity is updated.
-    user_key_info = user_client.context.new_api_key()
-    assert user_key_info["attributes"]["latest_activity"] is None  # never used
-    user_client_from_key = from_config(
-        config, api_key=user_key_info["attributes"]["secret"]
-    )
+    user_key_info = user_client.context.create_api_key()
+    assert user_key_info["latest_activity"] is None  # never used
+    user_client_from_key = from_config(config, api_key=user_key_info["secret"])
     # Check that api_key property is set.
-    assert user_client_from_key.context.api_key == user_key_info["attributes"]["secret"]
+    assert user_client_from_key.context.api_key == user_key_info["secret"]
     # Use the key for a couple requests and see that latest_activity becomes set and then increases.
     user_client_from_key["A1"]
-    activity1 = user_client_from_key.context.which_api_key()["data"]["attributes"][
-        "latest_activity"
-    ]
+    activity1 = user_client_from_key.context.which_api_key()["latest_activity"]
     assert activity1 is not None
     user_client_from_key["A1"]
-    activity2 = user_client_from_key.context.which_api_key()["data"]["attributes"][
-        "latest_activity"
-    ]
+    activity2 = user_client_from_key.context.which_api_key()["latest_activity"]
     assert activity2 > activity1
-    assert len(user_client_from_key.context.whoami()["attributes"]["api_keys"]) == 1
+    assert len(user_client_from_key.context.whoami()["api_keys"]) == 1
 
     # Unset the API key.
     secret = user_client_from_key.context.api_key
@@ -268,42 +262,40 @@ def test_api_keys(enter_password, config):
     user_client_from_key.context.which_api_key()
 
     # Request a key with reduced scope that cannot read metadata.
-    admin_key_info = admin_client.context.new_api_key(scopes=["metrics"])
+    admin_key_info = admin_client.context.create_api_key(scopes=["metrics"])
     with fail_with_status_code(401):
-        from_config(config, api_key=admin_key_info["attributes"]["secret"])
+        from_config(config, api_key=admin_key_info["secret"])
 
     # Request a key with reduced scope that can *only* read metadata.
-    admin_key_info = admin_client.context.new_api_key(scopes=["read:metadata"])
-    restricted_client = from_config(
-        config, api_key=admin_key_info["attributes"]["secret"]
-    )
+    admin_key_info = admin_client.context.create_api_key(scopes=["read:metadata"])
+    restricted_client = from_config(config, api_key=admin_key_info["secret"])
     restricted_client["A1"]
     with fail_with_status_code(401):
         restricted_client["A1"].read()  # no 'read:data' scope
 
     # Try to request a key with more scopes that the user has.
     with fail_with_status_code(400):
-        user_client.context.new_api_key(scopes=["admin:apikeys"])
+        user_client.context.create_api_key(scopes=["admin:apikeys"])
 
     # Create and revoke key.
-    user_key_info = user_client.context.new_api_key(note="will revoke soon")
-    assert len(user_client_from_key.context.whoami()["attributes"]["api_keys"]) == 2
+    user_key_info = user_client.context.create_api_key(note="will revoke soon")
+    assert len(user_client_from_key.context.whoami()["api_keys"]) == 2
     # There should now be two keys, one from above and this new one, with our note.
-    for api_key in user_client_from_key.context.whoami()["attributes"]["api_keys"]:
+    for api_key in user_client_from_key.context.whoami()["api_keys"]:
         if api_key["note"] == "will revoke soon":
             break
     else:
         assert False, "No api keys had a matching note."
     # Revoke the new key.
-    user_client_from_key.context.revoke_api_key(user_key_info["id"])
+    user_client_from_key.context.revoke_api_key(user_key_info["first_eight"])
     with fail_with_status_code(401):
-        from_config(config, api_key=user_key_info["attributes"]["secret"])
-    assert len(user_client_from_key.context.whoami()["attributes"]["api_keys"]) == 1
+        from_config(config, api_key=user_key_info["secret"])
+    assert len(user_client_from_key.context.whoami()["api_keys"]) == 1
 
     # Create a key with a very short lifetime.
-    user_key_info = user_client.context.new_api_key(
-        note="will expire very soon", lifetime=1
-    )  # lifetime units: seconds
+    user_key_info = user_client.context.create_api_key(
+        note="will expire very soon", expires_in=1
+    )  # units: seconds
     time.sleep(2)
     with fail_with_status_code(401):
-        from_config(config, api_key=user_key_info["attributes"]["secret"])
+        from_config(config, api_key=user_key_info["secret"])

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -308,7 +308,8 @@ class Context:
         Parameters
         ----------
         scopes : Optional[List[str]]
-            If None, this will have the same access as the user.
+            Restrict the access available to the API key by listing specific scopes.
+            By default, this will have the same access as the user.
         expires_in : Optional[int]
             Number of seconds until API key expires. If None,
             it will never expire or it will have the maximum lifetime

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -174,10 +174,12 @@ class Context:
         prompt_for_reauthentication=PromptForReauthentication.AT_INIT,
         app=None,
     ):
-        if (api_key is not None) and (
-            (username is not None) or (auth_provider is not None)
-        ):
-            raise ValueError("Use api_key or username/auth_provider, not both.")
+        if (username is not None) or (auth_provider is not None):
+            if api_key is not None:
+                raise ValueError("Use api_key or username/auth_provider, not both.")
+        elif api_key is None:
+            # Check for an API key from the environment.
+            api_key = os.getenv("TILED_API_KEY")
         self._client = client
         self._cache = cache
         self._revalidate = Revalidate.IF_WE_MUST

--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -1,14 +1,18 @@
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 
 cli_app = typer.Typer()
 serve_app = typer.Typer()
 profile_app = typer.Typer()
+api_key_app = typer.Typer()
 cli_app.add_typer(serve_app, name="serve", help="Launch a Tiled server.")
 cli_app.add_typer(
     profile_app, name="profile", help="Examine Tiled 'profiles' (client-side config)."
+)
+cli_app.add_typer(
+    api_key_app, name="api_key", help="Create, list, and revoke API keys."
 )
 
 
@@ -31,12 +35,12 @@ def login(
     from tiled.client.utils import ClientError
 
     options = {}
-    if no_verify:
-        options["verify"] = False
     if refresh_or_fail:
         options["prompt_for_reauthentication"] = "never"
     try:
-        client = _client_from_uri_or_profile(uri_or_profile, **options)
+        client = _client_from_uri_or_profile(
+            uri_or_profile, no_verify=no_verify, **options
+        )
     except (ValueError, ClientError) as err:
         (msg,) = err.args
         typer.echo(msg)
@@ -62,10 +66,104 @@ def sessions(
         sessions_ = sessions()
         max_netloc_len = max(len(netloc) for netloc in sessions_)
         for netloc, token in sessions_.items():
-            typer.echo(f"{netloc}{' ' * (max_netloc_len - len(netloc))}   {token}")
+            padding = max_netloc_len - len(netloc)
+            typer.echo(f"{netloc}{' ' * padding}   {token}")
     else:
         for netloc in sessions():
             typer.echo(netloc)
+
+
+@api_key_app.command("create")
+def create_api_key(
+    uri_or_profile: str = typer.Argument(
+        ..., help="URI 'http[s]://...' or a profile name."
+    ),
+    expires_in: Optional[int] = typer.Option(
+        None,
+        help=(
+            "Number of seconds until API key expires. If None, "
+            "it will never expire or it will have the maximum lifetime "
+            "allowed by the server."
+        ),
+    ),
+    scopes: Optional[List[str]] = typer.Option(
+        None,
+        help=(
+            "Restrict the access available to this API key by listing scopes. "
+            "By default, it will inherit the scopes of its owner."
+        ),
+    ),
+    note: Optional[str] = typer.Option(None, help="Add a note to label this API key."),
+    no_verify: bool = typer.Option(False, "--no-verify", help="Skip SSL verification."),
+):
+    client = _client_from_uri_or_profile(uri_or_profile, no_verify=no_verify)
+    if not scopes:
+        # This is how typer interprets unspecified scopes.
+        # Replace with None to get default scopes.
+        scopes = None
+    info = client.context.create_api_key(
+        scopes=scopes, expires_in=expires_in, note=note
+    )
+    # TODO Print other info to the stderr?
+    typer.echo(info["secret"])
+
+
+@api_key_app.command("list")
+def list_api_keys(
+    uri_or_profile: str = typer.Argument(
+        ..., help="URI 'http[s]://...' or a profile name."
+    ),
+    no_verify: bool = typer.Option(False, "--no-verify", help="Skip SSL verification."),
+):
+    client = _client_from_uri_or_profile(uri_or_profile, no_verify=no_verify)
+    info = client.context.whoami()
+    if not info["api_keys"]:
+        type.echo("No API keys found")
+        return
+    max_note_len = max(len(api_key["note"] or "") for api_key in info["api_keys"])
+    COLUMNS = f"First 8   Expires at (UTC)     Latest activity      Note{' ' * (max_note_len - 4)}  Scopes"
+    typer.echo(COLUMNS)
+    for api_key in info["api_keys"]:
+        note_padding = 2 + max_note_len - len(api_key["note"] or "")
+        if api_key["expiration_time"] is None:
+            expiration_time = "-"
+        else:
+            expiration_time = (
+                api_key["expiration_time"]
+                .replace(microsecond=0, tzinfo=None)
+                .isoformat()
+            )
+        if api_key["latest_activity"] is None:
+            latest_activity = "-"
+        else:
+            latest_activity = (
+                api_key["latest_activity"]
+                .replace(microsecond=0, tzinfo=None)
+                .isoformat()
+            )
+        typer.echo(
+            (
+                f"{api_key['first_eight']:10}"
+                f"{expiration_time:21}"
+                f"{latest_activity:21}"
+                f"{(api_key['note'] or '')}{' ' * note_padding}"
+                f"{' '.join(api_key['scopes']) or '-'}"
+            )
+        )
+
+
+@api_key_app.command("revoke")
+def revoke_api_key(
+    uri_or_profile: str = typer.Argument(
+        ..., help="URI 'http[s]://...' or a profile name."
+    ),
+    first_eight: str = typer.Argument(
+        ..., help="First eight characters of API key (or the whole key)"
+    ),
+    no_verify: bool = typer.Option(False, "--no-verify", help="Skip SSL verification."),
+):
+    client = _client_from_uri_or_profile(uri_or_profile, no_verify=no_verify)
+    client.context.revoke_api_key(first_eight[:8])
 
 
 @cli_app.command("logout")
@@ -103,11 +201,7 @@ def tree(
     """
     from ..utils import gen_tree
 
-    if no_verify:
-        tree_obj = _client_from_uri_or_profile(uri_or_profile, verify=False)
-    else:
-        # Defer to the profile, which may or may not verify.
-        tree_obj = _client_from_uri_or_profile(uri_or_profile)
+    tree_obj = _client_from_uri_or_profile(uri_or_profile, no_verify=no_verify)
     for counter, line in enumerate(gen_tree(tree_obj), start=1):
         if (max_lines is not None) and (counter > max_lines):
             print(
@@ -133,11 +227,9 @@ def download(
     from ..client.cache import Cache, download
 
     cache = Cache.on_disk(cache_path, available_bytes=available_bytes)
-    if no_verify:
-        client = _client_from_uri_or_profile(uri_or_profile, cache=cache, verify=False)
-    else:
-        # Defer to the profile, which may or may not verify.
-        client = _client_from_uri_or_profile(uri_or_profile, cache=cache)
+    client = _client_from_uri_or_profile(
+        uri_or_profile, cache=cache, no_verify=no_verify
+    )
     download(client)
 
 
@@ -373,12 +465,12 @@ def serve_config(
 
 
 def _client_from_uri_or_profile(
-    uri_or_profile, verify=None, cache=None, prompt_for_reauthentication=None
+    uri_or_profile, no_verify, cache=None, prompt_for_reauthentication=None
 ):
     from ..client import from_profile, from_uri
 
     options = {}
-    if verify is False:
+    if no_verify:
         options["verify"] = False
     if prompt_for_reauthentication is not None:
         options["prompt_for_reauthentication"] = prompt_for_reauthentication

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -110,7 +110,7 @@ def check_database(engine):
         )
 
 
-def purge_expired(cls, db):
+def purge_expired(db, cls):
     """
     Remove expired entries.
 
@@ -122,7 +122,7 @@ def purge_expired(cls, db):
     deleted = False
     for obj in (
         db.query(cls)
-        .filter(cls.expiration_time is not None)
+        .filter(cls.expiration_time.is_not(None))
         .filter(cls.expiration_time < now)
     ):
         deleted = True

--- a/tiled/database/migrations/versions/481830dd6c11_initialize.py
+++ b/tiled/database/migrations/versions/481830dd6c11_initialize.py
@@ -71,16 +71,16 @@ def upgrade():
         Column("time_created", DateTime(timezone=False), server_default=func.now()),
         Column("time_updated", DateTime(timezone=False), onupdate=func.now()),
         Column(
-            "uuid",
-            UUID,
-            index=True,
-            nullable=False,
-            default=lambda: uuid.uuid4(),
-        ),
-        Column(
             "hashed_secret",
             LargeBinary(32),
             primary_key=True,
+            index=True,
+            nullable=False,
+        ),
+        Column(
+            "first_eight",
+            Unicode(8),
+            primary_eky=True,
             index=True,
             nullable=False,
         ),

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -227,7 +227,7 @@ def build_app(
         for authenticator in authenticators:
             background_tasks.extend(getattr(authenticator, "background_tasks", []))
         for task in background_tasks or []:
-            asyncio_task = app.asyncio.create_task(task())
+            asyncio_task = asyncio.create_task(task())
             app.state.tasks.append(asyncio_task)
 
         # The /search route is defined at server startup so that the user has the

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -317,17 +317,12 @@ def build_app(
             async def purge_expired_sessions_and_api_keys():
                 logger.info("Purging expired Sessions and API keys from the database.")
                 while True:
-                    if engine.name == "sqlite":
-                        # Run in the main thread.
-                        purge_expired(db, orm.Session)
-                        purge_expired(db, orm.APIKey)
-                    else:
-                        await asyncio.get_running_loop().run_in_executor(
-                            None, purge_expired(db, orm.Session)
-                        )
-                        await asyncio.get_running_loop().run_in_executor(
-                            None, purge_expired(db, orm.APIKey)
-                        )
+                    await asyncio.get_running_loop().run_in_executor(
+                        None, purge_expired(engine, orm.Session)
+                    )
+                    await asyncio.get_running_loop().run_in_executor(
+                        None, purge_expired(engine, orm.APIKey)
+                    )
                     await asyncio.sleep(600)
 
             app.state.tasks.append(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -317,12 +317,17 @@ def build_app(
             async def purge_expired_sessions_and_api_keys():
                 logger.info("Purging expired Sessions and API keys from the database.")
                 while True:
-                    await asyncio.get_running_loop().run_in_executor(
-                        None, purge_expired(db, orm.Session)
-                    )
-                    await asyncio.get_running_loop().run_in_executor(
-                        None, purge_expired(db, orm.APIKey)
-                    )
+                    if engine.name == "sqlite":
+                        # Run in the main thread.
+                        purge_expired(db, orm.Session)
+                        purge_expired(db, orm.APIKey)
+                    else:
+                        await asyncio.get_running_loop().run_in_executor(
+                            None, purge_expired(db, orm.Session)
+                        )
+                        await asyncio.get_running_loop().run_in_executor(
+                            None, purge_expired(db, orm.APIKey)
+                        )
                     await asyncio.sleep(600)
 
             app.state.tasks.append(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -85,7 +85,6 @@ async def about(
         authentication["links"] = {
             "whoami": f"{base_url}auth/whoami",
             "apikey": f"{base_url}auth/apikey",
-            "revoke_apikey": f"{base_url}auth/apikey/{{uuid}}",
             "refresh_session": f"{base_url}auth/session/refresh",
             "revoke_session": f"{base_url}auth/session/revoke/{{session_id}}",
             "logout": f"{base_url}auth/logout",


### PR DESCRIPTION
- Simplify HTTP API response layouts (abandon attempting to apply JSON API for this)
- Remove uuid column from APIKey table; instead use first eight chars of hex-encoded secret to identify. (This seems to be how GitHub handles personal access tokens. See also https://www.freecodecamp.org/news/best-practices-for-building-api-keys-97c26eabfea9/.)
- Use `(first_eight, hashed_secret)` as primary key.
- Use `DELETE /apikey?first_eight={first_eight}` instead of `DELETE /apikey/{uuid}`.
- Add `tiled api_key {create, list, revoke}` CLI subcommands.
- Docs