### PR TITLE
Slim down the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install && npm run build
 
 # We cannot upgrade to Python 3.11 until numba supports it.
 # The `sparse` library relies on numba.
-FROM python:3.10 as base
+FROM python:3.10-slim as builder
 WORKDIR /code
 
 # Ensure logs and error messages do not get stuck in a buffer.
@@ -44,7 +44,11 @@ RUN pip install '.[array, compression, dataframe, formats, server, sparse, xarra
 # RUN pip install -r requirements-dev.txt
 # RUN pytest -v
 
-FROM base as app
+FROM python:3.10-slim as runner
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
 
 WORKDIR /deploy
 


### PR DESCRIPTION
The image produced by #382 is large:

```
ghcr.io/bluesky/tiled      v0.1.0a81   475c9aaae631  14 hours ago    1.67 GB
```

We can cut the size in half by using a stripped-down Debian image, `python:3.10-slim`. Unlike `alpine`, the `slim` variant still uses glibc, and Python's `manylinux` wheels run on it. More info [the excellent Normcore talk, "How small can I get this Docker container?"](https://youtu.be/kx-SeGbkNPU).

```
localhost/tiled-slim       latest      964bf88d7066  13 minutes ago  860 MB
```

In #382 there was a nonsensical multi-stage build being used, equivalent to:

```
FROM python:3.10-slim as X
...

FROM X as Y
...
```

The second stage has no effect because it builds directly on top of the previous stage, discarding nothing. (This was introduced by me, due to a fuzzy mental model of layering.) Consolidating those to stages into one produces an image of exactly the same size, as expected:

```
localhost/tiled-slim-1s    latest      468085b843ce  5 minutes ago   860 MB
```

If we use multi-stage builds properly, we can keep the source tree out of the final image and shave off another 37 MB:

```
localhost/tiled-slim-ms    latest      0ed63eef6a81  2 minutes ago   823 MB
```

Using [Dive](https://github.com/wagoodman/dive) I inspected where that size is coming from. The vast majority (664 MB) lives in `/opt/venv/lib/python3.10/site-packages/`. The dependencies include some heavyweights like scipy (84 MB) and pandas (56 MB). That seems right.

As the talk linked at the top shows, it's possible to make more progress if we're willing to accept much more complexity and longer build times. But as the talk recommends, something close to this approach is the pragmatic sweet spot.