### PR TITLE
Faster tests

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -326,7 +326,7 @@ def test_api_keys(enter_password, config):
 def test_api_key_limit(enter_password, config):
     # Decrease the limit so this test runs faster.
     original_limit = authentication.API_KEY_LIMIT
-    authentication.API_KEY_LIMIT = 10
+    authentication.API_KEY_LIMIT = 3
     try:
         with enter_password("secret2"):
             user_client = from_config(config, username="bob", token_cache={})
@@ -343,7 +343,7 @@ def test_api_key_limit(enter_password, config):
 def test_session_limit(enter_password, config):
     # Decrease the limit so this test runs faster.
     original_limit = authentication.SESSION_LIMIT
-    authentication.SESSION_LIMIT = 10
+    authentication.SESSION_LIMIT = 3
     try:
         with enter_password("secret1"):
             for _ in range(authentication.SESSION_LIMIT):

--- a/tiled/_tests/test_directory_walker.py
+++ b/tiled/_tests/test_directory_walker.py
@@ -335,5 +335,7 @@ def test_mimetype_detection_hook(tmpdir):
             }
         ]
     }
-    client = from_config(config)
+    # Tiled warns about the couple unrecognized files.
+    with pytest.warns(UserWarning):
+        client = from_config(config)
     assert set(client) == {"a0", "a.0.asfwoeijviojefeiofw", "c.csv"}

--- a/tiled/_tests/test_distinct.py
+++ b/tiled/_tests/test_distinct.py
@@ -32,11 +32,10 @@ for _ in range(10):
     )
 
 tree = MapAdapter(mapping)
+client = from_tree(tree)
 
 
 def test_distinct():
-    client = from_tree(tree)
-
     # test without counts
     distinct = client.distinct(
         "foo.bar", structure_families=True, specs=True, counts=False

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -57,6 +57,7 @@ tree = MapAdapter(
         ),
     }
 )
+client = from_tree(tree)
 
 
 # We test a little bit of actual file export, using the tmpdir fixture,
@@ -66,18 +67,15 @@ tree = MapAdapter(
 
 @pytest.mark.parametrize("filename", ["numbers.csv", "image.png", "image.tiff"])
 def test_export_2d_array(filename, tmpdir):
-    client = from_tree(tree)
     client["A"].export(Path(tmpdir, filename))
 
 
 @pytest.mark.parametrize("filename", ["numbers.csv", "spreadsheet.xlsx"])
 def test_export_table(filename, tmpdir):
-    client = from_tree(tree)
     client["C"].export(Path(tmpdir, filename))
 
 
 def test_export_weather_data_var(tmpdir):
-    client = from_tree(tree)
     buffer = io.BytesIO()
     client["structured_data"]["weather"]["temperature"].export(
         buffer, slice=(0,), format="text/csv"
@@ -85,7 +83,6 @@ def test_export_weather_data_var(tmpdir):
 
 
 def test_export_weather_all():
-    client = from_tree(tree)
     buffer = io.BytesIO()
     client["structured_data"]["weather"].export(buffer, format="application/x-hdf5")
 
@@ -100,12 +97,10 @@ def test_serialization_error_hdf5_metadata():
 
 
 def test_path_as_Path_or_string(tmpdir):
-    client = from_tree(tree)
     client["A"].export(Path(tmpdir, "test_path_as_path.txt"))
     client["A"].export(str(Path(tmpdir, "test_path_as_str.txt")))
 
 
 def test_formats():
-    client = from_tree(tree)
     client.formats
     client["A"].formats

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -58,33 +58,29 @@ tree = MapAdapter(
 )
 
 
-@pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
 @pytest.mark.parametrize("filename", ["numbers.csv", "image.png", "image.tiff"])
-def test_export_2d_array(filename, structure_clients, tmpdir):
-    client = from_tree(tree, structure_clients=structure_clients)
+def test_export_2d_array(filename, tmpdir):
+    client = from_tree(tree)
     client["A"].export(Path(tmpdir, filename))
 
 
-@pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
 @pytest.mark.parametrize("filename", ["numbers.csv", "spreadsheet.xlsx"])
-def test_export_table(filename, structure_clients, tmpdir):
-    client = from_tree(tree, structure_clients=structure_clients)
+def test_export_table(filename, tmpdir):
+    client = from_tree(tree)
     client["C"].export(Path(tmpdir, filename))
 
 
-@pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
 @pytest.mark.parametrize("filename", ["numbers.csv"])
-def test_export_weather_data_var(filename, structure_clients, tmpdir):
-    client = from_tree(tree, structure_clients=structure_clients)
+def test_export_weather_data_var(filename, tmpdir):
+    client = from_tree(tree)
     client["structured_data"]["weather"]["temperature"].export(
         Path(tmpdir, filename), slice=(0,)
     )
 
 
-@pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
 @pytest.mark.parametrize("filename", ["test.h5"])
-def test_export_weather_all(filename, structure_clients, tmpdir):
-    client = from_tree(tree, structure_clients=structure_clients)
+def test_export_weather_all(filename, tmpdir):
+    client = from_tree(tree)
     client["structured_data"]["weather"].export(Path(tmpdir, filename))
 
 

--- a/tiled/_tests/test_history.py
+++ b/tiled/_tests/test_history.py
@@ -2,12 +2,11 @@ from ..adapters.mapping import MapAdapter
 from ..client import from_tree, record_history
 
 tree = MapAdapter({})
+client = from_tree(tree)
 
 
 def test_history():
     "Very basic exercise of history"
-    client = from_tree(tree)
-
     with record_history() as history:
         repr(client)  # trigger a request
     assert history.requests

--- a/tiled/_tests/test_indexers.py
+++ b/tiled/_tests/test_indexers.py
@@ -15,11 +15,11 @@ tree = MapAdapter(
     }
 )
 empty_tree = MapAdapter({})
+client = from_tree(tree)
+empty_client = from_tree(empty_tree)
 
 
 def test_indexers():
-    client = from_tree(tree)
-    empty_client = from_tree(empty_tree)
     assert client.keys()[0] == client.keys().first() == keys[0] == "a"
     assert client.keys()[-1] == client.keys().last() == keys[-1] == "z"
     assert client.keys()[:3] == client.keys().head(3) == keys[:3] == list("abc")
@@ -63,7 +63,6 @@ def test_indexers():
 
 
 def test_deprecated_indexer_accessors():
-    client = from_tree(tree)
     with pytest.warns(DeprecationWarning):
         assert client.keys_indexer[:3] == keys[:3] == list("abc")
     # smoke test the others

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -37,6 +37,7 @@ mapping["does_not_contain_z"] = ArrayAdapter.from_array(
 mapping["specs_foo_bar"] = MapAdapter({}, specs=["foo", "bar"])
 mapping["specs_foo_bar_baz"] = MapAdapter({}, specs=["foo", "bar", "baz"])
 tree = MapAdapter(mapping)
+client = from_tree(tree)
 
 
 def test_key():
@@ -50,8 +51,6 @@ def test_key():
 
 
 def test_eq():
-    client = from_tree(tree)
-
     # Test encoding letters and ints.
     assert list(client.search(Eq("letter", "a"))) == ["a"]
     assert list(client.search(Eq("letter", "b"))) == ["b"]
@@ -62,8 +61,6 @@ def test_eq():
 
 
 def test_noteq():
-    client = from_tree(tree)
-
     # Test encoding letters and ints.
     assert list(client.search(NotEq("letter", "a"))) != ["a"]
     assert list(client.search(NotEq("letter", "b"))) != ["b"]
@@ -72,8 +69,6 @@ def test_noteq():
 
 
 def test_comparison():
-    client = from_tree(tree)
-
     assert list(client.search(Comparison("gt", "number", 24))) == ["z"]
     assert list(client.search(Comparison("ge", "number", 24))) == ["y", "z"]
     assert list(client.search(Comparison("lt", "number", 1))) == ["a"]
@@ -81,20 +76,14 @@ def test_comparison():
 
 
 def test_contains():
-    client = from_tree(tree)
-
     assert list(client.search(Contains("letters", "z"))) == ["does_contain_z"]
 
 
 def test_full_text():
-    client = from_tree(tree)
-
     assert list(client.search(FullText("z"))) == ["z", "does_contain_z"]
 
 
 def test_regex():
-    client = from_tree(tree)
-
     assert list(client.search(Regex("letter", "^z$"))) == ["z"]
     assert (
         list(client.search(Regex("letter", "^Z$"))) == []
@@ -116,22 +105,16 @@ def test_not_and_and_or():
 
 
 def test_in():
-    client = from_tree(tree)
-
     assert list(client.search(In("letter", ["a", "k", "z"]))) == ["a", "k", "z"]
 
 
 def test_notin():
-    client = from_tree(tree)
-
     assert list(client.search(NotIn("letter", ["a", "k", "z"]))) == sorted(
         list(set(keys) - set(["a", "k", "z"]))
     )
 
 
 def test_specs():
-    client = from_tree(tree)
-
     with pytest.raises(TypeError):
         Specs("foo")
 
@@ -145,8 +128,6 @@ def test_specs():
 
 
 def test_structure_families():
-    client = from_tree(tree)
-
     with pytest.raises(ValueError):
         StructureFamily("foo")
 

--- a/tiled/_tests/test_search.py
+++ b/tiled/_tests/test_search.py
@@ -19,6 +19,7 @@ tree = MapAdapter(
         ),
     }
 )
+client = from_tree(tree)
 
 
 @pytest.mark.parametrize(
@@ -32,20 +33,17 @@ tree = MapAdapter(
     ],
 )
 def test_search(term, expected_keys):
-    client = from_tree(tree)
     query = FullText(term)
     results = client.search(query)
     assert list(results) == expected_keys
 
 
 def test_compound_search():
-    client = from_tree(tree)
     results = client.search(FullText("dog")).search(FullText("yellow"))
     assert list(results) == ["b"]
 
 
 def test_key_into_results():
-    client = from_tree(tree)
     results = client.search(FullText("dog"))
     assert "apple" in results["a"].metadata
     assert "banana" in results["b"].metadata

--- a/tiled/_tests/test_size_limit.py
+++ b/tiled/_tests/test_size_limit.py
@@ -37,7 +37,6 @@ config = {
     ],
     "response_bytesize_limit": size_limit,
 }
-client = from_config(config)
 
 
 @contextlib.contextmanager
@@ -59,13 +58,14 @@ def test_array(tmpdir):
     A password that is wrong, empty, or belonging to a different user fails.
     """
 
+    c = from_config(config)
     path = str(tmpdir / "test.csv")
-    client["tiny_array"].read()  # This is fine.
-    client["tiny_array"].export(path)  # This is fine.
+    c["tiny_array"].read()  # This is fine.
+    c["tiny_array"].export(path)  # This is fine.
     with fail_with_status_code(400):
-        client["small_array"].read()  # too big
+        c["small_array"].read()  # too big
     with fail_with_status_code(400):
-        client["small_array"].export(path)  # too big
+        c["small_array"].export(path)  # too big
 
 
 def test_dataframe(tmpdir):
@@ -73,10 +73,11 @@ def test_dataframe(tmpdir):
     A password that is wrong, empty, or belonging to a different user fails.
     """
 
+    c = from_config(config)
     path = str(tmpdir / "test.csv")
-    client["tiny_df"].read()  # This is fine.
-    client["tiny_df"].export(path)
+    c["tiny_df"].read()  # This is fine.
+    c["tiny_df"].export(path)
     with fail_with_status_code(400):
-        client["small_df"].read()  # too big
+        c["small_df"].read()  # too big
     with fail_with_status_code(400):
-        client["small_df"].export(path)  # too big
+        c["small_df"].export(path)  # too big

--- a/tiled/_tests/test_size_limit.py
+++ b/tiled/_tests/test_size_limit.py
@@ -37,6 +37,7 @@ config = {
     ],
     "response_bytesize_limit": size_limit,
 }
+client = from_config(config)
 
 
 @contextlib.contextmanager
@@ -58,14 +59,13 @@ def test_array(tmpdir):
     A password that is wrong, empty, or belonging to a different user fails.
     """
 
-    c = from_config(config)
     path = str(tmpdir / "test.csv")
-    c["tiny_array"].read()  # This is fine.
-    c["tiny_array"].export(path)  # This is fine.
+    client["tiny_array"].read()  # This is fine.
+    client["tiny_array"].export(path)  # This is fine.
     with fail_with_status_code(400):
-        c["small_array"].read()  # too big
+        client["small_array"].read()  # too big
     with fail_with_status_code(400):
-        c["small_array"].export(path)  # too big
+        client["small_array"].export(path)  # too big
 
 
 def test_dataframe(tmpdir):
@@ -73,11 +73,10 @@ def test_dataframe(tmpdir):
     A password that is wrong, empty, or belonging to a different user fails.
     """
 
-    c = from_config(config)
     path = str(tmpdir / "test.csv")
-    c["tiny_df"].read()  # This is fine.
-    c["tiny_df"].export(path)
+    client["tiny_df"].read()  # This is fine.
+    client["tiny_df"].export(path)
     with fail_with_status_code(400):
-        c["small_df"].read()  # too big
+        client["small_df"].read()  # too big
     with fail_with_status_code(400):
-        c["small_df"].export(path)  # too big
+        client["small_df"].export(path)  # too big

--- a/tiled/_tests/test_sort.py
+++ b/tiled/_tests/test_sort.py
@@ -31,6 +31,7 @@ tree = MapAdapter(
         for letter, number, repeated_letter in zip(letters, numbers, repeated_letters)
     }
 )
+client = from_tree(tree)
 
 
 @pytest.mark.parametrize(
@@ -41,7 +42,6 @@ tree = MapAdapter(
     ],
 )
 def test_sort(key, sorted_list):
-    client = from_tree(tree)
     unsorted = [node.metadata[key] for node in client.values()]
     assert unsorted != sorted_list
     sorted_ascending = [node.metadata[key] for node in client.sort((key, 1)).values()]
@@ -52,9 +52,9 @@ def test_sort(key, sorted_list):
 
 def test_sort_two_columns():
     # Sort by (repeated) letter, then by number.
-    client = from_tree(tree).sort(("repeated_letter", 1), ("number", 1))
-    letters_ = [node.metadata["repeated_letter"] for node in client.values()]
-    numbers_ = [node.metadata["number"] for node in client.values()]
+    client_sorted = client.sort(("repeated_letter", 1), ("number", 1))
+    letters_ = [node.metadata["repeated_letter"] for node in client_sorted.values()]
+    numbers_ = [node.metadata["number"] for node in client_sorted.values()]
     # Letters are sorted.
     assert letters_ == ["a"] * 5 + ["b"] * 5
     # Numbers *within* each block of letters are sorted
@@ -76,8 +76,9 @@ def test_sort_sparse():
             "no2": ArrayAdapter.from_array(numpy.arange(10), metadata={}),
         }
     )
-    client = from_tree(tree).sort(("stuff", 1))
-    assert list(client)[:2] == ["yes1", "yes2"]
+    client = from_tree(tree)
+    client_sorted = client.sort(("stuff", 1))
+    assert list(client_sorted)[:2] == ["yes1", "yes2"]
 
 
 def test_sort_missing():
@@ -90,5 +91,6 @@ def test_sort_missing():
             "no2": ArrayAdapter.from_array(numpy.arange(10), metadata={}),
         }
     )
-    client = from_tree(tree).sort(("stuff", 1))
-    list(client)  # Just check for no errors.
+    client = from_tree(tree)
+    client_sorted = client.sort(("stuff", 1))
+    list(client_sorted)  # Just check for no errors.

--- a/tiled/_tests/test_sparse.py
+++ b/tiled/_tests/test_sparse.py
@@ -27,10 +27,10 @@ mapping = {
     ),
 }
 tree = MapAdapter(mapping)
+client = from_tree(tree)
 
 
 def test_sparse_single_chunk():
-    client = from_tree(tree)
     sc = client["single_chunk"]
     actual_via_slice = sc[:]
     actual_via_read = sc.read()
@@ -49,7 +49,6 @@ def test_sparse_single_chunk():
 
 
 def test_sparse_multi_chunk():
-    client = from_tree(tree)
     sc = client["multi_chunk"]
     actual_via_slice = sc[:]
     actual_via_read = sc.read()

--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -11,8 +11,8 @@ from ..client import from_config, from_tree
 
 @pytest.fixture
 def directory(tmpdir):
-    data = numpy.random.random((100, 100))
-    for i in range(10):
+    data = numpy.random.random((5, 7))
+    for i in range(3):
         tf.imwrite(Path(tmpdir, f"temp{i:05}.tif"), data)
     return str(Path(tmpdir, "*.tif"))
 
@@ -20,11 +20,11 @@ def directory(tmpdir):
 @pytest.mark.parametrize(
     "slice_input, correct_shape",
     [
-        (None, (10, 100, 100)),
-        (0, (100, 100)),
-        (slice(0, 10, 2), (5, 100, 100)),
-        ((1, slice(0, 10), slice(0, 10)), (10, 10)),
-        ((slice(0, 10), slice(0, 10), slice(0, 10)), (10, 10, 10)),
+        (None, (3, 5, 7)),
+        (0, (5, 7)),
+        (slice(0, 3, 2), (2, 5, 7)),
+        ((1, slice(0, 3), slice(0, 3)), (3, 3)),
+        ((slice(0, 3), slice(0, 3), slice(0, 3)), (3, 3, 3)),
     ],
 )
 def test_tiff_sequence(directory, slice_input, correct_shape):
@@ -34,7 +34,7 @@ def test_tiff_sequence(directory, slice_input, correct_shape):
     assert arr.shape == correct_shape
 
 
-@pytest.mark.parametrize("block_input, correct_shape", [((0, 0, 0), (1, 100, 100))])
+@pytest.mark.parametrize("block_input, correct_shape", [((0, 0, 0), (1, 5, 7))])
 def test_tiff_sequence_block(directory, block_input, correct_shape):
     tree = MapAdapter({"A": TiffSequenceAdapter(tf.TiffSequence(directory))})
     client = from_tree(tree)

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -50,13 +50,11 @@ def test_write_large_array_full():
         tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
-    a = numpy.ones(100)
+    a = numpy.ones(100, dtype=numpy.uint8)
     # Low the limit so we can test on small data, for speed.
     original = client._SUGGESTED_MAX_UPLOAD_SIZE
-    client._SUGGESTED_MAX_UPLOAD_SIZE = 50
+    client._SUGGESTED_MAX_UPLOAD_SIZE = a.nbytes - 1
     try:
-        assert a.nbytes > client._SUGGESTED_MAX_UPLOAD_SIZE
-
         metadata = {"scan_id": 1, "method": "A"}
         specs = ["SomeSpec"]
         with record_history() as history:

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -9,7 +9,7 @@ from ..adapters.xarray import DatasetAdapter
 from ..client import from_tree, record_history
 from ..client import xarray as xarray_client
 
-image = numpy.random.random((11, 13))
+image = numpy.random.random((3, 5))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
 precip = 10 * numpy.random.rand(2, 2, 3)
 lon = [[-99.83, -99.32], [-99.79, -99.23]]
@@ -45,13 +45,13 @@ EXPECTED = {
         },
     ),
     "wide": xarray.Dataset(
-        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(10)) for i in range(100)},
-        coords={"time": numpy.arange(10)},
+        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(2)) for i in range(10)},
+        coords={"time": numpy.arange(2)},
     ),
     "ragged": xarray.Dataset(
         {
             f"{i}": xarray.DataArray(i * numpy.ones(2 * i), dims=f"dim{i}")
-            for i in range(10)
+            for i in range(3)
         }
     ),
 }
@@ -88,7 +88,7 @@ def test_wide_table_optimization():
     # This should be just a couple requests.
     # This upper bound is somewhat arbitrary to give wiggle room for future
     # minor changes. The point is: it's much less than one request per variable.
-    assert len(history.requests) < 100 / 10
+    assert len(history.requests) < 4
 
 
 def test_wide_table_optimization_off():
@@ -96,13 +96,13 @@ def test_wide_table_optimization_off():
     wide = client["wide"]
     with record_history() as history:
         wide.read(optimize_wide_table=False)
-    assert len(history.requests) >= 100
+    assert len(history.requests) >= 10
 
 
 def test_url_limit_handling():
     "Check that requests and split up to stay below the URL length limit."
     expected = xarray.Dataset(
-        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(10)) for i in range(500)}
+        {f"column_{i:03}": xarray.DataArray(i * numpy.ones(2)) for i in range(10)}
     )
     tree = MapAdapter({"very_wide": DatasetAdapter.from_dataset(expected)})
     client = from_tree(tree)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -390,7 +390,7 @@ def array_block(
         raise HTTPException(
             status_code=400,
             detail=(
-                "Response would exceed {settings.response_bytesize_limit}. "
+                f"Response would exceed {settings.response_bytesize_limit}. "
                 "Use slicing ('?slice=...') to request smaller chunks."
             ),
         )


### PR DESCRIPTION
This should make some progress on #325. Strategies:

* Switch some (not all) file-export tests to write to in-memory buffers instead of disks, which can be very slow on CI workers.
* Use smaller example data sets.
* In place we artificially reduce limits and then test that we hit them. We can reduce them more.
* Reuse the same `app` and `client` objects where possible---where there is no coupling between tests.