### PR TITLE
Handle HTML-formatted error responses

### DIFF
--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -27,11 +27,13 @@ def handle_error(response):
     except httpx.HTTPStatusError as exc:
         if response.status_code < 500:
             # Include more detail that httpx does by default.
-            message = (
-                f"{exc.response.status_code}: "
-                f"{exc.response.json()['detail'] if response.content else ''} "
-                f"{exc.request.url}"
-            )
+            if response.headers["Content-Type"] == "application/json":
+                detail = response.json().get("detail", "")
+            else:
+                # This can happen when we get an error from a proxy,
+                # such as a 502.
+                detail = ""
+            message = f"{exc.response.status_code}: " f"{detail} " f"{exc.request.url}"
             raise ClientError(message, exc.request, exc.response) from exc
         else:
             raise

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -31,8 +31,10 @@ def handle_error(response):
                 detail = response.json().get("detail", "")
             else:
                 # This can happen when we get an error from a proxy,
-                # such as a 502.
-                detail = ""
+                # such as a 502, which serves an HTML error page.
+                # Use the stock "reason phrase" for the error code
+                # instead of dumping HTML into the terminal.
+                detail = response.reason_phrase
             message = f"{exc.response.status_code}: " f"{detail} " f"{exc.request.url}"
             raise ClientError(message, exc.request, exc.response) from exc
         else:


### PR DESCRIPTION
When Tiled is served behind a proxy like nginx, sometimes the proxy will serve HTML-formatted error pages. This PR updates the client to handle that possibility.

Before:

```py
In [1]: from tiled.client import from_uri

In [2]: c = from_uri('https://tiled-staging.nsls2.bnl.gov/api')['lix']['sandbox']

In [3]: import numpy

In [4]: a = numpy.ones((10000, 10000))

In [5]: c.write_array(a)
<snipped>
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After:

```py
In [1]: from tiled.client import from_uri

In [2]: c = from_uri('https://tiled-staging.nsls2.bnl.gov/api')['lix']['sandbox']

In [3]: import numpy

In [4]: a = numpy.ones((10000, 10000))

In [5]: c.write_array(a)
<snipped>
ClientError: 413: Request Entity Too Large https://tiled-staging.nsls2.bnl.gov/api/array/full/lix/sandbox/1d49a216-19eb-44a0-94bb-b3ea5acd65b2
```

Closes #263 