### PR TITLE
API: Use varargs in distinct().

### DIFF
--- a/tiled/_tests/test_distinct.py
+++ b/tiled/_tests/test_distinct.py
@@ -39,7 +39,7 @@ def test_distinct():
 
     # test without counts
     distinct = client.distinct(
-        metadata_keys=["foo.bar"], structure_families=True, specs=True, counts=False
+        "foo.bar", structure_families=True, specs=True, counts=False
     )
     expected = {
         "metadata": {"foo.bar": [{"value": v, "count": None} for v in values]},
@@ -61,7 +61,7 @@ def test_distinct():
 
     # test with counts
     distinct = client.distinct(
-        metadata_keys=["foo.bar"], structure_families=True, specs=True, counts=True
+        "foo.bar", structure_families=True, specs=True, counts=True
     )
     expected = {
         "metadata": {
@@ -84,6 +84,6 @@ def test_distinct():
     assert distinct["structure_families"] == expected["structure_families"]
 
     # test with no matches
-    distinct = client.distinct(metadata_keys=["baz"], counts=True)
+    distinct = client.distinct("baz", counts=True)
     expected = {"baz": []}
     assert distinct["metadata"] == expected

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -494,7 +494,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         return self.new_variation(queries=self._queries + [query])
 
     def distinct(
-        self, metadata_keys, structure_families=False, specs=False, counts=False
+        self, *metadata_keys, structure_families=False, specs=False, counts=False
     ):
         """
         Get the unique values and optionally counts of metadata_keys,
@@ -503,7 +503,13 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         Examples
         --------
 
-        >>> tree.distinct(["foo"], counts=True)
+        Query all the distinct values of a key.
+
+        >>> tree.distinct("foo", counts=True)
+
+        Query for multiple keys at once.
+
+        >>> tree.distinct("foo", "bar", counts=True)
         """
 
         path = (


### PR DESCRIPTION
Seeing the demo of distinct, I realize this is a good place to use variadic arguments, changing

```py
c.distinct(["foo"])
```

to

```py
c.distinct("foo")
```

Multiple metadata keys may be passed like

```py
c.distinct("foo", "bar")
```

This side-steps the potential issue where `c.distinct("foo")` becomes `c.distinct(["f", "o", "o"])`. It's also generally more memorable and readable, especially for Python novices.

I think the downside is that it's less obvious that multiple keys _can_ be queried at once. But in this case, on balance, I think variadic args are a net win.

If needed we can do a deprecation cycle here (accepting the old way `["foo"]` and issuing a warning) but given that this is very new I think we can just tell the AIMM folks and make a backward-incompatible change.