### PR TITLE
Special case output for tree(empty_node)

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -373,6 +373,9 @@ def tree(tree, max_lines=20):
         └── wolf
 
     """
+    if len(tree) == 0:
+        print("<Empty>")
+        return
     for counter, line in enumerate(gen_tree(tree), start=1):
         if (max_lines is not None) and (counter > max_lines):
             print(


### PR DESCRIPTION
Consider an empty node, like this example of a BlueskyRun with no data (no streams) in it:

```
In [6]: c['chx']['raw']['1ddec21d-c6ee-4404-b0cd-6e1601095592']
Out[6]: <BlueskyRun set() scan_id=13 uid='1ddec21d' 2015-03-14 15:34>

In [7]: len(c['chx']['raw']['1ddec21d-c6ee-4404-b0cd-6e1601095592'])
Out[7]: 0
```

When the utility `tiled.utils.tree()` is passed an empty node, it gives no output:

```py
In [8]: tree(c['chx']['raw']['1ddec21d-c6ee-4404-b0cd-6e1601095592'])

In [9]:
```

That can be confusing or make the user wonder whether `tree(...)` might be broken. This PR shows `<Empty>` to avoid confusion:

```py
In [8]: tree(c['chx']['raw']['1ddec21d-c6ee-4404-b0cd-6e1601095592'])
<Empty>
```
