### PR TITLE
Make 'timeout' configurable, and raise defaults.

### DIFF
--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -1,0 +1,13 @@
+import httpx
+
+from ..adapters.mapping import MapAdapter
+from ..client import from_tree
+
+tree = MapAdapter({})
+
+
+def test_configurable_timeout():
+    c = from_tree(tree)
+    assert c.context._client.timeout.connect != 17
+    c = from_tree(tree, timeout=httpx.Timeout(17))
+    assert c.context._client.timeout.connect == 17

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -17,6 +17,7 @@ from .cache import Revalidate
 from .utils import (
     ASYNC_EVENT_HOOKS,
     DEFAULT_ACCEPTED_ENCODINGS,
+    DEFAULT_TIMEOUT_PARAMS,
     NotAvailableOffline,
     handle_error,
 )
@@ -830,6 +831,7 @@ def context_from_tree(
     auth_provider=None,
     api_key=None,
     headers=None,
+    timeout=None,
 ):
     from ..server.app import build_app
 
@@ -872,6 +874,9 @@ def context_from_tree(
         # startup.
         await app.router.startup()
 
+    if timeout is None:
+        timeout = httpx.Timeout(**DEFAULT_TIMEOUT_PARAMS)
+
     client = AsyncClientBridge(
         base_url="http://local-tiled-app/api/",
         params=params,
@@ -879,7 +884,7 @@ def context_from_tree(
         _startup_hook=startup,
         event_hooks=ASYNC_EVENT_HOOKS,
         headers=headers,
-        timeout=httpx.Timeout(5.0, read=20.0),
+        timeout=timeout,
     )
     # Block for application startup.
     try:

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -283,3 +283,14 @@ def client_for_item(context, structure_clients, item, path):
         path=path,
         structure_clients=structure_clients,
     )
+
+
+# These timeouts are really high, but in practice we find that
+# ~100 MB chunks over very slow home Internet connections
+# can bump into lower timeouts.
+DEFAULT_TIMEOUT_PARAMS = {
+    "connect": 5.0,
+    "read": 30.0,
+    "write": 30.0,
+    "pool": 5.0,
+}

--- a/tiled/config_schemas/client_profiles.yml
+++ b/tiled/config_schemas/client_profiles.yml
@@ -152,6 +152,26 @@ properties:
           available_bytes:
             type: number
             description: Deprecated alias for "capacity"
+  timeout:
+    description: |
+      Configure timeouts for the HTTP client.
+
+      Tiled sets read and write timeouts very high (30 seconds) by default to
+      accommodate pulling ~100 MB chunks over a slow network connection.
+
+      Units are seconds.
+      For details see https://www.python-httpx.org/advanced/#timeout-configuration
+
+    type: object
+    properties:
+      connection:
+        type: number
+      read:
+        type: number
+      write:
+        type: number
+      pool:
+        type: number
   token_cache:
     type: string
     description: |


### PR DESCRIPTION
Users connecting over slow home Internet connections have sometimes bumped into our 20-second read timeout. It's rare, but it happens. This raises the read and write timeouts to 30 seconds. (Beyond that, we're likely to hit timeouts elsewhere in the networking stack, like nginx and gunicorn.)

It also makes all timeouts configurable, both from Python


```py
from_uri(..., timeout=httpx.Timeout(...)))
```

```yaml
nsls2:
  timeout:
    connect: 5
    read: 17
    write: 3
    pool: 5
```