### PR TITLE
Support chunked-encoding streaming export.

### DIFF
--- a/docs/source/how-to/custom-export-formats.md
+++ b/docs/source/how-to/custom-export-formats.md
@@ -216,6 +216,20 @@ In that case, it must be given as a MIME type, in accordance with the standard.
 The file extension alias is not accepted.
 ```
 
+## Advanced: Streaming export
+
+HTTP supports chunked responses, where data is streamed incrementally. This
+is a good fit for streaming-oriented formats such as newline-delimited JSON.
+
+To create a chunked exporter, implement your exporter as a Python generator
+that yields bytes.
+
+```python
+def export(array, metadata):
+    for ... in ...:
+        yield b"..."
+```
+
 ## Further examples
 
 At the bottom of each of the modules in `tiled/structures`, you will

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -33,6 +33,9 @@ tree = MapAdapter(
             ),
             npartitions=3,
         ),
+        "empty_table": DataFrameAdapter.from_pandas(
+            pandas.DataFrame({"A": []}), npartitions=1
+        ),
         "structured_data": MapAdapter(
             {
                 "pets": ArrayAdapter.from_array(
@@ -85,6 +88,15 @@ def test_streaming_export():
     buffer.seek(0)
     for line in buffer.read().decode().splitlines():
         json.loads(line)
+
+
+def test_streaming_export_empty():
+    "The application/json-seq format is streamed via a generator."
+    client = from_tree(tree)
+    buffer = io.BytesIO()
+    client["empty_table"].export(buffer, format="application/json-seq")
+    buffer.seek(0)
+    assert buffer.read() == b""
 
 
 def test_export_weather_data_var(tmpdir):

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -1,4 +1,5 @@
 import io
+import json
 from pathlib import Path
 
 import numpy
@@ -73,6 +74,17 @@ def test_export_2d_array(filename, tmpdir):
 @pytest.mark.parametrize("filename", ["numbers.csv", "spreadsheet.xlsx"])
 def test_export_table(filename, tmpdir):
     client["C"].export(Path(tmpdir, filename))
+
+
+def test_streaming_export():
+    "The application/json-seq format is streamed via a generator."
+    client = from_tree(tree)
+    buffer = io.BytesIO()
+    client["C"].export(buffer, format="application/json-seq")
+    # Verify that output is valid newline-delimited JSON.
+    buffer.seek(0)
+    for line in buffer.read().decode().splitlines():
+        json.loads(line)
 
 
 def test_export_weather_data_var(tmpdir):

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -6,6 +6,7 @@ import math
 import operator
 import re
 import sys
+import types
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -333,8 +334,12 @@ def construct_data_response(
         raise UnsupportedMediaTypes(
             f"This type is supported in general but there was an error packing this specific data: {err.args[0]}",
         )
-    return PatchedResponse(
-        content=content,
+    if isinstance(content, types.GeneratorType):
+        response_class = PatchedStreamingResponse
+    else:
+        response_class = PatchedResponse
+    return response_class(
+        content,
         media_type=media_type,
         headers=headers,
     )


### PR DESCRIPTION
Closes #70 

This extends the export functionality to support _generators_ that yield a chunk of bytes at a time. It applies this feature to the newline-delimited JSON exporter (`application/json-seq`). It is a really strong fit for that streaming-oriented format. In future PRs we can explore applying it to other formats.

Demo below. Notice `transfer-encoding: chunked` in the response header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding.

```
$ http ":8000/api/node/full/short_table?format=application/json-seq"
HTTP/1.1 200 OK
content-type: application/json-seq
date: Wed, 05 Oct 2022 16:35:18 GMT
etag: c8adf2361038a9c936ab5d916bb219dd
server: uvicorn
server-timing: read;dur=0.5, tok;dur=0.1, pack;dur=0.2, app;dur=6.1
set-cookie: tiled_csrf=CFuHBOsYkdEnRoTvVCwG4JmfOHBDPnJytzAthdlG-FY; HttpOnly; Path=/; SameSite=lax
transfer-encoding: chunked

{"A":0.8393166285564699,"B":1.6786332571129399,"C":2.5179498856694096}
{"A":0.5688795868599656,"B":1.1377591737199313,"C":1.706638760579897}
{"A":0.6336226887581975,"B":1.267245377516395,"C":1.9008680662745925}
{"A":0.16052909847062302,"B":0.32105819694124604,"C":0.48158729541186907}
{"A":0.9191461227402795,"B":1.838292245480559,"C":2.7574383682208383}
{"A":0.8768191851466749,"B":1.7536383702933498,"C":2.6304575554400245}
{"A":0.38387163231094434,"B":0.7677432646218887,"C":1.151614896932833}
{"A":0.5438938247574789,"B":1.0877876495149579,"C":1.6316814742724368}
{"A":0.9415108546995818,"B":1.8830217093991637,"C":2.8245325640987455}
{"A":0.7571506359189891,"B":1.5143012718379782,"C":2.2714519077569673}
```
