### PR TITLE
Require msgpack >=1.0.0.

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,8 +2,8 @@
 appdirs
 entrypoints
 heapdict
-httpx>=0.20.0
+httpx >=0.20.0
 jsonschema
-msgpack
+msgpack >=1.0.0
 pyyaml
 typer

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -10,7 +10,7 @@ fastapi
 jinja2
 jmespath
 jsonschema
-msgpack
+msgpack >=1.0.0
 orjson
 psutil
 prometheus_client


### PR DESCRIPTION
Prompted by a user bug report where tiled was installed into an
existing env that had a too-old version (0.6.1) missing timestamp
support.