### PR TITLE
Change Regex to be case sensitive by default.

### DIFF
--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -102,7 +102,9 @@ class Regex(NoBool):
     pattern : str
         regular expression
     case_sensitive : bool, optional
-        Default False (case-insensitive).
+        Default True (case-sensitive).
+        Note that this is the opposite of the default for FullText;
+        regex users generally expect case sensitivity by default.
 
     Examples
     --------
@@ -114,7 +116,7 @@ class Regex(NoBool):
 
     key: str
     pattern: str
-    case_sensitive: bool = False
+    case_sensitive: bool = True
 
     def encode(self):
         return {
@@ -124,7 +126,7 @@ class Regex(NoBool):
         }
 
     @classmethod
-    def decode(cls, *, key, pattern, case_sensitive=False):
+    def decode(cls, *, key, pattern, case_sensitive=True):
         # Note: FastAPI decodes case_sensitive into a boolean for us.
         return cls(
             key=key,


### PR DESCRIPTION
The `FullText` query is _not_ case sensitive by default. I think this is important: with a naive "Google search" mentality users don't expect case sensitivity.

What to do with `Regex`? At first I thought consistency with `FullText` was best, but I have reconsidered. `Regex` is for people who know regex, and I think they would bring more of a programmer's sensibility, likely assuming that Tiled regex, like most (all?) regex _is_ case sensitive by default.