### PR TITLE
Reorganize database settings. Use pessimistic disconnect handling.

### DIFF
--- a/docs/source/how-to/tiled-database.md
+++ b/docs/source/how-to/tiled-database.md
@@ -34,7 +34,8 @@ in place of `...` below. Inject the password via an environment variable as show
 do not hard-code it in the configuration file. Be sure to quote the URI.
 
 ```yaml
-database_uri: "postgresql://tiled:${TILED_DATABASE_PASSWORD}@.../tiled"
+database
+  uri: "postgresql://tiled:${TILED_DATABASE_PASSWORD}@.../tiled"
 ```
 
 Initialize the database. Initialization only has to be done once ever. (If you

--- a/docs/source/how-to/tiled-database.md
+++ b/docs/source/how-to/tiled-database.md
@@ -49,6 +49,5 @@ The database is ready to use.
 
 ## Reference
 
-See `database` in the service configuration reference
-{doc}`../reference/service` for a comprehensive list of the options for tuning
-database performance and reliability.
+See `database` in {doc}`../reference/service-configuration` for comprehensive
+documentation of the options for tuning database performance and reliability.

--- a/docs/source/how-to/tiled-database.md
+++ b/docs/source/how-to/tiled-database.md
@@ -46,3 +46,9 @@ $ tiled admin initialize-database postgresql://tiled:${TILED_DATABASE_PASSWORD}@
 ```
 
 The database is ready to use.
+
+## Reference
+
+See `database` in the service configuration reference
+{doc}`../reference/service` for a comprehensive list of the options for tuning
+database performance and reliability.

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -31,7 +31,9 @@ def config(tmpdir):
                 }
             ],
         },
-        "database_uri": f"sqlite:///{tmpdir}/tiled.sqlite",
+        "database": {
+            "uri": f"sqlite:///{tmpdir}/tiled.sqlite",
+        },
         "access_control": {
             "access_policy": "tiled.adapters.mapping:SimpleAccessPolicy",
             "args": {"access_lists": {"alice": ["a"]}, "provider": "toy"},

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -46,7 +46,9 @@ def config(tmpdir):
                 }
             ],
         },
-        "database_uri": f"sqlite:///{tmpdir}/tiled.sqlite",
+        "database": {
+            "uri": f"sqlite:///{tmpdir}/tiled.sqlite",
+        },
         "trees": [
             {
                 "tree": f"{__name__}:tree",

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -164,7 +164,7 @@ def construct_build_app_kwargs(
         server_settings["response_bytesize_limit"] = config.get(
             "response_bytesize_limit"
         )
-        server_settings["database_uri"] = config.get("database_uri")
+        server_settings["database"] = config.get("database", {})
         metrics = config.get("metrics", {})
         if metrics.get("prometheus", False):
             prometheus_multiproc_dir = os.getenv("PROMETHEUS_MULTIPROC_DIR", None)
@@ -212,8 +212,7 @@ def merge(configs):
     uvicorn_config_source = None
     object_cache_config_source = None
     metrics_config_source = None
-    database_uri_config_source = None
-    database_settings_config_source = None
+    database_config_source = None
     response_bytesize_limit_config_source = None
     allow_origins = []
     media_types = defaultdict(dict)
@@ -279,24 +278,15 @@ def merge(configs):
                 )
             metrics_config_source = filepath
             merged["metrics"] = config["metrics"]
-        if "database_uri" in config:
-            if "database_uri" in merged:
+        if "database" in config:
+            if "database" in merged:
                 raise ConfigError(
-                    "database_uri can only be specified in one file. "
-                    f"It was found in both {database_uri_config_source} and "
+                    "database configuration can only be specified in one file. "
+                    f"It was found in both {database_config_source} and "
                     f"{filepath}"
                 )
-            database_uri_config_source = filepath
-            merged["database_uri"] = config["database_uri"]
-        if "database_settings" in config:
-            if "database_settings" in merged:
-                raise ConfigError(
-                    "database_settings can only be specified in one file. "
-                    f"It was found in both {database_settings_config_source} and "
-                    f"{filepath}"
-                )
-            database_settings_config_source = filepath
-            merged["database_settings"] = config["database_settings"]
+            database_config_source = filepath
+            merged["database"] = config["database"]
         for item in config.get("trees", []):
             if item["path"] in paths:
                 msg = "A given path may be only be specified once."

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -286,23 +286,29 @@ properties:
           this is unset and active session are never shut down.
     description:
       This section describes whether and how to authenticate users.
-  database_uri:
-    type: string
-    description: |
-      When Tiled is configured with authentication providers, it uses a SQL database
-      to persist information related to identities, sessions, and keys. (When it is
-      used without authentication providers, no database is used.)
-
-      If Tiled is configured with authentication providers above but a database
-      URI is not specified, `sqlite:///./tiled.sqlite` (i.e. a SQLite database in
-      the current working directory) will be used.
-
-      Tiled officially supports PostgreSQL and SQLite, but any database engine
-      supported by SQLAlchemy *may* work.
-  database_settings:
+  database:
     type: object
     additionalProperties: false
+    required:
+      - uri
     properties:
+      uri:
+        type: string
+        description: |
+          When Tiled is configured with authentication providers, it uses a SQL database
+          to persist information related to identities, sessions, and keys. (When it is
+          used without authentication providers, no database is used.)
+
+          If Tiled is configured with authentication providers above but a database
+          URI is not specified, `sqlite:///./tiled.sqlite` (i.e. a SQLite database in
+          the current working directory) will be used.
+
+          Tiled officially supports PostgreSQL and SQLite, but any database engine
+          supported by SQLAlchemy *may* work.
+      pool_pre_ping:
+        type: boolean
+        description: |
+          If true (default), use pessimistic connection testings. This is recommended.
       pool_size:
         type: integer
         description: Connection pool size

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -311,7 +311,7 @@ properties:
           If true (default), use pessimistic connection testings. This is recommended.
       pool_size:
         type: integer
-        description: Connection pool size
+        description: Connection pool size. Default is 5.
   access_control:
     type: object
     additionalProperties: false

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -266,11 +266,11 @@ def build_app(
         database = server_settings.get("database", {})
         if database is not None:
             if database.get("uri"):
-                settings.datbase_uri = database["uri"]
+                settings.database_uri = database["uri"]
             if database.get("pool_size"):
-                settings.datbase_pool_size = database["pool_size"]
+                settings.database_pool_size = database["pool_size"]
             if database.get("pool_pre_ping"):
-                settings.datbase_pool_pre_ping = database["pool_pre_ping"]
+                settings.database_pool_pre_ping = database["pool_pre_ping"]
         object_cache_available_bytes = server_settings.get("object_cache", {}).get(
             "available_bytes"
         )

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -264,13 +264,12 @@ def build_app(
             if server_settings.get(item) is not None:
                 setattr(settings, item, server_settings[item])
         database = server_settings.get("database", {})
-        if database is not None:
-            if database.get("uri"):
-                settings.database_uri = database["uri"]
-            if database.get("pool_size"):
-                settings.database_pool_size = database["pool_size"]
-            if database.get("pool_pre_ping"):
-                settings.database_pool_pre_ping = database["pool_pre_ping"]
+        if database.get("uri"):
+            settings.database_uri = database["uri"]
+        if database.get("pool_size"):
+            settings.database_pool_size = database["pool_size"]
+        if database.get("pool_pre_ping"):
+            settings.database_pool_pre_ping = database["pool_pre_ping"]
         object_cache_available_bytes = server_settings.get("object_cache", {}).get(
             "available_bytes"
         )

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -260,12 +260,16 @@ def build_app(
         ]:
             if authentication.get(item) is not None:
                 setattr(settings, item, authentication[item])
-        for item in ["allow_origins", "response_bytesize_limit", "database_uri"]:
+        for item in ["allow_origins", "response_bytesize_limit"]:
             if server_settings.get(item) is not None:
                 setattr(settings, item, server_settings[item])
-        pool_size = server_settings.get("database_settings", {}).get("pool_size")
-        if pool_size is not None:
-            settings.database_pool_size = pool_size
+        database = server_settings.get("database")
+        if database is not None:
+            settings.datbase_uri = database["uri"]
+            if database.get("pool_size"):
+                settings.datbase_pool_size = database["pool_size"]
+            if database.get("pool_pre_ping"):
+                settings.datbase_pool_pre_ping = database["pool_pre_ping"]
         object_cache_available_bytes = server_settings.get("object_cache", {}).get(
             "available_bytes"
         )

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -263,9 +263,10 @@ def build_app(
         for item in ["allow_origins", "response_bytesize_limit"]:
             if server_settings.get(item) is not None:
                 setattr(settings, item, server_settings[item])
-        database = server_settings.get("database")
+        database = server_settings.get("database", {})
         if database is not None:
-            settings.datbase_uri = database["uri"]
+            if database.get("uri"):
+                settings.datbase_uri = database["uri"]
             if database.get("pool_size"):
                 settings.datbase_pool_size = database["pool_size"]
             if database.get("pool_pre_ping"):

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -7,7 +7,9 @@ from typing import Any, List, Optional
 
 from pydantic import BaseSettings
 
-DatabaseSettings = collections.namedtuple("DatabaseSettings", "uri pool_size")
+DatabaseSettings = collections.namedtuple(
+    "DatabaseSettings", "uri pool_size pool_pre_ping"
+)
 
 
 class Settings(BaseSettings):

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -51,9 +51,9 @@ class Settings(BaseSettings):
         os.getenv("TILED_RESPONSE_BYTESIZE_LIMIT", 300_000_000)
     )  # 300 MB
     database_uri: Optional[str] = os.getenv("TILED_DATABASE_URI")
-    database_pool_size: Optional[int] = int(os.getenv("TILED_DATABASE_POOL_SIZE", 0))
+    database_pool_size: Optional[int] = int(os.getenv("TILED_DATABASE_POOL_SIZE", 5))
     database_pool_pre_ping: Optional[bool] = bool(
-        int(os.getenv("TILED_DATABASE_POOL_PRE_PING", 0))
+        int(os.getenv("TILED_DATABASE_POOL_PRE_PING", 1))
     )
 
     @property
@@ -78,10 +78,8 @@ def get_sessionmaker(database_settings):
 
     connect_args = {}
     kwargs = {}  # extra kwargs passed to create_engine
-    if database_settings.pool_size:
-        kwargs["pool_size"] = database_settings.pool_size
-    if database_settings.pool_pre_ping:
-        kwargs["pool_pre_ping"] = True
+    kwargs["pool_size"] = database_settings.pool_size
+    kwargs["pool_pre_ping"] = database_settings.pool_pre_ping
     if database_settings.uri.startswith("sqlite"):
         from sqlalchemy.pool import QueuePool
 

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -52,12 +52,17 @@ class Settings(BaseSettings):
     )  # 300 MB
     database_uri: Optional[str] = os.getenv("TILED_DATABASE_URI")
     database_pool_size: Optional[int] = int(os.getenv("TILED_DATABASE_POOL_SIZE", 0))
+    database_pool_pre_ping: Optional[bool] = bool(
+        int(os.getenv("TILED_DATABASE_POOL_PRE_PING", 0))
+    )
 
     @property
     def database_settings(self):
         # The point of this alias is to return a hashable argument for get_sessionmaker.
         return DatabaseSettings(
-            uri=self.database_uri, pool_size=self.database_pool_size
+            uri=self.database_uri,
+            pool_size=self.database_pool_size,
+            pool_pre_ping=self.database_pool_pre_ping,
         )
 
 
@@ -75,11 +80,12 @@ def get_sessionmaker(database_settings):
     kwargs = {}  # extra kwargs passed to create_engine
     if database_settings.pool_size:
         kwargs["pool_size"] = database_settings.pool_size
+    if database_settings.pool_pre_ping:
+        kwargs["pool_pre_ping"] = True
     if database_settings.uri.startswith("sqlite"):
         from sqlalchemy.pool import QueuePool
 
         kwargs["poolclass"] = QueuePool
-    if database_settings.uri.startswith("sqlite"):
         connect_args.update({"check_same_thread": False})
     engine = create_engine(database_settings.uri, connect_args=connect_args, **kwargs)
     sm = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
Two changes:

First, a backward-incompatible change to the config structure for database-related config from

```yaml
database_uri: ...
database_settings:
  pool_size: ...
```

to

```yaml
database:
  uri: ...
  pool_size: ...
```

I started to do this in a backward-compatible way, but it got messy and error-prone, and I think a clean break is best. I believe the only deployments that would be affected are tiled-demo, AIMM, and NSLS2.

Second, the use of [pessimistic disconnection handling](https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic) by default. It can be turned off via a new config setting:

```yaml
database:
  uri: ...
  pool_size: ...
  pool_pre_ping: False
```

This solves a critical issue that we observed in the NSLS2 deployment where long-running servers would end up with broken database connections in their pool. You have a small performance hit for this, but I think it's necessary. As another data point, JupyterHub uses this setting as well.