### PR TITLE
Simplify OIDC configuration and ship two working examples

### DIFF
--- a/docs/source/explanations/security.md
+++ b/docs/source/explanations/security.md
@@ -227,7 +227,8 @@ pip install httpx
 
 1. Deploy Tiled with HTTPS.
 2. Register your application with the OIDC Provider. You will be asked to
-   provide a Redirect URI. Give `https://.../auth/code`. You will be given a
+   provide redirect URIs. Enter two: `https://.../api/v1/auth/provider/SOME_NAME_HERE/code`
+   and `https://.../api/v1/auth/provider/SOME_NAME_HERE/device_code`. You will be given a
    Client ID and Client Secret.
 3. It is recommended to set the Client Secret as an environment variable, such
    as `OIDC_CLIENT_SECRET`, and reference that from configuration file as shown
@@ -236,6 +237,7 @@ pip install httpx
    Starting from a URL like:
 
    * [https://accounts.google.com/.well-known/openid-configuration](https://accounts.google.com/.well-known/openid-configuration)
+   * [https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration)
    * [https://orcid.org/.well-known/openid-configuration](https://orcid.org/.well-known/openid-configuration)
 
    Navigate to the link under the key `jwks_uri`. These public key(s) are designed
@@ -246,17 +248,16 @@ The configuration file(s) must include the following.
 ```yaml
 authentication:
   providers:
-  - provider: some-oidc-service
+  - provider: SOME_NAME_HERE
     authenticator: tiled.authenticators:OIDCAuthenticator
     args:
       # All of these are given by the OIDC provider you register
       # your application.
       client_id: ...
       client_secret: ${OIDC_CLIENT_SECRET}  # reference an environment variable
+      # These come from the OIDC provider as described above.
       token_uri: ...
       authorization_endpoint: ...
-      redirect_uri: ...  # https://{YOUR_TILED_SERVER_ADDRESS}/provider/{some-oidc-service}/auth/code
-      # These come from the OIDC provider as described above.
       public_keys:
         - kty: ...
           e: ...
@@ -267,31 +268,8 @@ authentication:
       confirmation_message: "You have logged in with ... as {id}."
 ```
 
-Here is an example for ORCID authentication running at
-`https://tiled-demo.blueskyproject.io`.
-
-```yaml
-authentication:
-  providers:
-  - provider: orcid
-    authenticator: tiled.authenticators:OIDCAuthenticator
-    args:
-      client_id: APP-0ROS9DU5F717F7XN  # obtained from ORCID for tiled-demo.blueskyproject.io; not secret
-      client_secret: ${OIDC_CLIENT_SECRET}  # reference an environment variable
-      redirect_uri: https://tiled-demo.blueskyproject.io/api/auth/provider/orcid/code
-      token_uri: "https://orcid.org/oauth/token"
-      authorization_endpoint: "https://orcid.org/oauth/authorize?client_id={client_id}&response_type=code&scope=openid&redirect_uri={redirect_uri}"
-      # These values come from https://orcid.org/.well-known/openid-configuration.
-      # Obtain them directly from ORCID. They may change over time.
-      public_keys:
-        - kty: ...
-          e: ...
-          use: ...
-          kid: ...
-          n: ...
-          alg: RS256
-      confirmation_message: "You have logged in with ORCID as {id}."
-```
+There are example configurations for ORCID and Google in the directory
+`example_configs/` in the Tiled source repository.
 
 ### Toy examples for testing and development
 

--- a/example_configs/google_auth.yml
+++ b/example_configs/google_auth.yml
@@ -1,0 +1,32 @@
+# Must set environment variables GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to run.
+authentication:
+  providers:
+  - provider: google
+    authenticator: tiled.authenticators:OIDCAuthenticator
+    args:
+      # These values come from https://console.cloud.google.com/apis/credential
+      client_id: ${GOOGLE_CLIENT_ID}
+      client_secret: ${GOOGLE_CLIENT_SECRET}
+      # These values come from https://accounts.google.com/.well-known/openid-configuration
+      # Obtain them directly from Google. They may change over time.
+      token_uri: "https://oauth2.googleapis.com/token"
+      authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth"
+      public_keys:
+      - alg: RS256
+        e: AQAB
+        kid: ee1b9f88cfe3151ddd284a61bf8cecf659b130cf
+        kty: RSA
+        n: rTOxVQCdPMM6n3XRW7VW5e8bGCoimxT-m4cUyaTtLCIf1IqFJRhzc3rgdxsdpg5fjj1Ln2yG_r-3FbkFYJw1ebOCwJ_xlrIeL7FZWqKHl2u5tPKhYkBpPsh-SFZrlEv6X6W2tLcXaFs_8qeHbEasW3A7S6SiS6vMLvcEgufvHSHM1W61U6R9wzOo0lr3rBBOahZFr2Vym8P3eZZ9u_i07RFEqUEFhHXnHYHMLY2Ch9-JbZlCRVbBOfTxCPdOqOkZyFQfGOMj5XLbPHXLSBlmsNzFSv3KgPhZgvmfK113VUN3RFgnDZ5q_-4FK82j_L0FrYZUPRGBA9Crlvtxg_LJWQ
+        use: sig
+      - alg: RS256
+        e: AQAB
+        kid: 77cc0ef4c7181cf4c0dcef7b60ae28cc9022c76b
+        kty: RSA
+        n: yCR1Za9HjpT49GymRQlYSsNg8z7PZGFh5a26IaCo86xPuAcf6VumrKYG6aK9Y1Bh9qJ9MBV1oajmatTuXtc-FtqwqH9Jzbb_-mCYGylx08Mqr83ydV_fIa64ilpVlBz_LHDeDKIYNepQLGqlMNQ6iVuM9MX9NesN3_twudqgz_Ll3FZkpi0DsVOIwV-fOP3zH6h_e0YPbIIjIcxCUs3Pe0rkcjUVRf3yDfPQTjaNtUh9Qg6DGIi1xe5DU0egLvQv6CdbR3wMxNDp8unhForCaenlD8ulzB_tZT0ft6uxPOHEx29FpH6mzfIsbcTZ7VaBfw6KYUaPsZOCcspY14exow
+        use: sig
+      confirmation_message: "You have logged in with Google as {id}."
+trees:
+ # Just some example data...
+ # The point of this tutorial is the authenticaiton above.
+ - tree: tiled.examples.generated_minimal:tree
+   path: /

--- a/example_configs/google_auth.yml
+++ b/example_configs/google_auth.yml
@@ -26,7 +26,7 @@ authentication:
         use: sig
       confirmation_message: "You have logged in with Google as {id}."
 trees:
- # Just some example data...
- # The point of this tutorial is the authenticaiton above.
+ # Just some arbitrary example data...
+ # The point of this example is the authenticaiton above.
  - tree: tiled.examples.generated_minimal:tree
    path: /

--- a/example_configs/orcid_auth.yml
+++ b/example_configs/orcid_auth.yml
@@ -20,7 +20,7 @@ authentication:
           alg: RS256
       confirmation_message: "You have logged in with ORCID as {id}."
 trees:
- # Just some example data...
- # The point of this tutorial is the authenticaiton above.
+ # Just some arbitrary example data...
+ # The point of this example is the authenticaiton above.
  - tree: tiled.examples.generated_minimal:tree
    path: /

--- a/example_configs/orcid_auth.yml
+++ b/example_configs/orcid_auth.yml
@@ -1,0 +1,26 @@
+# Must set environment variables ORCID_CLIENT_ID and ORCID_CLIENT_SECRET to run.
+authentication:
+  providers:
+  - provider: orcid
+    authenticator: tiled.authenticators:OIDCAuthenticator
+    args:
+      # These values come from https://orcid.org/developer-tools
+      client_id: ${ORCID_CLIENT_ID}
+      client_secret: ${ORCID_CLIENT_SECRET}
+      # These values come from https://orcid.org/.well-known/openid-configuration
+      # Obtain them directly from ORCID. They may change over time.
+      token_uri: "https://orcid.org/oauth/token"
+      authorization_endpoint: "https://orcid.org/oauth/authorize"
+      public_keys:
+        - kty: "RSA"
+          e: "AQAB"
+          use: "sig"
+          kid: "production-orcid-org-7hdmdswarosg3gjujo8agwtazgkp1ojs"
+          n: "jxTIntA7YvdfnYkLSN4wk__E2zf_wbb0SV_HLHFvh6a9ENVRD1_rHK0EijlBzikb-1rgDQihJETcgBLsMoZVQqGj8fDUUuxnVHsuGav_bf41PA7E_58HXKPrB2C0cON41f7K3o9TStKpVJOSXBrRWURmNQ64qnSSryn1nCxMzXpaw7VUo409ohybbvN6ngxVy4QR2NCC7Fr0QVdtapxD7zdlwx6lEwGemuqs_oG5oDtrRuRgeOHmRps2R6gG5oc-JqVMrVRv6F9h4ja3UgxCDBQjOVT1BFPWmMHnHCsVYLqbbXkZUfvP2sO1dJiYd_zrQhi-FtNth9qrLLv3gkgtwQ"
+          alg: RS256
+      confirmation_message: "You have logged in with ORCID as {id}."
+trees:
+ # Just some example data...
+ # The point of this tutorial is the authenticaiton above.
+ - tree: tiled.examples.generated_minimal:tree
+   path: /

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -7,6 +7,7 @@ cachetools
 click !=8.1.0
 dask
 fastapi
+httpx >=0.20.0
 jinja2
 jmespath
 jsonschema

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -482,9 +482,21 @@ def build_device_code_authorize_route(authenticator, provider):
             None, create_pending_session, settings
         )
         verification_uri = f"{get_base_url(request)}/auth/provider/{provider}/token"
+        authorization_uri = authenticator.authorization_endpoint.copy_with(
+            params={
+                "client_id": authenticator.client_id,
+                "response_type": "code",
+                "scope": "openid",
+                "redirect_uri": f"{get_base_url(request)}/auth/provider/{provider}/device_code",
+            }
+        )
         return {
-            "authorization_uri": authenticator.authorization_endpoint,  # URL that user should visit in browser
-            "verification_uri": verification_uri,  # URL that terminal client will poll
+            "authorization_uri": str(
+                authorization_uri
+            ),  # URL that user should visit in browser
+            "verification_uri": str(
+                verification_uri
+            ),  # URL that terminal client will poll
             "interval": DEVICE_CODE_POLLING_INTERVAL,  # suggested polling interval
             "device_code": pending_session["device_code"],
             "expires_in": DEVICE_CODE_MAX_AGE,  # seconds


### PR DESCRIPTION
This adds two working examples of OIDC auth to `example_config/`:

* `orcid_auth.yml`
* `google_auth.yml`

All the user has to do is set environment variables for the client id and client secret. (The user might also check that the `public_keys` are still current, as suggested in a comment, but we ship the current values to streamline getting started.)

This also removes `redirect_uri` from the configuration file. In fact, it was never necessary to make the user spell this out: we have all the information we need to construct it automatically. And now that there are _two_ potential redirect URIs, one for "code" flow and one for "device code" flow, it really doesn't make sense to spell `redirect_uri` out in the configuration file.