### PR TITLE
Give better error when API key auth is required.

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -243,6 +243,14 @@ class Context:
                 or (username is not None)
             )
         ):
+            if not self._handshake_data["authentication"]["providers"]:
+                raise RuntimeError(
+                    """This server requires API key authentication.
+Set an api_key as in:
+
+>>> c = from_uri("...", api_key="...")
+"""
+                )
             # Authenticate. If a valid refresh_token is available in the token_cache,
             # it will be used. Otherwise, this will prompt for input from the stdin
             # or raise CannotRefreshAuthentication.
@@ -546,7 +554,8 @@ class Context:
             raise RuntimeError("API key authentication is being used.")
         providers = self._handshake_data["authentication"]["providers"]
         if len(providers) == 0:
-            raise Exception(
+            raise RuntimeError(
+                "The authenticate() method is not applicable. "
                 "This server does not support any authentication providers."
             )
         if provider is not None:


### PR DESCRIPTION
Before:

```
In [6]: c = from_uri("https://aimm-staging.lbl.gov")
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
~/Repos/bnl/tiled/tiled/client/context.py in __getitem__(self, key)
    859         try:
--> 860             with open(filepath, "r") as file:
    861                 return file.read()

FileNotFoundError: [Errno 2] No such file or directory: '/home/dallan/.config/tiled/tokens/aimm-staging.lbl.gov/refresh_token'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
~/Repos/bnl/tiled/tiled/client/context.py in _refresh(self, refresh_token)
    718                 try:
--> 719                     refresh_token = self._token_cache["refresh_token"]
    720                 except KeyError:

~/Repos/bnl/tiled/tiled/client/context.py in __getitem__(self, key)
    862         except FileNotFoundError:
--> 863             raise KeyError(key)
    864 

KeyError: 'refresh_token'

During handling of the above exception, another exception occurred:

CannotRefreshAuthentication               Traceback (most recent call last)
~/Repos/bnl/tiled/tiled/client/context.py in reauthenticate(self, prompt)
    667         try:
--> 668             return self._refresh()
    669         except CannotRefreshAuthentication:

~/Repos/bnl/tiled/tiled/client/context.py in _refresh(self, refresh_token)
    720                 except KeyError:
--> 721                     raise CannotRefreshAuthentication(
    722                         "No refresh token was found in token cache. "

CannotRefreshAuthentication: No refresh token was found in token cache. Provide fresh credentials. For a given client c, use c.context.authenticate().

During handling of the above exception, another exception occurred:

Exception                                 Traceback (most recent call last)
<ipython-input-6-320181ec438f> in <module>
----> 1 c = from_uri("https://aimm-staging.lbl.gov")

~/Repos/bnl/tiled/tiled/client/constructors.py in from_uri(uri, structure_clients, cache, offline, username, auth_provider, api_key, token_cache, verify, prompt_for_reauthentication, headers)
     92         params=params,
     93     )
---> 94     context = Context(
     95         client,
     96         username=username,

~/Repos/bnl/tiled/tiled/client/context.py in __init__(self, client, username, auth_provider, api_key, cache, offline, token_cache, prompt_for_reauthentication, app)
    251                 or prompt_for_reauthentication == PromptForReauthentication.ALWAYS
    252             )
--> 253             tokens = self.reauthenticate(prompt=prompt)
    254             access_token = tokens["access_token"]
    255             client.headers["Authorization"] = f"Bearer {access_token}"

~/Repos/bnl/tiled/tiled/client/context.py in reauthenticate(self, prompt)
    671                 prompt = self._prompt_for_reauthentication
    672             if prompt:
--> 673                 return self.authenticate()
    674             raise
    675 

~/Repos/bnl/tiled/tiled/client/context.py in authenticate(self, provider)
    547         providers = self._handshake_data["authentication"]["providers"]
    548         if len(providers) == 0:
--> 549             raise Exception(
    550                 "This server does not support any authentication providers."
    551             )

Exception: This server does not support any authentication providers.
```

After:

```
In [3]: c = from_uri("https://aimm-staging.lbl.gov")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-3-320181ec438f> in <module>
----> 1 c = from_uri("https://aimm-staging.lbl.gov")

~/Repos/bnl/tiled/tiled/client/constructors.py in from_uri(uri, structure_clients, cache, offline, username, auth_provider, api_key, token_cache, verify, prompt_for_reauthentication, headers)
     92         params=params,
     93     )
---> 94     context = Context(
     95         client,
     96         username=username,

~/Repos/bnl/tiled/tiled/client/context.py in __init__(self, client, username, auth_provider, api_key, cache, offline, token_cache, prompt_for_reauthentication, app)
    245         ):
    246             if not self._handshake_data["authentication"]["providers"]:
--> 247                 raise RuntimeError("""This server requires API key authentication.
    248 Set an api_key as in:
    249 

RuntimeError: This server requires API key authentication.
Set an api_key as in:

>>> c = from_uri("...", api_key="...")
```