### PR TITLE
Fix write dataframe path.

### DIFF
--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -659,7 +659,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         uid = document["uid"]
 
         full_path_data = (
-            "/dataframe/full"
+            "/node/full"
             + "".join(f"/{part}" for part in self.context.path_parts)
             + "".join(f"/{part}" for part in self._path)
             + "/"


### PR DESCRIPTION
As @kleinhenz pointed out, this should be `PUT /node/full` to match the `GET /node/full` route.

We _formerly_ had `GET /dataframe/full` and I had momentarily forgotten about the shift in our thinking on this.