### PR TITLE
Test Prometheus metrics, and fix bug where 500s weren't reported

### DIFF
--- a/tiled/_tests/test_metrics.py
+++ b/tiled/_tests/test_metrics.py
@@ -1,0 +1,50 @@
+import re
+
+from fastapi import APIRouter
+
+from ..client.constructors import from_app
+from ..config import construct_build_app_kwargs
+from ..server.app import build_app
+
+config = {
+    "authentication": {"single_user_api_key": "secret"},
+    "trees": [{"path": "/", "tree": "tiled.examples.generated_minimal:tree"}],
+}
+build_app_kwargs = construct_build_app_kwargs(config)
+
+router = APIRouter()
+
+
+@router.get("/error")
+def error():
+    1 / 0  # error!
+
+
+def total_request_time(client, code):
+    metrics = client.context.http_client.get("/api/v1/metrics").read().splitlines()
+    pattern = re.compile(
+        rf'^tiled_request_duration_seconds_bucket{{code="{code}",.*}} (\d+.\d+)$'.encode()
+    )
+    request_duration_buckets = []
+    for metric in metrics:
+        match = pattern.match(metric)
+        if match:
+            request_duration_buckets.append(float(match.group(1)))
+    return sum(request_duration_buckets)
+
+
+def test_error_code():
+    app = build_app(**build_app_kwargs)
+    app.include_router(router)
+
+    client = from_app(app, raise_server_exceptions=False)
+    list(client)
+    assert total_request_time(client, 200) > 0
+    assert total_request_time(client, 500) == 0
+    client.context.http_client.raise_server_exceptions = False
+    response_500 = client.context.http_client.get("/error")
+    assert response_500.status_code == 500
+    assert total_request_time(client, 500) > 0
+    response_404 = client.context.http_client.get("/does_not_exist")
+    assert response_404.status_code == 404
+    assert total_request_time(client, 404) > 0

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -50,6 +50,7 @@ class Context:
         verify=True,
         token_cache=DEFAULT_TOKEN_CACHE,
         app=None,
+        raise_server_exceptions=True,
     ):
         # The uri is expected to reach the root API route.
         uri = httpx.URL(uri)
@@ -106,6 +107,7 @@ class Context:
                 event_hooks=EVENT_HOOKS,
                 timeout=timeout,
                 headers=headers,
+                raise_server_exceptions=raise_server_exceptions,
             )
             client.follow_redirects = True
             client.__enter__()

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -8,7 +8,7 @@ import os
 from functools import lru_cache
 
 from fastapi import APIRouter, Request, Response, Security
-from prometheus_client import Histogram
+from prometheus_client import CONTENT_TYPE_LATEST, Histogram, generate_latest
 
 from .authentication import get_current_principal
 
@@ -162,7 +162,6 @@ async def metrics(
     """
     Prometheus metrics
     """
-    from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
     request.state.endpoint = "metrics"
     data = generate_latest(prometheus_registry())


### PR DESCRIPTION
When an unhandled exception makes it way up the call stack, FastAPI handles it and returns a response with status code `500` (Internal Server Error). These responses are not being captured by our Prometheus metrics, giving the false impression that there are no 500 responses being issued.

This PR fixes that, and adds the first unit tests covering the metrics in general.