### PR TITLE
Add zstandard dependency.

### DIFF
--- a/requirements-compression.txt
+++ b/requirements-compression.txt
@@ -2,3 +2,4 @@
 # They fall back to gzip (which is slower) if these are not installed.
 blosc
 lz4
+zstandard


### PR DESCRIPTION
The server supports zstd compression. The Python client does not
support it yet, but it can still be useful to test/use with other
clients.