### PR TITLE
Add todense() method to sparse client.

### DIFF
--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -114,3 +114,16 @@ def test_array_format_shape_from_cube():
         hyper_cube = client["tiny_hypercube"].export("test.png")  # noqa: F841
     # Check that the error is 406 (Not Acceptable).
     assert err.match("406")
+
+
+def test_array_interface():
+    client = from_tree(array_tree)
+    for k, v in client.items():
+        assert v.shape == array_cases[k].shape
+        assert v.ndim == array_cases[k].ndim
+        assert v.nbytes == array_cases[k].nbytes
+        assert v.dtype == array_cases[k].dtype
+        assert numpy.array_equal(numpy.asarray(v), array_cases[k])
+        # smoke test
+        v.chunks
+        v.dims

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -39,6 +39,7 @@ def test_dataframe_basic():
     actual = client["basic"].read()
     assert client["basic"].structure().macro.npartitions == 3
     pandas.testing.assert_frame_equal(actual, expected)
+    assert client["basic"].columns == list(expected.columns) == list(actual.columns)
 
 
 def test_dataframe_column_access():

--- a/tiled/_tests/test_sparse.py
+++ b/tiled/_tests/test_sparse.py
@@ -18,10 +18,12 @@ for i in range(2):
         # coordinates should be in the reference frame of the whole array.
         coords = chunk.coords + [[i * N], [j * M]]
         blocks[i, j] = coords, chunk.data
+chunks = ((N, N), (M, M))
+dims = ["x", "y"]
 mapping = {
-    "single_chunk": COOAdapter.from_coo(sparse.COO(a)),
+    "single_chunk": COOAdapter.from_coo(sparse.COO(a), dims=dims),
     "multi_chunk": COOAdapter.from_global_ref(
-        blocks=blocks, shape=(2 * N, 2 * M), chunks=((N, N), (M, M))
+        blocks=blocks, shape=(2 * N, 2 * M), chunks=chunks, dims=dims
     ),
 }
 tree = MapAdapter(mapping)
@@ -29,19 +31,33 @@ tree = MapAdapter(mapping)
 
 def test_sparse_single_chunk():
     client = from_tree(tree)
-    actual_via_slice = client["single_chunk"][:]
-    actual_via_read = client["single_chunk"].read()
-    actual_via_read_block = client["single_chunk"].read_block((0, 0))
+    sc = client["single_chunk"]
+    actual_via_slice = sc[:]
+    actual_via_read = sc.read()
+    actual_via_todense = sc.todense()
+    actual_via_read_block = sc.read_block((0, 0))
     assert numpy.array_equal(actual_via_slice.todense(), actual_via_read.todense())
     assert numpy.array_equal(
         actual_via_slice.todense(), actual_via_read_block.todense()
     )
     assert numpy.array_equal(actual_via_slice.todense(), a)
+    assert numpy.array_equal(actual_via_todense, a)
+    assert sc.shape == a.shape
+    assert sc.ndim == a.ndim
+    assert sc.chunks == tuple((i,) for i in a.shape)
+    assert sc.dims == dims
 
 
 def test_sparse_multi_chunk():
     client = from_tree(tree)
-    actual_via_slice = client["multi_chunk"][:]
-    actual_via_read = client["multi_chunk"].read()
+    sc = client["multi_chunk"]
+    actual_via_slice = sc[:]
+    actual_via_read = sc.read()
+    actual_via_todense = sc.todense()
     assert numpy.array_equal(actual_via_slice.todense(), actual_via_read.todense())
     assert numpy.array_equal(actual_via_slice.todense(), a)
+    assert numpy.array_equal(actual_via_todense, a)
+    assert sc.shape == a.shape
+    assert sc.ndim == a.ndim
+    assert sc.chunks == chunks
+    assert sc.dims == dims

--- a/tiled/adapters/sparse.py
+++ b/tiled/adapters/sparse.py
@@ -10,7 +10,7 @@ class COOAdapter:
     structure_family = "sparse"
 
     @classmethod
-    def from_arrays(cls, coords, data, shape):
+    def from_arrays(cls, coords, data, shape, dims=None, metadata=None, specs=None):
         """
         Simplest constructor. Single chunk from coords, data arrays.
         """
@@ -18,12 +18,22 @@ class COOAdapter:
             {(0, 0): (coords, data)},
             shape=shape,
             chunks=tuple((dim,) for dim in shape),
+            dims=dims,
+            metadata=metadata,
+            specs=specs,
         )
 
     @classmethod
-    def from_coo(cls, coo):
+    def from_coo(cls, coo, *, dims=None, metadata=None, specs=None):
         "Construct from sparse.COO object."
-        return cls.from_arrays(coords=coo.coords, data=coo.data, shape=coo.shape)
+        return cls.from_arrays(
+            coords=coo.coords,
+            data=coo.data,
+            shape=coo.shape,
+            dims=dims,
+            metadata=metadata,
+            specs=specs,
+        )
 
     @classmethod
     def from_global_ref(

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -39,6 +39,10 @@ class SparseClient(BaseStructureClient):
     def __array__(self, *args, **kwargs):
         return self.read().__array__(*args, **kwargs)
 
+    def todense(self, *args, **kwargs):
+        "Return a dense numpy array. May be large."
+        return self.read().todense(*args, **kwargs)
+
     def read_block(self, block, slice=None):
         # Fetch the data as an Apache Arrow table
         # with columns named dim0, dim1, ..., dimN, data.

--- a/tiled/structures/sparse.py
+++ b/tiled/structures/sparse.py
@@ -21,10 +21,10 @@ class COOStructure:
     @classmethod
     def from_json(cls, structure):
         return cls(
-            chunks=structure["chunks"],
-            shape=structure["shape"],
+            chunks=tuple(map(tuple, structure["chunks"])),
+            shape=tuple(structure["shape"]),
             dims=structure["dims"],
-            resizable=structure["resizable"],
+            resizable=structure.get("resizable", False),
         )
 
 


### PR DESCRIPTION
This provides `c.todense()` as a convenience around `c.read().todense()`.

It also adds tests to the array interface properties and fixes some minor bugs.