### PR TITLE
Avoid using deserialization registry for simple case.

### DIFF
--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -4,7 +4,6 @@ import dask
 import dask.array
 import numpy
 
-from ..media_type_registration import deserialization_registry
 from .base import BaseStructureClient
 from .utils import export_util, params_from_slice
 
@@ -104,7 +103,7 @@ class DaskArrayClient(BaseStructureClient):
                 "expected_shape": expected_shape,
             },
         )
-        return deserialization_registry("array", media_type, content, dtype, shape)
+        return numpy.frombuffer(content, dtype=dtype).reshape(shape)
 
     def read_block(self, block, slice=None):
         """


### PR DESCRIPTION
We defer registering (de)serializers unless we need them because it triggers imports of many optional dependencies.

I think the best solution is to incorporate dask's clever "lazy registration" mechanism, but for now this is a simpler path.