### PR TITLE
Support varargs in search().

### DIFF
--- a/docs/source/reference/queries.md
+++ b/docs/source/reference/queries.md
@@ -26,6 +26,13 @@ Follow the links in the table below for examples specific to each query.
 
 ## Query expressions
 
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.queries.Key
+```
+
 The `Key` object can be used to construct queries in a readable way using
 standard Python comparison operators, as in
 
@@ -38,13 +45,28 @@ Key("temperature") > 300
 used in searches like
 
 ```python
-c.search(Key("color") == "red").search(Key("shape") != "circle").search(Key("temperature") > 300)
+c.search(Key("color") == "red", Key("shape") != "circle", Key("temperature") > 300)
 ```
 
-Notice that, to compound searches, you may use repeated calls to `.search()` as in
+Passing _multiple_ queries to `search(...)`, as shown above, compounds them
+(logical AND).  Alternatively, you may progressively narrow results and store
+them in separate variables.
 
 ```python
-c.search(...).search(...).search(...)
+results1 = c.search(...)
+results2 = results1.search(...)
+results3 = results2.search(...)
+```
+
+There is no support for logical OR. You must perform separate queries and
+combine them yourself. It may convenient to combine them like so in a `dict`,
+as long as the results are not too numerous to fit in memory.
+
+```python
+a = c.search(...)
+b = c.search(...)
+c = c.search(...)
+combined_results = dict(**a, **b, **c)
 ```
 
 ````{warning}
@@ -71,13 +93,6 @@ a query with `not`, `in`, `and`, or `or`.
 
 ````
 
-
-```{eval-rst}
-.. autosummary::
-   :toctree: generated
-
-   tiled.queries.Key
-```
 
 ## Convenience Functions
 

--- a/docs/source/tutorials/search.md
+++ b/docs/source/tutorials/search.md
@@ -1,7 +1,7 @@
 # Search
 
-In this tutorial we will find a dataset in a Node by performing a search
-over the entries' metadata.
+In this tutorial we will find a dataset by performing a search over
+metadata.
 
 To follow along, start the Tiled server with example data from a Terminal.
 
@@ -48,21 +48,23 @@ anywhere in the metadata.
 <Node {'short_table', 'long_table'}>
 ```
 
-The result is another client, with a subset of the entries or the original.
-We might next stash it in a variable and drill further down.
+The result has a subset of the entries or the original.
+
+Searches may be chained to progressively narrow results.
 
 ```python
->>> results = client.search(FullText("dog"))
->>> results['short_table']
-<DataFrameClient>
-```
-
-Searches may be chained:
-
-```python
->>> client.search(FullText("dog")).search(FullText("red"))
+>>> results1 = client.search(FullText("dog"))
+>>> results1
+<Node {'short_table', 'long_table'}>
+>>> results2 = results1.search(FullText("red"))
 <Node {'short_table'}>
 ```
+
+If you do not need to inspect the intermediate results `results1`,
+you can spell this more succinct with by passing multiple queries
+to `search()`:
+
+>>> client.search(FullText("dog"), FullText("red"))
 
 If there no matches, the result is an empty Node:
 
@@ -71,7 +73,7 @@ If there no matches, the result is an empty Node:
 <Node {}>
 ```
 
-## Roadmap
+## More Queries
 
-Currently, ``FullText`` is the only outwardly-useful query supported. More
-will be added, as well as documentation on how to register user-defined ones.
+Above, use the `FullText` query. Tiled supports many queries;
+see {doc}`../reference/queries`.

--- a/docs/source/tutorials/search.md
+++ b/docs/source/tutorials/search.md
@@ -61,7 +61,7 @@ Searches may be chained to progressively narrow results.
 ```
 
 If you do not need to inspect the intermediate results `results1`,
-you can spell this more succinct with by passing multiple queries
+you can express this more succinctly with by passing multiple queries
 to `search()`:
 
 >>> client.search(FullText("dog"), FullText("red"))

--- a/tiled/_tests/test_search.py
+++ b/tiled/_tests/test_search.py
@@ -42,6 +42,8 @@ def test_compound_search():
     client = from_tree(tree)
     results = client.search(FullText("dog")).search(FullText("yellow"))
     assert list(results) == ["b"]
+    results = client.search(FullText("dog"), FullText("yellow"))
+    assert list(results) == ["b"]
 
 
 def test_key_into_results():

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -481,17 +481,18 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
     def items(self):
         return ItemsView(lambda: len(self), self._items_slice)
 
-    def search(self, query):
+    def search(self, *query):
         """
         Make a Node with a subset of this Node's entries, filtered by query.
 
         Examples
         --------
 
-        >>> from tiled.queries import FullText
+        >>> from tiled.queries import FullText, Eq
         >>> tree.search(FullText("hello"))
+        >>> tree.search(FullText("hello"), Eq("color", "red"))
         """
-        return self.new_variation(queries=self._queries + [query])
+        return self.new_variation(queries=self._queries + list(query))
 
     def distinct(
         self, metadata_keys, structure_families=False, specs=False, counts=False


### PR DESCRIPTION
This supports

```py
c.search(q1, q2, q3)
```

as equivalent to

```py
c.search(q1).search(q2).search(q3)
```

_This has no performance benefits_ because no network traffic occurs until you actually start fetching results from the search. But it does not have a succinctness benefit. And it _may_ have a readability benefit as long as the behavior is sufficiently obvious: that is, that the queries are being logically AND-ed.