### PR TITLE
Ensure fast import.

### DIFF
--- a/tiled/_tests/test_no_heavy_imports.py
+++ b/tiled/_tests/test_no_heavy_imports.py
@@ -1,0 +1,20 @@
+"""
+importing tiled.client should not import any heavy optional dependencies.
+"""
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "numpy",
+        "pandas",
+        "xarray",
+    ],
+)
+def test_no_heavy_imports(module):
+    code = f"import tiled.client; import sys; assert '{module}' not in sys.modules"
+    subprocess.check_call([sys.executable, "-c", code])

--- a/tiled/client/__init__.py
+++ b/tiled/client/__init__.py
@@ -1,9 +1,5 @@
-from ..serialization import register_builtin_serializers
 from .constructors import from_context  # noqa: F401
 from .constructors import from_config, from_profile, from_tree, from_uri  # noqa: F401
 from .context import logout, logout_all, sessions  # noqa: F401
 from .node import ASCENDING, DESCENDING  # noqa: F401
 from .utils import hide_logs, record_history, show_logs  # noqa: F401
-
-register_builtin_serializers()
-del register_builtin_serializers


### PR DESCRIPTION
In #246 I unnecessarily added some client-side code that eagerly imported numpy, pandas, and xarray (if they are installed) making tiled much slower to import.

This PR fixes that regression and adds a test to ensure that `import tiled.client` does not cause these heavy optional dependencies to also be imported. I confirmed interactively that creating a client also does not cause the import. As before, and as intended, these libraries are only imported when tiled first encounters a structure that requires them.