### PR TITLE
Update pickle test to use /v1 URL.

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -9,7 +9,8 @@ source start_LDAP.sh
 # installation problems if out of date.
 python -m pip install --upgrade pip setuptools wheel numpy
 # Versioneer uses the most recent git tag to generate __version__, which appears
-# in the published documentation.
-git fetch --tags
+# in the published documentation and is declared by the client when it
+# connects to a server.
+git fetch --tags --unshallow
 python -m pip install '.[complete]'
 python -m pip list

--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -9,7 +9,7 @@ import pytest
 from ..client import from_uri
 from ..client.context import Context
 
-API_URL = "https://tiled-demo.blueskyproject.io/api/"
+API_URL = "https://tiled-demo.blueskyproject.io/api/v1/"
 
 
 def test_pickle_context():


### PR DESCRIPTION
This test was being skipped because the external server it connects to has been returning returning `404` since #358 was deployed.