### PR TITLE
Track more activity

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -244,12 +244,15 @@ def test_api_keys(enter_password, config):
     assert user_client_from_key.context.api_key == user_key_info["secret"]
     # Use the key for a couple requests and see that latest_activity becomes set and then increases.
     user_client_from_key["A1"]
-    activity1 = user_client_from_key.context.which_api_key()["latest_activity"]
-    assert activity1 is not None
+    key_activity1 = user_client_from_key.context.which_api_key()["latest_activity"]
+    principal_activity1 = user_client_from_key.context.whoami()["latest_activity"]
+    assert key_activity1 is not None
     time.sleep(2)  # Ensure time resolution (1 second) has ticked up.
     user_client_from_key["A1"]
-    activity2 = user_client_from_key.context.which_api_key()["latest_activity"]
-    assert activity2 > activity1
+    key_activity2 = user_client_from_key.context.which_api_key()["latest_activity"]
+    principal_activity2 = user_client_from_key.context.whoami()["latest_activity"]
+    assert key_activity2 > key_activity1
+    assert principal_activity2 > principal_activity1
     assert len(user_client_from_key.context.whoami()["api_keys"]) == 1
 
     # Unset the API key.

--- a/tiled/_tests/test_directory_walker.py
+++ b/tiled/_tests/test_directory_walker.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 from pathlib import Path
 
 import numpy
@@ -262,12 +263,14 @@ def test_subdirectory_handler(tmpdir):
     # Adding, changing, or, removing files should notify the handler.
     df1.to_csv(Path(tmpdir, "separately_managed", "c.csv"))  # added
     df1.to_csv(Path(tmpdir, "separately_managed", "a.csv"))  # modified
+    time.sleep(0.5)  # Give slow CI filesystem time to catch up.
     force_update(client)
 
     Path(tmpdir, "separately_managed", "c.csv").unlink()  # removed
     # Add a new file in a new subdirectory.
     Path(tmpdir, "separately_managed", "new_subdir").mkdir()
     df1.to_csv(Path(tmpdir, "separately_managed", "new_subdir", "d.csv"))
+    time.sleep(0.5)  # Give slow CI filesystem time to catch up.
     force_update(client)
 
     expected_first_batch = [

--- a/tiled/database/migrations/versions/481830dd6c11_initialize.py
+++ b/tiled/database/migrations/versions/481830dd6c11_initialize.py
@@ -51,6 +51,7 @@ def upgrade():
         Column("id", Unicode(255), primary_key=True, nullable=False),
         Column("provider", Unicode(255), primary_key=True, nullable=False),
         Column("principal_id", Integer, ForeignKey("principals.id")),
+        Column("latest_login", DateTime(timezone=False), nullable=True),
     )
     op.create_table(
         "roles",

--- a/tiled/database/orm.py
+++ b/tiled/database/orm.py
@@ -134,6 +134,7 @@ class Identity(Timestamped, Base):
     id = Column(Unicode(255), primary_key=True, nullable=False)
     provider = Column(Unicode(255), primary_key=True, nullable=False)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
+    latest_login = Column(DateTime(timezone=False), nullable=True)
     # In the future we may add a notion of "primary" identity.
 
     principal = relationship("Principal", back_populates="identities")

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -206,6 +206,7 @@ class PrincipalType(str, enum.Enum):
 class Identity(pydantic.BaseModel, orm_mode=True):
     id: pydantic.constr(max_length=255)
     provider: pydantic.constr(max_length=255)
+    latest_login: Optional[datetime]
 
 
 class Role(pydantic.BaseModel, orm_mode=True):
@@ -263,6 +264,13 @@ class Principal(pydantic.BaseModel, orm_mode=True):
     roles: List[Role] = []
     api_keys: List[APIKey] = []
     sessions: List[Session] = []
+    latest_activity: Optional[datetime] = None
+
+    @classmethod
+    def from_orm(cls, orm, latest_activity=None):
+        instance = super().from_orm(orm)
+        instance.latest_activity = latest_activity
+        return instance
 
 
 class APIKeyRequestParams(pydantic.BaseModel):


### PR DESCRIPTION
* Record time of `latest_login` on `Identity`.
* As a convenience, add a derived quantity `latest_activity` on Principal, which takes in account activity on their identities, sessions, and API keys.