### PR TITLE
Add writing scopes.

### DIFF
--- a/docs/source/reference/scopes.md
+++ b/docs/source/reference/scopes.md
@@ -10,6 +10,8 @@ with restricted scopes.
   associated with this key, resolved at access time.
 * `read:metadata` --- List and search metadata.
 * `read:data` --- Fetch (array, dataframe) data.
+* `write:metadata` --- Write metadata. This is not yet used by Tiled itself. It is made available for use by experimental externally-developed adapters that support writing.
+* `write:data` --- Write (array, dataframe) data. This is not yet used by Tiled itself. It is made available for use by experimental externally-developed adapters that support writing.
 * `apikeys` --- Manage API keys for the currently-authenticated user or service.
 * `metrics` --- Access Prometheus metrics.
 * `admin:apikeys` --- Manage API keys on behalf of any user or service.

--- a/tiled/database/alembic_utils.py
+++ b/tiled/database/alembic_utils.py
@@ -57,3 +57,29 @@ def temp_alembic_ini(database_uri):
         alembic_ini = os.path.join(td, "alembic.ini")
         write_alembic_ini(alembic_ini, database_uri)
         yield alembic_ini
+
+
+def main(args=None):
+    """
+    This is runs the alembic CLI with a dynamically genericated config file.
+
+    A database can be specified via TILED_DATABASE_URI, but it is not necessary to set
+    it for operations that do not connect to any database, such as defining new database
+    revisions (i.e. migrations).
+
+    To define a new revision:
+
+    $ python -m tiled.database.alembic_utils revision -m "description..."
+
+    """
+    import subprocess
+    import sys
+
+    if args is None:
+        args = sys.argv[1:]
+    with temp_alembic_ini(os.getenv("TILED_DATABASE_URI", "")) as config_file:
+        return subprocess.check_output(["alembic", "-c", config_file, *args])
+
+
+if __name__ == "__main__":
+    main()

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -14,9 +14,9 @@ from .orm import APIKey, Identity, Principal, Role, Session
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "481830dd6c11"
-# This is set of all valid revisions.
-ALL_REVISIONS = {"481830dd6c11"}
+REQUIRED_REVISION = "722ff4e4fcc7"
+# This is list of all valid revisions (from current to oldest).
+ALL_REVISIONS = ["722ff4e4fcc7", "481830dd6c11"]
 
 
 def create_default_roles(engine):
@@ -64,6 +64,24 @@ def initialize_database(engine):
     with temp_alembic_ini(engine.url) as alembic_ini:
         alembic_cfg = Config(alembic_ini)
         command.stamp(alembic_cfg, "head")
+
+
+def upgrade(engine, revision):
+    """
+    Upgrade schema to the specified revision.
+    """
+    with temp_alembic_ini(engine.url) as alembic_ini:
+        alembic_cfg = Config(alembic_ini)
+        command.upgrade(alembic_cfg, revision)
+
+
+def downgrade(engine, revision):
+    """
+    Downgrade schema to the specified revision.
+    """
+    with temp_alembic_ini(engine.url) as alembic_ini:
+        alembic_cfg = Config(alembic_ini)
+        command.downgrade(alembic_cfg, revision)
 
 
 class UnrecognizedDatabase(Exception):

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -28,7 +28,13 @@ def create_default_roles(engine):
         Role(
             name="user",
             description="Default Role for users.",
-            scopes=["read:metadata", "read:data", "apikeys"],
+            scopes=[
+                "read:metadata",
+                "read:data",
+                "write:metadata",
+                "write:data",
+                "apikeys",
+            ],
         ),
     )
     db.add(

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -38,6 +38,8 @@ def create_default_roles(engine):
             scopes=[
                 "read:metadata",
                 "read:data",
+                "write:metadata",
+                "write:data",
                 "admin:apikeys",
                 "read:principals",
                 "metrics",

--- a/tiled/database/migrations/versions/722ff4e4fcc7_add_write_scopes_to_default_roles.py
+++ b/tiled/database/migrations/versions/722ff4e4fcc7_add_write_scopes_to_default_roles.py
@@ -1,0 +1,51 @@
+""""Add write scopes to default Roles."
+
+Revision ID: 722ff4e4fcc7
+Revises: 481830dd6c11
+Create Date: 2022-03-22 16:54:02.764016
+
+"""
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+from tiled.database.orm import Role
+
+# revision identifiers, used by Alembic.
+revision = "722ff4e4fcc7"
+down_revision = "481830dd6c11"
+branch_labels = None
+depends_on = None
+
+
+ROLES = ["admin", "user"]
+NEW_SCOPES = ["write:metadata", "write:data"]
+
+
+def upgrade():
+    """
+    Add new scopes to Roles.
+    """
+    connection = op.get_bind()
+    with Session(bind=connection) as db:
+        for role_name in ROLES:
+            role = db.query(Role).filter(Role.name == role_name).first()
+            scopes = role.scopes.copy()
+            scopes.extend(NEW_SCOPES)
+            role.scopes = scopes
+            db.commit()
+
+
+def downgrade():
+    """
+    Remove new scopes from Roles, if present.
+    """
+    connection = op.get_bind()
+    with Session(bind=connection) as db:
+        for role_name in ROLES:
+            role = db.query(Role).filter(Role.name == role_name).first()
+            scopes = role.scopes.copy()
+            for scope in NEW_SCOPES:
+                if scope in scopes:
+                    scopes.remove(scope)
+            role.scopes = scopes
+            db.commit()

--- a/tiled/scopes.py
+++ b/tiled/scopes.py
@@ -4,6 +4,8 @@ SCOPES = {
     },
     "read:metadata": {"description": "Read metadata."},
     "read:data": {"description": "Read data."},
+    "write:metadata": {"description": "Write metadata."},
+    "write:data": {"description": "Write data."},
     "metrics": {"description": "Access (Prometheus) metrics."},
     "apikeys": {
         "description": "Create and revoke API keys as the currently-authenticated user or service."

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -616,13 +616,13 @@ def print_admin_api_key_if_generated(web_app, host, port):
     if settings.allow_anonymous_access:
         print(
             """
-    Tiled server is running in "public" mode, permitting open, anonymous access.
-    Any data that is not specifically controlled with an access policy
-    will be visible to anyone who can connect to this server.
+    Tiled server is running in "public" mode, permitting open, anonymous access
+    for reading. Any data that is not specifically controlled with an access
+    policy will be visible to anyone who can connect to this server.
 """,
             file=sys.stderr,
         )
-    elif (not authenticators) and settings.single_user_api_key_generated:
+    if (not authenticators) and settings.single_user_api_key_generated:
         print(
             f"""
     Navigate a web browser to:

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -367,6 +367,7 @@ def build_app(
             from ..database import orm
             from ..database.core import (
                 REQUIRED_REVISION,
+                DatabaseUpgradeNeeded,
                 UninitializedDatabase,
                 check_database,
                 initialize_database,
@@ -388,6 +389,21 @@ def build_app(
                 )
                 initialize_database(engine)
                 logger.info("Database initialized.")
+            except DatabaseUpgradeNeeded as err:
+                print(
+                    f"""
+
+The database used by Tiled to store authentication-related information
+was created using an older version of Tiled. It needs to be upgraded to
+work with this version of Tiled.
+
+Back up the database, and then run:
+
+    tiled admin upgrade-database {redacted_url}
+""",
+                    file=sys.stderr,
+                )
+                raise err from None
             else:
                 logger.info(f"Connected to existing database at {redacted_url}.")
             SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -242,7 +242,13 @@ def get_current_principal(
             # Tiled is in a "single user" mode with only one API key.
             if secrets.compare_digest(api_key, settings.single_user_api_key):
                 principal = SpecialUsers.admin
-                scopes = {"read:metadata", "read:data", "metrics"}
+                scopes = {
+                    "read:metadata",
+                    "read:data",
+                    "write:metadata",
+                    "write:data",
+                    "metrics",
+                }
             else:
                 raise HTTPException(
                     status_code=401, detail="Invalid API key", headers=headers_for_401


### PR DESCRIPTION
This defines the scopes `write:metadata` and `write:data` and adds them to the built-in Roles `user` and `admin`, making it possible for externally-developed Tiled adapters to experiment with writing via custom routes, protecting those routes with `write:metadata` and/or `write:data` security scopes.

This doesn't change the database _schema_ but it does change the initial state of the database (the `scopes` list on the default Roles) so we implement it as a database migration. By doing it this way, we ensure that the new scopes are added exactly once to existing deployments, leaving them free to customize the Roles (for example, removing the writing scopes if they want) and have those customizations persist.

This is the first time we've needed to do a database migration, so some of the changes here are one-time additions to support migrations in general.

Unit testing this is a hassle that I want to punt for now. Here is evidence that it works....

Running this branch against an existing database prints clear instructions on how to upgrade the database.

```
$ tiled serve config example_configs/toy_authentication.yml 
Using configuration from /home/dallan/Repos/bnl/tiled/example_configs/toy_authentication.yml
INFO:     Started server process [1581164]
INFO:     Waiting for application startup.
OBJECT CACHE: Will use up to 6_291_725_107 bytes (15% of total physical RAM)


The database used by Tiled to store authentication-related information
was created using an older version of Tiled. It needs to be upgraded to
work with this version of Tiled.

Back up the database, and then run:

    tiled admin upgrade-database sqlite:///./tiled.sqlite

ERROR:    Traceback (most recent call last):
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/starlette/routing.py", line 621, in lifespan
    async with self.lifespan_context(app):
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/starlette/routing.py", line 518, in __aenter__
    await self._router.startup()
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/starlette/routing.py", line 598, in startup
    await handler()
  File "/home/dallan/Repos/bnl/tiled/tiled/server/app.py", line 404, in startup_event
    raise err from None
  File "/home/dallan/Repos/bnl/tiled/tiled/server/app.py", line 384, in startup_event
    check_database(engine)
  File "/home/dallan/Repos/bnl/tiled/tiled/database/core.py", line 130, in check_database
    raise DatabaseUpgradeNeeded(
tiled.database.core.DatabaseUpgradeNeeded: The database sqlite:///./tiled.sqlite has revision 481830dd6c11 and needs to be upgraded to revision 722ff4e4fcc7.

ERROR:    Application startup failed. Exiting.
```

Then, after running

```
tiled admin upgrade-database sqlite:///./tiled.sqlite
```

it works.

Going the other way, if we run the `main` branch of tiled against the upgraded database, we get a clear error:

```
tiled.database.core.UnrecognizedDatabase: The datbase sqlite:///./tiled.sqlite has an unrecognized revision 722ff4e4fcc7. It may have been created by a newer version of Tiled.
```

From this branch, we can _downgrade_ the database:

```
tiled admin downgrade-database sqlite:///./tiled.sqlite 481830dd6c11
```

and now it is usable again by the `main` branch. This gives us a path to retreat if an upgrade goes poorly and we need to roll back. (It is also good practice to backup databases before running migrations, of course.)
