### PR TITLE
MNT: be a bit more cautious about importing numpy

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -486,9 +486,8 @@ def safe_json_dump(content):
 
     def default(content):
         # No need to import numpy if it hasn't been used already.
-        if "numpy" in sys.modules:
-            import numpy
-
+        numpy = sys.modules.get("numpy", None)
+        if numpy is not None:
             if isinstance(content, numpy.ndarray):
                 # If we make it here, OPT_NUMPY_SERIALIZE failed because we have hit some edge case.
                 # Give up on the numpy fast-path and convert to Python list.


### PR DESCRIPTION
Small follow on to #157

A documented way to prevent a module from being imported is to set `sys.modules['foo'] = None` which would have passed the previous test and failed on import.  This will only try to use numpy if it is actually already imported.

I know this because we had a similar check for IPython in Matplotlib and get bit by someone who wanted to prevent importing IPython!