### PR TITLE
Add env var for in-lined contents for HDF5 adapter.

### DIFF
--- a/tiled/_tests/test_hdf5.py
+++ b/tiled/_tests/test_hdf5.py
@@ -51,8 +51,8 @@ def test_from_file_with_vlen_str_dataset(example_file_with_vlen_str_in_dataset):
     """Serve a single HDF5 file at top level."""
     h5py = pytest.importorskip("h5py")
     tree = HDF5Adapter(example_file_with_vlen_str_in_dataset)
-    client = from_tree(tree)
     with pytest.warns(UserWarning):
+        client = from_tree(tree)
         arr = client["a"]["b"]["c"]["d"].read()
     assert isinstance(arr, numpy.ndarray)
     buffer = io.BytesIO()

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -11,6 +11,7 @@ from ..utils import DictView, node_repr
 from .array import ArrayAdapter
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
+INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 
 
 class HDF5DatasetAdapter(ArrayAdapter):
@@ -150,3 +151,6 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         if direction < 0:
             items = reversed(items)
         return items[start:stop]
+
+    def inlined_contents_enabled(self, depth):
+        return depth < INLINED_DEPTH

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -153,4 +153,4 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         return items[start:stop]
 
     def inlined_contents_enabled(self, depth):
-        return depth < INLINED_DEPTH
+        return depth <= INLINED_DEPTH


### PR DESCRIPTION
Awhile back we made it possible for the server to send nested information about generations of tiled nodes "in-lined" into a single response, for large reductions in latency. The motivating use case for xarray datasets.

A comment from @SimonHeybrock on Slack reminded me that we never applied this to our HDF5 reader. In this PR, the internal structure and metadata (attrs) of an HDF5 file are in-lined up to 7 generations by default.

Take the NeXus example. 

```sh
tiled serve pyobject tiled.examples.nexus:tree --public
```

Traversing this tree (downloading all group/dataset names and attrs, but not data) issues a single request for all that information and takes about 80 ms to run, including connection time.

```python
from tiled.client import from_uri
from tiled.utils import tree
%timeit tree(from_uri("http://localhost:8000"), None)
```

Reverting to the old behavior, like so:

```sh
TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH=0 tiled serve pyobject tiled.examples.nexus:tree --public
```

the same client-side command issues 150 HTTP requests and take over 800 ms (10X).