### PR TITLE
Use device code flow for improved CLI-based login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,5 @@ docs/source/reference/api.yml
 # placed React bundle
 share/tiled/ui
 
+config.yaml
 config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ share/tiled/ui
 
 config.yaml
 config.yml
+*.sqlite

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -140,7 +140,6 @@ Tiled currently includes two clients for each structure family:
    tiled.client.base.BaseClient.formats
    tiled.client.base.BaseClient.metadata
    tiled.client.base.BaseClient.uri
-   tiled.client.base.BaseClient.username
    tiled.client.base.BaseClient.item
    tiled.client.base.BaseClient.login
    tiled.client.base.BaseClient.logout

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -137,11 +137,15 @@ Tiled currently includes two clients for each structure family:
    :toctree: generated
 
    tiled.client.base.BaseClient
+   tiled.client.base.BaseClient.formats
    tiled.client.base.BaseClient.metadata
    tiled.client.base.BaseClient.uri
    tiled.client.base.BaseClient.username
    tiled.client.base.BaseClient.item
+   tiled.client.base.BaseClient.login
+   tiled.client.base.BaseClient.logout
    tiled.client.base.BaseClient.new_variation
+   tiled.client.base.BaseClient.specs
    tiled.client.base.BaseStructureClient.download
    tiled.client.base.BaseStructureClient.refresh
    tiled.client.base.BaseStructureClient.structure
@@ -158,7 +162,6 @@ Tiled currently includes two clients for each structure family:
    tiled.client.array.DaskArrayClient.read_block
    tiled.client.array.DaskArrayClient.read
    tiled.client.array.DaskArrayClient.export
-   tiled.client.array.DaskArrayClient.formats
 ```
 
 ```{eval-rst}
@@ -169,7 +172,6 @@ Tiled currently includes two clients for each structure family:
    tiled.client.array.ArrayClient.read_block
    tiled.client.array.ArrayClient.read
    tiled.client.array.DaskArrayClient.export
-   tiled.client.array.DaskArrayClient.formats
 ```
 
 ### Sparse Array
@@ -181,7 +183,6 @@ Tiled currently includes two clients for each structure family:
    tiled.client.sparse.SparseClient
    tiled.client.sparse.SparseClient.read
    tiled.client.sparse.SparseClient.export
-   tiled.client.sparse.SparseClient.formats
 ```
 
 ### DataFrame
@@ -256,9 +257,10 @@ the same source directory as the `tiled.client.cache` module. (Cachey itself
    :toctree: generated
 
    tiled.client.context.Context
-   tiled.client.context.Context.offline
    tiled.client.context.Context.authenticate
+   tiled.client.context.Context.offline
    tiled.client.context.Context.force_auth_refresh
+   tiled.client.context.Context.login
    tiled.client.context.Context.logout
    tiled.client.context.Context.tokens
 ```

--- a/share/tiled/templates/device_code_failure.html
+++ b/share/tiled/templates/device_code_failure.html
@@ -1,0 +1,9 @@
+{% extends "page.html" %}
+{% block main %}
+<div class = "container">
+  <section class="section">
+    <h1 class="title">Failed</h1>
+		<p>{{ message }}</p>
+  </section>
+</div>
+{% endblock %}

--- a/share/tiled/templates/device_code_form.html
+++ b/share/tiled/templates/device_code_form.html
@@ -1,17 +1,24 @@
 {% extends "page.html" %}
-{% block stylesheet %}
-{{ super() }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
-{% endblock %}
 {% block main %}
 <div class = "container">
   <section class="section">
     <h1 class="title">Authorize Tiled Session</h1>
+		{% if message %}
+		  <article class="message is-danger">
+				<div class="message-header">
+					<p>Error</p>
+					<button class="delete" aria-label="delete"></button>
+				</div>
+				<div class="message-body">
+					{{ message }}
+				</div>
+			</article>
+		{% endif %}
     <form action="{{ action }}" method="post">
       <label for="user_code">Enter code</label>
       <input type="text" id="user_code" name="user_code" />
       <input type="hidden" id="code" name="code" value="{{ code }}" />
-      <submit>Submit</submit>
+      <input type="submit" value="Enter" />
     </form>
   </section>
 </div>

--- a/share/tiled/templates/device_code_form.html
+++ b/share/tiled/templates/device_code_form.html
@@ -1,0 +1,18 @@
+{% extends "page.html" %}
+{% block stylesheet %}
+{{ super() }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+{% endblock %}
+{% block main %}
+<div class = "container">
+  <section class="section">
+    <h1 class="title">Authorize Tiled Session</h1>
+    <form action="{{ action }}" method="post">
+      <label for="user_code">Enter code</label>
+      <input type="text" id="user_code" name="user_code" />
+      <input type="hidden" id="code" name="code" value="{{ code }}" />
+      <submit>Submit</submit>
+    </form>
+  </section>
+</div>
+{% endblock %}

--- a/share/tiled/templates/device_code_success.html
+++ b/share/tiled/templates/device_code_success.html
@@ -1,0 +1,9 @@
+{% extends "page.html" %}
+{% block main %}
+<div class = "container">
+  <section class="section">
+    <h1 class="title">Success</h1>
+		<p>Return to your Tiled application. Within {{ interval }} seconds it should be succesfully logged in.</p>
+  </section>
+</div>
+{% endblock %}

--- a/share/tiled/templates/page.html
+++ b/share/tiled/templates/page.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Tiled{% endblock %}</title>
     {% block stylesheet %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     {% endblock %}
     {% block favicon %}
     {% endblock %}

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -1,7 +1,6 @@
 import io
 import tempfile
 import time
-from datetime import timedelta
 from pathlib import Path
 
 import numpy
@@ -163,7 +162,7 @@ def test_refresh_flow(enter_password, config):
 
     # Pathological configuration: a refresh is almost immediately required
     with tempfile.TemporaryDirectory() as tmpdir:
-        config["authentication"]["access_token_max_age"] = timedelta(seconds=1)
+        config["authentication"]["access_token_max_age"] = 1
         with enter_password("secret1"):
             client = from_config(
                 config,
@@ -180,7 +179,7 @@ def test_refresh_flow(enter_password, config):
 
     # Pathological configuration: sessions do not last
     with tempfile.TemporaryDirectory() as tmpdir:
-        config["authentication"]["session_max_age"] = timedelta(seconds=1)
+        config["authentication"]["session_max_age"] = 1
         with enter_password("secret1"):
             client = from_config(
                 config,

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -80,31 +80,28 @@ class BaseClient:
 
     def login(self, username=None, provider=None):
         """
-        Depending on the server's authentication method, this will prompt for username/password
+        Depending on the server's authentication method, this will prompt for username/password:
 
         >>> c.login()
         Username: USERNAME
         Password: <input is hidden>
 
-        or prompt you to open a link in a web browser to login with a third party and paste in a access code
+        or prompt you to open a link in a web browser to login with a third party:
 
         >>> c.login()
-        Navigate your web browser to this address to obtain access code:
+        You have ... minutes visit this URL
 
-        ...
+        https://...
 
-        Access code (quotes optional): <input is hidden>
-
-        See also c.context.authenticate() and c.context.reauthenticate().
+        and enter the code: XXXX-XXXX
         """
-        provider_spec, username = self.context.authenticate(provider=provider)
-        confirmation_message = provider_spec.get("confirmation_message")
-        if confirmation_message:
-            print(confirmation_message.format(id=username))
+        self.context.login(username=username, provider=provider)
 
     def logout(self):
         """
         Log out.
+
+        This method is idempotent: if you are already logged out, it will do nothing.
         """
         self.context.logout()
 
@@ -144,10 +141,6 @@ class BaseClient:
     def uri(self):
         "Direct link to this entry"
         return self.item["links"]["self"]
-
-    @property
-    def username(self):
-        return self.context.username
 
     @property
     def offline(self):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -642,6 +642,7 @@ class Context:
                 # No need to log in again.
                 return
 
+        self.http_client.auth = None
         mode = spec["mode"]
         auth_endpoint = spec["links"]["auth_endpoint"]
         if mode == "password":
@@ -697,10 +698,11 @@ and enter the code: {verification['user_code']}
                 if (access_response.status_code == 400) and (
                     access_response.json()["detail"]["error"] == "authorization_pending"
                 ):
+                    print(".", end="", flush=True)
                     continue
                 handle_error(access_response)
-                print(access_response.json())
-                print(".", end="", flush=True)
+                break
+            tokens = access_response.json()
 
         else:
             raise ValueError(f"Server has unknown authentication mechanism {mode!r}")

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -6,6 +6,7 @@ See profiles.py for client configuration.
 import copy
 import os
 from collections import defaultdict
+from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 
@@ -68,6 +69,9 @@ def construct_build_app_kwargs(
         sys_path_additions.append(directory)
     with prepend_to_sys_path(*sys_path_additions):
         auth_spec = config.get("authentication", {}) or {}
+        for age in ["refresh_token_max_age", "session_max_age", "access_token_max_age"]:
+            if age in auth_spec:
+                auth_spec[age] = timedelta(seconds=auth_spec[age])
         root_access_control = config.get("access_control", {}) or {}
         auth_aliases = {}  # TODO Enable entrypoint as alias for authenticator_class?
         providers = list(auth_spec.get("providers", []))

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -14,9 +14,9 @@ from .orm import APIKey, Identity, Principal, Role, Session
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "56809bcbfcb0"
+REQUIRED_REVISION = "4a9dfaba4a98"
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["56809bcbfcb0", "722ff4e4fcc7", "481830dd6c11"]
+ALL_REVISIONS = ["4a9dfaba4a98", "56809bcbfcb0", "722ff4e4fcc7", "481830dd6c11"]
 
 
 def create_default_roles(engine):

--- a/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
+++ b/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
@@ -27,9 +27,7 @@ def upgrade():
         ),
         Column("user_code", Unicode(8), index=True, nullable=False),
         Column("expiration_time", DateTime(timezone=False), nullable=False),
-        session_id=Column(
-            "session_id", Integer, ForeignKey("session.id"), nullable=True
-        ),
+        Column("session_id", Integer, ForeignKey("session.id"), nullable=True),
     )
 
 

--- a/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
+++ b/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
@@ -26,7 +26,7 @@ def upgrade():
             nullable=False,
         ),
         Column("user_code", Unicode(8), index=True, nullable=False),
-        Column("expiration_time", DateTime(timezone=False), nullable=True),
+        Column("expiration_time", DateTime(timezone=False), nullable=False),
         session_id=Column(
             "session_id", Integer, ForeignKey("session.id"), nullable=True
         ),

--- a/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
+++ b/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
@@ -1,0 +1,34 @@
+"""Add PendingSession.
+
+Revision ID: 4a9dfaba4a98
+Revises: 56809bcbfcb0
+Create Date: 2022-10-22 19:11:37.926595
+
+"""
+from alembic import op
+from sqlalchemy import Column, DateTime, LargeBinary, Unicode
+
+# revision identifiers, used by Alembic.
+revision = "4a9dfaba4a98"
+down_revision = "56809bcbfcb0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "pending_sessions",
+        Column(
+            "hashed_device_code",
+            LargeBinary(32),
+            primary_key=True,
+            index=True,
+            nullable=False,
+        ),
+        Column("user_code", Unicode(8), index=True, nullable=False),
+        Column("expiration_time", DateTime(timezone=False), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("pending_sessions")

--- a/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
+++ b/tiled/database/migrations/versions/4a9dfaba4a98_add_pendingsession.py
@@ -6,7 +6,7 @@ Create Date: 2022-10-22 19:11:37.926595
 
 """
 from alembic import op
-from sqlalchemy import Column, DateTime, LargeBinary, Unicode
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, LargeBinary, Unicode
 
 # revision identifiers, used by Alembic.
 revision = "4a9dfaba4a98"
@@ -27,6 +27,9 @@ def upgrade():
         ),
         Column("user_code", Unicode(8), index=True, nullable=False),
         Column("expiration_time", DateTime(timezone=False), nullable=True),
+        session_id=Column(
+            "session_id", Integer, ForeignKey("session.id"), nullable=True
+        ),
     )
 
 

--- a/tiled/database/orm.py
+++ b/tiled/database/orm.py
@@ -203,3 +203,17 @@ class Session(Timestamped, Base):
     revoked = Column(Boolean, default=False, nullable=False)
 
     principal = relationship("Principal", back_populates="sessions")
+
+
+class PendingSession(Base):
+    """
+    This is used only in Device Code Flow.
+    """
+
+    __tablename__ = "pending_sessions"
+
+    hashed_device_code = Column(
+        LargeBinary(32), primary_key=True, index=True, nullable=False
+    )
+    user_code = Column(Unicode(8), index=True, nullable=False)
+    expiration_time = Column(DateTime(timezone=False), nullable=False)

--- a/tiled/database/orm.py
+++ b/tiled/database/orm.py
@@ -217,3 +217,6 @@ class PendingSession(Base):
     )
     user_code = Column(Unicode(8), index=True, nullable=False)
     expiration_time = Column(DateTime(timezone=False), nullable=False)
+    session_id = Column(Integer, ForeignKey("sessions.id"), nullable=True)
+
+    session = relationship("Session")

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -236,30 +236,17 @@ def build_app(
                     build_handle_credentials_route(authenticator, provider)
                 )
             elif mode == Mode.external:
-                # HACK
-                verification_uri = (
-                    f"http://localhost:8000/api/auth/provider/{provider}/token"
-                )
-                action = (
-                    f"http://localhost:8000/api/auth/provider/{provider}/device_code"
-                )
                 # Client starts here to create a PendingSession.
                 authentication_router.post(f"/provider/{provider}/authorize")(
-                    build_device_code_authorize_route(
-                        authenticator, provider, verification_uri
-                    )
+                    build_device_code_authorize_route(authenticator, provider)
                 )
                 # External OAuth redirects here with code, presenting form for user code.
                 authentication_router.get(f"/provider/{provider}/device_code")(
-                    build_device_code_user_code_form_route(
-                        authenticator, provider, action
-                    )
+                    build_device_code_user_code_form_route(authenticator, provider)
                 )
                 # User code and auth code are submitted here.
                 authentication_router.post(f"/provider/{provider}/device_code")(
-                    build_device_code_user_code_submit_route(
-                        authenticator, provider, action
-                    )
+                    build_device_code_user_code_submit_route(authenticator, provider)
                 )
                 # Client polls here for token.
                 authentication_router.post(f"/provider/{provider}/token")(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -257,7 +257,9 @@ def build_app(
                 )
                 # User code and auth code are submitted here.
                 authentication_router.post(f"/provider/{provider}/device_code")(
-                    build_device_code_user_code_submit_route(authenticator, provider)
+                    build_device_code_user_code_submit_route(
+                        authenticator, provider, action
+                    )
                 )
                 # Client polls here for token.
                 authentication_router.post(f"/provider/{provider}/token")(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -85,14 +85,12 @@ async def about(
                 ),
             }
         elif authenticator.mode == Mode.external:
-            endpoint = authenticator.authorization_endpoint
-            if endpoint.startswith("/"):
-                # This is relative.
-                endpoint = f"{base_url}/auth/provider/{provider}{endpoint}"
             spec = {
                 "provider": provider,
                 "mode": authenticator.mode.value,
-                "links": {"auth_endpoint": endpoint},
+                "links": {
+                    "auth_endpoint": f"{base_url}/auth/provider/{provider}/authorize"
+                },
                 "confirmation_message": getattr(
                     authenticator, "confirmation_message", None
                 ),

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -175,6 +175,11 @@ class RefreshToken(pydantic.BaseModel):
     refresh_token: str
 
 
+class DeviceCode(pydantic.BaseModel):
+    device_code: str
+    grant_type: str
+
+
 class AuthenticationMode(str, enum.Enum):
     password = "password"
     external = "external"


### PR DESCRIPTION
Closes https://github.com/bluesky/tiled/issues/341

This is deployed on https://tiled-demo-dev.blueskyproject.io (note `-dev` in the URL!) for interactive testing. Example:

```python
In [1]: from tiled.client import from_uri

In [2]: c = from_uri("https://tiled-demo-dev.blueskyproject.io/api")

In [3]: c.login()

You have 15 minutes visit this URL

https://orcid.org/oauth/authorize?client_id=APP-0ROS9DU5F717F7XN&response_type=code&scope=openid&redirect_uri=https://tiled-demo.blueskyproject.io/api/auth/provider/orcid/device_code

and enter the code: 44B7-F2C5


Waiting......
```

A browser tab is automatically opened to that URL. First we are prompted to log in to ORCID and to authorize Tiled (if we haven't done so before):

![image](https://user-images.githubusercontent.com/2279598/199491171-65efff8b-89a7-48ae-b9f3-b174f23de539.png)

Then ORCID redirect back to Tiled and prompts us to enter the code (`user_code`) printed in the terminal above:

![image](https://user-images.githubusercontent.com/2279598/199491345-7d8d1580-8b27-420b-bd15-bdd8b5dbc60b.png)

If we do it wrong (e.g. miss a character) we get a clear error message:

![image](https://user-images.githubusercontent.com/2279598/199491410-dbb20d1c-d473-4f35-8821-287c2c124164.png)

and the opportunity to try again. If we do it right, we get a success page in the browser:

![image](https://user-images.githubusercontent.com/2279598/199491577-67cd1cad-1a7f-439b-9105-be88ede661f1.png)

and, over in the Terminal (which has been polling a URL in the background) we see a success message, and the prompt returns:

```python
In [3]: c.login()

You have 15 minutes visit this URL

https://orcid.org/oauth/authorize?client_id=APP-0ROS9DU5F717F7XN&response_type=code&scope=openid&redirect_uri=https://tiled-demo-dev.blueskyproject.io/api/auth/provider/orcid/device_code

and enter the code: 4BF8-FED4


Waiting.......................................
You have logged in with ORCID as 0000-0002-5947-6017.

In [4]:
```
