### PR TITLE
Fix specs configuration and add 'reject_undeclared_specs'.

### DIFF
--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -481,3 +481,9 @@ properties:
       success or raise a `tiled.validation_registration.ValidationError`
       exception to indicate failure. If a metadata object is returned it
       will be sent back to client in the response to the POST.
+  reject_undeclared_specs:
+    type: boolean
+    description: |
+      If true, any data uploaded with a "spec" that is not declared in this
+      configuration file will be rejected. By default, this is set to false
+      ---i.e., permissive.

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -323,7 +323,11 @@ def build_app(
         ]:
             if authentication.get(item) is not None:
                 setattr(settings, item, authentication[item])
-        for item in ["allow_origins", "response_bytesize_limit"]:
+        for item in [
+            "allow_origins",
+            "response_bytesize_limit",
+            "reject_undeclared_specs",
+        ]:
             if server_settings.get(item) is not None:
                 setattr(settings, item, server_settings[item])
         database = server_settings.get("database", {})

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
     response_bytesize_limit = int(
         os.getenv("TILED_RESPONSE_BYTESIZE_LIMIT", 300_000_000)
     )  # 300 MB
+    reject_undeclared_specs = bool(int(os.getenv("TILED_REJECT_UNDECLARED_SPECS", 0)))
     database_uri: Optional[str] = os.getenv("TILED_DATABASE_URI")
     database_pool_size: Optional[int] = int(os.getenv("TILED_DATABASE_POOL_SIZE", 5))
     database_pool_pre_ping: Optional[bool] = bool(


### PR DESCRIPTION
* Fixes bug in the code that merges one or more configuration files that entirely dropped the section that declares specs
* Make `reject_undeclared_specs` configurable, and off by default, for easy experimentation without getting the server admin to add specs (for @cjtitus)