### PR TITLE
Include XDG and hard-coded paths in profile-gathering.

### DIFF
--- a/docs/source/how-to/profiles.md
+++ b/docs/source/how-to/profiles.md
@@ -33,8 +33,19 @@ my_data:
 
 ## Where are profiles kept?
 
-Profiles are specified in YAML files located in any of several locations. To
-list where Tiled looks for profiles on your system, use the command line:
+Profiles are specified in YAML files located in any of several locations,
+including:
+
+```
+/etc/tiled/profiles
+~/.config/tiled/profiles
+```
+
+Tiled will also look for profiles in locations specific to the
+operating system and the software environment,
+[in accordance](https://pypi.org/project/appdirs/) with
+[standards](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+To see the full list on your system, use the command line:
 
 ```
 $ tiled profile paths
@@ -70,10 +81,6 @@ Tiled always looks in three places for profiles:
    software.
 3. A user-controlled directory (a subdirectory of `$HOME`). This is
    for users' personal productivity.
-
-The exact locations depend on which operating system you are using and other
-system-specific details, in accordance with standards, which is why we can't
-list them here.
 
 The default locations for (1) and (3) can be overridden by setting the
 environment variables `TILED_SITE_PROFILES` and `TILED_PROFILES`, respectively,

--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -238,7 +238,7 @@ def profile_paths():
     "List the locations that the client will search for profiles (client-side configuration)."
     from ..profiles import paths
 
-    print("\n".join(paths))
+    print("\n".join(str(p) for p in paths))
 
 
 @profile_app.command("list")

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -35,7 +35,7 @@ def schema():
 
 # Some items in the search path is system-dependent, and others are hard-coded.
 # Paths later in the list ("closer" to the user) have higher precedence.
-_paths = [
+_all_paths = [
     Path(
         os.getenv("TILED_SITE_PROFILES", Path("/etc/tiled/profiles"))
     ),  # hard-coded system path
@@ -54,8 +54,8 @@ _paths = [
 ]
 # Remove duplicates (i.e. if XDG and hard-coded are the same on this system).
 _seen = set()
-paths = [x for x in _paths if not (x in _seen or _seen.add(x))]
-del _seen, _paths
+paths = [x for x in _all_paths if not (x in _seen or _seen.add(x))]
+del _seen
 
 
 def gather_profiles(paths, strict=True):
@@ -171,7 +171,11 @@ defines a profile with the name {profile_name!r}.
 
 The profile will be ommitted. Fix this by removing one of the duplicates"""
     for profile_name, filepaths in collisions.items():
-        if filepaths[0].is_relative_to(paths[-1]):
+        # Is this file in either the XDG user or hard-coded user directory
+        # (which might or might not be the same directory)?
+        if filepaths[0].is_relative_to(_all_paths[-1]) or filepaths[0].is_relative_to(
+            _all_paths[-2]
+        ):
             msg = (MSG + ".").format(
                 filepaths="\n".join(filepaths), profile_name=profile_name
             )

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -33,18 +33,29 @@ def schema():
         return yaml.safe_load(file)
 
 
+# Some items in the search path is system-dependent, and others are hard-coded.
 # Paths later in the list ("closer" to the user) have higher precedence.
-paths = [
+_paths = [
+    Path(
+        os.getenv("TILED_SITE_PROFILES", Path("/etc/tiled/profiles"))
+    ),  # hard-coded system path
     Path(
         os.getenv(
             "TILED_SITE_PROFILES", Path(appdirs.site_config_dir("tiled"), "profiles")
         )
-    ),  # system
+    ),  # XDG-compliant system path
     Path(sys.prefix, "etc", "tiled", "profiles"),  # environment
     Path(
+        os.getenv("TILED_PROFILES", Path.home() / ".config/tiled/profiles")
+    ),  # hard-coded user path
+    Path(
         os.getenv("TILED_PROFILES", Path(appdirs.user_config_dir("tiled"), "profiles"))
-    ),  # user
+    ),  # system-dependent user path
 ]
+# Remove duplicates (i.e. if XDG and hard-coded are the same on this system).
+_seen = set()
+paths = [x for x in _paths if not (x in _seen or _seen.add(x))]
+del _seen, _paths
 
 
 def gather_profiles(paths, strict=True):


### PR DESCRIPTION
Awhile back, we comparative advantages of hard-coded search path (you can list the directories right in the docs!) and a dynamic XDG-compliant search path that depends on the operating system and the environment variables (it's a standard!).

I noticed that IPython has a nice pragmatic compromise: just support both.

For example, with this PR branch, on my system:

```
$ tiled profile paths
/etc/tiled/profiles
/etc/xdg/xdg-pop/tiled/profiles
/home/dallan/miniconda3/envs/py38/etc/tiled/profiles
/home/dallan/.config/tiled/profiles
```

I can use the hard-coded `/etc/tiled` if I know that off the top of my head, but tiled will also behave will with deployments that want to use the XDG standard location which is `/etc/xdg/xdg-pop/tiled` on this system.