### PR TITLE
Support updating metadata and accessing metadata revision history

### DIFF
--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -139,14 +139,15 @@ class BaseClient:
 
         self._cached_len = None
 
-        data = {  # noqa: F841
+        metadata = metadata or {}
+        specs = specs or []
+
+        data = {
             "metadata": metadata,
-            # "structure": asdict(structure),
-            # "structure_family": StructureFamily.dataframe,
             "specs": specs,
         }
 
-        full_path_meta = (  # noqa: F841
+        full_path_meta = (
             "/node/metadata"
             + "".join(f"/{part}" for part in self.context.path_parts)
             + "".join(f"/{part}" for part in (self._path or [""]))

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -121,6 +121,39 @@ class BaseClient:
         )
         return sorted(formats)
 
+    def update_metadata(self, metadata=None, specs=None):
+        """
+        EXPERIMENTAL: Update metadata.
+
+        This is subject to change or removal without notice
+
+        Parameters
+        ----------
+        metadata : dict, optional
+            User metadata. May be nested. Must contain only basic types
+            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        specs : List[str], optional
+            List of names that are used to label that the data and/or metadata
+            conform to some named standard specification.
+        """
+
+        self._cached_len = None
+
+        data = {  # noqa: F841
+            "metadata": metadata,
+            # "structure": asdict(structure),
+            # "structure_family": StructureFamily.dataframe,
+            "specs": specs,
+        }
+
+        full_path_meta = (  # noqa: F841
+            "/node/metadata"
+            + "".join(f"/{part}" for part in self.context.path_parts)
+            + "".join(f"/{part}" for part in (self._path or [""]))
+        )
+
+        self.context.put_content(full_path_meta, content=data)
+
 
 class BaseStructureClient(BaseClient):
     def __init__(self, *args, structure=None, **kwargs):

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -52,7 +52,8 @@ class MetadataRevisions:
                 path, params={"page[offset]": offset, "page[limit]": limit}
             )
 
-            return content["data"]
+            (result,) = content["data"]
+            return result
 
         elif isinstance(item_, slice):
             offset = item_.start
@@ -237,11 +238,14 @@ class BaseClient:
         content = self.context.put_json(full_path_meta, data)
 
         if metadata is not None:
-            if len(content["metadata"]) > 0:
+            if "metadata" in content:
+                # Metadata was accepted and modified by the specs validator on the server side.
+                # It is updated locally using the new version.
                 self._item["attributes"]["metadata"] = content["metadata"]
-            elif len(content["metadata"]) == 0:
-                if len(metadata) > 0:
-                    self._item["attributes"]["metadata"] = metadata
+            else:
+                # Metadata was accepted as it si by the server.
+                # It is updated locally with the version submitted buy the client.
+                self._item["attributes"]["metadata"] = metadata
 
         if specs is not None:
             self._item["attributes"]["specs"] = specs

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -139,9 +139,6 @@ class BaseClient:
 
         self._cached_len = None
 
-        metadata = metadata or {}
-        specs = specs or []
-
         data = {
             "metadata": metadata,
             "specs": specs,

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -58,17 +58,16 @@ class MetadataRevisions:
             offset = item_.start
             if offset is None:
                 offset = 0
-
             if item_.stop is None:
                 params = f"?page[offset]={offset}"
             else:
                 limit = item_.stop - offset
-                params = f"page[offset]={offset}&page[limit]={limit}"
+                params = f"?page[offset]={offset}&page[limit]={limit}"
 
             next_page = path + params
             result = []
             while next_page is not None:
-                content = self.context.get_json(path)
+                content = self.context.get_json(next_page)
                 if len(result) == 0:
                     result = content.copy()
                 else:
@@ -235,7 +234,17 @@ class BaseClient:
             + "".join(f"/{part}" for part in (self._path or [""]))
         )
 
-        self.context.put_json(full_path_meta, data)
+        content = self.context.put_json(full_path_meta, data)
+
+        if metadata is not None:
+            if len(content["metadata"]) > 0:
+                self._item["attributes"]["metadata"] = content["metadata"]
+            elif len(content["metadata"]) == 0:
+                if len(metadata) > 0:
+                    self._item["attributes"]["metadata"] = metadata
+
+        if specs is not None:
+            self._item["attributes"]["specs"] = specs
 
     @property
     def metadata_revisions(self):

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -152,7 +152,7 @@ class BaseClient:
             + "".join(f"/{part}" for part in (self._path or [""]))
         )
 
-        self.context.put_content(full_path_meta, content=data)
+        self.context.put_json(full_path_meta, data)
 
 
 class BaseStructureClient(BaseClient):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -579,17 +579,14 @@ Set an api_key as in:
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
-    def delete_content(self, path, content, headers=None):
+    def delete_content(self, path, content, headers=None, params=None):
         # Submit CSRF token in both header and cookie.
         # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
         headers = headers or {}
         headers.setdefault("x-csrf", self._client.cookies["tiled_csrf"])
         headers.setdefault("accept", "application/x-msgpack")
         request = self._client.build_request(
-            "DELETE",
-            path,
-            content=None,
-            headers=headers,
+            "DELETE", path, content=None, headers=headers, params=params
         )
         response = self._send(request)
         handle_error(response)

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -540,6 +540,25 @@ Set an api_key as in:
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
+    def put_json(self, path, content):
+        request = self._client.build_request(
+            "PUT",
+            path,
+            json=content,
+            # Submit CSRF token in both header and cookie.
+            # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+            headers={
+                "x-csrf": self._client.cookies["tiled_csrf"],
+                "accept": "application/x-msgpack",
+            },
+        )
+        response = self._send(request)
+        handle_error(response)
+        return msgpack.unpackb(
+            response.content,
+            timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
+        )
+
     def put_content(self, path, content, headers=None, params=None):
         # Submit CSRF token in both header and cookie.
         # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -853,6 +853,37 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         return client
 
+    def update_metadata(self, metadata=None, specs=None):
+        """
+        EXPERIMENTAL: Update metadata.
+
+        This is subject to change or removal without notice
+
+        Parameters
+        ----------
+        metadata : dict, optional
+            User metadata. May be nested. Must contain only basic types
+            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        specs : List[str], optional
+            List of names that are used to label that the data and/or metadata
+            conform to some named standard specification.
+        """
+
+        self._cached_len = None
+
+        data = {  # noqa: F841
+            "metadata": metadata,
+            # "structure": asdict(structure),
+            # "structure_family": StructureFamily.dataframe,
+            "specs": specs,
+        }
+
+        full_path_meta = (  # noqa: F841
+            "/node/metadata"
+            + "".join(f"/{part}" for part in self.context.path_parts)
+            + "".join(f"/{part}" for part in (self._path or [""]))
+        )
+
 
 def _queries_to_params(*queries):
     "Compute GET params from the queries."

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -853,37 +853,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         return client
 
-    def update_metadata(self, metadata=None, specs=None):
-        """
-        EXPERIMENTAL: Update metadata.
-
-        This is subject to change or removal without notice
-
-        Parameters
-        ----------
-        metadata : dict, optional
-            User metadata. May be nested. Must contain only basic types
-            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
-        specs : List[str], optional
-            List of names that are used to label that the data and/or metadata
-            conform to some named standard specification.
-        """
-
-        self._cached_len = None
-
-        data = {  # noqa: F841
-            "metadata": metadata,
-            # "structure": asdict(structure),
-            # "structure_family": StructureFamily.dataframe,
-            "specs": specs,
-        }
-
-        full_path_meta = (  # noqa: F841
-            "/node/metadata"
-            + "".join(f"/{part}" for part in self.context.path_parts)
-            + "".join(f"/{part}" for part in (self._path or [""]))
-        )
-
 
 def _queries_to_params(*queries):
     "Compute GET params from the queries."

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -222,6 +222,35 @@ DEFAULT_MEDIA_TYPES = {
 }
 
 
+def construct_revisions_response(
+    entry,
+    route,
+    path,
+    offset,
+    limit,
+    media_type,
+):
+    path_parts = [segment for segment in path.split("/") if segment]
+    revisions = entry.revisions[offset:limit]
+    data = []
+    for revision in revisions:
+        item = {
+            "id": revision["key"],
+            "attributes": {
+                "metadata": revision["metadata"],
+                "specs": revision["specs"],
+                "updated_at": revision["updated_at"],
+                "revision": revision["revision"],
+            },
+        }
+        data.append(item)
+    count = len(entry.revisions)
+    links = pagination_links(
+        route, path_parts, offset, limit, count
+    )  # maybe reuse or maybe make a new pagination_revision_links
+    return schemas.Response(data=data, links=links, meta={"count": count})
+
+
 def construct_data_response(
     structure_family,
     serialization_registry,

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -231,7 +231,7 @@ def construct_revisions_response(
     media_type,
 ):
     path_parts = [segment for segment in path.split("/") if segment]
-    revisions = entry.revisions[offset:limit]
+    revisions = entry.revisions[offset : offset + limit]  # noqa: E203
     data = []
     for revision in revisions:
         item = {

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -235,12 +235,11 @@ def construct_revisions_response(
     data = []
     for revision in revisions:
         item = {
-            "id": revision["key"],
+            "revision": revision["revision"],
             "attributes": {
                 "metadata": revision["metadata"],
                 "specs": revision["specs"],
                 "updated_at": revision["updated_at"],
-                "revision": revision["revision"],
             },
         }
         data.append(item)

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -243,7 +243,7 @@ def construct_revisions_response(
             },
         }
         data.append(item)
-    count = len(entry.revisions)
+    count = len(data)
     links = pagination_links(
         route, path_parts, offset, limit, count
     )  # maybe reuse or maybe make a new pagination_revision_links

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -746,7 +746,10 @@ async def put_metadata(
     entry=Security(entry, scopes=["write:data", "write:metadata"]),
 ):
     if hasattr(entry, "put_metadata"):
-        entry.put_metadata()
+        entry.put_metadata(
+            metadata=body.metadata,
+            specs=body.specs,
+        )
     else:
         raise HTTPException(
             status_code=405, detail="This path does not support update of metadata."

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -738,5 +738,18 @@ async def put_dataframe_partition(
     else:
         raise HTTPException(
             status_code=405, detail="This path cannot accept dataframe data."
+
+
+@router.put("/node/metadata/{path:path}")
+async def put_metadata(
+    request: Request,
+    body: schemas.PutMetadataRequest,
+    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+):
+    if hasattr(entry, "put"):
+        entry.put_metadata()
+    else:
+        raise HTTPException(
+            status_code=405, detail="This path does not support update of metadata."
         )
     return json_or_msgpack(request, None)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -738,6 +738,7 @@ async def put_dataframe_partition(
         raise HTTPException(
             status_code=405, detail="This path cannot accept dataframe data."
         )
+    return json_or_msgpack(request, None)
 
 
 @router.put("/node/metadata/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -766,7 +766,7 @@ async def node_revisions(
     path: str,
     offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
     limit: Optional[int] = Query(
-        DEFAULT_PAGE_SIZE, alias="page[limit]", le=MAX_PAGE_SIZE
+        DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
     ),
     entry=Security(entry, scopes=["read:metadata"]),
 ):

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -682,7 +682,6 @@ async def put_array_full(
     entry=Security(entry, scopes=["write:data"]),
 ):
     data = await request.body()
-
     if hasattr(entry, "put_data"):
         entry.put_data(data)
     else:
@@ -746,7 +745,7 @@ async def put_metadata(
     body: schemas.PutMetadataRequest,
     entry=Security(entry, scopes=["write:data", "write:metadata"]),
 ):
-    if hasattr(entry, "put"):
+    if hasattr(entry, "put_metadata"):
         entry.put_metadata()
     else:
         raise HTTPException(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -737,6 +737,7 @@ async def put_dataframe_partition(
     else:
         raise HTTPException(
             status_code=405, detail="This path cannot accept dataframe data."
+        )
 
 
 @router.put("/node/metadata/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -745,7 +745,7 @@ async def put_dataframe_partition(
 async def put_metadata(
     request: Request,
     body: schemas.PutMetadataRequest,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:metadata"]),
 ):
     if hasattr(entry, "put_metadata"):
         entry.put_metadata(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -785,8 +785,6 @@ async def put_metadata(
         response_data = {"id": entry.key}
         if metadata_modified:
             response_data["metadata"] = metadata
-        else:
-            response_data["metadata"] = {}
         return json_or_msgpack(request, response_data)
 
     else:
@@ -828,5 +826,5 @@ async def revisions_delitem(
             detail="This path does not support a del request for revisions.",
         )
 
-    del entry.revisions[n]
+    entry.revisions.delete_revision(n)
     return json_or_msgpack(request, None)

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -307,4 +307,3 @@ class PutMetadataRequest(pydantic.BaseModel):
 
 
 NodeStructure.update_forward_refs()
-

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -302,3 +302,9 @@ class GetDistinctResponse(pydantic.BaseModel):
 
 
 NodeStructure.update_forward_refs()
+
+
+class PutMetadataRequest(pydantic.BaseModel):
+    metadata: Optional[Dict]
+    specs: Optional[List[str]]
+

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -301,10 +301,10 @@ class GetDistinctResponse(pydantic.BaseModel):
     specs: Optional[List[DistinctValueInfo]]
 
 
-NodeStructure.update_forward_refs()
-
-
 class PutMetadataRequest(pydantic.BaseModel):
     metadata: Optional[Dict]
     specs: Optional[List[str]]
+
+
+NodeStructure.update_forward_refs()
 


### PR DESCRIPTION
This PR supports the client and server features that are being tested alongside the experiments in https://github.com/bluesky/databroker/pull/716 which, by itself, allows the client to change the content of the `metadata` and `specs` of an existing sample