### PR TITLE
Add alias 'tiled serve demo' for easy demos.

### DIFF
--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -136,6 +136,32 @@ def serve_pyobject(
     uvicorn.run(web_app, host=host, port=port)
 
 
+@serve_app.command("demo")
+def serve_demo(
+    host: str = typer.Option(
+        "127.0.0.1",
+        help=(
+            "Bind socket to this host. Use `--host 0.0.0.0` to make the application "
+            "available on your local network. IPv6 addresses are supported, for "
+            "example: --host `'::'`."
+        ),
+    ),
+    port: int = typer.Option(8000, help="Bind to a socket with this port."),
+):
+    "Start a public server with example data."
+    from ..server.app import build_app, print_admin_api_key_if_generated
+    from ..utils import import_object
+
+    EXAMPLE = "tiled.examples.generated:tree"
+    tree = import_object(EXAMPLE)
+    web_app = build_app(tree, {"allow_anonymous_access": True}, {})
+    print_admin_api_key_if_generated(web_app, host=host, port=port)
+
+    import uvicorn
+
+    uvicorn.run(web_app, host=host, port=port)
+
+
 @serve_app.command("config")
 def serve_config(
     config_path: Path = typer.Argument(


### PR DESCRIPTION
```
$ tiled serve --help
                                                                                                                                                                                              
 Usage: tiled serve [OPTIONS] COMMAND [ARGS]...                                                                                                                                               
                                                                                                                                                                                              
 Launch a Tiled server.                                                                                                                                                                       
                                                                                                                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                                                                                                                │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ config                         Serve a Tree as specified in configuration file(s).                                                                                                         │
│ demo                           Start a public server with example data.                                                                                                                    │
│ directory                      Serve a Tree instance from a directory of files.                                                                                                            │
│ pyobject                       Serve a Tree instance from a Python module.                                                                                                                 │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

$ tiled serve demo
Generating large example data...
Done generating example data.

    Tiled server is running in "public" mode, permitting open, anonymous access
    for reading. Any data that is not specifically controlled with an access
    policy will be visible to anyone who can connect to this server.


    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=c1c89cf607bed21ea88e68a87dc11063485182f3fe62c733923dc9b08a59dd62


INFO:     Started server process [578429]
INFO:     Waiting for application startup.
OBJECT CACHE: Will use up to 6_290_642_534 bytes (15% of total physical RAM)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```