### PR TITLE
Add [experimental] methods for writing arrays and dataframes

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -539,6 +539,25 @@ Set an api_key as in:
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
+    def put_content(self, path, content, headers=None, **kwargs):
+        # Submit CSRF token in both header and cookie.
+        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+        headers = headers or {}
+        headers.setdefault("x-csrf", self._client.cookies["tiled_csrf"])
+        headers.setdefault("accept", "application/x-msgpack")
+        request = self._client.build_request(
+            "PUT",
+            path,
+            content=content,
+            headers=headers,
+        )
+        response = self._client.send(request)
+        handle_error(response)
+        return msgpack.unpackb(
+            response.content,
+            timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
+        )
+
     def _send(self, request, stream=False, attempts=0):
         """
         If sending results in an authentication error, reauthenticate.

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -550,9 +550,17 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
     def write_array(self, array, metadata=None, specs=None):
         """
-        EXPERIMENTAL: write an array
+        EXPERIMENTAL: Write an array.
 
-        This is subject to change or removal without notice
+        Parameters
+        ----------
+        array : array-like
+        metadata : dict, optional
+            User metadata. May be nested. Must contain only basic types
+            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        specs : List[str], optional
+            List of names that are used to label that the data and/or metadata
+            conform to some named standard specification.
 
         """
 
@@ -593,15 +601,27 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             + "/"
             + uid
         )
-        self.context.put_content(full_path_data, content=array.tobytes())
+        self.context.put_content(
+            full_path_data,
+            content=array.tobytes(),
+            headers={"Content-Type": "application/octet-stream"},
+        )
 
     def write_dataframe(self, dataframe, metadata=None, specs=None):
         """
-        EXPERIMENTAL: write a dataframe
+        EXPERIMENTAL: Write a DataFrame.
 
         This is subject to change or removal without notice
 
-
+        Parameters
+        ----------
+        dataframe : pandas.DataFrame
+        metadata : dict, optional
+            User metadata. May be nested. Must contain only basic types
+            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        specs : List[str], optional
+            List of names that are used to label that the data and/or metadata
+            conform to some named standard specification.
         """
         from dask.dataframe.utils import make_meta
 

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -568,7 +568,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         metadata = metadata or {}
         specs = specs or []
-        mimetype = "application/octet-stream"
 
         structure = ArrayStructure(
             macro=ArrayMacroStructure(
@@ -583,7 +582,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             "structure": asdict(structure),
             "structure_family": StructureFamily.array,
             "specs": specs,
-            "mimetype": mimetype,
         }
 
         full_path_meta = (
@@ -633,7 +631,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         metadata = metadata or {}
         specs = specs or []
-        mimetype = APACHE_ARROW_FILE_MIME_TYPE
 
         structure = DataFrameStructure(
             micro=DataFrameMicroStructure(meta=make_meta(dataframe), divisions=[]),
@@ -647,7 +644,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             "structure": asdict(structure),
             "structure_family": StructureFamily.dataframe,
             "specs": specs,
-            "mimetype": mimetype,
         }
 
         data["structure"]["micro"]["meta"] = base64.b64encode(
@@ -670,7 +666,9 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             + uid
         )
         self.context.put_content(
-            full_path_data, content=bytes(serialize_arrow(dataframe, {}))
+            full_path_data,
+            content=bytes(serialize_arrow(dataframe, {})),
+            headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
         )
 
 


### PR DESCRIPTION
NOTE:
The methods that were added to node.py and context.py are intended to be experimental. We are testing approaches to make tiled receive data and put it in a node in the tree. This might be subject to changes in the future. The idea behind this approach is to make it as easy as possible to the user to use a write command  for tiled while the data validation, data storage and management happens internally and with no complicated or convoluted steps for the user.