### PR TITLE
Log human-readable content length (bytesize).

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -618,3 +618,15 @@ def node_repr(tree, sample):
     else:
         out += "}>"
     return out
+
+
+def bytesize_repr(num):
+    # adapted from dask.utils
+    for x in ["B", "MB", "GB", "TB"]:
+        if num < 1024.0:
+            if x == "B":
+                s = f"{num:.0f} {x}"
+            else:
+                s = f"{num:.1f} {x}"
+            return s
+        num /= 1024.0


### PR DESCRIPTION
*To do this right, we need #116 and #281. This is on ice until those are addressed.*

<hr />

When the `Content-Length` header (giving the bytesize of a response) is large, it is hard to read. This puts the bitesize in human readable units using a metric prefix at the front of each response log message.

A small response's log message looks like

```
10:26:47.582 <- 200 514.0B server:nginx/1.18.0 (Ubuntu) date:Thu, 04 Aug 2022 14:26:47 GMT content-type:application/x-msgpack content-length:514 connection:keep-alive etag:073e89cae536cc46212d597e25210c72 server-timing:acl;dur=0.0, tok;dur=0.0, pack;dur=0.0, app;dur=6.4
```

and a large response's log message looks like:

```
10:27:38.753 <- 200 703.1MB server:nginx/1.18.0 (Ubuntu) date:Thu, 04 Aug 2022 14:27:38 GMT content-type:application/octet-stream content-length:720000 connection:keep-alive etag:bcdc0ac54467c43b37038182b9f0e0fb server-timing:acl;dur=0.0, read;dur=0.7, tok;dur=0.5, pack;dur=0.5, app;dur=6.9
```