### PR TITLE
Add configuration-checking CLI utility

### DIFF
--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -43,12 +43,13 @@ def initialize_database(database_uri: str):
     except UninitializedDatabase:
         # Create tables and stamp (alembic) revision.
         typer.echo(
-            f"Database {redacted_url} is new. Creating tables and marking revision {REQUIRED_REVISION}."
+            f"Database {redacted_url} is new. Creating tables and marking revision {REQUIRED_REVISION}.",
+            err=True,
         )
         initialize_database(engine)
-        typer.echo("Database initialized.")
+        typer.echo("Database initialized.", err=True)
     else:
-        typer.echo(f"Database at {redacted_url} is already initialized.")
+        typer.echo(f"Database at {redacted_url} is already initialized.", err=True)
         raise typer.Abort()
 
 
@@ -73,7 +74,8 @@ def upgrade_database(
     if current_revision is None:
         # Create tables and stamp (alembic) revision.
         typer.echo(
-            f"Database {redacted_url} has not been initialized. Use `tiled admin initialize-database`."
+            f"Database {redacted_url} has not been initialized. Use `tiled admin initialize-database`.",
+            err=True,
         )
         raise typer.Abort()
     upgrade(engine, revision or "head")
@@ -130,7 +132,7 @@ def login(
         )
     except (ValueError, ClientError) as err:
         (msg,) = err.args
-        typer.echo(msg)
+        typer.echo(msg, err=True)
         raise typer.Abort()
     if show_secret_tokens:
         from pprint import pformat
@@ -205,7 +207,7 @@ def list_api_keys(
     client = _client_from_uri_or_profile(uri_or_profile, no_verify=no_verify)
     info = client.context.whoami()
     if not info["api_keys"]:
-        typer.echo("No API keys found")
+        typer.echo("No API keys found", err=True)
         return
     max_note_len = max(len(api_key["note"] or "") for api_key in info["api_keys"])
     COLUMNS = f"First 8   Expires at (UTC)     Latest activity      Note{' ' * (max_note_len - 4)}  Scopes"
@@ -363,7 +365,8 @@ def profile_show(profile_name: str):
     except KeyError:
         typer.echo(
             f"The profile {profile_name!r} could not be found. "
-            "Use tiled profile list to see profile names."
+            "Use tiled profile list to see profile names.",
+            err=True,
         )
         raise typer.Abort()
     print(f"Source: {filepath}", file=sys.stderr)
@@ -517,7 +520,7 @@ def serve_config(
     try:
         parsed_config = parse_configs(config_path)
     except Exception as err:
-        typer.echo(str(err))
+        typer.echo(str(err), err=True)
         raise typer.Abort()
 
     # Let --public flag override config.
@@ -576,7 +579,8 @@ def _client_from_uri_or_profile(
             f"Not sure what to do with tree {uri_or_profile!r}. "
             "It does not look like a URI (it does not start with http[s]://) "
             "and it does not match any profiles. Use `tiled profiles list` to "
-            "see profiles."
+            "see profiles.",
+            err=True,
         )
         raise typer.Abort()
 


### PR DESCRIPTION
This will make it possible to catch configuration errors in CI/CD pipelines before they are deployed. Inspired by `nginx -t`.

Tested on a working configuration file and on a broken one:

```
$ tiled admin check-config ~/tiled_configs/broken.yml 
ValidationError while parsing configuration file /home/dallan/tiled_configs/broken.yml: Additional properties are not allowed ('catalogs', 'stuff' were unexpected)

$ tiled admin check-config ~/tiled_configs/bmm_direct.yml 
No errors found in configuration.
```

It properly writes to the `stderr` (I updated the other CLIs to do this also, in a separate commit). It returns exit code 1 if the configuration is broken.