### PR TITLE
Adapt to change in FastAPI, Starlette

### DIFF
--- a/tiled/_tests/test_allow_origins.py
+++ b/tiled/_tests/test_allow_origins.py
@@ -1,0 +1,44 @@
+from tiled.client import from_config
+
+strict_config = {
+    "authentication": {
+        "allow_anonymous_access": True,
+    },
+    "trees": [
+        {
+            "tree": "tiled.examples.generated_minimal:tree",
+            "path": "/",
+        },
+    ],
+}
+
+permissive_config = strict_config.copy()
+permissive_config["allow_origins"] = ["https://example.com"]
+
+
+def test_cors_enforcement():
+    client = from_config(strict_config)
+    request = client.context.http_client.build_request(
+        "OPTIONS",
+        "/",
+        headers={
+            "Access-Control-Request-Method": "GET",
+            "Origin": "https://example.com",
+        },
+    )
+    response = client.context.http_client.send(request)
+    assert response.status_code == 400
+
+
+def test_allow_origins():
+    client = from_config(permissive_config)
+    request = client.context.http_client.build_request(
+        "OPTIONS",
+        "/",
+        headers={
+            "Access-Control-Request-Method": "GET",
+            "Origin": "https://example.com",
+        },
+    )
+    response = client.context.http_client.send(request)
+    assert response.status_code == 200

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -226,7 +226,16 @@ def build_app(
                 },
             )
 
+    # This list will be mutated when settings are processed at app startup.
     app.state.allow_origins = []
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=app.state.allow_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
     app.include_router(router, prefix="/api/v1")
 
     # The Tree and Authenticator have the opportunity to add custom routes to
@@ -392,14 +401,6 @@ def build_app(
         app.include_router(declare_search_router(query_registry), prefix="/api/v1")
 
         app.state.allow_origins.extend(settings.allow_origins)
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=app.state.allow_origins,
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
-
         object_cache_logger.setLevel(settings.object_cache_log_level.upper())
         object_cache_available_bytes = settings.object_cache_available_bytes
         import psutil


### PR DESCRIPTION
In `main`, we add ASGI middleware for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enforcement during server startup. This is no longer allowed, as of a recent release of FastAPI/Starlette. (I haven't bothered to trace down which one is responsible for the change.) That seem sensible enough.

In this PR, the CORS middleware is added before server startup, and only the state affecting its _configuration_ is mutated during server startup. A unit test was added to ensure that:

* We block cross-origin requests by default.
* Setting `allow_origins` mutates the configuration during server startup and has the intended effect.