### PR TITLE
Support lookup like c['a', 'b'].

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 # These are the requirements needed for basic client functionality.
 appdirs
+click !=8.1.0
 entrypoints
 heapdict
 httpx >=0.20.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -5,6 +5,7 @@ anyio
 cachey
 cached-property; python_version < '3.8'
 cachetools
+click !=8.1.0
 dask
 fastapi
 jinja2

--- a/tiled/_tests/test_search.py
+++ b/tiled/_tests/test_search.py
@@ -50,3 +50,15 @@ def test_key_into_results():
     assert "apple" in results["a"].metadata
     assert "banana" in results["b"].metadata
     assert "c" not in results  # This *is* in the tree but not among the results.
+
+
+def test_compound_key_into_results():
+    nested_tree = MapAdapter(
+        {
+            "i": MapAdapter({"X": tree}, metadata={"temp": "hot"}),
+            "j": MapAdapter({}, metadata={"temp": "cold"}),
+        }
+    )
+    client = from_tree(nested_tree)
+    result = client.search(FullText("hot"))["i", "X", "a"]
+    assert "apple" in result.metadata


### PR DESCRIPTION
With this PR, these are equivalent:

```py
>>> node['a']['b']['c']
>>> node[('a', 'b', 'c')]
>>> node['a', 'b', 'c']
```

The last two, it should be noted, are equivalent on a Python level, nothing to do with tiled:

```py
In [1]: class A:
   ...:     def __getitem__(self, stuff):
   ...:         print(repr(stuff))
   ...: 

In [2]: a = A()

In [3]: a[1]
1

In [4]: a[1, 2]
(1, 2)

In [5]: a[(1, 2)]
(1, 2)
```

As noted  in the code comments, this could be made faster by eliding `c['a', 'b', 'c']` into a single request rather than issuing chained requests. But there are some tricky aspects to that (described in more detail in the comments) so we'll leave it for another time.