### PR TITLE
Ban old pydantic versions.

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -14,7 +14,7 @@ msgpack
 orjson
 psutil
 prometheus_client
-pydantic
+pydantic >=1.8.2
 python-dateutil
 python-jose[cryptography]
 python-multipart


### PR DESCRIPTION
We established in #178 that pydantic `1.7` and `1.7.*` are problematic because they break class kwargs. Looking at FastAPI, it looks like FastAPI has a problem with anything older than `1.8.2` as well, _except_ `1.7.4` but we have a problem with `1.7.4` because of the class kwargs. So, we can simply put a minimum version pin at 1.8.2.