### PR TITLE
Fix wide table

### DIFF
--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -45,7 +45,8 @@ EXPECTED = {
         },
     ),
     "wide": xarray.Dataset(
-        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(10)) for i in range(100)}
+        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(10)) for i in range(100)},
+        coords={"time": numpy.arange(10)},
     ),
     "ragged": xarray.Dataset(
         {

--- a/tiled/serialization/dataframe.py
+++ b/tiled/serialization/dataframe.py
@@ -31,19 +31,19 @@ def serialize_parquet(df, metadata, preserve_index=True):
     return memoryview(sink.getvalue())
 
 
-def serialize_csv(df, metadata, preserve_index=True):
+def serialize_csv(df, metadata, preserve_index=False):
     file = io.StringIO()
     df.to_csv(file, index=preserve_index)
     return file.getvalue().encode()
 
 
-def serialize_excel(df, metadata, preserve_index=True):
+def serialize_excel(df, metadata, preserve_index=False):
     file = io.BytesIO()
     df.to_excel(file, index=preserve_index)
     return file.getbuffer()
 
 
-def serialize_html(df, metadata, preserve_index=True):
+def serialize_html(df, metadata, preserve_index=False):
     file = io.StringIO()
     df.to_html(file, index=preserve_index)
     return file.getvalue().encode()


### PR DESCRIPTION
The wide table optimization was broken on xarray.Datasets that have a coordinate. This includes Datasets from Databroker. This PR adds a test for that case and fixes the bug.