### PR TITLE
Provide better feedback on HDF5 metadata serialization failure.

### DIFF
--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -10,6 +10,7 @@ from ..adapters.dataframe import DataFrameAdapter
 from ..adapters.mapping import MapAdapter
 from ..adapters.xarray import DatasetAdapter
 from ..client import from_tree
+from ..client.utils import ClientError
 
 data = numpy.random.random((10, 10))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
@@ -85,6 +86,14 @@ def test_export_weather_data_var(filename, structure_clients, tmpdir):
 def test_export_weather_all(filename, structure_clients, tmpdir):
     client = from_tree(tree, structure_clients=structure_clients)
     client["structured_data"]["weather"].export(Path(tmpdir, filename))
+
+
+def test_serialization_error_hdf5_metadata(tmpdir):
+    good = MapAdapter({}, metadata={"a": 1})
+    bad = MapAdapter({}, metadata={"a": {"b": 1}})
+    from_tree(good).export(Path(tmpdir, "test.h5"))
+    with pytest.raises(ClientError, match="contains types or structure"):
+        from_tree(bad).export(Path(tmpdir, "test.h5"))
 
 
 def test_path_as_Path_or_string(tmpdir):


### PR DESCRIPTION
Tiled supports JSON-like metadata. HDF5 does not support nested objects.

As discussed in #169 we want to raise a clear error when there is no safe solution. In specific cases (e.g. BlueskyRun) we can make assumptions about the metadata (e.g. keys do not contain `.`) to invent a compatible encoding.

This PR raises a clear error:

```
tiled.client.utils.ClientError: 406: This type is supported in general but there was an error packing this specific data: Metadata contains types or structure that does not fit into HDF5. http://local-tiled-app/api/node/full/?format=h5
```

Closes #169