### PR TITLE
Enable queries to use generic sequences

### DIFF
--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -114,7 +114,7 @@ def test_not_and_and_or():
     ],
 )
 def test_in(query_values):
-    assert list(client.search(In("letter", query_values))) == ["a", "k", "z"]
+    assert sorted(list(client.search(In("letter", query_values)))) == ["a", "k", "z"]
 
 
 @pytest.mark.parametrize(
@@ -127,7 +127,7 @@ def test_in(query_values):
     ],
 )
 def test_notin(query_values):
-    assert list(client.search(NotIn("letter", query_values))) == sorted(
+    assert sorted(list(client.search(NotIn("letter", query_values)))) == sorted(
         list(set(keys) - set(["a", "k", "z"]))
     )
 
@@ -145,7 +145,7 @@ def test_specs(include_values, exclude_values):
     with pytest.raises(TypeError):
         Specs("foo")
 
-    assert list(client.search(Specs(include=include_values))) == sorted(
+    assert sorted(list(client.search(Specs(include=include_values)))) == sorted(
         ["specs_foo_bar", "specs_foo_bar_baz"]
     )
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -104,25 +104,52 @@ def test_not_and_and_or():
         (Key("color") == "red") or (Key("sample") == "Ni")
 
 
-def test_in():
-    assert list(client.search(In("letter", ["a", "k", "z"]))) == ["a", "k", "z"]
+@pytest.mark.parametrize(
+    "query_values",
+    [
+        ["a", "k", "z"],
+        ("a", "k", "z"),
+        {"a", "k", "z"},
+        {"a", "k", "z", "a", "z", "z"},
+    ],
+)
+def test_in(query_values):
+    assert list(client.search(In("letter", query_values))) == ["a", "k", "z"]
 
 
-def test_notin():
-    assert list(client.search(NotIn("letter", ["a", "k", "z"]))) == sorted(
+@pytest.mark.parametrize(
+    "query_values",
+    [
+        ["a", "k", "z"],
+        ("a", "k", "z"),
+        {"a", "k", "z"},
+        {"a", "k", "z", "a", "z", "z"},
+    ],
+)
+def test_notin(query_values):
+    assert list(client.search(NotIn("letter", query_values))) == sorted(
         list(set(keys) - set(["a", "k", "z"]))
     )
 
 
-def test_specs():
+@pytest.mark.parametrize(
+    "include_values,exclude_values",
+    [
+        (["foo", "bar"], ["baz"]),
+        (("foo", "bar"), ("baz")),
+        ({"foo", "bar"}, {"baz"}),
+        ({"foo", "bar", "foo", "bar", "bar"}, {"baz", "baz", "baz"}),
+    ],
+)
+def test_specs(include_values, exclude_values):
     with pytest.raises(TypeError):
         Specs("foo")
 
-    assert list(client.search(Specs(include=["foo", "bar"]))) == sorted(
+    assert list(client.search(Specs(include=include_values))) == sorted(
         ["specs_foo_bar", "specs_foo_bar_baz"]
     )
 
-    assert list(client.search(Specs(include=["foo", "bar"], exclude=["baz"]))) == [
+    assert list(client.search(Specs(include=include_values, exclude=exclude_values))) == [
         "specs_foo_bar"
     ]
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -136,7 +136,7 @@ def test_notin(query_values):
     "include_values,exclude_values",
     [
         (["foo", "bar"], ["baz"]),
-        (("foo", "bar"), ("baz")),
+        (("foo", "bar"), ("baz",)),
         ({"foo", "bar"}, {"baz"}),
         ({"foo", "bar", "foo", "bar", "bar"}, {"baz", "baz", "baz"}),
     ],

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -149,9 +149,9 @@ def test_specs(include_values, exclude_values):
         ["specs_foo_bar", "specs_foo_bar_baz"]
     )
 
-    assert list(client.search(Specs(include=include_values, exclude=exclude_values))) == [
-        "specs_foo_bar"
-    ]
+    assert list(
+        client.search(Specs(include=include_values, exclude=exclude_values))
+    ) == ["specs_foo_bar"]
 
 
 def test_structure_families():

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -315,7 +315,7 @@ class Contains(NoBool):
 @dataclass
 class In:
     """
-    Query if a given key's value is present in the specified list of values.
+    Query if a given key's value is present in the specified sequence of values.
 
     Parameters
     ----------
@@ -335,6 +335,9 @@ class In:
     key: str
     value: List[JSONSerializable]
 
+    def __post_init__(self):
+        self.value = list(self.value)
+
     def encode(self):
         return {"key": self.key, "value": json.dumps(self.value)}
 
@@ -347,7 +350,7 @@ class In:
 @dataclass
 class NotIn:
     """
-    Query if a given key's value is not present in the specified list of values.
+    Query if a given key's value is not present in the specified sequence of values.
 
     Parameters
     ----------
@@ -366,6 +369,9 @@ class NotIn:
 
     key: str
     value: List[JSONSerializable]
+
+    def __post_init__(self):
+        self.value = list(self.value)
 
     def encode(self):
         return {"key": self.key, "value": json.dumps(self.value)}


### PR DESCRIPTION
Queries such as `In(key, value)` and `NotIn(key, value)` require `value` to be a List. Trying to pass other sequences such as a `tuple` or a `set` causes an error. Instead these should be cast to list.

This PR partially resolves #376.  Relevant tests have been parameterized to verify functionality when `value` is a `list`, `tuple`, or `set`.