### PR TITLE
Verify block is fully-specified.

### DIFF
--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -128,11 +128,9 @@ def test_dask():
 def test_array_format_shape_from_cube():
     client = from_tree(cube_tree)
 
-    with pytest.raises(httpx.HTTPStatusError) as err:
+    with fail_with_status_code(406):
         # export...
         hyper_cube = client["tiny_hypercube"].export("test.png")  # noqa: F841
-    # Check that the error is 406 (Not Acceptable).
-    assert err.match("406")
 
 
 def test_array_interface():

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -1,8 +1,7 @@
 import contextlib
 
+import httpx
 import pytest
-
-from ..client.utils import ClientError
 
 
 def force_update(client):
@@ -18,6 +17,6 @@ def force_update(client):
 
 @contextlib.contextmanager
 def fail_with_status_code(status_code):
-    with pytest.raises(ClientError) as info:
+    with pytest.raises(httpx.HTTPStatusError) as info:
         yield
     assert info.value.response.status_code == status_code

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -364,6 +364,7 @@ def array_block(
             status_code=404,
             detail=f"Cannot read {entry.structure_family} structure with /array/block route.",
         )
+    # Check that block dimensionality matches array dimensionality.
     shape = entry.macrostructure().shape
     ndim = len(shape)
     if len(block) != ndim:

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -364,9 +364,19 @@ def array_block(
             status_code=404,
             detail=f"Cannot read {entry.structure_family} structure with /array/block route.",
         )
+    shape = entry.macrostructure().shape
+    ndim = len(shape)
+    if len(block) != ndim:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Block parameter must have {ndim} comma-separated parameters, "
+                f"corresponding to the dimensions of this {ndim}-dimensional array."
+            ),
+        )
     if block == ():
         # Handle special case of numpy scalar.
-        if entry.macrostructure().shape != ():
+        if shape != ():
             raise HTTPException(
                 status_code=400,
                 detail=f"Requested scalar but shape is {entry.macrostructure().shape}",

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -359,13 +359,16 @@ def array_block(
     """
     Fetch a chunk of array-like data.
     """
-    if entry.structure_family not in {"array", "sparse"}:
+    if entry.structure_family == "array":
+        shape = entry.macrostructure().shape
+    elif entry.structure_family == "sparse":
+        shape = entry.structure().shape
+    else:
         raise HTTPException(
             status_code=404,
             detail=f"Cannot read {entry.structure_family} structure with /array/block route.",
         )
     # Check that block dimensionality matches array dimensionality.
-    shape = entry.macrostructure().shape
     ndim = len(shape)
     if len(block) != ndim:
         raise HTTPException(


### PR DESCRIPTION
@jwlodek, @jmaruland, and I observed strange (undefined?) behavior when the server is provided the block parameter `?block=0,0` for a 4-dimensional array. (It should be `?block=0,0,0,0`.) It returned an unexpected number of bytes, with no error.

This PR would raise a clear error if the number of `,`-separated elements in `block=...` is does not match the dimensionality of the array.

~Needs a unit test before being merged.~ Test added.