### PR TITLE
Bugfix import_object

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -397,7 +397,7 @@ class Sentinel:
 UNCHANGED = Sentinel("UNCHANGED")
 
 
-def import_object(colon_separated_string, accept_live_object=False):
+def import_object(colon_separated_string, accept_live_object=True):
     if not isinstance(colon_separated_string, str):
         if not accept_live_object:
             raise ValueError(

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -399,6 +399,11 @@ UNCHANGED = Sentinel("UNCHANGED")
 
 def import_object(colon_separated_string, accept_live_object=False):
     if not isinstance(colon_separated_string, str):
+        if not accept_live_object:
+            raise ValueError(
+                "accept_live_object is False, but live object has been passed"
+            )
+
         # We have been handed the live object itself.
         # Nothing to import. Pass it through.
         return colon_separated_string


### PR DESCRIPTION
The optional argument accept_live_object was never used in the tiled/utils:import_object function. Change the function so that if a live object is passed but `accept_live_object==False`, a ValueError is thrown.

Based on a simple search, it appears that `import_object` is used in quite a few places with different values for `accept_live_object`, so hopefully this tightens up expected behavior.