### PR TITLE
Debug cleanup on Python 3.9.

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -95,8 +95,6 @@ class Context:
                 follow_redirects=True,
             )
         else:
-            import atexit
-
             from ._testclient import TestClient
 
             # verify parameter is dropped, as there is no SSL in ASGI mode
@@ -108,7 +106,7 @@ class Context:
             )
             client.follow_redirects = True
             client.__enter__()
-            atexit.register(client.__exit__)
+            # TODO Is there a reasonable way to clean this up?
 
         self.http_client = client
         self._cache = cache


### PR DESCRIPTION
The CI has been often hanging at the end of the `pytest` run on Python 3.9. I suspect it's related to the changes in the client.