### PR TITLE
Give nicer error when typer is missing.

### DIFF
--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -1,7 +1,27 @@
 from pathlib import Path
 from typing import List, Optional
 
-import typer
+try:
+    import typer
+except Exception as err:
+    raise Exception(
+        """
+
+You trying to the run the tiled commandline tool but you do not have the
+necessary dependencies. It looks like tiled has been installed with
+bare-minimum dependencies, possibly via
+
+    pip install tiled
+
+Instead, try:
+
+    pip install tiled[all]  # Note: on a Mac, you may need quotes like 'tiled[all]'.
+
+which installs *everything* you might want. For other options, see:
+
+    https://blueskyproject.io/tiled/tutorials/installation.html
+"""
+    ) from err
 
 cli_app = typer.Typer()
 serve_app = typer.Typer()


### PR DESCRIPTION
If a user does `pip install tiled` without any selectors (e.g. `tiled[client]`, `tiled[server]`, `tiled[all]`) they get a bare-bones installation that doesn't even support the CLI tool.

The CLI tool carries a handful of dependencies that I really don't want to force onto users running (for example) HPC jobs, so I think it's correct that we don't support it in the base installation. But we should fail more gracefully. This PR does the following:

```
$ tiled --help
Traceback (most recent call last):
  File "/home/dallan/Repos/bnl/tiled/tiled/commandline/main.py", line 5, in <module>
    import typer
ModuleNotFoundError: No module named 'typer'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dallan/miniconda3/envs/py38/bin/tiled", line 33, in <module>
    sys.exit(load_entry_point('tiled', 'console_scripts', 'tiled')())
  File "/home/dallan/miniconda3/envs/py38/bin/tiled", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/home/dallan/miniconda3/envs/py38/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/dallan/Repos/bnl/tiled/tiled/commandline/main.py", line 7, in <module>
    raise Exception(
Exception: 

You trying to the run the tiled commandline tool but you do not have the
necessary dependencies. It looks like tiled has been installed with
bare-minimum dependencies, possibly via

    pip install tiled

Instead, try:

    pip install tiled[all]  # Note: on a Mac, you may need quotes like 'tiled[all]'.

which installs *everything* you might want. For other options, see:

    https://blueskyproject.io/tiled/tutorials/installation.html

```