### PR TITLE
Add compute method to Dask client objects.

### DIFF
--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -106,6 +106,14 @@ def test_nan_infinity_handler(tmpdir):
     assert open_json == expected_list
 
 
+def test_dask():
+    expected = cube_cases["tiny_cube"]
+    client = from_tree(cube_tree, "dask")["tiny_cube"]
+    assert numpy.array_equal(client.read().compute(), expected)
+    assert numpy.array_equal(client.compute(), expected)
+    assert numpy.array_equal(client[:].compute(), expected)
+
+
 def test_array_format_shape_from_cube():
     client = from_tree(cube_tree)
 

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -57,3 +57,10 @@ def test_dataframe_single_partition():
     actual = client["single_partition"].read()
     assert client["single_partition"].structure().macro.npartitions == 1
     pandas.testing.assert_frame_equal(actual, expected)
+
+
+def test_dask():
+    client = from_tree(tree, "dask")["basic"]
+    expected = tree["basic"].read()
+    pandas.testing.assert_frame_equal(client.read().compute(), expected)
+    pandas.testing.assert_frame_equal(client.compute(), expected)

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -8,7 +8,7 @@ from .base import BaseStructureClient
 from .utils import export_util, params_from_slice
 
 
-class DaskArrayClient(BaseStructureClient):
+class _DaskArrayClient(BaseStructureClient):
     "Client-side wrapper around an array-like that returns dask arrays"
 
     def __init__(self, *args, item, **kwargs):
@@ -233,6 +233,17 @@ class DaskArrayClient(BaseStructureClient):
             self.item["links"][link].format(**template_vars),
             params=params,
         )
+
+
+# Subclass with a public class that adds the dask-specific methods.
+
+
+class DaskArrayClient(_DaskArrayClient):
+    "Client-side wrapper around an array-like that returns dask arrays"
+
+    def compute(self):
+        "Alias to client.read().compute()"
+        return self.read().compute()
 
 
 class ArrayClient(DaskArrayClient):

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -7,8 +7,8 @@ from .base import BaseStructureClient
 from .utils import ClientError, client_for_item, export_util
 
 
-class DaskDataFrameClient(BaseStructureClient):
-    "Client-side wrapper around an array-like that returns dask arrays"
+class _DaskDataFrameClient(BaseStructureClient):
+    "Client-side wrapper around an dataframe-like that returns dask dataframes"
 
     def new_variation(self, structure=UNCHANGED, **kwargs):
         if structure is UNCHANGED:
@@ -217,7 +217,18 @@ class DaskDataFrameClient(BaseStructureClient):
         )
 
 
-class DataFrameClient(DaskDataFrameClient):
+# Subclass with a public class that adds the dask-specific methods.
+
+
+class DaskDataFrameClient(_DaskDataFrameClient):
+    "Client-side wrapper around an dataframe-like that returns dask dataframes"
+
+    def compute(self):
+        "Alias to client.read().compute()"
+        return self.read().compute()
+
+
+class DataFrameClient(_DaskDataFrameClient):
     "Client-side wrapper around a dataframe-like that returns in-memory dataframes"
 
     def read_partition(self, partition, columns=None):


### PR DESCRIPTION
Using the tiled client today in a small project, I found myself wishing that the dask clients had a `compute()` method so I can type

```py
c["x"].compute()
```

instead of

```py
c["x"].read().compute()
```

These client objects do not attempt to be array-like or dataframe-like objects, but it is help to elide the `read()` step in this case I think.