### PR TITLE
Deprecate Specs query. Add Spec query.

### DIFF
--- a/docs/source/reference/queries.md
+++ b/docs/source/reference/queries.md
@@ -23,7 +23,6 @@ Follow the links in the table below for examples specific to each query.
    tiled.queries.NotIn
    tiled.queries.Regex
    tiled.queries.Spec
-   tiled.queries.Specs
    tiled.queries.StructureFamily
 ```
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -16,6 +16,7 @@ from ..queries import (
     NotEq,
     NotIn,
     Regex,
+    Spec,
     Specs,
     StructureFamily,
 )
@@ -129,19 +130,30 @@ def test_notin():
     )
 
 
+def test_spec():
+    client = from_tree(tree)
+
+    assert list(client.search(Spec("foo")).search(Spec("bar"))) == sorted(
+        ["specs_foo_bar", "specs_foo_bar_baz"]
+    )
+
+
 def test_specs():
     client = from_tree(tree)
 
     with pytest.raises(TypeError):
-        Specs("foo")
+        with pytest.warns(UserWarning):
+            Specs("foo")
 
-    assert list(client.search(Specs(include=["foo", "bar"]))) == sorted(
-        ["specs_foo_bar", "specs_foo_bar_baz"]
-    )
+    with pytest.warns(UserWarning):
+        assert list(client.search(Specs(include=["foo", "bar"]))) == sorted(
+            ["specs_foo_bar", "specs_foo_bar_baz"]
+        )
 
-    assert list(client.search(Specs(include=["foo", "bar"], exclude=["baz"]))) == [
-        "specs_foo_bar"
-    ]
+    with pytest.warns(UserWarning):
+        assert list(client.search(Specs(include=["foo", "bar"], exclude=["baz"]))) == [
+            "specs_foo_bar"
+        ]
 
 
 def test_structure_families():

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -15,6 +15,7 @@ from ..queries import (
     NotEq,
     NotIn,
     Regex,
+    Spec,
     Specs,
     StructureFamily,
 )
@@ -467,6 +468,9 @@ def notin(query, tree):
 MapAdapter.register_query(NotIn, notin)
 
 
+# The 'specs' query is deprecated but supported here for now.
+
+
 def specs(query, tree):
     matches = {}
     include = set(query.include)
@@ -481,6 +485,19 @@ def specs(query, tree):
 
 
 MapAdapter.register_query(Specs, specs)
+
+
+def spec(query, tree):
+    matches = {}
+
+    for key, value in tree.items():
+        if query.spec in value.specs:
+            matches[key] = value
+
+    return tree.new_variation(mapping=matches)
+
+
+MapAdapter.register_query(Spec, spec)
 
 
 def structure_family(query, tree):

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -7,6 +7,7 @@ The are encoded into and decoded from URL query parameters.
 
 import enum
 import json
+import warnings
 from dataclasses import dataclass
 from typing import Any, List
 
@@ -375,6 +376,12 @@ class Specs:
     exclude: List[str]
 
     def __init__(self, include, exclude=None):
+        warnings.warn(
+            """Specs is deprecated. Use 'Spec' (singular).
+
+If you need to filter for multiple specs, chain multiple calls to search().
+If you need to *exclude* specs please open an issue with your use case."""
+        )
         exclude = exclude or []
 
         if isinstance(include, str):
@@ -397,11 +404,14 @@ class Specs:
         return cls(include=json.loads(include), exclude=json.loads(exclude))
 
 
-def Spec(spec):
+@register(name="spec")
+@dataclass
+class Spec:
     """
-    Convenience function for querying if specs list contains a given spec
+    Query for items that are labeled with the given 'spec'.
 
-    Equivalent to Specs([spec]).
+    A spec is used to convey that an item's metadata and/or structure adhere to
+    a certain standard or set of expectations or constraints.
 
     Parameters
     ----------
@@ -415,7 +425,14 @@ def Spec(spec):
     >>> c.search(Spec("foo"))
     """
 
-    return Specs([spec])
+    spec: str
+
+    def encode(self):
+        return {"spec": self.spec}
+
+    @classmethod
+    def decode(cls, *, spec):
+        return cls(spec=spec)
 
 
 @register(name="structure_family")


### PR DESCRIPTION
Upon reflection, I think my initiate suggestion for `Specs` in #305 was overbuilt. The most common use case will be to look for one spec, as in:

```py
c.search(Spec("XDI"))
```

Typically, because it seems that specs tend to follow an "inheritance" pattern of increasing specificity, one spec will often be enough. But, when the need arises, multiple specs can be filtered the same way we would do multiple rounds of filtering (logical AND) with Tiled queries generally, by chaining calls to `search`:

```py
c.search(Spec("XDI")).search(Spec("HasBatteryChargeMetadata"))
```

The behavior is completely unambiguous. The original proposal provided a way to do this that was more succinct

```py
c.search(Specs(["XDI", "HasBatteryChargeMetadata"]))
```

but its behavior was ambiguous. Does this match items that have both specs or just one? Also, as a minor point, in the situation where you want just one spec `Specs(["XDI"])` with the `[]` is a little ungainly.

The original proposal also provides an `excludes` option, but it's not yet shown that this would really be used.

Therefore, in this PR, I deprecate `Specs` and un-document it. I add `Spec` as a first-class query (not just a wrapper function around `Specs`). Let's see how it goes. If we need `Specs` we can reinstate it easily.