### PR TITLE
More helpful error if Authorization type is omitted or misspelled

### DIFF
--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -207,7 +207,7 @@ def build_app(
         # For the OpenAPI schema, inject a OAuth2PasswordBearer URL.
         first_provider = authentication["providers"][0]["provider"]
         oauth2_scheme.model.flows.password.tokenUrl = (
-            f"/auth/provider/{first_provider}/token"
+            f"/api/auth/provider/{first_provider}/token"
         )
         # Authenticators provide Router(s) for their particular flow.
         # Collect them in the authentication_router.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -91,8 +91,17 @@ class APIKeyAuthorizationHeader(APIKeyBase):
     async def __call__(self, request: Request) -> Optional[str]:
         authorization: str = request.headers.get("Authorization")
         scheme, param = get_authorization_scheme_param(authorization)
-        if not authorization or scheme.lower() != "apikey":
+        if not authorization or scheme.lower() == "bearer":
             return None
+        if scheme.lower() != "apikey":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Authorization header must include the authorization type "
+                    "followed by a space and then the secret, as in "
+                    "'Bearer SECRET' or 'Apikey SECRET'. "
+                ),
+            )
         return param
 
 


### PR DESCRIPTION
When hand-writing HTTP requests that use API key or auth token authentication, you have to remember to prefix the secret with `Apikey ` or `Bearer ` (respectively) to distinguish what kind of credential is being used.

This PR responds with a clear error if the prefix is omitted

```
$ http :8000/api/node/metadata/A 'Authorization:697ed7f7e645b18cb5ae27a579eb5af98ba803ad2b5ebae54171f61e906c1d1bb884f6b6'
HTTP/1.1 400 Bad Request
content-length: 153
content-type: application/json
date: Fri, 18 Mar 2022 19:48:21 GMT
server: uvicorn
server-timing: app;dur=2.1
set-cookie: tiled_csrf=5bX-LZzKzhjDioFMlSMPxqWx6S20n5MbtErDfSshh3Y; HttpOnly; Path=/; SameSite=lax

{
    "detail": "Authorization header must include the authorization type followed by a space and then the secret, as in 'Bearer SECRET' or 'Apikey SECRET'. "
}
```

or misspelled.

```
$ http :8000/api/node/metadata/ 'Authorization:Misspelled 697ed7f7e645b18cb5ae27a579eb5af98ba803ad2b5ebae54171f61e906c1d1bb884f6b6'
HTTP/1.1 400 Bad Request
content-length: 153
content-type: application/json
date: Fri, 18 Mar 2022 19:53:49 GMT
server: uvicorn
server-timing: app;dur=1.9
set-cookie: tiled_csrf=D3a5dp0CN0vtdwXCQ8jwX0riEYgva7MdWMzZkP4uSfI; HttpOnly; Path=/; SameSite=lax

{
    "detail": "Authorization header must include the authorization type followed by a space and then the secret, as in 'Bearer SECRET' or 'Apikey SECRET'. "
}
```

