### PR TITLE
`follow_redirects=True` for `httpx` in examples/nexus.py

### DIFF
--- a/tiled/examples/nexus.py
+++ b/tiled/examples/nexus.py
@@ -28,7 +28,7 @@ from tiled.adapters.hdf5 import HDF5Adapter
 
 def build_tree(url):
     # Download a Nexus file into a memory buffer.
-    buffer = io.BytesIO(httpx.get(url).content)
+    buffer = io.BytesIO(httpx.get(url, follow_redirects=True).content)
     # Access the buffer with h5py, which can treat it like a "file".
     file = h5py.File(buffer, "r")
     # Wrap the h5py.File in a MapAdapter to serve it with Tiled.


### PR DESCRIPTION
Unlike `requests`, that is automatically following redirects, `httpx` requires to pass `follow_redirects=True` (False by default) to follow from https://github.com/bluesky/tiled/blob/8bb3369fcce72096e00d1e1aff90b52b11e66fb4/tiled/examples/nexus.py#L38
to
```
https://github.com/nexusformat/exampledata/raw/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5
```
to
```
https://raw.githubusercontent.com/nexusformat/exampledata/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5
```

### Some inspection
```py
$ ipython --profile=tiled
Python 3.9.12 | packaged by conda-forge | (main, Mar 24 2022, 23:27:05)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.2.0 -- An enhanced Interactive Python. Type '?' for help.

IPython profile: tiled

In [1]: from tiled.examples.nexus import EXAMPLE_URL

In [2]: EXAMPLE_URL
Out[2]: 'https://github.com/nexusformat/exampledata/blob/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5?raw=true'

In [3]: import requests

In [4]: resp = requests.get(EXAMPLE_URL)
re
In [5]: resp
Out[5]: <Response [200]>

In [6]: resp.headers["content-length"]
Out[6]: '436820'

In [7]: resp.content[:200]
Out[7]: b'\x89HDF\r\n\x1a\n\x00\x00\x00\x00\x00\x08\x08\x00\x04\x00\x10\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xffT\xaa\x06\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x03\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00\x00\x00HEAP\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00entry\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xf0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

In [8]:

In [8]: import httpx

In [9]: respx1 = httpx.get(EXAMPLE_URL)

In [10]: respx1
Out[10]: <Response [302 Found]>

In [11]: respx1.content[:200]
Out[11]: b'<html><body>You are being <a href="https://github.com/nexusformat/exampledata/raw/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5">redirected</a>.</body></html>'

In [12]: respx1.headers["location"]
Out[12]: 'https://github.com/nexusformat/exampledata/raw/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5'

In [13]: respx2 = httpx.get(respx1.headers["location"])

In [14]: respx2
Out[14]: <Response [302 Found]>

In [15]: respx2.content[:200]
Out[15]: b'<html><body>You are being <a href="https://raw.githubusercontent.com/nexusformat/exampledata/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5">redirected</a>.</body></html>'

In [16]: respx2.headers["location"]
Out[16]: 'https://raw.githubusercontent.com/nexusformat/exampledata/master/APS/EPICSareaDetector/hdf5/AgBehenate_228.hdf5'

In [17]: respx3 = httpx.get(respx2.headers["location"])

In [18]: respx3
Out[18]: <Response [200 OK]>

In [19]: respx3.content[:200]
Out[19]: b'\x89HDF\r\n\x1a\n\x00\x00\x00\x00\x00\x08\x08\x00\x04\x00\x10\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xffT\xaa\x06\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x03\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00\x00\x00HEAP\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00entry\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\xf0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

In [20]: respx3.content[:200] == resp.content[:200]
Out[20]: True

In [21]:
```