### PR TITLE
Require specs be declared, but validation optional.

### DIFF
--- a/tiled/_tests/test_validation.py
+++ b/tiled/_tests/test_validation.py
@@ -5,7 +5,7 @@ This tests tiled's validation registry
 import numpy as np
 import pandas as pd
 
-from ..client import from_tree
+from ..client import from_config, from_tree
 from ..validation_registration import ValidationError, ValidationRegistry
 from .utils import fail_with_status_code
 from .writable_adapters import WritableMapAdapter
@@ -81,3 +81,21 @@ def test_validators():
     assert result.metadata == metadata_lower
     result_df = result.read()
     pd.testing.assert_frame_equal(result_df, df)
+
+
+tree = WritableMapAdapter({})
+
+
+def test_unknown_spec():
+    "Test unknown spec rejected for upload."
+    config = {
+        "trees": [{"tree": f"{__name__}:tree", "path": "/"}],
+        "specs": [{"spec": "a"}],
+        "authentication": {"single_user_api_key": API_KEY},
+    }
+    client = from_config(config, api_key=API_KEY)
+    a = np.ones((5, 7))
+    client.write_array(a, metadata={}, specs=["a"])
+
+    with fail_with_status_code(400):
+        client.write_array(a, metadata={}, specs=["b"])

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -12,16 +12,22 @@ import sparse
 from ..client import from_tree, record_history
 from ..queries import Key
 from ..structures.sparse import COOStructure
+from ..validation_registration import ValidationRegistry
 from .writable_adapters import WritableMapAdapter
 
 API_KEY = "secret"
+validation_registry = ValidationRegistry()
+validation_registry.register("SomeSpec", lambda *args, **kwargs: None)
 
 
 def test_write_array_full():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     a = numpy.ones((5, 7))
@@ -49,7 +55,10 @@ def test_write_large_array_full():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     a = numpy.ones(100, dtype=numpy.uint8)
@@ -81,7 +90,10 @@ def test_write_array_chunked():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     a = dask.array.arange(1500).reshape((50, 30)).rechunk((20, 15))
@@ -108,7 +120,10 @@ def test_write_dataframe_full():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     data = {f"Column{i}": (1 + i) * numpy.ones(5) for i in range(5)}
@@ -138,7 +153,10 @@ def test_write_dataframe_partitioned():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     data = {f"Column{i}": (1 + i) * numpy.ones(10) for i in range(5)}
@@ -169,7 +187,10 @@ def test_write_sparse_full():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     coo = sparse.COO(coords=[[0, 1], [2, 3]], data=[3.8, 4.0], shape=(4, 4))
@@ -203,7 +224,10 @@ def test_write_sparse_chunked():
 
     tree = WritableMapAdapter({})
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree,
+        api_key=API_KEY,
+        authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     metadata = {"scan_id": 1, "method": "A"}

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -195,9 +195,13 @@ def construct_build_app_kwargs(
         for ext, media_type in config.get("file_extensions", {}).items():
             serialization_registry.register_alias(ext, media_type)
 
-        for spec, validator_path in config.get("validation", {}).items():
-            validator = import_object(validator_path)
-            validation_registry.register(spec, validator)
+        for item in config.get("specs", []):
+            if "validator" in item:
+                validator = import_object(item["validator"])
+            else:
+                # no-op
+                validator = _no_op_validator
+            validation_registry.register(item["spec"], validator)
 
     # TODO Make compression_registry extensible via configuration.
     return {
@@ -450,3 +454,7 @@ def direct_access_from_profile(name):
 
 class ConfigError(ValueError):
     pass
+
+
+def _no_op_validator(*args, **kwargs):
+    return None

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -452,23 +452,34 @@ properties:
           Enable/Disable prometheus metrics. Default is false.
           If enabled `PROMETHEUS_MULTIPROC_DIR` environment variable
           must be set to the path of a writable directory.
-  validation:
-    type: object
-    additionProperties: true
+  specs:
+    type: array
+    items:
+      type: object
+      required:
+        - spec
+      additionalProperties: false
+      properties:
+        spec:
+          type: string
+        validator:
+          type: string
     description: |
-      validation functions for specs.
+      List of specs accepted for uploaded data, with optional validation.
 
-      Given as a spec mapped to an importable function, as in
+      Given as a spec with an importable function, as in
 
       ```yaml
-      my-spec: package.module:validator_function
+      - spec: my-spec
+        validator: package.module:validator_function
       ```
 
       The validation function should have signature
+
       ```python
       f(metadata, structure_family, structure, spec, references)
       ```
       and return `None` or a possibly modified metadata object to indicate
-      success or throw a `tiled.validation_registration.ValidationError`
+      success or raise a `tiled.validation_registration.ValidationError`
       exception to indicate failure. If a metadata object is returned it
       will be sent back to client in the response to the POST.


### PR DESCRIPTION
Backward-incompatible change to config from

```yaml
validators:
  my-spec: validators:validate_my_spec
```

to

```yaml
specs:
- spec: my-spec
  validator: validators:validate_my_spec
```

where `validator:` is now optional.

The server rejects uploads with an unrecognized spec. Thus, you must at least _declare_ the spec in the server configuration to support client upload, but you don't have to write a validator. This will catch spelling mistakes and prohibit a client from exploding the spec namespace without consulting the server admin.

Note that Adapters can still declare specs (from the server side) without declaration. This only affects client upload.