### PR TITLE
update client writing methods

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -532,14 +532,14 @@ Set an api_key as in:
                 "accept": "application/x-msgpack",
             },
         )
-        response = self._client.send(request)
+        response = self._send(request)
         handle_error(response)
         return msgpack.unpackb(
             response.content,
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
-    def put_content(self, path, content, headers=None, **kwargs):
+    def put_content(self, path, content, headers=None):
         # Submit CSRF token in both header and cookie.
         # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
         headers = headers or {}
@@ -551,7 +551,7 @@ Set an api_key as in:
             content=content,
             headers=headers,
         )
-        response = self._client.send(request)
+        response = self._send(request)
         handle_error(response)
         return msgpack.unpackb(
             response.content,

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -558,6 +558,25 @@ Set an api_key as in:
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
+    def delete_content(self, path, content, headers=None):
+        # Submit CSRF token in both header and cookie.
+        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+        headers = headers or {}
+        headers.setdefault("x-csrf", self._client.cookies["tiled_csrf"])
+        headers.setdefault("accept", "application/x-msgpack")
+        request = self._client.build_request(
+            "DELETE",
+            path,
+            content=None,
+            headers=headers,
+        )
+        response = self._send(request)
+        handle_error(response)
+        return msgpack.unpackb(
+            response.content,
+            timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
+        )
+
     def _send(self, request, stream=False, attempts=0):
         """
         If sending results in an authentication error, reauthenticate.

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -592,20 +592,22 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             + "".join(f"/{part}" for part in (self._path or [""]))
         )
         document = self.context.post_json(full_path_meta, data)
-        uid = document["uid"]
+        key = document["key"]
 
         full_path_data = (
             "/array/full"
             + "".join(f"/{part}" for part in self.context.path_parts)
             + "".join(f"/{part}" for part in self._path)
             + "/"
-            + uid
+            + key
         )
         self.context.put_content(
             full_path_data,
             content=array.tobytes(),
             headers={"Content-Type": "application/octet-stream"},
         )
+
+        return key
 
     def write_dataframe(self, dataframe, metadata=None, specs=None):
         """
@@ -660,20 +662,22 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             + "".join(f"/{part}" for part in (self._path or [""]))
         )
         document = self.context.post_json(full_path_meta, data)
-        uid = document["uid"]
+        key = document["key"]
 
         full_path_data = (
             "/node/full"
             + "".join(f"/{part}" for part in self.context.path_parts)
             + "".join(f"/{part}" for part in self._path)
             + "/"
-            + uid
+            + key
         )
         self.context.put_content(
             full_path_data,
             content=bytes(serialize_arrow(dataframe, {})),
             headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
         )
+
+        return key
 
 
 def _queries_to_params(*queries):

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -358,6 +358,19 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         (item,) = data
         return self.client_for_item(item, path=self._path + (item["id"],))
 
+    def __delitem__(self, key):
+        self._cached_len = None
+
+        path = (
+            "/node/delete/"
+            + "".join(f"/{part}" for part in self.context.path_parts)
+            + "".join(f"/{part}" for part in self._path)
+            + "/"
+            + key
+        )
+
+        self.context.delete_content(path, None)
+
     def items(self):
         # The base implementation would use __iter__ and __getitem__, making
         # one HTTP request per item. Pull pages instead.


### PR DESCRIPTION
1. Rename "uid" to "key" to be slightly more generic and match usage elsewhere in tiled
2. Return the key for the newly created object in the client methods. This makes it so that you can do
```
k = c.create_array(...)
array_client = c[k]
...
del c[k]
```
This is useful for keeping track of what has been inserted especially when the keys are uids generated by the server.
Another option would be to return the node itself but returning the key is simpler and doesn't require talking to the server again (I don't think we can assume that what we get back from the server matches exactly what is submitted since the server may choose to add additional metadata).

3. Use client.context._send for `post_metadata` and `put_content` so that we revalidate if necessary
4. Add `delete_content` method to context
5. Add `__delitem__` method to node