### PR TITLE
Ldap authenticator

### DIFF
--- a/continuous_integration/docker-configs/ldap-docker-compose.yml
+++ b/continuous_integration/docker-configs/ldap-docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  openldap:
+    image: docker.io/bitnami/openldap:2.6
+    ports:
+      - '1389:1389'
+      - '1636:1636'
+    environment:
+      - LDAP_ADMIN_USERNAME=admin
+      - LDAP_ADMIN_PASSWORD=adminpassword
+      - LDAP_USERS=user01,user02
+      - LDAP_PASSWORDS=password1,password2
+    volumes:
+      - 'openldap_data:/bitnami/openldap'
+
+volumes:
+  openldap_data:
+    driver: local

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -vxeuo pipefail
 
+# Start LDAP (in docker)
+source start_LDAP.sh
+
 # These packages are installed in the base environment but may be older
 # versions. Explicitly upgrade them because they often create
 # installation problems if out of date.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 codecov
 coverage
 flake8
+ldap3
 pre-commit
 pytest
 pytest-asyncio

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -11,6 +11,7 @@ fastapi
 jinja2
 jmespath
 jsonschema
+ldap3
 msgpack >=1.0.0
 orjson
 psutil

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -11,7 +11,6 @@ fastapi
 jinja2
 jmespath
 jsonschema
-ldap3
 msgpack >=1.0.0
 orjson
 psutil

--- a/start_LDAP.sh
+++ b/start_LDAP.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Start LDAP server in docker container
+sudo docker pull bitnami/openldap:latest
+sudo docker-compose -f continuous_integration/docker-configs/ldap-docker-compose.yml up -d
+sudo docker ps

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+
+from ..authenticators import LDAPAuthenticator
+
+
+@pytest.mark.parametrize("use_tls,use_ssl", [(False, False)])
+def test_LDAPAuthenticator_01(use_tls, use_ssl):
+    """
+    Basic test for ``LDAPAuthenticator``.
+
+    TODO: The test could be extended with enabled TLS or SSL, but it requires configuration
+    of the LDAP server.
+    """
+    authenticator = LDAPAuthenticator(
+        "localhost",
+        1389,
+        bind_dn_template="cn={username},ou=users,dc=example,dc=org",
+        use_tls=use_tls,
+        use_ssl=use_ssl,
+    )
+
+    async def testing():
+        assert await authenticator.authenticate("user01", "password1") == "user01"
+        assert await authenticator.authenticate("user02", "password2") == "user02"
+        assert await authenticator.authenticate("user02a", "password2") is None
+        assert await authenticator.authenticate("user02", "password2a") is None
+
+    asyncio.run(testing())

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from ..authenticators import LDAPAuthenticator

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 import secrets
@@ -569,17 +570,17 @@ class LDAPAuthenticator:
         else:
             return 389  # default plaintext port for LDAP
 
-    def resolve_username(self, username_supplied_by_user):
+    async def resolve_username(self, username_supplied_by_user):
         import ldap3
         import ldap3.utils.conv
 
         search_dn = self.lookup_dn_search_user
         if self.escape_userdn:
             search_dn = ldap3.utils.conv.escape_filter_chars(search_dn)
-        conn = self.get_connection(
-            userdn=search_dn, password=self.lookup_dn_search_password
+        conn = await asyncio.get_running_loop().run_in_executor(
+            None, self.get_connection, search_dn, self.lookup_dn_search_password
         )
-        is_bound = conn.bind()
+        is_bound = await asyncio.get_running_loop().run_in_executor(None, conn.bind)
         if not is_bound:
             msg = "Failed to connect to LDAP server with search user '{search_dn}'"
             self.log.warning(msg.format(search_dn=search_dn))
@@ -705,7 +706,7 @@ class LDAPAuthenticator:
             return None
 
         if self.lookup_dn:
-            username, resolved_dn = self.resolve_username(username)
+            username, resolved_dn = await self.resolve_username(username)
             if not username:
                 return None
             if str(self.lookup_dn_user_dn_attribute).upper() == "CN":
@@ -726,7 +727,9 @@ class LDAPAuthenticator:
             logger.debug(msg.format(username=username, userdn=userdn))
             msg = "Status of user bind {username} with {userdn} : {is_bound}"
             try:
-                conn = self.get_connection(userdn, password)
+                conn = asyncio.get_running_loop().run_in_executor(
+                    None, self.get_connection, userdn, password
+                )
             except ldap3.core.exceptions.LDAPBindError as exc:
                 is_bound = False
                 msg += "\n{exc_type}: {exc_msg}".format(
@@ -734,7 +737,13 @@ class LDAPAuthenticator:
                     exc_msg=exc.args[0] if exc.args else "",
                 )
             else:
-                is_bound = True if conn.bound else conn.bind()
+                is_bound = (
+                    True
+                    if conn.bound
+                    else await asyncio.get_running_loop().run_in_executor(
+                        None, conn.bind
+                    )
+                )
             msg = msg.format(username=username, userdn=userdn, is_bound=is_bound)
             logger.debug(msg)
             if is_bound:

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -727,7 +727,7 @@ class LDAPAuthenticator:
             logger.debug(msg.format(username=username, userdn=userdn))
             msg = "Status of user bind {username} with {userdn} : {is_bound}"
             try:
-                conn = asyncio.get_running_loop().run_in_executor(
+                conn = await asyncio.get_running_loop().run_in_executor(
                     None, self.get_connection, userdn, password
                 )
             except ldap3.core.exceptions.LDAPBindError as exc:

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -571,11 +571,11 @@ class LDAPAuthenticator:
 
     def resolve_username(self, username_supplied_by_user):
         import ldap3
-        from ldap3.utils.conv import escape_filter_chars
+        import ldap3.utils.conv
 
         search_dn = self.lookup_dn_search_user
         if self.escape_userdn:
-            search_dn = escape_filter_chars(search_dn)
+            search_dn = ldap3.utils.conv.escape_filter_chars(search_dn)
         conn = self.get_connection(
             userdn=search_dn, password=self.lookup_dn_search_password
         )
@@ -674,7 +674,7 @@ class LDAPAuthenticator:
 
     async def authenticate(self, username: str, password: str):
         import ldap3
-        from ldap3.utils.conv import escape_filter_chars
+        import ldap3.utils.conv
 
         username_saved = username  # Save the user name passed as a parameter
 
@@ -721,7 +721,7 @@ class LDAPAuthenticator:
                 continue
             userdn = dn.format(username=username)
             if self.escape_userdn:
-                userdn = escape_filter_chars(userdn)
+                userdn = ldap3.utils.conv.escape_filter_chars(userdn)
             msg = "Attempting to bind {username} with {userdn}"
             logger.debug(msg.format(username=username, userdn=userdn))
             msg = "Status of user bind {username} with {userdn} : {is_bound}"

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -1,4 +1,7 @@
+import ldap3
+from ldap3.utils.conv import escape_filter_chars
 import logging
+import re
 import secrets
 
 from fastapi import APIRouter, Request
@@ -336,3 +339,424 @@ async def prepare_saml_from_fastapi_request(request, debug=False):
         RelayState = form_data["RelayState"]
         rv["post_data"]["RelayState"] = RelayState
     return rv
+
+
+class LDAPAuthenticator:
+    """
+    The authenticator code is based on https://github.com/jupyterhub/ldapauthenticator
+    The parameter ``use_tls`` was added for convenience of testing.
+
+    Parameters
+    ----------
+    server_address: str
+        Address of the LDAP server to contact.
+
+        Could be an IP address or hostname.
+    server_port: int or None
+        Port on which to contact the LDAP server. Default port is used if ``None``.
+
+        Defaults to ``636`` if ``use_ssl`` is set, ``389`` otherwise.
+    use_ssl: boolean
+        Use SSL to communicate with the LDAP server.
+
+        Deprecated in version 3 of LDAP. Your LDAP server must be configured to support this, however.
+    use_tls: boolean
+        Enable/disable TLS if ``use_ssl`` is False. By default TLS is enabled. It should not be disabled
+        in production systems.
+
+    bind_dn_template: list or str
+        Template from which to construct the full dn
+        when authenticating to LDAP. ``{username}`` is replaced
+        with the actual username used to log in.
+
+        If your LDAP is set in such a way that the userdn can not
+        be formed from a template, but must be looked up with an attribute
+        (such as uid or ``sAMAccountName``), please see ``lookup_dn``. It might
+        be particularly relevant for ActiveDirectory installs.
+
+        Unicode Example:
+
+        .. code-block::
+
+            "uid={username},ou=people,dc=wikimedia,dc=org"
+
+        List Example:
+
+        .. code-block::
+
+            [
+                "uid={username},ou=people,dc=wikimedia,dc=org",
+                "uid={username},ou=Developers,dc=wikimedia,dc=org"
+                ]
+    allowed_groups: list or None
+        List of LDAP group DNs that users could be members of to be granted access.
+
+        If a user is in any one of the listed groups, then that user is granted access.
+        Membership is tested by fetching info about each group and looking for the User's
+        dn to be a value of one of `member` or `uniqueMember`, *or* if the username being
+        used to log in with is value of the `uid`.
+
+        Set to an empty list or None to allow all users that have an LDAP account to log in,
+        without performing any group membership checks.
+    valid_username_regex: str
+        Regex for validating usernames - those that do not match this regex will be rejected.
+
+        This is primarily used as a measure against LDAP injection, which has fatal security
+        considerations. The default works for most LDAP installations, but some users might need
+        to modify it to fit their custom installs. If you are modifying it, be sure to understand
+        the implications of allowing additional characters in usernames and what that means for
+        LDAP injection issues. See https://www.owasp.org/index.php/LDAP_injection for an overview
+        of LDAP injection.
+    lookup_dn: boolean
+        Form user's DN by looking up an entry from directory
+
+        By default, LDAPAuthenticator finds the user's DN by using `bind_dn_template`.
+        However, in some installations, the user's DN does not contain the username, and
+        hence needs to be looked up. You can set this to True and then use ``user_search_base``
+        and ``user_attribute`` to accomplish this.
+    user_search_base: str
+        Base for looking up user accounts in the directory, if `lookup_dn` is set to True.
+
+        LDAPAuthenticator will search all objects matching under this base where the `user_attribute`
+        is set to the current username to form the userdn.
+
+        For example, if all users objects existed under the base ou=people,dc=wikimedia,dc=org, and
+        the username users use is set with the attribute `uid`, you can use the following config:
+
+        .. code-block::
+
+            c.LDAPAuthenticator.lookup_dn = True
+            c.LDAPAuthenticator.lookup_dn_search_filter = '({login_attr}={login})'
+            c.LDAPAuthenticator.lookup_dn_search_user = 'ldap_search_user_technical_account'
+            c.LDAPAuthenticator.lookup_dn_search_password = 'secret'
+            c.LDAPAuthenticator.user_search_base = 'ou=people,dc=wikimedia,dc=org'
+            c.LDAPAuthenticator.user_attribute = 'sAMAccountName'
+            c.LDAPAuthenticator.lookup_dn_user_dn_attribute = 'cn'
+            c.LDAPAuthenticator.bind_dn_template = '{username}'
+    user_attribute: str
+        Attribute containing user's name, if ``lookup_dn`` is set to True.
+
+        See ``user_search_base`` for info on how this attribute is used.
+
+        For most LDAP servers, this is uid.  For Active Directory, it is
+        sAMAccountName.
+    lookup_dn_search_filter: str or None
+        How to query LDAP for user name lookup, if ``lookup_dn`` is set to True.
+    lookup_dn_search_user: str or None
+        Technical account for user lookup, if ``lookup_dn`` is set to True.
+
+        If both lookup_dn_search_user and lookup_dn_search_password are None,
+        then anonymous LDAP query will be done.
+    lookup_dn_search_password: str or None
+        Technical account for user lookup, if ``lookup_dn`` is set to True.
+    lookup_dn_user_dn_attribute: str or None
+        Attribute containing user's name needed for  building DN string, if ``lookup_dn`` is set to True.
+
+        See ``user_search_base`` for info on how this attribute is used.
+
+        For most LDAP servers, this is username.  For Active Directory, it is cn.
+    escape_userdn: boolean
+        If set to True, escape special chars in userdn when authenticating in LDAP.
+
+        On some LDAP servers, when userdn contains chars like '(', ')', '\'
+        authentication may fail when those chars
+        are not escaped.
+    search_filter: str
+        LDAP3 Search Filter whose results are allowed access
+    attributes: list or None
+        List of attributes to be searched
+    auth_state_attributes: list or None
+        List of attributes to be returned in auth_state for a user
+    use_lookup_dn_username: boolean
+        If set to true uses the ``lookup_dn_user_dn_attribute`` attribute as username instead of
+        the supplied one.
+
+        This can be useful in an heterogeneous environment, when supplying a UNIX username
+        to authenticate against AD.
+
+    Examples
+    --------
+
+    Using the authenticator class (the code runs in ``asyncio`` loop):
+
+    .. code-block::
+
+        from bluesky_httpserver.authenticators import LDAPAuthenticator
+        authenticator = LDAPAuthenticator(
+            "localhost", 1389, bind_dn_template="cn={username},ou=users,dc=example,dc=org", use_tls=False
+        )
+        await authenticator.authenticate("user01", "password1")
+        await authenticator.authenticate("user02", "password2")
+
+
+    Simple example of a config file (e.g. ``config_ldap.yml``):
+
+    .. code-block::
+
+        uvicorn:
+            host: localhost
+            port: 60610
+        authentication:
+            providers:
+                - provider: ldap_local
+                authenticator: bluesky_httpserver.authenticators:LDAPAuthenticator
+                args:
+                    server_address: localhost
+                    server_port: 1389
+                    bind_dn_template: "cn={username},ou=users,dc=example,dc=org"
+                    use_tls: false
+                    use_ssl: false
+            tiled_admins:
+                - provider: ldap_local
+                id: user02
+    """
+
+    mode = Mode.password
+
+    def __init__(
+        self,
+        server_address,
+        server_port=None,
+        *,
+        use_ssl=False,
+        use_tls=True,
+        bind_dn_template=None,
+        allowed_groups=None,
+        valid_username_regex=r"^[a-z][.a-z0-9_-]*$",
+        lookup_dn=False,
+        user_search_base=None,
+        user_attribute=None,
+        lookup_dn_search_filter="({login_attr}={login})",
+        lookup_dn_search_user=None,
+        lookup_dn_search_password=None,
+        lookup_dn_user_dn_attribute=None,
+        escape_userdn=False,
+        search_filter="",
+        attributes=None,
+        auth_state_attributes=None,
+        use_lookup_dn_username=True,
+    ):
+        self.use_ssl = use_ssl
+        self.use_tls = use_tls
+        self.bind_dn_template = bind_dn_template
+        self.allowed_groups = allowed_groups
+        self.valid_username_regex = valid_username_regex
+        self.lookup_dn = lookup_dn
+        self.user_search_base = user_search_base
+        self.user_attribute = user_attribute
+        self.lookup_dn_search_filter = lookup_dn_search_filter
+        self.lookup_dn_search_user = lookup_dn_search_user
+        self.lookup_dn_search_password = lookup_dn_search_password
+        self.lookup_dn_user_dn_attribute = lookup_dn_user_dn_attribute
+        self.escape_userdn = escape_userdn
+        self.search_filter = search_filter
+        self.attributes = attributes if attributes else []
+        self.auth_state_attributes = auth_state_attributes if auth_state_attributes else []
+        self.use_lookup_dn_username = use_lookup_dn_username
+
+        self.server_address = server_address
+        self.server_port = server_port if server_port is not None else self._server_port_default()
+
+    def _server_port_default(self):
+        if self.use_ssl:
+            return 636  # default SSL port for LDAP
+        else:
+            return 389  # default plaintext port for LDAP
+
+    def resolve_username(self, username_supplied_by_user):
+        search_dn = self.lookup_dn_search_user
+        if self.escape_userdn:
+            search_dn = escape_filter_chars(search_dn)
+        conn = self.get_connection(userdn=search_dn, password=self.lookup_dn_search_password)
+        is_bound = conn.bind()
+        if not is_bound:
+            msg = "Failed to connect to LDAP server with search user '{search_dn}'"
+            self.log.warning(msg.format(search_dn=search_dn))
+            return (None, None)
+
+        search_filter = self.lookup_dn_search_filter.format(
+            login_attr=self.user_attribute, login=username_supplied_by_user
+        )
+        msg = "\n".join(
+            [
+                "Looking up user with:",
+                "    search_base = '{search_base}'",
+                "    search_filter = '{search_filter}'",
+                "    attributes = '{attributes}'",
+            ]
+        )
+        logger.debug(
+            msg.format(
+                search_base=self.user_search_base,
+                search_filter=search_filter,
+                attributes=self.user_attribute,
+            )
+        )
+        conn.search(
+            search_base=self.user_search_base,
+            search_scope=ldap3.SUBTREE,
+            search_filter=search_filter,
+            attributes=[self.lookup_dn_user_dn_attribute],
+        )
+        response = conn.response
+        if len(response) == 0 or "attributes" not in response[0].keys():
+            msg = "No entry found for user '{username}' " "when looking up attribute '{attribute}'"
+            logger.warning(msg.format(username=username_supplied_by_user, attribute=self.user_attribute))
+            return (None, None)
+
+        user_dn = response[0]["attributes"][self.lookup_dn_user_dn_attribute]
+        if isinstance(user_dn, list):
+            if len(user_dn) == 0:
+                return (None, None)
+            elif len(user_dn) == 1:
+                user_dn = user_dn[0]
+            else:
+                msg = (
+                    "A lookup of the username '{username}' returned a list "
+                    "of entries for the attribute '{attribute}'. Only the "
+                    "first among these ('{first_entry}') was used. The other "
+                    "entries ({other_entries}) were ignored."
+                )
+                logger.warning(
+                    msg.format(
+                        username=username_supplied_by_user,
+                        attribute=self.lookup_dn_user_dn_attribute,
+                        first_entry=user_dn[0],
+                        other_entries=", ".join(user_dn[1:]),
+                    )
+                )
+                user_dn = user_dn[0]
+
+        return (user_dn, response[0]["dn"])
+
+    def get_connection(self, userdn, password):
+        server = ldap3.Server(self.server_address, port=self.server_port, use_ssl=self.use_ssl)
+        auto_bind_no_ssl = ldap3.AUTO_BIND_TLS_BEFORE_BIND if self.use_tls else ldap3.AUTO_BIND_NO_TLS
+        auto_bind = ldap3.AUTO_BIND_NO_TLS if self.use_ssl else auto_bind_no_ssl
+        conn = ldap3.Connection(server, user=userdn, password=password, auto_bind=auto_bind)
+        return conn
+
+    def get_user_attributes(self, conn, userdn):
+        attrs = {}
+        if self.auth_state_attributes:
+            found = conn.search(userdn, "(objectClass=*)", attributes=self.auth_state_attributes)
+            if found:
+                attrs = conn.entries[0].entry_attributes_as_dict
+        return attrs
+
+    async def authenticate(self, username: str, password: str):
+
+        username_saved = username  # Save the user name passed as a parameter
+
+        # Protect against invalid usernames as well as LDAP injection attacks
+        if not re.match(self.valid_username_regex, username):
+            logger.warning(
+                "username:%s Illegal characters in username, must match regex %s",
+                username,
+                self.valid_username_regex,
+            )
+            return None
+
+        # No empty passwords!
+        if password is None or password.strip() == "":
+            logger.warning("username:%s Login denied for blank password", username)
+            return None
+
+        # bind_dn_template should be of type List[str]
+        bind_dn_template = self.bind_dn_template
+        if isinstance(bind_dn_template, str):
+            bind_dn_template = [bind_dn_template]
+
+        # sanity check
+        if not self.lookup_dn and not bind_dn_template:
+            logger.warning("Login not allowed, please configure 'lookup_dn' or 'bind_dn_template'.")
+            return None
+
+        if self.lookup_dn:
+            username, resolved_dn = self.resolve_username(username)
+            if not username:
+                return None
+            if str(self.lookup_dn_user_dn_attribute).upper() == "CN":
+                # Only escape commas if the lookup attribute is CN
+                username = re.subn(r"([^\\]),", r"\1\,", username)[0]
+            if not bind_dn_template:
+                bind_dn_template = [resolved_dn]
+
+        is_bound = False
+        for dn in bind_dn_template:
+            if not dn:
+                logger.warning("Ignoring blank 'bind_dn_template' entry!")
+                continue
+            userdn = dn.format(username=username)
+            if self.escape_userdn:
+                userdn = escape_filter_chars(userdn)
+            msg = "Attempting to bind {username} with {userdn}"
+            logger.debug(msg.format(username=username, userdn=userdn))
+            msg = "Status of user bind {username} with {userdn} : {is_bound}"
+            try:
+                conn = self.get_connection(userdn, password)
+            except ldap3.core.exceptions.LDAPBindError as exc:
+                is_bound = False
+                msg += "\n{exc_type}: {exc_msg}".format(
+                    exc_type=exc.__class__.__name__,
+                    exc_msg=exc.args[0] if exc.args else "",
+                )
+            else:
+                is_bound = True if conn.bound else conn.bind()
+            msg = msg.format(username=username, userdn=userdn, is_bound=is_bound)
+            logger.debug(msg)
+            if is_bound:
+                break
+
+        if not is_bound:
+            msg = "Invalid password for user '{username}'"
+            logger.warning(msg.format(username=username))
+            return None
+
+        if self.search_filter:
+            search_filter = self.search_filter.format(userattr=self.user_attribute, username=username)
+            conn.search(
+                search_base=self.user_search_base,
+                search_scope=ldap3.SUBTREE,
+                search_filter=search_filter,
+                attributes=self.attributes,
+            )
+            n_users = len(conn.response)
+            if n_users == 0:
+                msg = "User with '{userattr}={username}' not found in directory"
+                logger.warning(msg.format(userattr=self.user_attribute, username=username))
+                return None
+            if n_users > 1:
+                msg = "Duplicate users found! " "{n_users} users found with '{userattr}={username}'"
+                logger.warning(msg.format(userattr=self.user_attribute, username=username, n_users=n_users))
+                return None
+
+        if self.allowed_groups:
+            logger.debug("username:%s Using dn %s", username, userdn)
+            found = False
+            for group in self.allowed_groups:
+                group_filter = "(|" "(member={userdn})" "(uniqueMember={userdn})" "(memberUid={uid})" ")"
+                group_filter = group_filter.format(userdn=userdn, uid=username)
+                group_attributes = ["member", "uniqueMember", "memberUid"]
+                found = conn.search(
+                    group,
+                    search_scope=ldap3.BASE,
+                    search_filter=group_filter,
+                    attributes=group_attributes,
+                )
+                if found:
+                    break
+            if not found:
+                # If we reach here, then none of the groups matched
+                msg = "username:{username} User not in any of the allowed groups"
+                logger.warning(msg.format(username=username))
+                return None
+
+        if not self.use_lookup_dn_username:
+            username = username_saved
+
+        user_info = self.get_user_attributes(conn, userdn)
+        if user_info:
+            logger.debug("username:%s attributes:%s", username, user_info)
+            return {"name": username, "auth_state": user_info}
+        return username

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -536,6 +536,10 @@ class LDAPAuthenticator:
         auth_state_attributes=None,
         use_lookup_dn_username=True,
     ):
+        if not modules_available("ldap3"):
+            raise ModuleNotFoundError(
+                "This LDAPAuthenticator requires the module 'ldap3' to be installed."
+            )
         self.use_ssl = use_ssl
         self.use_tls = use_tls
         self.bind_dn_template = bind_dn_template
@@ -568,6 +572,9 @@ class LDAPAuthenticator:
             return 389  # default plaintext port for LDAP
 
     def resolve_username(self, username_supplied_by_user):
+        import ldap3
+        from ldap3.utils.conv import escape_filter_chars
+
         search_dn = self.lookup_dn_search_user
         if self.escape_userdn:
             search_dn = escape_filter_chars(search_dn)
@@ -643,6 +650,8 @@ class LDAPAuthenticator:
         return (user_dn, response[0]["dn"])
 
     def get_connection(self, userdn, password):
+        import ldap3
+
         server = ldap3.Server(
             self.server_address, port=self.server_port, use_ssl=self.use_ssl
         )
@@ -666,6 +675,8 @@ class LDAPAuthenticator:
         return attrs
 
     async def authenticate(self, username: str, password: str):
+        import ldap3
+        from ldap3.utils.conv import escape_filter_chars
 
         username_saved = username  # Save the user name passed as a parameter
 

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -1,5 +1,3 @@
-import ldap3
-from ldap3.utils.conv import escape_filter_chars
 import logging
 import re
 import secrets


### PR DESCRIPTION
Implementation of LDAP authenticator. The authenticator could be configured in .yml file as

```
authentication:
    providers:
        - provider: ldap_local 
          authenticator: tiled.authenticators:LDAPAuthenticator
          args:
              server_address: localhost
              server_port: 1389
              bind_dn_template: "cn={username},ou=users,dc=example,dc=org"
              use_tls: false
              use_ssl: false
    tiled_admins:
        - provider: ldap_local 
          id: user02
```
