### PR TITLE
add configurable validation registry

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -1,4 +1,3 @@
-import contextlib
 import io
 import time
 from datetime import timedelta
@@ -10,20 +9,13 @@ from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter
 from ..client import from_config
 from ..client.context import CannotRefreshAuthentication
-from ..client.utils import ClientError
 from ..server import authentication
+from .utils import fail_with_status_code
 
 arr = ArrayAdapter.from_array(numpy.ones((5, 5)))
 
 
 tree = MapAdapter({"A1": arr, "A2": arr})
-
-
-@contextlib.contextmanager
-def fail_with_status_code(status_code):
-    with pytest.raises(ClientError) as info:
-        yield
-    assert info.value.response.status_code == status_code
 
 
 @pytest.fixture

--- a/tiled/_tests/test_validation.py
+++ b/tiled/_tests/test_validation.py
@@ -1,0 +1,64 @@
+"""
+This tests tiled's validation registry
+"""
+
+import httpx
+import numpy as np
+import pandas as pd
+import pytest
+
+from ..client import from_tree
+from ..validation_registration import ValidationError, ValidationRegistry
+from .writable_adapters import WritableMapAdapter
+
+API_KEY = "secret"
+
+
+def validate_foo(metadata, structure_family, structure, spec):
+    if structure_family != "dataframe":
+        raise ValidationError(f"structure family for spec {spec} must be dataframe")
+
+    if list(structure.macro.columns) != ["a", "b"]:
+        raise ValidationError(f"structure for spec {spec} must have columns ['a', 'b']")
+
+    if "foo" not in metadata:
+        raise ValidationError("metadata for spec {spec} must contain foo")
+
+
+def test_validators():
+
+    validation_registry = ValidationRegistry()
+    validation_registry.register("foo", validate_foo)
+
+    tree = WritableMapAdapter({})
+    client = from_tree(
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as err:
+        a = np.ones((5, 7))
+        client.write_array(a, metadata={}, specs=["foo"])
+    assert err.match("400")
+
+    with pytest.raises(httpx.HTTPStatusError) as err:
+        df = pd.DataFrame({"x": np.zeros(100), "y": np.zeros(100)})
+        client.write_dataframe(df, metadata={}, specs=["foo"])
+    assert err.match("400")
+
+    with pytest.raises(httpx.HTTPStatusError) as err:
+        df = pd.DataFrame({"a": np.zeros(100), "b": np.zeros(100)})
+        client.write_dataframe(df, metadata={}, specs=["foo"])
+    assert err.match("400")
+
+    df = pd.DataFrame({"a": np.zeros(100), "b": np.zeros(100)})
+    client.write_dataframe(df, metadata={"foo": "bar"}, specs=["foo"])
+
+    assert len(client.values()) == 1
+
+    result = client.values().first()
+
+    result_df = result.read()
+    pd.testing.assert_frame_equal(result_df, df)

--- a/tiled/_tests/test_validation.py
+++ b/tiled/_tests/test_validation.py
@@ -2,13 +2,12 @@
 This tests tiled's validation registry
 """
 
-import httpx
 import numpy as np
 import pandas as pd
-import pytest
 
 from ..client import from_tree
 from ..validation_registration import ValidationError, ValidationRegistry
+from .utils import fail_with_status_code
 from .writable_adapters import WritableMapAdapter
 
 API_KEY = "secret"
@@ -38,20 +37,17 @@ def test_validators():
         validation_registry=validation_registry,
     )
 
-    with pytest.raises(httpx.HTTPStatusError) as err:
+    with fail_with_status_code(400):
         a = np.ones((5, 7))
         client.write_array(a, metadata={}, specs=["foo"])
-    assert err.match("400")
 
-    with pytest.raises(httpx.HTTPStatusError) as err:
+    with fail_with_status_code(400):
         df = pd.DataFrame({"x": np.zeros(100), "y": np.zeros(100)})
         client.write_dataframe(df, metadata={}, specs=["foo"])
-    assert err.match("400")
 
-    with pytest.raises(httpx.HTTPStatusError) as err:
+    with fail_with_status_code(400):
         df = pd.DataFrame({"a": np.zeros(100), "b": np.zeros(100)})
         client.write_dataframe(df, metadata={}, specs=["foo"])
-    assert err.match("400")
 
     df = pd.DataFrame({"a": np.zeros(100), "b": np.zeros(100)})
     client.write_dataframe(df, metadata={"foo": "bar"}, specs=["foo"])

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -3,94 +3,16 @@ This tests tiled's writing routes with an in-memory store.
 
 Persistent stores are being developed externally to the tiled package.
 """
-import uuid
 
 import dask.dataframe
 import numpy
 import pandas.testing
 import sparse
 
-from ..adapters.array import ArrayAdapter, slice_and_shape_from_block_and_chunks
-from ..adapters.dataframe import DataFrameAdapter
-from ..adapters.mapping import MapAdapter
-from ..adapters.sparse import COOAdapter
 from ..client import from_tree, record_history
 from ..queries import Key
-from ..serialization.dataframe import deserialize_arrow
-from ..structures.core import StructureFamily
 from ..structures.sparse import COOStructure
-
-
-class WritableArrayAdapter(ArrayAdapter):
-    def put_data(self, body, block=None):
-        macrostructure = self.macrostructure()
-        if block is None:
-            shape = macrostructure.shape
-            slice_ = numpy.s_[:]
-        else:
-            slice_, shape = slice_and_shape_from_block_and_chunks(
-                block, macrostructure.chunks
-            )
-        array = numpy.frombuffer(
-            body, dtype=self.microstructure().to_numpy_dtype()
-        ).reshape(shape)
-        self._array[slice_] = array
-
-
-class WritableDataFrameAdapter(DataFrameAdapter):
-    def put_data(self, body, partition=0):
-        df = deserialize_arrow(body)
-        self._partitions[partition] = df
-
-
-class WritableCOOAdapter(COOAdapter):
-    def put_data(self, body, block=None):
-        if not block:
-            block = (0,) * len(self.shape)
-        df = deserialize_arrow(body)
-        coords = df[df.columns[:-1]].values.T
-        data = df["data"].values
-        self.blocks[block] = (coords, data)
-
-
-class WritableMapAdapter(MapAdapter):
-    def post_metadata(self, metadata, structure_family, structure, specs):
-        key = str(uuid.uuid4())
-        if structure_family == StructureFamily.array:
-            # Initialize an array of zeros, similar to how chunked storage
-            # formats (e.g. HDF5, Zarr) use a fill_value.
-            array = dask.array.zeros(
-                structure.macro.shape,
-                dtype=structure.micro.to_numpy_dtype(),
-                chunks=structure.macro.chunks,
-            )
-            self._mapping[key] = WritableArrayAdapter(
-                array, metadata=metadata, specs=specs
-            )
-        elif structure_family == StructureFamily.dataframe:
-            # Initialize an empty DataFrame with the right columns/types.
-            meta = deserialize_arrow(structure.micro.meta)
-            divisions_wrapped_in_df = deserialize_arrow(structure.micro.divisions)
-            divisions = tuple(divisions_wrapped_in_df["divisions"].values)
-            self._mapping[key] = WritableDataFrameAdapter(
-                [None] * structure.macro.npartitions,
-                meta=meta,
-                divisions=divisions,
-                metadata=metadata,
-                specs=specs,
-            )
-        elif structure_family == StructureFamily.sparse:
-            self._mapping[key] = WritableCOOAdapter(
-                {},
-                shape=structure.shape,
-                chunks=structure.chunks,
-                metadata=metadata,
-                specs=specs,
-            )
-        else:
-            raise NotImplementedError(structure_family)
-        return key
-
+from .writable_adapters import WritableMapAdapter
 
 API_KEY = "secret"
 

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -1,3 +1,10 @@
+import contextlib
+
+import pytest
+
+from ..client.utils import ClientError
+
+
 def force_update(client):
     """
     Reach into the tree force it to process an updates. Block until complete.
@@ -7,3 +14,10 @@ def force_update(client):
     where things can take longer than they do in normal use.
     """
     client.context.app.state.root_tree.update_now()
+
+
+@contextlib.contextmanager
+def fail_with_status_code(status_code):
+    with pytest.raises(ClientError) as info:
+        yield
+    assert info.value.response.status_code == status_code

--- a/tiled/_tests/writable_adapters.py
+++ b/tiled/_tests/writable_adapters.py
@@ -1,0 +1,82 @@
+import uuid
+
+import dask
+import numpy
+
+from ..adapters.array import ArrayAdapter, slice_and_shape_from_block_and_chunks
+from ..adapters.dataframe import DataFrameAdapter
+from ..adapters.mapping import MapAdapter
+from ..adapters.sparse import COOAdapter
+from ..serialization.dataframe import deserialize_arrow
+from ..structures.core import StructureFamily
+
+
+class WritableArrayAdapter(ArrayAdapter):
+    def put_data(self, body, block=None):
+        macrostructure = self.macrostructure()
+        if block is None:
+            shape = macrostructure.shape
+            slice_ = numpy.s_[:]
+        else:
+            slice_, shape = slice_and_shape_from_block_and_chunks(
+                block, macrostructure.chunks
+            )
+        array = numpy.frombuffer(
+            body, dtype=self.microstructure().to_numpy_dtype()
+        ).reshape(shape)
+        self._array[slice_] = array
+
+
+class WritableDataFrameAdapter(DataFrameAdapter):
+    def put_data(self, body, partition=0):
+        df = deserialize_arrow(body)
+        self._partitions[partition] = df
+
+
+class WritableCOOAdapter(COOAdapter):
+    def put_data(self, body, block=None):
+        if not block:
+            block = (0,) * len(self.shape)
+        df = deserialize_arrow(body)
+        coords = df[df.columns[:-1]].values.T
+        data = df["data"].values
+        self.blocks[block] = (coords, data)
+
+
+class WritableMapAdapter(MapAdapter):
+    def post_metadata(self, metadata, structure_family, structure, specs):
+        key = str(uuid.uuid4())
+        if structure_family == StructureFamily.array:
+            # Initialize an array of zeros, similar to how chunked storage
+            # formats (e.g. HDF5, Zarr) use a fill_value.
+            array = dask.array.zeros(
+                structure.macro.shape,
+                dtype=structure.micro.to_numpy_dtype(),
+                chunks=structure.macro.chunks,
+            )
+            self._mapping[key] = WritableArrayAdapter(
+                array, metadata=metadata, specs=specs
+            )
+        elif structure_family == StructureFamily.dataframe:
+            # Initialize an empty DataFrame with the right columns/types.
+            meta = deserialize_arrow(structure.micro.meta)
+            divisions_wrapped_in_df = deserialize_arrow(structure.micro.divisions)
+            divisions = tuple(divisions_wrapped_in_df["divisions"].values)
+            self._mapping[key] = WritableDataFrameAdapter(
+                [None] * structure.macro.npartitions,
+                meta=meta,
+                divisions=divisions,
+                metadata=metadata,
+                specs=specs,
+            )
+        elif structure_family == StructureFamily.sparse:
+            self._mapping[key] = WritableCOOAdapter(
+                {},
+                shape=structure.shape,
+                chunks=structure.chunks,
+                metadata=metadata,
+                specs=specs,
+            )
+        else:
+            raise NotImplementedError(structure_family)
+        return key

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -120,6 +120,7 @@ def from_tree(
     query_registry=None,
     serialization_registry=None,
     compression_registry=None,
+    validation_registry=None,
     cache=None,
     offline=False,
     username=None,
@@ -176,6 +177,7 @@ def from_tree(
         query_registry=query_registry,
         serialization_registry=serialization_registry,
         compression_registry=compression_registry,
+        validation_registry=validation_registry,
         # The cache and "offline" mode do not make much sense when we have an
         # in-process connection, but we support it for the sake of testing and
         # making direct access a drop in replacement for the normal service.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -824,6 +824,7 @@ def context_from_tree(
     query_registry=None,
     serialization_registry=None,
     compression_registry=None,
+    validation_registry=None,
     cache=None,
     offline=False,
     token_cache=DEFAULT_TOKEN_CACHE,
@@ -863,6 +864,7 @@ def context_from_tree(
         query_registry=query_registry,
         serialization_registry=serialization_registry,
         compression_registry=compression_registry,
+        validation_registry=validation_registry,
     )
 
     # Only an AsyncClient can be used over ASGI.

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -598,8 +598,14 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             ).decode()
 
         document = self.context.post_json(self.uri, item["attributes"])
+
+        # if server returned modified metadata update the local copy
+        if "metadata" in document:
+            item["attributes"]["metadata"] = document.pop("metadata")
+
         # Merge in "id" and "links" returned by the server.
         item.update(document)
+
         return client_for_item(
             self.context,
             self.structure_clients,

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -468,5 +468,7 @@ properties:
       ```python
       f(metadata, structure_family, structure, spec)
       ```
-      and return `metadata` (possibly modified) if validation passes
-      and otherwise throw a `tiled.validation_registration.ValidationError` exception.
+      and return `None` or a possibly modified metadata object to indicate
+      success or throw a `tiled.validation_registration.ValidationError`
+      exception to indicate failure. If a metadata object is returned it
+      will be sent back to client in the response to the POST.

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -452,3 +452,21 @@ properties:
           Enable/Disable prometheus metrics. Default is false.
           If enabled `PROMETHEUS_MULTIPROC_DIR` environment variable
           must be set to the path of a writable directory.
+  validation:
+    type: object
+    additionProperties: true
+    description: |
+      validation functions for specs.
+
+      Given as a spec mapped to an importable function, as in
+
+      ```yaml
+      my-spec: package.module:validator_function
+      ```
+
+      The validation function should have signature
+      ```python
+      f(metadata, structure_family, structure, spec)
+      ```
+      and return `metadata` (possibly modified) if validation passes
+      and otherwise throw a `tiled.validation_registration.ValidationError` exception.

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -10,6 +10,9 @@ from .utils import (
     modules_available,
 )
 
+# Since we use mimetypes.types_map directly need to manually init here
+mimetypes.init()
+
 
 class SerializationRegistry:
     """

--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -44,6 +44,7 @@ def serialize_csv(array, metadata):
 
 
 serialization_registry.register("array", "text/csv", serialize_csv)
+serialization_registry.register("array", "text/x-comma-separated-values", serialize_csv)
 serialization_registry.register("array", "text/plain", serialize_csv)
 deserialization_registry.register(
     "array",

--- a/tiled/serialization/dataframe.py
+++ b/tiled/serialization/dataframe.py
@@ -59,6 +59,9 @@ deserialization_registry.register(
 # https://issues.apache.org/jira/browse/PARQUET-1889
 serialization_registry.register("dataframe", "application/x-parquet", serialize_parquet)
 serialization_registry.register("dataframe", "text/csv", serialize_csv)
+serialization_registry.register(
+    "dataframe", "text/x-comma-separated-values", serialize_csv
+)
 serialization_registry.register("dataframe", "text/plain", serialize_csv)
 serialization_registry.register("dataframe", "text/html", serialize_html)
 if modules_available("openpyxl", "pandas"):

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -60,6 +60,11 @@ serialization_registry.register(
 )
 serialization_registry.register(
     "xarray_dataset",
+    "text/x-comma-separated-values",
+    lambda node, metadata: serialize_csv(node.as_dataset().to_dataframe(), metadata),
+)
+serialization_registry.register(
+    "xarray_dataset",
     "text/plain",
     lambda node, metadata: serialize_csv(node.as_dataset().to_dataframe(), metadata),
 )

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -8,6 +8,7 @@ from ..media_type_registration import (
     serialization_registry as default_serialization_registry,
 )
 from ..query_registration import query_registry as default_query_registry
+from ..validation_registration import validation_registry as default_validation_registry
 from .authentication import get_current_principal
 from .core import NoEntry
 from .utils import record_timing
@@ -23,6 +24,12 @@ def get_query_registry():
 def get_serialization_registry():
     "This may be overridden via dependency_overrides."
     return default_serialization_registry
+
+
+@lru_cache(1)
+def get_validation_registry():
+    "This may be overridden via dependency_overrides."
+    return default_validation_registry
 
 
 def get_root_tree():

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -573,6 +573,11 @@ def post_metadata(
         body.specs,
     )
 
+    # Known Issue:
+    # When there is more than one spec, it's possible for the validator for
+    # Spec 2 to make a modification that breaks the validation for Spec 1.
+    # For now we leave it to the server maintainer to ensure that validators
+    # won't step on each other in this way, but this may need revisiting.
     metadata_modified = False
 
     for spec in specs:

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -286,6 +286,7 @@ class PostMetadataRequest(pydantic.BaseModel):
 
 class PostMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):
     id: str
+    metadata: Optional[Dict]  # may be None if validators did not alter metadata
     links: Union[ArrayLinks, DataFrameLinks, SparseLinks]
 
 

--- a/tiled/validation_registration.py
+++ b/tiled/validation_registration.py
@@ -1,0 +1,31 @@
+class ValidationRegistry:
+    """
+    Register validation functions for specs
+    """
+
+    def __init__(self):
+        self._lookup = {}
+
+    def register(self, spec, func):
+        self._lookup[spec] = func
+
+    def dispatch(self, spec):
+        try:
+            return self._lookup[spec]
+        except KeyError:
+            pass
+        raise ValueError(f"No dispatch for spec {spec}")
+
+    def __call__(self, spec):
+        return self.dispatch(spec)
+
+    def __contains__(self, spec):
+        return spec in self._lookup
+
+
+validation_registry = ValidationRegistry()
+"Global validation registry"
+
+
+class ValidationError(Exception):
+    pass


### PR DESCRIPTION
This adds a configurable validation registry which allows attaching a function to validate data with a given spec posted to the `/node/metadata` route.

The validation configuration consists of a new `validation` section in the config file which maps specs to importable functions.
The validation function is called as `f(metadata, structure_family, structure, spec)` and must return `metadata` (possibly modified) or else throw a `tiled.validation_registration.ValidationError` exception.

Unfortunately not really possible to test without a builtin writable tree but hopefully not too complicated. It think this is generally useful and will improve the validation in aimmdb.