### PR TITLE
API: Change AccessControlPolicy API.

### DIFF
--- a/docs/source/explanations/access-control.md
+++ b/docs/source/explanations/access-control.md
@@ -72,8 +72,7 @@ class PASSAccessPolicy:
     def _get_id(self, principal):
         for identity in principal.identities:
             if identity.provider == self.provider:
-                username = identity.id
-                break
+                return identity.id
         else:
             raise ValueError(
                 f"Principcal {principal} has no identity from provider {self.provider}. "

--- a/docs/source/reference/scopes.md
+++ b/docs/source/reference/scopes.md
@@ -6,10 +6,9 @@ with restricted scopes.
 
 ## List of Scopes
 
-* `inherit` --- Default scope for API keys. Inherit scopes of the Principal
-  associated with this key, resolved at access time.
 * `read:metadata` --- List and search metadata.
 * `read:data` --- Fetch (array, dataframe) data.
+* `create` --- Create a new node. This is not yet used by Tiled itself. It is made available for use by experimental externally-developed adapters that support writing.
 * `write:metadata` --- Write metadata. This is not yet used by Tiled itself. It is made available for use by experimental externally-developed adapters that support writing.
 * `write:data` --- Write (array, dataframe) data. This is not yet used by Tiled itself. It is made available for use by experimental externally-developed adapters that support writing.
 * `apikeys` --- Manage API keys for the currently-authenticated user or service.
@@ -17,12 +16,16 @@ with restricted scopes.
 * `admin:apikeys` --- Manage API keys on behalf of any user or service.
 * `read:principals` --- Read list of all users and services and their attributes.
 
+Finally, there is the meta-scope `inherit`, the default for API keys. It
+inherits the scopes of the Principal associated with this key, resolved at
+access time.
+
 ## Roles
 
 An authenticated entity ("Principal") may be assigned roles that confer a list
 of scopes.
 
-* `user` --- default role, granted scopes `["read:metadata", "read:data", "apikeys"]`
+* `user` --- default role, granted scopes `["read:metadata", "read:data", "write:metadata", "write:data", "create", "apikeys"]`
 * `admin` --- granted all scopes
 
 There is support for custom roles at the database level, but neither role

--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -11,7 +11,7 @@ authentication:
     - provider: toy
       id: alice
 access_control:
-  access_policy: tiled.adapters.mapping:SimpleAccessPolicy
+  access_policy: tiled.access_policies:SimpleAccessPolicy
   args:
     provider: toy  # matches provider above
     access_lists:
@@ -21,7 +21,7 @@ access_control:
       bob:
       - A
       - C
-      cara: tiled.adapters.mapping:SimpleAccessPolicy.ALL
+      cara: tiled.access_policies:SimpleAccessPolicy.ALL
     scopes:
     - "read:metadata"
     - "read:data"

--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -15,10 +15,18 @@ access_control:
   args:
     provider: toy  # matches provider above
     access_lists:
-      alice: ["A", "B"]
-      bob: ["A", "C"]
+      alice:
+      - A
+      - B
+      bob:
+      - A
+      - C
       cara: tiled.adapters.mapping:SimpleAccessPolicy.ALL
-    public: ["D"]
+    scopes:
+    - "read:metadata"
+    - "read:data"
+    public:
+    - D
 trees:
   - path: /
     tree: tiled.examples.toy_authentication:tree

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -35,7 +35,7 @@ def config(tmpdir):
             "uri": f"sqlite:///{tmpdir}/tiled.sqlite",
         },
         "access_control": {
-            "access_policy": "tiled.adapters.mapping:SimpleAccessPolicy",
+            "access_policy": "tiled.access_policies:SimpleAccessPolicy",
             "args": {"access_lists": {"alice": ["a"]}, "provider": "toy"},
         },
         "trees": [
@@ -43,7 +43,7 @@ def config(tmpdir):
                 "tree": f"{__name__}:tree_a",
                 "path": "/a",
                 "access_control": {
-                    "access_policy": "tiled.adapters.mapping:SimpleAccessPolicy",
+                    "access_policy": "tiled.access_policies:SimpleAccessPolicy",
                     "args": {
                         "provider": "toy",
                         "access_lists": {

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -8,11 +8,11 @@ from ..client import from_config
 arr = ArrayAdapter.from_array(numpy.ones((5, 5)))
 
 
-def tree_a(access_policy):
+def tree_a(access_policy=None):
     return MapAdapter({"A1": arr, "A2": arr}, access_policy=access_policy)
 
 
-def tree_b(access_policy):
+def tree_b(access_policy=None):
     return MapAdapter({"B1": arr, "B2": arr}, access_policy=access_policy)
 
 
@@ -55,7 +55,7 @@ def config(tmpdir):
                     },
                 },
             },
-            {"tree": f"{__name__}:tree_b", "path": "/b"},
+            {"tree": f"{__name__}:tree_b", "path": "/b", "access_policy": None},
         ],
     }
 

--- a/tiled/_tests/writable_adapters.py
+++ b/tiled/_tests/writable_adapters.py
@@ -11,7 +11,22 @@ from ..serialization.dataframe import deserialize_arrow
 from ..structures.core import StructureFamily
 
 
-class WritableArrayAdapter(ArrayAdapter):
+class _WritableMixin:
+    def __init__(self, *args, key="", **kwargs):
+        self.key = key
+        super().__init__(*args, **kwargs)
+
+    def put_metadata(self, metadata, specs):
+        # TODO This skips over validation and has a race condition in it, but
+        # this test harness is not long for this world anyway, so good enough
+        # for now.
+        self._metadata.clear()
+        self._metadata.update(metadata)
+        self.specs.clear()
+        self.specs.extend(specs)
+
+
+class WritableArrayAdapter(_WritableMixin, ArrayAdapter):
     def put_data(self, body, block=None):
         macrostructure = self.macrostructure()
         if block is None:
@@ -27,13 +42,13 @@ class WritableArrayAdapter(ArrayAdapter):
         self._array[slice_] = array
 
 
-class WritableDataFrameAdapter(DataFrameAdapter):
+class WritableDataFrameAdapter(_WritableMixin, DataFrameAdapter):
     def put_data(self, body, partition=0):
         df = deserialize_arrow(body)
         self._partitions[partition] = df
 
 
-class WritableCOOAdapter(COOAdapter):
+class WritableCOOAdapter(_WritableMixin, COOAdapter):
     def put_data(self, body, block=None):
         if not block:
             block = (0,) * len(self.shape)
@@ -43,7 +58,7 @@ class WritableCOOAdapter(COOAdapter):
         self.blocks[block] = (coords, data)
 
 
-class WritableMapAdapter(MapAdapter):
+class WritableMapAdapter(_WritableMixin, MapAdapter):
     def post_metadata(self, metadata, structure_family, structure, specs):
         key = str(uuid.uuid4())
         if structure_family == StructureFamily.array:
@@ -55,7 +70,10 @@ class WritableMapAdapter(MapAdapter):
                 chunks=structure.macro.chunks,
             )
             self._mapping[key] = WritableArrayAdapter(
-                array, metadata=metadata, specs=specs
+                array,
+                metadata=metadata,
+                specs=specs,
+                key=key,
             )
         elif structure_family == StructureFamily.dataframe:
             # Initialize an empty DataFrame with the right columns/types.
@@ -68,6 +86,7 @@ class WritableMapAdapter(MapAdapter):
                 divisions=divisions,
                 metadata=metadata,
                 specs=specs,
+                key=key,
             )
         elif structure_family == StructureFamily.sparse:
             self._mapping[key] = WritableCOOAdapter(
@@ -76,6 +95,7 @@ class WritableMapAdapter(MapAdapter):
                 chunks=structure.chunks,
                 metadata=metadata,
                 specs=specs,
+                key=key,
             )
         else:
             raise NotImplementedError(structure_family)

--- a/tiled/access_policies.py
+++ b/tiled/access_policies.py
@@ -12,7 +12,7 @@ class DummyAccessPolicy:
     def allowed_scopes(self, node, principal):
         return ALL_SCOPES
 
-    def filers(self, node, principal, scopes):
+    def filters(self, node, principal, scopes):
         return []
 
 

--- a/tiled/access_policies.py
+++ b/tiled/access_policies.py
@@ -1,0 +1,69 @@
+from .queries import KeysFilter
+from .scopes import SCOPES
+from .utils import Sentinel, SpecialUsers, import_object
+
+ALL_SCOPES = set(SCOPES)
+NO_ACCESS = Sentinel("NO_ACCESS")
+
+
+class DummyAccessPolicy:
+    "Impose no access restrictions."
+
+    def allowed_scopes(self, node, principal):
+        return ALL_SCOPES
+
+    def filers(self, node, principal, scopes):
+        return []
+
+
+class SimpleAccessPolicy:
+    """
+    A mapping of user names to lists of entries they have full access.
+
+    This simple policy does not provide fine-grained control of scopes.
+
+    >>> SimpleAccessPolicy({"alice": ["A", "B"], "bob": ["B"]}, provider="toy")
+    """
+
+    ALL = object()  # sentinel
+
+    def __init__(self, access_lists, *, provider, scopes=None, public=None):
+        self.access_lists = {}
+        self.provider = provider
+        self.scopes = scopes if (scopes is not None) else ALL_SCOPES
+        self.public = set(public or [])
+        for key, value in access_lists.items():
+            if isinstance(value, str):
+                value = import_object(value)
+            self.access_lists[key] = value
+
+    def _get_id(self, principal):
+        # Get the id (i.e. username) of this Principal for the
+        # associated authentication provider.
+        for identity in principal.identities:
+            if identity.provider == self.provider:
+                id = identity.id
+                break
+        else:
+            raise ValueError(
+                f"Principcal {principal} has no identity from provider {self.provider}. "
+                f"Its identities are: {principal.identities}"
+            )
+        return id
+
+    def allowed_scopes(self, node, principal):
+        # The simple policy does not provide for different Principals to
+        # have different scopes on different Nodes. If the Principal has access,
+        # they have the same hard-coded access everywhere.
+        return self.scopes
+
+    def filters(self, node, principal, scopes):
+        if not scopes.issubset(self.scopes):
+            return NO_ACCESS
+        id = self._get_id(principal)
+        access_list = self.access_lists.get(id, [])
+        queries = []
+        if not ((principal is SpecialUsers.admin) or (access_list is self.ALL)):
+            allowed = set(access_list or []) | self.public
+            queries.append(KeysFilter(allowed))
+        return queries

--- a/tiled/adapters/files.py
+++ b/tiled/adapters/files.py
@@ -127,7 +127,6 @@ class DirectoryAdapter(MapAdapter):
         sorting=None,
         specs=None,
         access_policy=None,
-        principal=None,
         error_if_missing=True,
         greedy=False,
         poll_interval=DEFAULT_POLL_INTERVAL,
@@ -162,7 +161,6 @@ class DirectoryAdapter(MapAdapter):
             Metadata for the top-level node of this tree.
         specs : List[str]
         access_policy : AccessPolicy, optional
-        principal : str, optional
         error_if_missing : boolean, optional
             If True (default) raise an error if the directory does not exist.
             If False, wait and poll for the directory to be created later.
@@ -357,7 +355,6 @@ class DirectoryAdapter(MapAdapter):
             metadata=metadata,
             sorting=sorting,
             specs=specs,
-            principal=principal,
             access_policy=access_policy,
             entries_stale_after=entries_stale_after,
             metadata_stale_after=metadata_stale_after,
@@ -380,7 +377,6 @@ class DirectoryAdapter(MapAdapter):
         sorting,
         specs,
         access_policy,
-        principal,
         entries_stale_after=None,
         metadata_stale_after=None,
         must_revalidate=True,
@@ -391,7 +387,6 @@ class DirectoryAdapter(MapAdapter):
             sorting=sorting,
             specs=specs,
             access_policy=access_policy,
-            principal=principal,
             entries_stale_after=entries_stale_after,
             metadata_stale_after=metadata_stale_after,
             must_revalidate=must_revalidate,

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -48,7 +48,7 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
 
     structure_family = "node"
 
-    def __init__(self, node, *, specs=None, access_policy=None, principal=None):
+    def __init__(self, node, *, specs=None, access_policy=None):
         if (access_policy is not None) and (
             not access_policy.check_compatibility(self)
         ):
@@ -57,7 +57,6 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
             )
         self._node = node
         self._access_policy = access_policy
-        self._principal = principal
         self.specs = specs or []
         super().__init__()
 
@@ -73,22 +72,6 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
     @property
     def access_policy(self):
         return self._access_policy
-
-    @property
-    def principal(self):
-        return self._principal
-
-    def authenticated_as(self, principal):
-        if self._principal is not None:
-            raise RuntimeError(f"Already authenticated as {self.principal}")
-        if self._access_policy is not None:
-            raise NotImplementedError
-        tree = type(self)(
-            self._node,
-            access_policy=self._access_policy,
-            principal=principal,
-        )
-        return tree
 
     @property
     def metadata(self):

--- a/tiled/adapters/xarray.py
+++ b/tiled/adapters/xarray.py
@@ -26,27 +26,6 @@ class DatasetAdapter(MapAdapter):
             )
         super().__init__(mapping, *args, specs=specs, **kwargs)
 
-    def as_dataset(self):
-        # We do not stash the original dataset as state.
-        # We (re)construct one here, ensure that any filtering that was done
-        # is respected.
-        data_vars = {}
-        coords = {}
-        for key, array_adapter in self.items():
-            if "xarray_data_var" in array_adapter.specs:
-                data_vars[key] = (
-                    array_adapter.macrostructure().dims,
-                    array_adapter.read(),
-                )
-            elif "xarray_coord" in array_adapter.specs:
-                coords[key] = (
-                    array_adapter.macrostructure().dims,
-                    array_adapter.read(),
-                )
-        return xarray.Dataset(
-            data_vars=data_vars, coords=coords, attrs=self.metadata["attrs"]
-        )
-
     def inlined_contents_enabled(self, depth):
         # Tell the server to in-line the description of each array
         # (i.e. data_vars and coords) to avoid latency of a second

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -112,7 +112,7 @@ def construct_build_app_kwargs(
             tree_spec = item["tree"]
             import_path = tree_aliases.get(tree_spec, tree_spec)
             obj = import_object(import_path, accept_live_object=True)
-            if ("args" in item) or ("access_policy" in item) and (not callable(obj)):
+            if (("args" in item) or ("access_policy" in item)) and (not callable(obj)):
                 raise ValueError(
                     f"Object imported from {import_path} cannot take args. "
                     "It is not callable."

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -14,9 +14,9 @@ from .orm import APIKey, Identity, Principal, Role, Session
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "722ff4e4fcc7"
+REQUIRED_REVISION = "56809bcbfcb0"
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["722ff4e4fcc7", "481830dd6c11"]
+ALL_REVISIONS = ["56809bcbfcb0", "722ff4e4fcc7", "481830dd6c11"]
 
 
 def create_default_roles(engine):
@@ -31,6 +31,7 @@ def create_default_roles(engine):
             scopes=[
                 "read:metadata",
                 "read:data",
+                "create",
                 "write:metadata",
                 "write:data",
                 "apikeys",
@@ -44,6 +45,7 @@ def create_default_roles(engine):
             scopes=[
                 "read:metadata",
                 "read:data",
+                "create",
                 "write:metadata",
                 "write:data",
                 "admin:apikeys",

--- a/tiled/database/migrations/versions/56809bcbfcb0_add_create_scope_to_default_roles.py
+++ b/tiled/database/migrations/versions/56809bcbfcb0_add_create_scope_to_default_roles.py
@@ -1,0 +1,51 @@
+"""Add 'create' scope to default roles.
+
+Revision ID: 56809bcbfcb0
+Revises: 722ff4e4fcc7
+Create Date: 2022-09-29 09:16:32.797138
+
+"""
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+from tiled.database.orm import Role
+
+# revision identifiers, used by Alembic.
+revision = "56809bcbfcb0"
+down_revision = "722ff4e4fcc7"
+branch_labels = None
+depends_on = None
+
+
+ROLES = ["admin", "user"]
+NEW_SCOPES = ["create"]
+
+
+def upgrade():
+    """
+    Add new scopes to Roles.
+    """
+    connection = op.get_bind()
+    with Session(bind=connection) as db:
+        for role_name in ROLES:
+            role = db.query(Role).filter(Role.name == role_name).first()
+            scopes = role.scopes.copy()
+            scopes.extend(NEW_SCOPES)
+            role.scopes = scopes
+            db.commit()
+
+
+def downgrade():
+    """
+    Remove new scopes from Roles, if present.
+    """
+    connection = op.get_bind()
+    with Session(bind=connection) as db:
+        for role_name in ROLES:
+            role = db.query(Role).filter(Role.name == role_name).first()
+            scopes = role.scopes.copy()
+            for scope in NEW_SCOPES:
+                if scope in scopes:
+                    scopes.remove(scope)
+            role.scopes = scopes
+            db.commit()

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -90,6 +90,29 @@ class KeyLookup(NoBool):
         return cls(key=key)
 
 
+@register(name="keys_filter")
+@dataclass
+class KeysFilter(NoBool):
+    """
+    Filter entries that do not match one of these keys.
+
+    This is used by the SimpleAccessPolicy.
+
+    Parameters
+    ----------
+    keys : List[str]
+    """
+
+    keys: List[str]
+
+    def encode(self):
+        return {"keys": json.dumps(self.keys)}
+
+    @classmethod
+    def decode(cls, *, keys):
+        return cls(keys=json.loads(keys))
+
+
 @register(name="regex")
 @dataclass
 class Regex(NoBool):

--- a/tiled/scopes.py
+++ b/tiled/scopes.py
@@ -1,7 +1,4 @@
 SCOPES = {
-    "inherit": {
-        "description": "Default scope for API keys. Inherit scopes of Principal, resolved at access time."
-    },
     "read:metadata": {"description": "Read metadata."},
     "read:data": {"description": "Read data."},
     "write:metadata": {"description": "Write metadata."},

--- a/tiled/scopes.py
+++ b/tiled/scopes.py
@@ -3,6 +3,7 @@ SCOPES = {
     "read:data": {"description": "Read data."},
     "write:metadata": {"description": "Write metadata."},
     "write:data": {"description": "Write data."},
+    "create": {"description": "Add a node."},
     "metrics": {"description": "Access (Prometheus) metrics."},
     "apikeys": {
         "description": "Create and revoke API keys as the currently-authenticated user or service."

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -255,6 +255,7 @@ def get_current_principal(
                     "read:data",
                     "write:metadata",
                     "write:data",
+                    "create",
                     "metrics",
                 }
             else:

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -112,8 +112,6 @@ def construct_entries_response(
     max_depth,
 ):
     path_parts = [segment for segment in path.split("/") if segment]
-    if tree.structure_family != "node":
-        raise WrongTypeForRoute("This is not a Node; it does not have entries.")
     queries = defaultdict(
         dict
     )  # e.g. {"text": {"text": "dog"}, "lookup": {"key": "..."}}

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -79,9 +79,9 @@ def SecureEntry(scopes):
                             # You can see this, but you cannot perform the requested
                             # operation on it.
                             raise HTTPException(
-                                status_code=401,
+                                status_code=403,
                                 detail=(
-                                    "Not enough permissions. "
+                                    "Not enough permissions to perform this action on this node. "
                                     f"Requires scopes {scopes}. "
                                     f"Principal had scopes {list(allowed_scopes)} on this node."
                                 ),

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -591,7 +591,7 @@ def post_metadata(
     path: str,
     body: schemas.PostMetadataRequest,
     validation_registry=Depends(get_validation_registry),
-    entry=SecureEntry(scopes=["write:metadata"]),
+    entry=SecureEntry(scopes=["write:metadata", "create"]),
 ):
     if body.structure_family == StructureFamily.dataframe:
         # Decode meta for pydantic validation

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -35,7 +35,13 @@ from .dependencies import (
     slice_,
 )
 from .settings import get_settings
-from .utils import FilteredNode, filter_for_access, get_base_url, record_timing
+from .utils import (
+    FilteredNode,
+    filter_for_access,
+    get_base_url,
+    get_structure,
+    record_timing,
+)
 
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGE_SIZE = 300
@@ -763,7 +769,7 @@ async def put_metadata(
         metadata, structure_family, structure, specs = (
             input_metadata,
             entry.structure_family,
-            entry.structure,
+            get_structure(entry),
             input_specs,
         )
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -26,8 +26,8 @@ from .core import (
     resolve_media_type,
 )
 from .dependencies import (
+    SecureEntry,
     block,
-    entry,
     expected_shape,
     get_query_registry,
     get_serialization_registry,
@@ -155,7 +155,7 @@ def declare_search_router(query_registry):
         sort: Optional[str] = Query(None),
         max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
         omit_links: bool = Query(False),
-        entry: Any = Security(entry, scopes=["read:metadata"]),
+        entry: Any = SecureEntry(scopes=["read:metadata"]),
         query_registry=Depends(get_query_registry),
         **filters,
     ):
@@ -267,7 +267,7 @@ async def node_distinct(
     specs: bool = False,
     metadata: Optional[List[str]] = Query(default=[]),
     counts: bool = False,
-    entry: Any = Security(entry, scopes=["read:metadata"]),
+    entry: Any = SecureEntry(scopes=["read:metadata"]),
 ):
     if hasattr(entry, "get_distinct"):
         distinct = entry.get_distinct(
@@ -298,7 +298,7 @@ async def node_metadata(
     select_metadata: Optional[str] = Query(None),
     max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
     omit_links: bool = Query(False),
-    entry: Any = Security(entry, scopes=["read:metadata"]),
+    entry: Any = SecureEntry(scopes=["read:metadata"]),
     root_path: bool = Query(False),
 ):
     "Fetch the metadata and structure information for one entry."
@@ -335,7 +335,7 @@ async def node_metadata(
 )
 def array_block(
     request: Request,
-    entry=Security(entry, scopes=["read:data"]),
+    entry=SecureEntry(scopes=["read:data"]),
     block=Depends(block),
     slice=Depends(slice_),
     expected_shape=Depends(expected_shape),
@@ -403,7 +403,7 @@ def array_block(
 )
 def array_full(
     request: Request,
-    entry=Security(entry, scopes=["read:data"]),
+    entry=SecureEntry(scopes=["read:data"]),
     slice=Depends(slice_),
     expected_shape=Depends(expected_shape),
     format: Optional[str] = None,
@@ -469,7 +469,7 @@ def array_full(
 def dataframe_partition(
     request: Request,
     partition: int,
-    entry=Security(entry, scopes=["read:data"]),
+    entry=SecureEntry(scopes=["read:data"]),
     field: Optional[List[str]] = Query(None, min_length=1),
     format: Optional[str] = None,
     filename: Optional[str] = None,
@@ -527,7 +527,7 @@ def dataframe_partition(
 )
 def node_full(
     request: Request,
-    entry=Security(entry, scopes=["read:data"]),
+    entry=SecureEntry(scopes=["read:data"]),
     field: Optional[List[str]] = Query(None, min_length=1),
     format: Optional[str] = None,
     filename: Optional[str] = None,
@@ -583,7 +583,7 @@ def post_metadata(
     path: str,
     body: schemas.PostMetadataRequest,
     validation_registry=Depends(get_validation_registry),
-    entry=Security(entry, scopes=["write:metadata"]),
+    entry=SecureEntry(scopes=["write:metadata"]),
 ):
     if body.structure_family == StructureFamily.dataframe:
         # Decode meta for pydantic validation
@@ -666,7 +666,7 @@ def post_metadata(
 @router.delete("/node/metadata/{path:path}")
 async def delete(
     request: Request,
-    entry=Security(entry, scopes=["write:data", "write:metadata"]),
+    entry=SecureEntry(scopes=["write:data", "write:metadata"]),
 ):
     if hasattr(entry, "delete"):
         entry.delete()
@@ -680,7 +680,7 @@ async def delete(
 @router.put("/array/full/{path:path}")
 async def put_array_full(
     request: Request,
-    entry=Security(entry, scopes=["write:data"]),
+    entry=SecureEntry(scopes=["write:data"]),
 ):
     data = await request.body()
     if hasattr(entry, "put_data"):
@@ -695,7 +695,7 @@ async def put_array_full(
 @router.put("/array/block/{path:path}")
 async def put_array_block(
     request: Request,
-    entry=Security(entry, scopes=["write:data"]),
+    entry=SecureEntry(scopes=["write:data"]),
     block=Depends(block),
 ):
     data = await request.body()
@@ -712,7 +712,7 @@ async def put_array_block(
 @router.put("/node/full/{path:path}")
 async def put_dataframe_full(
     request: Request,
-    entry=Security(entry, scopes=["write:data"]),
+    entry=SecureEntry(scopes=["write:data"]),
 ):
     data = await request.body()
 
@@ -729,7 +729,7 @@ async def put_dataframe_full(
 async def put_dataframe_partition(
     partition: int,
     request: Request,
-    entry=Security(entry, scopes=["write:data"]),
+    entry=SecureEntry(scopes=["write:data"]),
 ):
     data = await request.body()
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -755,7 +755,7 @@ async def put_metadata(
     request: Request,
     body: schemas.PutMetadataRequest,
     validation_registry=Depends(get_validation_registry),
-    entry=Security(entry, scopes=["write:metadata"]),
+    entry=SecureEntry(scopes=["write:metadata"]),
 ):
     if hasattr(entry, "put_metadata"):
         input_metadata = body.metadata if body.metadata is not None else entry.metadata
@@ -809,7 +809,7 @@ async def node_revisions(
     limit: Optional[int] = Query(
         DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
     ),
-    entry=Security(entry, scopes=["read:metadata"]),
+    entry=SecureEntry(scopes=["read:metadata"]),
 ):
     if not hasattr(entry, "revisions"):
         raise HTTPException(
@@ -826,7 +826,7 @@ async def node_revisions(
 
 @router.delete("/node/revisions/{path:path}")
 async def revisions_delitem(
-    request: Request, n: int, entry=Security(entry, scopes=["write:metadata"])
+    request: Request, n: int, entry=SecureEntry(scopes=["write:metadata"])
 ):
     if not hasattr(entry, "revisions"):
         raise HTTPException(

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -4,6 +4,8 @@ import time
 
 from ..access_policies import NO_ACCESS
 from ..adapters.mapping import MapAdapter
+from ..structures.array import ArrayStructure
+from ..structures.dataframe import DataFrameStructure
 
 EMPTY_NODE = MapAdapter({})
 API_KEY_COOKIE_NAME = "tiled_api_key"
@@ -109,3 +111,25 @@ class FilteredNode(collections.abc.Mapping):
 
     def __iter__(self):
         yield from self._node
+
+
+def get_structure(entry):
+    "Abtract over the fact that some have micro/macrostructure."
+    structure_family = entry.structure_family
+    if structure_family == "node":
+        structure = None
+    elif structure_family == "array":
+        structure = ArrayStructure(
+            macro=entry.macrostructure(),
+            micro=entry.microstructure(),
+        )
+    elif structure_family == "dataframe":
+        structure = DataFrameStructure(
+            macro=entry.macrostructure(),
+            micro=entry.microstructure(),
+        )
+    elif structure_family == "sparse":
+        structure = entry.structure()
+    else:
+        raise ValueError(f"Unrecognized structure family {structure_family}")
+    return structure


### PR DESCRIPTION
The original Access Control Policy interface has two shortcomings:

1. A given Access Control Policy implementation is tightly coupled to a specific Adapter implementation.
2. The Access Control Policy interface predated any notion of scopes or write --- Tiled was read-only when we last considered this design.

We need two methods on AccessControlPolicy:

1. Given a Node and a Principal (user or service) return a list of scopes (actions) the Principal is allowed to perform on that Node.
4. Given a Node, a Principal (user or service) and a list of scopes (actions), return a list of Query objects that, when applied progressively via `Node.search(...)`, filters its children such that the Principal can do all of those actions on the remaining children (if any).

In code:

```py
class AccessControlPolicy:
    def allowed_scopes(self, node, principal) -> Set[str]:
        ...
    def filters(self, node, principal, scopes) -> List[Query] | NO_ACCESS:
        ...
```

In practice so far, a given ACP instance is bound to one Node, so `node` may not end up getting used in many cases. But, similarly to callbacks (as I learned in caproto) it can to be useful to tell the callback specifically who the caller is, so that there is a possibility of reuse of a given instance.

I like reusing our search queries for this API. We already have a fairly expressive language of filters, so we may as well reuse it. We even have a method for serializing them, which might come in handy if we want to do the Access Control Policy interaction across a process boundary, or cache or store these responses.

I can dream up others we _might_ want ("Give a paginated list of Principals who can do these Actions on this Node,") but those two seem like the most important ones that we _definitely_ want. It seems like the right place to start, and a significant improvement on the _status quo_.

This design was inspired in part by the PyCon 2022 talk [Why Authorization is ~Hard~ Fun](https://youtu.be/2BN96ON48U8).

It mentions the principal, “If you aren't allowed to see it, it doesn't exist.” It gives GitHub repos as an example: if you aren't logged in, any private repos in an org are just invisible to you. Similarly, if you aren't allowed to close an Issue on GitHub, GitHub just doesn't show the "close" button. (Much better than showing the button and then giving you a permission error.)

I think that the methods proposed above enable us to provide this kind of interaction in a scalable way. For example, we want to hide Nodes the user isn't allowed to see, and we want to provide "update metadata" functionality only on nodes where the user has `write:metadata` scope.

TO DO:
- [x] more tests
- [x] apply this to the implementation in `test_writing.py`

Closes https://github.com/bluesky/tiled/issues/287