### PR TITLE
provide tighter control over number of database connections

### DIFF
--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -312,6 +312,9 @@ properties:
       pool_size:
         type: integer
         description: Connection pool size. Default is 5.
+      max_overflow:
+        type: integer
+        description: Connection pool max overflow. Default is 0.
   access_control:
     type: object
     additionalProperties: false

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -385,7 +385,8 @@ def build_app(
                 except UninitializedDatabase:
                     # Create tables and stamp (alembic) revision.
                     logger.info(
-                        f"Database {redacted_url} is new. Creating tables and marking revision {REQUIRED_REVISION}."
+                        f"Database {redacted_url} is new. "
+                        f"Creating tables and marking revision {REQUIRED_REVISION}."
                     )
                     initialize_database(engine)
                     logger.info("Database initialized.")

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -32,7 +32,7 @@ from .object_cache import NO_CACHE, ObjectCache
 from .object_cache import logger as object_cache_logger
 from .object_cache import set_object_cache
 from .router import declare_search_router, router
-from .settings import get_settings
+from .settings import get_sessionmaker, get_settings
 from .utils import (
     API_KEY_COOKIE_NAME,
     CSRF_COOKIE_NAME,
@@ -270,6 +270,8 @@ def build_app(
             settings.database_pool_size = database["pool_size"]
         if database.get("pool_pre_ping"):
             settings.database_pool_pre_ping = database["pool_pre_ping"]
+        if database.get("max_overflow"):
+            settings.database_max_overflow = database["max_overflow"]
         object_cache_available_bytes = server_settings.get("object_cache", {}).get(
             "available_bytes"
         )
@@ -365,62 +367,54 @@ def build_app(
         app.state.root_tree = app.dependency_overrides[get_root_tree]()
 
         if settings.database_uri is not None:
-            from sqlalchemy import create_engine
-            from sqlalchemy.orm import sessionmaker
-
-            from ..database import orm
-            from ..database.core import (
-                REQUIRED_REVISION,
-                DatabaseUpgradeNeeded,
-                UninitializedDatabase,
-                check_database,
-                initialize_database,
-                make_admin_by_identity,
-            )
-
-            connect_args = {}
-            if settings.database_uri.startswith("sqlite"):
-                connect_args.update({"check_same_thread": False})
-
-            engine = create_engine(settings.database_uri, connect_args=connect_args)
-            redacted_url = engine.url._replace(password="[redacted]")
-            try:
-                check_database(engine)
-            except UninitializedDatabase:
-                # Create tables and stamp (alembic) revision.
-                logger.info(
-                    f"Database {redacted_url} is new. Creating tables and marking revision {REQUIRED_REVISION}."
+            with get_sessionmaker(settings.database_settings)() as db:
+                from ..database import orm
+                from ..database.core import (
+                    REQUIRED_REVISION,
+                    DatabaseUpgradeNeeded,
+                    UninitializedDatabase,
+                    check_database,
+                    initialize_database,
+                    make_admin_by_identity,
                 )
-                initialize_database(engine)
-                logger.info("Database initialized.")
-            except DatabaseUpgradeNeeded as err:
-                print(
-                    f"""
 
-The database used by Tiled to store authentication-related information
-was created using an older version of Tiled. It needs to be upgraded to
-work with this version of Tiled.
+                engine = db.get_bind()
+                redacted_url = engine.url._replace(password="[redacted]")
+                try:
+                    check_database(engine)
+                except UninitializedDatabase:
+                    # Create tables and stamp (alembic) revision.
+                    logger.info(
+                        f"Database {redacted_url} is new. Creating tables and marking revision {REQUIRED_REVISION}."
+                    )
+                    initialize_database(engine)
+                    logger.info("Database initialized.")
+                except DatabaseUpgradeNeeded as err:
+                    print(
+                        f"""
 
-Back up the database, and then run:
+    The database used by Tiled to store authentication-related information
+    was created using an older version of Tiled. It needs to be upgraded to
+    work with this version of Tiled.
 
-    tiled admin upgrade-database {redacted_url}
-""",
-                    file=sys.stderr,
-                )
-                raise err from None
-            else:
-                logger.info(f"Connected to existing database at {redacted_url}.")
-            SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-            db = SessionLocal()
-            for admin in authentication.get("tiled_admins", []):
-                logger.info(
-                    f"Ensuring that principal with identity {admin} has role 'admin'"
-                )
-                make_admin_by_identity(
-                    db,
-                    identity_provider=admin["provider"],
-                    id=admin["id"],
-                )
+    Back up the database, and then run:
+
+        tiled admin upgrade-database {redacted_url}
+    """,
+                        file=sys.stderr,
+                    )
+                    raise err from None
+                else:
+                    logger.info(f"Connected to existing database at {redacted_url}.")
+                for admin in authentication.get("tiled_admins", []):
+                    logger.info(
+                        f"Ensuring that principal with identity {admin} has role 'admin'"
+                    )
+                    make_admin_by_identity(
+                        db,
+                        identity_provider=admin["provider"],
+                        id=admin["id"],
+                    )
 
             async def purge_expired_sessions_and_api_keys():
                 logger.info("Purging expired Sessions and API keys from the database.")

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 from pydantic import BaseSettings
 
 DatabaseSettings = collections.namedtuple(
-    "DatabaseSettings", "uri pool_size pool_pre_ping"
+    "DatabaseSettings", "uri pool_size pool_pre_ping max_overflow"
 )
 
 
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     database_pool_pre_ping: Optional[bool] = bool(
         int(os.getenv("TILED_DATABASE_POOL_PRE_PING", 1))
     )
+    database_max_overflow: Optional[int] = int(
+        os.getenv("TILED_DATABASE_MAX_OVERFLOW", 0)
+    )
 
     @property
     def database_settings(self):
@@ -65,6 +68,7 @@ class Settings(BaseSettings):
             uri=self.database_uri,
             pool_size=self.database_pool_size,
             pool_pre_ping=self.database_pool_pre_ping,
+            max_overflow=self.database_max_overflow,
         )
 
 
@@ -82,6 +86,7 @@ def get_sessionmaker(database_settings):
     kwargs = {}  # extra kwargs passed to create_engine
     kwargs["pool_size"] = database_settings.pool_size
     kwargs["pool_pre_ping"] = database_settings.pool_pre_ping
+    kwargs["max_overflow"] = database_settings.max_overflow
     if database_settings.uri.startswith("sqlite"):
         from sqlalchemy.pool import QueuePool
 


### PR DESCRIPTION
This provides tighter control over the number of db connections established by tiled.

In particular, it makes the sqlalchemy max_overflow parameter configurable and avoids creating a separate engine during app startup. This limits the number of established connections to the value expected from the configuration.