### PR TITLE
Revamp client

### DIFF
--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -91,13 +91,8 @@ class DaskArrayClient(BaseStructureClient):
             expected_shape = ",".join(map(str, shape))
         else:
             expected_shape = "scalar"
-        full_path = (
-            "/array/block"
-            + "".join(f"/{part}" for part in self.context.path_parts)
-            + "".join(f"/{part}" for part in self._path)
-        )
         content = self.context.get_content(
-            full_path,
+            self.item["links"]["block"],
             headers={"Accept": media_type},
             params={
                 "block": ",".join(map(str, block)),

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -5,12 +5,8 @@ from .cache import Revalidate, verify_cache
 
 
 class BaseClient:
-    def __init__(self, context, *, item, path, structure_clients):
+    def __init__(self, context, *, item, structure_clients):
         self._context = context
-        if isinstance(path, str):
-            raise ValueError("path is expected to be a list of segments")
-        # Stash *immutable* copies just to be safe.
-        self._path = tuple(path or [])
         self._item = item
         self._cached_len = None  # a cache just for __len__
         self.structure_clients = structure_clients
@@ -72,11 +68,6 @@ class BaseClient:
         return ListView(self.item["attributes"]["specs"])
 
     @property
-    def path(self):
-        "Sequence of entry names from the root Tree to this entry"
-        return ListView(self._path)
-
-    @property
     def uri(self):
         "Direct link to this entry"
         return self.item["links"]["self"]
@@ -93,17 +84,14 @@ class BaseClient:
     def offline(self, value):
         self.context.offline = bool(value)
 
-    def new_variation(self, path=UNCHANGED, structure_clients=UNCHANGED, **kwargs):
+    def new_variation(self, structure_clients=UNCHANGED, **kwargs):
         """
         This is intended primarily for internal use and use by subclasses.
         """
-        if path is UNCHANGED:
-            path = self._path
         if structure_clients is UNCHANGED:
             structure_clients = self.structure_clients
         return type(self)(
             item=self._item,
-            path=path,
             structure_clients=structure_clients,
             **kwargs,
         )

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -191,7 +191,7 @@ def from_tree(
     return from_context(context, structure_clients=structure_clients)
 
 
-def from_context(context, structure_clients="numpy", *, path=None):
+def from_context(context, structure_clients="numpy"):
     """
     Advanced: Connect to a Node using a custom instance of httpx.Client or httpx.AsyncClient.
 
@@ -210,10 +210,9 @@ def from_context(context, structure_clients="numpy", *, path=None):
     # Interpret structure_clients="numpy" and structure_clients="dask" shortcuts.
     if isinstance(structure_clients, str):
         structure_clients = Node.DEFAULT_STRUCTURE_CLIENT_DISPATCH[structure_clients]
-    path = path or []
     content = context.get_json(f"/node/metadata/{'/'.join(context.path_parts)}")
     item = content["data"]
-    return client_for_item(context, structure_clients, item, path=path)
+    return client_for_item(context, structure_clients, item)
 
 
 def from_profile(name, structure_clients=None, **kwargs):

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -105,7 +105,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         self,
         context,
         *,
-        path,
         item,
         structure_clients,
         queries=None,
@@ -147,7 +146,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         super().__init__(
             context=context,
             item=item,
-            path=path,
             structure_clients=structure_clients,
         )
 
@@ -360,21 +358,11 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                         raise KeyError(key)
                     raise
                 item = content["data"]
-        return client_for_item(
-            self.context, self.structure_clients, item, path=self._path + (item["id"],)
-        )
+        return client_for_item(self.context, self.structure_clients, item)
 
     def __delitem__(self, key):
         self._cached_len = None
-
-        path = (
-            "/node/metadata"
-            + "".join(f"/{part}" for part in self.context.path_parts)
-            + "".join(f"/{part}" for part in self._path)
-            + "/"
-            + key
-        )
-        self.context.delete_content(path, None)
+        self.context.delete_content(f"{self.uri}/{key}", None)
 
     # The following two methods are used by keys(), values(), items().
 
@@ -439,7 +427,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                     self.context,
                     self.structure_clients,
                     item,
-                    path=self._path + (item["id"],),
                 )
             return
         if direction > 0:
@@ -468,7 +455,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                     self.context,
                     self.structure_clients,
                     item,
-                    path=self._path + (item["id"],),
                 )
             next_page_url = content["links"]["next"]
 
@@ -604,7 +590,6 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             self.context,
             self.structure_clients,
             item,
-            path=self._path + (item["id"],),
             structure=structure,
         )
 

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -259,7 +259,7 @@ def record_history():
     _history = None
 
 
-def client_for_item(context, structure_clients, item, path, structure=None):
+def client_for_item(context, structure_clients, item, structure=None):
     """
     Create an instance of the appropriate client class for an item.
 
@@ -285,7 +285,6 @@ def client_for_item(context, structure_clients, item, path, structure=None):
     return class_(
         context=context,
         item=item,
-        path=path,
         structure_clients=structure_clients,
         structure=structure,
     )


### PR DESCRIPTION
This is a placeholder for what I expect to be a large PR with many interdependent aspects, effectively ripping the client apart and reassembling better.

- [x] Remove vestigial `path` parameter. (This information is superseded by `item`).
- [ ] Factor authenticaiton logic from `Context` into a separate `httpx.Auth` subclass.
- [ ] Factor caching and `offline` ("airplane mode") logic into the transport layer, and rethink caching. More planning notes here: https://github.com/bluesky/tiled/issues/281
- [ ] Make async varieties of the client objects. This is a good thing to have in general in 2022, but in particular there is evidence it may unlock better throughput on batch downloading.
- [ ] https://github.com/bluesky/tiled/issues/288