### PR TITLE
Support chunked writes

### DIFF
--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -11,9 +11,9 @@ tree = MapAdapter(
         "basic": DataFrameAdapter.from_pandas(
             pandas.DataFrame(
                 {
-                    "x": 1 * numpy.ones(100),
-                    "y": 2 * numpy.ones(100),
-                    "z": 3 * numpy.ones(100),
+                    "x": 1 * numpy.ones(10),
+                    "y": 2 * numpy.ones(10),
+                    "z": 3 * numpy.ones(10),
                 }
             ),
             npartitions=3,
@@ -22,9 +22,9 @@ tree = MapAdapter(
         "single_partition": DataFrameAdapter.from_pandas(
             pandas.DataFrame(
                 {
-                    "x": 1 * numpy.ones(100),
-                    "y": 2 * numpy.ones(100),
-                    "z": 3 * numpy.ones(100),
+                    "x": 1 * numpy.ones(5),
+                    "y": 2 * numpy.ones(5),
+                    "z": 3 * numpy.ones(5),
                 }
             ),
             npartitions=1,

--- a/tiled/_tests/test_sparse.py
+++ b/tiled/_tests/test_sparse.py
@@ -5,22 +5,23 @@ from ..adapters.mapping import MapAdapter
 from ..adapters.sparse import COOAdapter
 from ..client import from_tree
 
-N = 3
+N, M = 3, 5
 state = numpy.random.RandomState(0)
-a = state.random((N * 2, N * 2))
+a = state.random((N * 2, M * 2))
 a[a < 0.5] = 0  # Fill half of the array with zeros.
 s = sparse.COO(a)
 blocks = {}
 for i in range(2):
     for j in range(2):
-        chunk = s[i * N : (1 + i) * N, j * N : (1 + j) * N]  # noqa: E203
-        # Coordinates should be in the reference frame of the whole array.
-        coords = chunk.coords + [[i * N], [j * N]]
+        chunk = s[i * N : (1 + i) * N, j * M : (1 + j) * M]  # noqa: E203
+        # Below we test the COOAdapter.from_global_ref constructor, so
+        # coordinates should be in the reference frame of the whole array.
+        coords = chunk.coords + [[i * N], [j * M]]
         blocks[i, j] = coords, chunk.data
 mapping = {
     "single_chunk": COOAdapter.from_coo(sparse.COO(a)),
     "multi_chunk": COOAdapter.from_global_ref(
-        blocks=blocks, shape=(2 * N, 2 * N), chunks=((N, N), (N, N))
+        blocks=blocks, shape=(2 * N, 2 * M), chunks=((N, N), (M, M))
     ),
 }
 tree = MapAdapter(mapping)

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -1,0 +1,104 @@
+"""
+This tests tiled's writing routes with an in-memory store.
+
+Persistent stores are being developed externally to the tiled package.
+"""
+import uuid
+
+import dask.dataframe
+import numpy
+import pandas.testing
+
+from ..adapters.array import ArrayAdapter
+from ..adapters.dataframe import DataFrameAdapter
+from ..adapters.mapping import MapAdapter
+from ..client import from_tree
+from ..queries import Key
+from ..serialization.dataframe import deserialize_arrow
+from ..structures.core import StructureFamily
+
+
+class WritableArrayAdapter(ArrayAdapter):
+    def put_data(self, body):
+        array = numpy.frombuffer(
+            body, dtype=self.microstructure().to_numpy_dtype()
+        ).reshape(self.macrostructure().shape)
+        self._data[:] = array
+
+
+class WritableDataFrameAdapter(DataFrameAdapter):
+    def put_data(self, body):
+        df = deserialize_arrow(body)
+        self._ddf = dask.dataframe.from_pandas(df, npartitions=1)
+
+
+class WritableMapAdapter(MapAdapter):
+    def post_metadata(self, metadata, structure_family, structure, specs):
+        key = str(uuid.uuid4())
+        if structure_family == StructureFamily.array:
+            # Initialize an array of zeros, similar to how chunked storage
+            # formats (e.g. HDF5, Zarr) use a fill_value.
+            array = numpy.zeros(
+                structure.macro.shape, dtype=structure.micro.to_numpy_dtype()
+            )
+            self._mapping[key] = WritableArrayAdapter.from_array(
+                array, metadata=metadata, specs=specs
+            )
+        elif structure_family == StructureFamily.dataframe:
+            # Initialize an empty DataFrame with the right columns/types.
+            df = deserialize_arrow(structure.micro.meta)
+            self._mapping[key] = WritableDataFrameAdapter.from_pandas(
+                df, npartitions=1, metadata=metadata, specs=specs
+            )
+        else:
+            raise NotImplementedError(structure_family)
+        return key
+
+
+API_KEY = "secret"
+
+
+def test_write_array():
+
+    tree = WritableMapAdapter({})
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    a = numpy.ones((5, 5))
+
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+    client.write_array(a, metadata, specs)
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_array = result.read()
+
+    numpy.testing.assert_equal(result_array, a)
+    assert result.metadata == metadata
+    assert result.specs == specs
+
+
+def test_write_dataframe():
+
+    tree = WritableMapAdapter({})
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    data = {f"Column{i}": (1 + i) * numpy.ones(5) for i in range(5)}
+    df = pandas.DataFrame(data)
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+
+    client.write_dataframe(df, metadata, specs)
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_dataframe = result.read()
+
+    pandas.testing.assert_frame_equal(result_dataframe, df)
+    assert result.metadata == metadata
+    # TODO In the future this will be accessible via result.specs.
+    assert result.item["attributes"]["specs"] == specs

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -98,7 +98,7 @@ def test_write_array_full():
         tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
-    a = numpy.ones((5, 5))
+    a = numpy.ones((5, 7))
 
     metadata = {"scan_id": 1, "method": "A"}
     specs = ["SomeSpec"]
@@ -123,7 +123,7 @@ def test_write_array_chunked():
         tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
-    a = dask.array.arange(2500).reshape((50, 50)).rechunk((20, 20))
+    a = dask.array.arange(1500).reshape((50, 30)).rechunk((20, 15))
 
     metadata = {"scan_id": 1, "method": "A"}
     specs = ["SomeSpec"]

--- a/tiled/adapters/dataframe.py
+++ b/tiled/adapters/dataframe.py
@@ -1,6 +1,8 @@
 import dask.base
 import dask.dataframe
+import pandas
 
+from ..serialization.dataframe import serialize_arrow
 from ..server.object_cache import NO_CACHE, get_object_cache
 from ..structures.dataframe import DataFrameMacroStructure, DataFrameMicroStructure
 from ..utils import DictView
@@ -27,8 +29,14 @@ class DataFrameAdapter:
 
     @classmethod
     def from_pandas(cls, *args, metadata=None, specs=None, **kwargs):
+        ddf = dask.dataframe.from_pandas(*args, **kwargs)
+        return cls.from_dask_dataframe(ddf, metadata=metadata, specs=specs)
+
+    @classmethod
+    def from_dask_dataframe(cls, ddf, metadata=None, specs=None):
+        # Danger: using internal attribute _meta here.
         return cls(
-            dask.dataframe.from_pandas(*args, **kwargs), metadata=metadata, specs=specs
+            ddf.partitions, ddf._meta, ddf.divisions, metadata=metadata, specs=specs
         )
 
     @classmethod
@@ -53,7 +61,7 @@ class DataFrameAdapter:
         cache = get_object_cache()
         if cache is not NO_CACHE:
             cache.discard_dask(ddf.__dask_keys__())
-        return cls(ddf, metadata=metadata, specs=specs)
+        return cls.from_dask_dataframe(ddf, metadata=metadata, specs=specs)
 
     read_csv.__doc__ = (
         """
@@ -63,48 +71,69 @@ class DataFrameAdapter:
         + dask.dataframe.read_csv.__doc__
     )
 
-    def __init__(self, ddf, *, metadata=None, specs=None):
+    def __init__(self, partitions, meta, divisions, *, metadata=None, specs=None):
         self._metadata = metadata or {}
-        self._ddf = ddf
+        self._partitions = list(partitions)
+        self._meta = meta
+        self._divisions = divisions
         self.specs = specs or []
 
     def __repr__(self):
-        return f"{type(self).__name__}({self._ddf!r})"
+        return f"{type(self).__name__}({self._meta.columns!r})"
 
     def __getitem__(self, key):
         # Must compute to determine shape.
-        return ArrayAdapter.from_array(self._ddf[key].values.compute())
+        return ArrayAdapter.from_array(self.read([key])[key].values)
 
     def items(self):
-        yield from ((key, self[key]) for key in self._ddf.columns)
+        yield from (
+            (key, ArrayAdapter.from_array(self.read([key])[key].values))
+            for key in self._meta.columns
+        )
 
     @property
     def metadata(self):
         return DictView(self._metadata)
 
     def macrostructure(self):
-        return DataFrameMacroStructure.from_dask_dataframe(self._ddf)
+        return DataFrameMacroStructure(
+            columns=list(self._meta.columns), npartitions=len(self._partitions)
+        )
 
     def microstructure(self):
-        return DataFrameMicroStructure.from_dask_dataframe(self._ddf)
+        meta = bytes(serialize_arrow(self._meta, {}))
+        divisions = bytes(
+            serialize_arrow(pandas.DataFrame({"divisions": list(self._divisions)}), {})
+        )
+        return DataFrameMicroStructure(meta=meta, divisions=divisions)
 
     def read(self, fields=None):
-        # TODO For the array reader we require returning a *lazy* object here.
-        # Should rethink that. As is, this is inconsistent.
-        # But we very intentionally do not support fancy row-slicing because
-        # that becomes complex fast and it out of scope for Tiled.
-        ddf = self._ddf
+        if any(p is None for p in self._partitions):
+            raise ValueError("Not all partitions have been stored.")
+        if isinstance(self._partitions[0], dask.dataframe.DataFrame):
+            if fields is not None:
+                ddf = dask.dataframe.concat(
+                    [p[fields] for p in self._partitions], axis=0
+                )
+            else:
+                ddf = dask.dataframe.concat(self._partitions, axis=0)
+            # Note: If the cache is set to NO_CACHE, this is a null context.
+            with get_object_cache().dask_context:
+                return ddf.compute()
+        df = pandas.concat(self._partitions, axis=0)
         if fields is not None:
-            ddf = ddf[fields]
-        # Note: If the cache is set to NO_CACHE, this is a null context.
-        with get_object_cache().dask_context:
-            return ddf.compute()
+            df = df[fields]
+        return df
 
     def read_partition(self, partition, fields=None):
-        partition = self._ddf.partitions[partition]
+        partition = self._partitions[partition]
+        if partition is None:
+            raise RuntimeError(f"partition {partition} has not be stored yet")
         if fields is not None:
-            # Sub-select fields.
             partition = partition[fields]
-        # Note: If the cache is set to NO_CACHE, this is a null context.
-        with get_object_cache().dask_context:
-            return partition.compute()
+        # Special case for dask to cache computed result in object cache.
+        if isinstance(partition, dask.dataframe.DataFrame):
+            # Note: If the cache is set to NO_CACHE, this is a null context.
+            with get_object_cache().dask_context:
+                return partition.compute()
+        return partition

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -53,5 +53,5 @@ class ExcelAdapter(MapAdapter):
             if cache is not NO_CACHE:
                 cache.discard(cache_key)  # parsed sheet content
                 cache.discard_dask(ddf.__dask_keys__())  # dask tasks
-            mapping[sheet_name] = DataFrameAdapter(ddf)
+            mapping[sheet_name] = DataFrameAdapter.from_dask_dataframe(ddf)
         return cls(mapping, specs=specs)

--- a/tiled/adapters/sparse.py
+++ b/tiled/adapters/sparse.py
@@ -2,6 +2,7 @@ import numpy
 import sparse
 
 from ..structures.sparse import COOStructure
+from .array import slice_and_shape_from_block_and_chunks
 
 
 class COOAdapter:
@@ -94,17 +95,3 @@ class COOAdapter:
         if slice:
             return arr[slice]
         return arr
-
-
-def slice_and_shape_from_block_and_chunks(block, chunks):
-    """
-    Given dask-like chunks and block id, return slice and shape of the block.
-    """
-    slice_ = []
-    shape = []
-    for b, c in zip(block, chunks):
-        start = sum(c[:b])
-        dim = c[b]
-        slice_.append(slice(start, start + dim))
-        shape.append(dim)
-    return tuple(slice_), tuple(shape)

--- a/tiled/adapters/xarray.py
+++ b/tiled/adapters/xarray.py
@@ -1,7 +1,6 @@
 import collections.abc
 import itertools
 
-import dask.array
 import xarray
 
 from ..adapters.array import ArrayAdapter
@@ -71,11 +70,7 @@ class _DatasetMap(collections.abc.Mapping):
             spec = "xarray_coord"
         else:
             spec = "xarray_data_var"
-        if isinstance(data_array.data, dask.array.Array):
-            func = ArrayAdapter
-        else:
-            func = ArrayAdapter.from_array
-        return func(
+        return ArrayAdapter(
             data_array.data,
             metadata={"attrs": data_array.attrs},
             dims=data_array.dims,

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -19,6 +19,52 @@ class DaskArrayClient(BaseStructureClient):
     def dims(self):
         return self.structure().macro.dims
 
+    @property
+    def shape(self):
+        return self.structure().macro.shape
+
+    @property
+    def size(self):
+        return numpy.product(self.structure().macro.shape)
+
+    @property
+    def dtype(self):
+        return self.structure().micro.to_numpy_dtype()
+
+    @property
+    def nbytes(self):
+        structure = self.structure()
+        return (
+            numpy.product(structure.macro.shape)
+            * structure.micro.to_numpy_dtype().itemsize
+        )
+
+    @property
+    def chunks(self):
+        return self.structure().macro.chunks
+
+    @property
+    def ndim(self):
+        return len(self.structure().macro.shape)
+
+    def __repr__(self):
+        structure = self.structure()
+        attrs = {
+            "shape": structure.macro.shape,
+            "chunks": structure.macro.chunks,
+            "dtype": structure.micro.to_numpy_dtype(),
+        }
+        if structure.macro.dims:
+            attrs["dims"] = structure.macro.dims
+        return (
+            f"<{type(self).__name__}"
+            + "".join(f" {k}={v}" for k, v in attrs.items())
+            + ">"
+        )
+
+    def __array__(self, *args, **kwargs):
+        return self.read().__array__(*args, **kwargs)
+
     def _get_block(self, block, dtype, shape, slice=None):
         """
         Fetch the actual data for one block in a chunked (dask) array.

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -118,6 +118,20 @@ class DaskArrayClient(BaseStructureClient):
             dask_array = dask_array[slice]
         return dask_array
 
+    def write(self, array):
+        self.context.put_content(
+            self.item["links"]["full"],
+            content=array.tobytes(),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+    def write_block(self, array, block):
+        self.context.put_content(
+            self.item["links"]["block"].format(*block),
+            content=array.tobytes(),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
     def __getitem__(self, slice):
         return self.read(slice)
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -540,7 +540,7 @@ Set an api_key as in:
             timestamp=3,  # Decode msgpack Timestamp as datetime.datetime object.
         )
 
-    def put_content(self, path, content, headers=None):
+    def put_content(self, path, content, headers=None, params=None):
         # Submit CSRF token in both header and cookie.
         # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
         headers = headers or {}
@@ -551,6 +551,7 @@ Set an api_key as in:
             path,
             content=content,
             headers=headers,
+            params=params,
         )
         response = self._send(request)
         handle_error(response)

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -74,6 +74,10 @@ class DaskDataFrameClient(BaseStructureClient):
             return []
         return columns
 
+    @property
+    def columns(self):
+        return self.structure().macro.columns
+
     def download(self):
         super().download()
         self._ipython_key_completions_()

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -1,7 +1,7 @@
 import dask
 import dask.dataframe
 
-from ..serialization.dataframe import deserialize_arrow
+from ..serialization.dataframe import deserialize_arrow, serialize_arrow
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE, UNCHANGED
 from .base import BaseStructureClient
 from .utils import ClientError, client_for_item, export_util
@@ -176,6 +176,20 @@ class DaskDataFrameClient(BaseStructureClient):
 
     # __len__ is intentionally not implemented. For DataFrames it means "number
     # of rows" which is expensive to compute.
+
+    def write(self, dataframe):
+        self.context.put_content(
+            self.item["links"]["full"],
+            content=bytes(serialize_arrow(dataframe, {})),
+            headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
+        )
+
+    def write_partition(self, dataframe, partition):
+        self.context.put_content(
+            self.item["links"]["partition"].format(index=partition),
+            content=bytes(serialize_arrow(dataframe, {})),
+            headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
+        )
 
     def export(self, filepath, columns=None, *, format=None):
         """

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -15,13 +15,7 @@ from ..queries import KeyLookup
 from ..query_registration import query_registry
 from ..serialization.dataframe import serialize_arrow
 from ..structures.core import StructureFamily
-from ..utils import (
-    APACHE_ARROW_FILE_MIME_TYPE,
-    UNCHANGED,
-    OneShotCachedMap,
-    Sentinel,
-    node_repr,
-)
+from ..utils import UNCHANGED, OneShotCachedMap, Sentinel, node_repr
 from .base import BaseClient
 from .cache import Revalidate, verify_cache
 from .utils import ClientError, client_for_item, export_util
@@ -117,9 +111,14 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         structure_clients,
         queries=None,
         sorting=None,
+        structure=None,
     ):
         "This is not user-facing. Use Node.from_uri."
 
+        if structure is not None:
+            # Node accepts 'structure' param for API compatibility with other clients,
+            # but it should always be None.
+            raise ValueError(f"Node received unexpected structure: {structure}")
         self.structure_clients = structure_clients
         self._queries = list(queries or [])
         self._queries_as_params = _queries_to_params(*self._queries)
@@ -567,7 +566,50 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             # Do not print messy traceback from thread. Just fail silently.
             return []
 
-    def write_array(self, array, metadata=None, specs=None):
+    def new(self, structure_family, structure, *, metadata=None, specs=None):
+        """
+        Create a new item within this Node.
+
+        This is a low-level method. See high-level convenience methods listed below.
+
+        See Also
+        --------
+        write_array
+        write_dataframe
+        write_coo_array
+        """
+        metadata = metadata or {}
+        specs = specs or []
+        item = {
+            "attributes": {
+                "metadata": metadata,
+                "structure": asdict(structure),
+                "structure_family": StructureFamily(structure_family),
+                "specs": specs,
+            }
+        }
+
+        if structure_family == StructureFamily.dataframe:
+            # send bytes base64 encoded
+            item["attributes"]["structure"]["micro"]["meta"] = base64.b64encode(
+                item["attributes"]["structure"]["micro"]["meta"]
+            ).decode()
+            item["attributes"]["structure"]["micro"]["divisions"] = base64.b64encode(
+                item["attributes"]["structure"]["micro"]["divisions"]
+            ).decode()
+
+        document = self.context.post_json(self.uri, item["attributes"])
+        # Merge in "id" and "links" returned by the server.
+        item.update(document)
+        return client_for_item(
+            self.context,
+            self.structure_clients,
+            item,
+            path=self._path + (item["id"],),
+            structure=structure,
+        )
+
+    def write_array(self, array, *, metadata=None, dims=None, specs=None):
         """
         EXPERIMENTAL: Write an array.
 
@@ -577,6 +619,72 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         metadata : dict, optional
             User metadata. May be nested. Must contain only basic types
             (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        dims : List[str], optional
+            A label for each dimension of the array.
+        specs : List[str], optional
+            List of names that are used to label that the data and/or metadata
+            conform to some named standard specification.
+
+        """
+        import dask.array
+        from dask.array.core import normalize_chunks
+
+        from ..structures.array import ArrayMacroStructure, ArrayStructure, BuiltinDtype
+
+        self._cached_len = None
+
+        chunked = hasattr(array, "chunks")
+        if chunked:
+            chunks = normalize_chunks(array.chunks)
+        else:
+            # one chunk
+            chunks = tuple((size,) for size in array.shape)
+
+        structure = ArrayStructure(
+            macro=ArrayMacroStructure(
+                shape=array.shape,
+                chunks=chunks,
+                dims=dims,
+            ),
+            micro=BuiltinDtype.from_numpy_dtype(array.dtype),
+        )
+        client = self.new(
+            StructureFamily.array, structure, metadata=metadata, specs=specs
+        )
+        if not chunked:
+            client.write(array)
+        else:
+            # Fan out client.write_block over each chunk using dask.
+            if isinstance(array, dask.array.Array):
+                da = array
+            else:
+                da = dask.array.from_array(array)
+
+            # Dask inspects the signature and passes block_id in if present.
+            # It also apparently calls it with an empty array and block_id
+            # once, so we catch that call and become a no-op.
+            def write_block(x, block_id, client):
+                if len(block_id):
+                    client.write_block(x, block=block_id)
+                return x
+
+            # TODO Is there a fire-and-forget analogue such that we don't need
+            # to bother with the return type?
+            da.map_blocks(write_block, dtype=da.dtype, client=client).compute()
+        return client
+
+    def write_sparse(self, array, metadata=None, dims=None, specs=None):
+        """
+        EXPERIMENTAL: Write a sparse array.
+
+        Parameters
+        ----------
+        array : array-like
+        metadata : dict, optional
+            User metadata. May be nested. Must contain only basic types
+            (e.g. numbers, strings, lists, dicts) that are JSON-serializable.
+        dims : List[str], optional
+            A label for each dimension of the array.
         specs : List[str], optional
             List of names that are used to label that the data and/or metadata
             conform to some named standard specification.
@@ -586,7 +694,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         import dask.array
         from dask.array.core import normalize_chunks
 
-        from ..structures.array import ArrayMacroStructure, ArrayStructure, BuiltinDtype
+        from ..structures.sparse import COOStructure
 
         self._cached_len = None
 
@@ -597,12 +705,10 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         else:
             chunks = tuple((size,) for size in array.shape)
 
-        structure = ArrayStructure(
-            macro=ArrayMacroStructure(
-                shape=array.shape,
-                chunks=chunks,
-            ),
-            micro=BuiltinDtype.from_numpy_dtype(array.dtype),
+        structure = COOStructure(
+            shape=array.shape,
+            chunks=chunks,
+            dims=dims,
         )
         data = {
             "metadata": metadata,
@@ -707,29 +813,9 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                 npartitions=npartitions, columns=list(dataframe.columns)
             ),
         )
-
-        data = {
-            "metadata": metadata,
-            "structure": asdict(structure),
-            "structure_family": StructureFamily.dataframe,
-            "specs": specs,
-        }
-
-        # send bytes base64 encoded
-        data["structure"]["micro"]["meta"] = base64.b64encode(
-            data["structure"]["micro"]["meta"]
-        ).decode()
-        data["structure"]["micro"]["divisions"] = base64.b64encode(
-            data["structure"]["micro"]["divisions"]
-        ).decode()
-
-        full_path_meta = (
-            "/node/metadata"
-            + "".join(f"/{part}" for part in self.context.path_parts)
-            + "".join(f"/{part}" for part in (self._path or [""]))
+        client = self.new(
+            StructureFamily.dataframe, structure, metadata=metadata, specs=specs
         )
-        document = self.context.post_json(full_path_meta, data)
-        key = document["key"]
 
         if hasattr(dataframe, "partitions"):
             if isinstance(dataframe, dask.dataframe.DataFrame):
@@ -739,38 +825,15 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                     f"Unsure how to handle type {type(dataframe)}"
                 )
 
-            def upload(x, partition_info):
-                full_path_data = (
-                    "/dataframe/partition"
-                    + "".join(f"/{part}" for part in self.context.path_parts)
-                    + "".join(f"/{part}" for part in self._path)
-                    + "/"
-                    + key
-                )
-                self.context.put_content(
-                    full_path_data,
-                    content=bytes(serialize_arrow(x, {})),
-                    headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
-                    params={"partition": str(partition_info["number"])},
-                )
+            def write_partition(x, partition_info):
+                client.write_partition(x, partition_info["number"])
                 return x
 
-            ddf.map_partitions(upload, meta=dataframe._meta).compute()
+            ddf.map_partitions(write_partition, meta=dataframe._meta).compute()
         else:
-            full_path_data = (
-                "/node/full"
-                + "".join(f"/{part}" for part in self.context.path_parts)
-                + "".join(f"/{part}" for part in self._path)
-                + "/"
-                + key
-            )
-            self.context.put_content(
-                full_path_data,
-                content=bytes(serialize_arrow(dataframe, {})),
-                headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
-            )
+            client.write(dataframe)
 
-        return key
+        return client
 
 
 def _queries_to_params(*queries):

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -630,11 +630,16 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         """
         import dask.array
+        import numpy
         from dask.array.core import normalize_chunks
 
         from ..structures.array import ArrayMacroStructure, ArrayStructure, BuiltinDtype
 
         self._cached_len = None
+        if not (hasattr(array, "shape") and hasattr(array, "dtype")):
+            # This does not implement enough of the array-like interface.
+            # Coerce to numpy.
+            array = numpy.asarray(array)
 
         # Determine chunks such that each chunk is not too large to upload.
         # Any existing chunking will be taken into account.
@@ -738,6 +743,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             StructureFamily.sparse, structure, metadata=metadata, specs=specs
         )
         client.write(coords, data)
+        return client
 
     def write_dataframe(self, dataframe, metadata=None, specs=None):
         """

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -9,6 +9,36 @@ from .utils import export_util, params_from_slice
 
 
 class SparseClient(BaseStructureClient):
+    @property
+    def dims(self):
+        return self.structure().dims
+
+    @property
+    def shape(self):
+        return self.structure().shape
+
+    @property
+    def chunks(self):
+        return self.structure().chunks
+
+    @property
+    def ndim(self):
+        return len(self.structure().shape)
+
+    def __repr__(self):
+        structure = self.structure()
+        attrs = {"shape": structure.shape, "chunks": structure.chunks}
+        if structure.dims:
+            attrs["dims"] = structure.dims
+        return (
+            f"<{type(self).__name__}"
+            + "".join(f" {k}={v}" for k, v in attrs.items())
+            + ">"
+        )
+
+    def __array__(self, *args, **kwargs):
+        return self.read().__array__(*args, **kwargs)
+
     def read_block(self, block, slice=None):
         # Fetch the data as an Apache Arrow table
         # with columns named dim0, dim1, ..., dimN, data.

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -259,7 +259,7 @@ def record_history():
     _history = None
 
 
-def client_for_item(context, structure_clients, item, path):
+def client_for_item(context, structure_clients, item, path, structure=None):
     """
     Create an instance of the appropriate client class for an item.
 
@@ -287,6 +287,7 @@ def client_for_item(context, structure_clients, item, path):
         item=item,
         path=path,
         structure_clients=structure_clients,
+        structure=structure,
     )
 
 

--- a/tiled/examples/xdi.py
+++ b/tiled/examples/xdi.py
@@ -95,7 +95,9 @@ class XDIDataFrameAdapter(DataFrameAdapter):
     @classmethod
     def from_file(cls, file):
         df, metadata = read_xdi(file)
-        return cls(dask.dataframe.from_pandas(df, npartitions=1), metadata=metadata)
+        return cls.from_dask_dataframe(
+            dask.dataframe.from_pandas(df, npartitions=1), metadata=metadata
+        )
 
 
 def write_xdi(df, metadata):

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -427,9 +427,7 @@ def construct_resource(
                     # accessed it, and we have access it specifically to construct this link.
                     shape = entry.structure().shape
                     structure = None
-                block_template = ",".join(
-                    f"{{index_{index}}}" for index in range(len(shape))
-                )
+                block_template = ",".join(f"{{{index}}}" for index in range(len(shape)))
                 links[
                     "block"
                 ] = f"{base_url}/array/block/{path_str}?block={block_template}"

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -554,7 +554,7 @@ def post_metadata(
     request: Request,
     path: str,
     body: schemas.PostMetadataRequest,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:metadata"]),
 ):
     if body.structure_family == StructureFamily.dataframe:
         # Decode meta for pydantic validation

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -574,6 +574,7 @@ def post_metadata(
         base_url = get_base_url(request)
         path_parts = [segment for segment in path.split("/") if segment] + [key]
         path_str = "/".join(path_parts)
+        links["self"] = f"{base_url}/node/metadata/{path_str}"
         if body.structure_family == StructureFamily.array:
             block_template = ",".join(
                 f"{{{index}}}" for index in range(len(body.structure.macro.shape))

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -605,6 +605,23 @@ async def put_array_full(
     return json_or_msgpack(request, None)
 
 
+@router.put("/array/block/{path:path}")
+async def put_array_block(
+    request: Request,
+    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    block=Depends(block),
+):
+    data = await request.body()
+
+    if hasattr(entry, "put_data"):
+        entry.put_data(data, block=block)
+    else:
+        raise HTTPException(
+            status_code=405, detail="This path cannot accept array data."
+        )
+    return json_or_msgpack(request, None)
+
+
 @router.put("/node/full/{path:path}")
 async def put_dataframe_full(
     request: Request,

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -618,7 +618,7 @@ async def delete(
 @router.put("/array/full/{path:path}")
 async def put_array_full(
     request: Request,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:data"]),
 ):
     data = await request.body()
 
@@ -634,7 +634,7 @@ async def put_array_full(
 @router.put("/array/block/{path:path}")
 async def put_array_block(
     request: Request,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:data"]),
     block=Depends(block),
 ):
     data = await request.body()
@@ -651,7 +651,7 @@ async def put_array_block(
 @router.put("/node/full/{path:path}")
 async def put_dataframe_full(
     request: Request,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:data"]),
 ):
     data = await request.body()
 
@@ -668,7 +668,7 @@ async def put_dataframe_full(
 async def put_dataframe_partition(
     partition: int,
     request: Request,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=Security(entry, scopes=["write:data"]),
 ):
     data = await request.body()
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -636,3 +636,20 @@ async def put_dataframe_full(
             status_code=405, detail="This path cannot accept dataframe data."
         )
     return json_or_msgpack(request, None)
+
+
+@router.put("/dataframe/partition/{path:path}")
+async def put_dataframe_partition(
+    partition: int,
+    request: Request,
+    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+):
+    data = await request.body()
+
+    if hasattr(entry, "put_data"):
+        entry.put_data(data, partition=partition)
+    else:
+        raise HTTPException(
+            status_code=405, detail="This path cannot accept dataframe data."
+        )
+    return json_or_msgpack(request, None)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -580,6 +580,14 @@ def post_metadata(
             )
             links["block"] = f"{base_url}/array/block/{path_str}?block={block_template}"
             links["full"] = f"{base_url}/array/full/{path_str}"
+        elif body.structure_family == StructureFamily.sparse:
+            # Different from array because of structure.macro.shape vs structure.shape
+            # Can be unified if we drop macro/micro namespace.
+            block_template = ",".join(
+                f"{{{index}}}" for index in range(len(body.structure.shape))
+            )
+            links["block"] = f"{base_url}/array/block/{path_str}?block={block_template}"
+            links["full"] = f"{base_url}/array/full/{path_str}"
         elif body.structure_family == StructureFamily.dataframe:
             links[
                 "partition"


### PR DESCRIPTION
## Support for chunked writes

* Add server routes `PUT /array/block` and `PUT /dataframe/partition`.
* Extend the JSON returned by `POST /node/metadata` to include links which can be used by the client to upload data. The client could figure out these links for itself, sure, but (1) this reduces client complexity and (2) this future-proofs us against moving links for optimization reasons.
* Add support for chunked/partitioned writes from the client. At the moment this relies on dask fairly heavily; it could be generalized in the future in a backward-compatible way.
* Change `ArrayAdapter.__init__` signature. Operate with any array-like, without insisting on dask arrays specifically. This removes dask from the HDF5-reading code path, reducing overhead and complexity.
* Change `DataFrameAdapter.__init__` signature. Operate with any list of DataFrame-like partitions.

The changes to the Adapters' internals also enable the testing described below.

## Self-contained testing of the experimental writing capability

The experimental work integrating writable persistent storage with Tiled is currently taking place external to tiled, in Databroker and aimmdb. Tiled contains the HTTP routes and the client that calls those routes, but it contains no writable Adapters to test them against. This PR adds, in the test suite, an implementation of writable "storage" that stores data only in memory. This enables changes to the writing-related code to be tested within Tiled.

## Refactor writing

The methods `Node.write_array` and `Node.write_dataframe` now return `ArrayClient` and `DataFrameClient` objects, respectively. (This does not require any additional interactions with the server.) They are reduced to convenience wrappers which call:

* `Node.new(...)` to `POST /node/metadata/`
* `[Array|DataFrame]Client` to `PUT /array/full`, `PUT /array/block`, `PUT /node/full`, or `PUT /dataframe/partition` as appropriate

This makes it possible for applications to control chunk upload more directly if desired. The convenience functions `write_*` fan them out using dask collections.

## Future work

~If the user provided chunks are too large for upload, we could automatically rechunk to smaller commensurate chunks using `normalize_chunks`.~ Added in a198819c31d8dac45cea0e5bf2bf93fa4159fa35 in anticipation of @cryos reaction if Tiled required users to chunk their own arrays. :-D