### PR TITLE
Ban httpx 0.23.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -3,7 +3,7 @@ appdirs
 click !=8.1.0
 entrypoints
 heapdict
-httpx >=0.20.0
+httpx >=0.20.0,!=0.23.1
 jsonschema
 msgpack >=1.0.0
 pyyaml

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -8,7 +8,7 @@ cachetools
 click !=8.1.0
 dask
 fastapi
-httpx >=0.20.0
+httpx >=0.20.0,!=0.23.1
 jinja2
 jmespath
 jsonschema


### PR DESCRIPTION
This made a backward-incompatible change, removing the attribute URL.raw. It looks like the maintainers plan to reinstate it as a namedtuple in a coming patch release.

https://github.com/encode/httpx/issues/2462