### PR TITLE
Tolerate stray files in config dir.

### DIFF
--- a/tiled/_tests/test_config.py
+++ b/tiled/_tests/test_config.py
@@ -1,6 +1,9 @@
+import yaml
+
 from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter
 from ..client import from_config
+from ..config import parse_configs
 
 tree = MapAdapter({"example": ArrayAdapter.from_array([1, 2, 3])})
 
@@ -90,3 +93,12 @@ def test_many_nested():
     assert list(client["a"]["d"]["f"]) == ["example"]
     assert list(client["a"]["d"]["g"]["h"]) == ["example"]
     assert list(client["a"]["d"]["g"]["i"]) == ["example"]
+
+
+def test_extra_files(tmpdir):
+    config = {"trees": [{"path": "/", "tree": "tiled.examples.generated_minimal:tree"}]}
+    with open(tmpdir / "config.yml", "w") as config_file:
+        yaml.dump(config, config_file)
+    with open(tmpdir / "README.md", "w") as extra_file:
+        extra_file.write("# Example")
+    parse_configs(str(tmpdir))

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -325,19 +325,18 @@ def parse_configs(config_path):
     """
     Parse configuration file or directory of configuration files.
 
-    If a directory is given it is expected to contain only valid
-    configuration files, except for the following which are ignored:
-
-    * Hidden files or directories (starting with .)
-    * Python scripts (ending in .py)
-    * The __pycache__ directory
+    If a directory is given, any files not ending in `.yml` or `.yaml` are
+    ignored. Therefore, the directory may also contain a README file and
+    supporting Python scripts with custom objects.
     """
     if isinstance(config_path, str):
         config_path = Path(config_path)
     if config_path.is_file():
         filepaths = [config_path]
     elif config_path.is_dir():
-        filepaths = list(config_path.iterdir())
+        filepaths = [
+            fn for fn in config_path.iterdir() if fn.suffix in (".yml", ".yaml")
+        ]
     elif not config_path.exists():
         raise ValueError(f"The config path {config_path!s} doesn't exist.")
     else:


### PR DESCRIPTION
Tiled accepts a _directory_ of config files to enable config to be split arbitrarily across separate files. This can help keep things tidy.

In `main`, tiled has a specific list of file types that it _ignores_. In practice, this was erroring out on a `README.md` file and some other things that we failed to account for in that list. I think it would be better to reverse the logic and use an allow-list containing only `.yml` and `.yaml`.