### PR TITLE
Set up recursive model correctly.

### DIFF
--- a/tiled/server/pydantic_array.py
+++ b/tiled/server/pydantic_array.py
@@ -236,6 +236,9 @@ class StructDtype(BaseModel):
         )
 
 
+Field.update_forward_refs()
+
+
 class ArrayStructure(BaseModel):
     macro: ArrayMacroStructure
     micro: Union[BuiltinDtype, StructDtype]


### PR DESCRIPTION
When we use `tiled.server.pydantic_array` to any annotation on a route (such as in #220) it OpenAPI documentation-generation code raises an error.

Specifically, we end up here:

```
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/site-packages/fastapi/utils.py", line 28, in get_model_definitions
    m_schema, m_definitions, m_nested_models = model_process_schema(
  File "pydantic/schema.py", line 590, in pydantic.schema.model_process_schema
  File "pydantic/schema.py", line 631, in pydantic.schema.model_type_schema
  File "pydantic/schema.py", line 258, in pydantic.schema.field_schema
  File "pydantic/schema.py", line 536, in pydantic.schema.field_type_schema
  File "pydantic/schema.py", line 858, in pydantic.schema.field_singleton_schema
  File "pydantic/schema.py", line 753, in pydantic.schema.field_singleton_sub_fields_schema
  File "pydantic/schema.py", line 536, in pydantic.schema.field_type_schema
  File "pydantic/schema.py", line 935, in pydantic.schema.field_singleton_schema
  File "pydantic/schema.py", line 590, in pydantic.schema.model_process_schema
  File "pydantic/schema.py", line 631, in pydantic.schema.model_type_schema
  File "pydantic/schema.py", line 258, in pydantic.schema.field_schema
  File "pydantic/schema.py", line 471, in pydantic.schema.field_type_schema
  File "pydantic/schema.py", line 935, in pydantic.schema.field_singleton_schema
  File "pydantic/schema.py", line 590, in pydantic.schema.model_process_schema
  File "pydantic/schema.py", line 631, in pydantic.schema.model_type_schema
  File "pydantic/schema.py", line 258, in pydantic.schema.field_schema
  File "pydantic/schema.py", line 536, in pydantic.schema.field_type_schema
  File "pydantic/schema.py", line 858, in pydantic.schema.field_singleton_schema
  File "pydantic/schema.py", line 753, in pydantic.schema.field_singleton_sub_fields_schema
  File "pydantic/schema.py", line 536, in pydantic.schema.field_type_schema
  File "pydantic/schema.py", line 932, in pydantic.schema.field_singleton_schema
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/abc.py", line 102, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

Inserting a `breakpoint()` there I find:

```
100  	        def __subclasscheck__(cls, subclass):
101  	            """Override for issubclass(subclass, cls)."""
102  	            try:
103  	                return _abc_subclasscheck(cls, subclass)
104  	            except Exception:
105  ->	                breakpoint()
106  	
107  	        def _dump_registry(cls, file=None):
108  	            """Debug helper to print the ABC registry."""
109  	            print(f"Class: {cls.__module__}.{cls.__qualname__}", file=file)
110  	            print(f"Inv. counter: {get_cache_token()}", file=file)
(Pdb) p cls
<class 'pydantic.main.BaseModel'>
(Pdb) p subclass
ForwardRef('StructDtype')
```

Evidently, a [pydantic `ForwardRef`](https://pydantic-docs.helpmanual.io/usage/postponed_annotations/) is ending up in here. It needs to be "resolved" to the thing that it references. This PR adds the necessary code to do that, per the documentation.