### PR TITLE
Target /deploy *directory* not /deploy/config.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ WORKDIR /deploy
 
 EXPOSE 8000
 
-CMD ["tiled", "serve", "config", "--host", "0.0.0.0", "--port", "8000", "--scalable"]
+CMD ["tiled", "serve", "config", "--host", "0.0.0.0", "--port", "8000", "--scalable", "/deploy"]


### PR DESCRIPTION
If a config file is not specified, Tiled falls back to `./config.yml`. Therefore, this works:

```
docker run -v /tmp/tiled_config/one_config.yml:/deploy/config.yml -p 8000:8000 ghcr.io/bluesky/tiled:v0.1.0a83
```

But if you try to use a configuration _directory_ it will look only `/deploy/config.yml`. If a file with them name happens to existing the directory it will use that alone and silently ignore all others. If a file with that name does not exist, it will fail.

```
docker run -v ./config_dir:/deploy -p 8000:8000 ghcr.io/bluesky/tiled
```

It's possible to work around this:

```
docker run -e TILED_CONFIG=/deploy -v /tmp/tiled_config:/deploy -p 8000:8000 ghcr.io/bluesky/tiled:v0.1.0a83
```

but I think it would be better if the default behavior was to look at `/deploy` instead of `/deploy/config.yml` specifically.