### PR TITLE
silently pass when prometheus_client is dead

### DIFF
--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -3,7 +3,10 @@ import prometheus_client.multiprocess
 
 
 def child_exit(server, worker):
-    prometheus_client.multiprocess.mark_process_dead(worker.pid)
+    try:
+        prometheus_client.multiprocess.mark_process_dead(worker.pid)
+    except:
+        pass
 
 
 bind = "0.0.0.0:8000"

--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -1,8 +1,9 @@
-# https://github.com/prometheus/client_python/#multiprocess-mode-eg-gunicorn
+import sys
 import prometheus_client.multiprocess
 
 
 def child_exit(server, worker):
+    # https://github.com/prometheus/client_python/#multiprocess-mode-eg-gunicorn
     try:
         prometheus_client.multiprocess.mark_process_dead(worker.pid)
     except TypeError:
@@ -11,7 +12,8 @@ def child_exit(server, worker):
         print(
             "Gunicorn worker process failed to stop prometheus client."
             "This is likely because of a previous error in starting up the "
-            "tiled worker."
+            "tiled worker.",
+            file=sys.stderr,
         )
 
 

--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -1,4 +1,5 @@
 import sys
+
 import prometheus_client.multiprocess
 
 

--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -5,8 +5,10 @@ import prometheus_client.multiprocess
 def child_exit(server, worker):
     try:
         prometheus_client.multiprocess.mark_process_dead(worker.pid)
-    except:
-        pass
+    except TypeError:
+        print("Gunicorn worker process failed to stop prometheus client."
+              "This is likely because of a previous error in starting up the "
+              "tiled worker.")
 
 
 bind = "0.0.0.0:8000"

--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -6,9 +6,13 @@ def child_exit(server, worker):
     try:
         prometheus_client.multiprocess.mark_process_dead(worker.pid)
     except TypeError:
-        print("Gunicorn worker process failed to stop prometheus client."
-              "This is likely because of a previous error in starting up the "
-              "tiled worker.")
+        """Prints a nice error in a race condition where gunicorn tries to
+        shut down a worker's child prometheus client but it was already shut down."""
+        print(
+            "Gunicorn worker process failed to stop prometheus client."
+            "This is likely because of a previous error in starting up the "
+            "tiled worker."
+        )
 
 
 bind = "0.0.0.0:8000"


### PR DESCRIPTION
Fixes #335. I'm not positive I understand what is going on, but in docker, when gunicorn tries taking down services, there's a scenario where you get a nasty error message trying to mark the prometheus client as dead.

Normally, I'd be very concerned with silently failing as the PR does, but since it's in the act of trying to shut down and the prometheus client is probably dead anyway, I'm ok with it.