### PR TITLE
Declare starlette dependency.

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -20,6 +20,7 @@ python-jose[cryptography]
 python-multipart
 pyyaml
 sqlalchemy
+starlette
 toolz
 typer
 uvicorn[standard]


### PR DESCRIPTION
We have a direct dependency on `starlette`. We should declare it. (We get it through our dependency on `fastapi` anyway, but it's best practice to declare anything we directly import.)