### PR TITLE
Raise clear error with 'and' or 'or'.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ release = tiled.__version__
 #
 # This is also used if you do content translation via gettext trees.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/reference/queries.md
+++ b/docs/source/reference/queries.md
@@ -43,7 +43,7 @@ c.search(...).search(...).search(...)
 
 ````{warning}
 
-**You cannot use queries with the Python keywords `and` or `or`.**
+**You cannot use queries with the Python keywords `not`, `and`, or `or`.**
 
 In Python, `and` and `or` have a particular behavior:
 
@@ -57,8 +57,10 @@ In Python, `and` and `or` have a particular behavior:
 
 which would result in the first or last query being used, respectively,
 ignoring all others. This is an unavoidable consequence of Python semantics.
+Likewise, `not X` must return `True` or `False`; it cannot return a query.
+
 To avoid confusion, Tiled raises a `TypeError` if you attempt to use
-a query with `and` or `or`.
+a query with `not`, `and`, or `or`.
 
 ````
 

--- a/docs/source/reference/queries.md
+++ b/docs/source/reference/queries.md
@@ -43,7 +43,7 @@ c.search(...).search(...).search(...)
 
 ````{warning}
 
-**Do not use queries with the Python keywords `and` or `or`.**
+**You cannot use queries with the Python keywords `and` or `or`.**
 
 In Python, `and` and `or` have a particular behavior:
 
@@ -56,8 +56,9 @@ In Python, `and` and `or` have a particular behavior:
 ```
 
 which would result in the first or last query being used, respectively,
-ignoring all others. This is an unavoidable consequence of Python semantics,
-so you just have to know not to mix queries with `and` and `or`.
+ignoring all others. This is an unavoidable consequence of Python semantics.
+To avoid confusion, Tiled raises a `TypeError` if you attempt to use
+a query with `and` or `or`.
 
 ````
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -80,7 +80,9 @@ def test_regex():
     assert list(client.search(Regex("letters", "anything"))) == []
 
 
-def test_and_and_or():
+def test_not_and_and_or():
+    with pytest.raises(TypeError):
+        not (Key("color") == "red")
     with pytest.raises(TypeError):
         (Key("color") == "red") and (Key("sample") == "Ni")
     with pytest.raises(TypeError):

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -1,6 +1,7 @@
 import string
 
 import numpy
+import pytest
 
 from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter
@@ -77,3 +78,10 @@ def test_regex():
     assert list(client.search(Regex("letter", "[a-c]"))) == ["a", "b", "c"]
     # Check that if the key is not a string it is ignored.
     assert list(client.search(Regex("letters", "anything"))) == []
+
+
+def test_and_and_or():
+    with pytest.raises(TypeError):
+        (Key("color") == "red") and (Key("sample") == "Ni")
+    with pytest.raises(TypeError):
+        (Key("color") == "red") or (Key("sample") == "Ni")

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -15,9 +15,23 @@ from .query_registration import register
 JSONSerializable = Any  # Feel free to refine this.
 
 
+class NoBool:
+    def __bool__(self):
+        raise TypeError(
+            """Queries are not "truth-y" or "false-y". They must be passed to search().
+
+You may be seeing this error message because you tried to use a tiled query
+with the Python keywords `and` or `or`. This does not (cannot) work.
+To compose queries, chain search calls like:
+
+    c.search(...).search(...).search(...)
+"""
+        )
+
+
 @register(name="fulltext")
 @dataclass
-class FullText:
+class FullText(NoBool):
     """
     Search the full text of all metadata values for word matches.
 
@@ -48,7 +62,7 @@ class FullText:
 
 @register(name="lookup")
 @dataclass
-class KeyLookup:
+class KeyLookup(NoBool):
     """
     Match a specific Entry by key. Mostly for internal use.
 
@@ -77,7 +91,7 @@ class KeyLookup:
 
 @register(name="regex")
 @dataclass
-class Regex:
+class Regex(NoBool):
     """
     Match a key's value to a regular expression.
 
@@ -121,7 +135,7 @@ class Regex:
 
 @register(name="eq")
 @dataclass
-class Eq:
+class Eq(NoBool):
     """
     Query equality of a given key's value to the specified value.
 
@@ -162,7 +176,7 @@ class Operator(str, enum.Enum):
 
 @register(name="comparison")
 @dataclass
-class Comparison:
+class Comparison(NoBool):
     """
     Query binary comparison between given key's value to the specified value.
 
@@ -207,7 +221,7 @@ class Comparison:
 
 @register(name="contains")
 @dataclass
-class Contains:
+class Contains(NoBool):
     """
     Query where a given key's value contains the specified value.
 


### PR DESCRIPTION
As noted in #227 queries cannot be made to work with the Python keywords `and` and `or`. Currently, they just silently ignore all but for the first or last query. We documented that, but it still seems likely to cause user confusion, silently giving them an answer to a different question than the one they meant to ask.

There is no hook for `and` or `or` specifically, but we can hook `bool` to ensure that attempts to use `and` or `or` raise an error:

```py
In [1]: from tiled.queries import Key

In [2]: Key("color") == "red"
Out[2]: Eq(key='color', value='red')

In [3]: (Key("color") == "red") and (Key("sample") == "Ni")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-b3c7952f4b70> in <module>
----> 1 (Key("color") == "red") and (Key("sample") == "Ni")

~/Repos/bnl/tiled/tiled/queries.py in __bool__(self)
     18 class NoBool:
     19     def __bool__(self):
---> 20         raise TypeError(
     21             """Queries are not "truth-y" or "false-y". They must be passed to search().
     22 

TypeError: Queries are not "truth-y" or "false-y". They must be passed to search().

You may be seeing this error message because you tried to use a tiled query
with the Python keywords `and` or `or`. This does not (cannot) work.
To compose queries, chain search calls like:

    c.search(...).search(...).search(...)
```