### PR TITLE
graphql

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -24,3 +24,4 @@ toolz
 typer
 uvicorn[standard]
 watchgod
+strawberry-graphql[fastapi]

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -143,6 +143,7 @@ def construct_build_app_kwargs(
             root_mapping = {}
             index = {(): root_mapping}
             include_routers = []
+            graphql_queries = []
             for segments, tree in trees.items():
                 for i in range(len(segments)):
                     if segments[:i] not in index:
@@ -156,6 +157,9 @@ def construct_build_app_kwargs(
                 for router in routers:
                     if router not in include_routers:
                         include_routers.append(router)
+                for query in getattr(tree, "graphql_queries", []):
+                    if query not in graphql_queries:
+                        graphql_queries.append(query)
             root_tree = MapAdapter(root_mapping, access_policy=root_access_policy)
             root_tree.include_routers.extend(include_routers)
         server_settings = {}

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -183,6 +183,7 @@ def construct_build_app_kwargs(
                     f"({prometheus_multiproc_dir}) is not writable"
                 )
         server_settings["metrics"] = metrics
+        server_settings["graphql"] = config.get("graphql", {})
         for structure_family, values in config.get("media_types", {}).items():
             for media_type, import_path in values.items():
                 serializer = import_object(import_path, accept_live_object=True)
@@ -212,6 +213,7 @@ def merge(configs):
     uvicorn_config_source = None
     object_cache_config_source = None
     metrics_config_source = None
+    graphql_config_source = None
     database_uri_config_source = None
     database_settings_config_source = None
     response_bytesize_limit_config_source = None
@@ -279,6 +281,15 @@ def merge(configs):
                 )
             metrics_config_source = filepath
             merged["metrics"] = config["metrics"]
+        if "graphql" in config:
+            if "graphql" in merged:
+                raise ConfigError(
+                    "graphql can only be specified in one file. "
+                    f"It was found in both {graphql_config_source} and "
+                    f"{filepath}"
+                )
+            graphql_config_source = filepath
+            merged["graphql"] = config["graphql"]
         if "database_uri" in config:
             if "database_uri" in merged:
                 raise ConfigError(

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -442,3 +442,10 @@ properties:
           Enable/Disable prometheus metrics. Default is false.
           If enabled `PROMETHEUS_MULTIPROC_DIR` environment variable
           must be set to the path of a writable directory.
+  graphql:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enable/Disable graphql. Default is false.

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -544,6 +544,11 @@ def build_app(
             metrics.capture_request_metrics(request, response)
             return response
 
+    graphql_config = server_settings.get("graphql", {})
+    if graphql_config.get("enabled", False):
+        from . import graphql
+        app.include_router(graphql.router, prefix="/graphql")
+
     return app
 
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -547,7 +547,12 @@ def build_app(
     graphql_config = server_settings.get("graphql", {})
     if graphql_config.get("enabled", False):
         from . import graphql
-        app.include_router(graphql.router, prefix="/graphql")
+
+        queries = [graphql.BaseQuery]
+        for query in getattr(tree, "graphql_queries", []):
+            queries.append(query)
+
+        app.include_router(graphql.get_router(queries), prefix="/graphql")
 
     return app
 

--- a/tiled/server/graphql.py
+++ b/tiled/server/graphql.py
@@ -1,0 +1,172 @@
+import math
+from typing import List, Optional
+
+import strawberry
+from fastapi import Depends, HTTPException, Security
+from strawberry.fastapi import GraphQLRouter
+from strawberry.scalars import JSON
+from strawberry.types import Info
+from strawberry.tools import create_type, merge_types
+
+from . import schemas
+from .authentication import get_current_principal
+from .core import JSON_MIME_TYPE, construct_resource, len_or_approx
+from .dependencies import entry, get_root_tree
+from .utils import get_base_url
+
+
+@strawberry.type
+class StructureType:
+    micro: Optional[JSON]
+    macro: Optional[JSON]
+
+
+@strawberry.type
+class NodeAttributesType:
+    structure_family: Optional[str]
+    specs: Optional[List[str]]
+    metadata: Optional[JSON]  # free-form, user-specified dict
+    structure: Optional[StructureType]
+    count: Optional[int]
+
+
+@strawberry.type
+class PaginationCursor:
+    offset: int
+    limit: int
+
+
+@strawberry.type
+class PaginationLinksType:
+    self: Optional[PaginationCursor]
+    next: Optional[PaginationCursor]
+    prev: Optional[PaginationCursor]
+    first: Optional[PaginationCursor]
+    last: Optional[PaginationCursor]
+
+
+@strawberry.type
+class ErrorType:
+    code: int
+    message: str
+
+
+@strawberry.type
+class ResourceType:
+    id: str
+    attributes: NodeAttributesType
+    links: Optional[JSON]
+    meta: Optional[JSON]
+
+
+@strawberry.type
+class ResponseType:
+    data: Optional[List[ResourceType]]
+    error: Optional[ErrorType]
+    links: Optional[PaginationLinksType]
+    meta: Optional[JSON]
+
+
+async def get_context(
+    principal=Security(get_current_principal, scopes=["read:metadata"]),
+    root_tree=Depends(get_root_tree),
+):
+    return {"principal": principal, "root_tree": root_tree}
+
+
+def pagination_links(offset, limit, length_hint):
+    links = {
+        "self": PaginationCursor(offset=offset, limit=limit),
+        "first": None,
+        "last": None,
+        "next": None,
+        "prev": None,
+    }
+    if limit:
+        last_page = math.floor(length_hint / limit) * limit
+        links.update(
+            {
+                "first": PaginationCursor(offset=0, limit=limit),
+                "last": PaginationCursor(offset=last_page, limit=limit),
+            }
+        )
+    if offset + limit < length_hint:
+        links["next"] = PaginationCursor(offset=offset + limit, limit=limit)
+    if offset > 0:
+        links["prev"] = PaginationCursor(offset=max(0, offset - limit), limit=limit)
+
+    return PaginationLinksType(**links)
+
+@strawberry.field
+def hello(info: Info) -> str:
+    return f"Hello {info.context['principal']}"
+
+
+@strawberry.field
+def search(path: str, offset: int, limit: int, info: Info) -> ResponseType:
+    request = info.context["request"]
+    principal = info.context["principal"]
+    root_tree = info.context["root_tree"]
+    try:
+        # FIXME within fastapi this would be constructed via dependency
+        # injection but not clear if this can be applied here
+        tree = entry(path, request, principal, root_tree)
+
+    except HTTPException:
+        return ResponseType(
+            data=None,
+            error=ErrorType(code=404, message=f"no entry at {path}"),
+            links=None,
+            meta=None,
+        )
+
+    count = len_or_approx(tree)
+    links = pagination_links(offset, limit, count)
+    base_url = get_base_url(request)
+    path_parts = [segment for segment in path.split("/") if segment]
+    fields = list(schemas.EntryFields)
+    select_metadata = None
+    omit_links = False
+    media_type = JSON_MIME_TYPE
+
+    data = []
+
+    items = tree.items_indexer[offset : offset + limit]  # noqa: E203
+
+    for k, v in items:
+        resource = construct_resource(
+            base_url,
+            path_parts + [k],
+            v,
+            fields,
+            select_metadata,
+            omit_links,
+            media_type,
+        )
+
+        # FIXME unpacking/repacking like this is tedious
+        # should probably just have a separate construct_resource function
+        data.append(
+            ResourceType(
+                id=resource.id,
+                attributes=NodeAttributesType(
+                    structure_family=resource.attributes.structure_family,
+                    specs=resource.attributes.specs,
+                    metadata=resource.attributes.metadata,
+                    structure=resource.attributes.structure,
+                    count=resource.attributes.count,
+                ),
+                links=resource.links.dict(),
+                meta=resource.meta,
+            )
+        )
+
+    return ResponseType(data=data, links=links, meta={"count": count}, error=None)
+
+BaseQuery = create_type("BaseQuery", [hello, search])
+
+def get_router(queries):
+    TiledQuery = merge_types("TiledQuery", tuple(queries))
+    schema = strawberry.Schema(query=TiledQuery)
+    router = GraphQLRouter(schema, context_getter=get_context)
+    return router


### PR DESCRIPTION
This is a concept implementation of graphql integration in tiled. Alternative to #140 using strawberry instead of ariadne. Strawberry has a dataclass approach to schema definition rather than the text based approach in ariadne. I don't have a strong preference between these approaches.

This pull request allows trees to provide a `graphql_queries` attribute which gets merged into the global `Query` object at initialization. This step is natively supported by strawberry (`strawberry.tools.merge_types`). From what I have seen this is not as easily supported in either graphene or ariadne but I could be just missing it.

As a proof of concept I implement a simple version of the `/node/search` route in graphql. This involves some code duplication of things in the rest api which have to be slightly modified to work correctly with graphql. In particular in the schema definitions all `dict` fields need to be changed to strawberry `JSON` scalars. Not sure if we even want this query but included just to get an idea of how interacting with the tree works.

Opening now to get feedback.