### PR TITLE
Facilitate JSON logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ share/tiled/ui
 config.yaml
 config.yml
 *.sqlite
+
+prometheus_data
+grafana_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,46 @@ services:
       - TILED_CONFIG=/deploy/config.yml
     ports:
       - 8000:8000
+    restart: unless-stopped
+
+  # Below we additionally configure monitoring with Prometheus and Grafana.
+  # This is optional; it is not required for Tiled to function.
+
+  prometheus:
+    image: docker.io/prom/prometheus:v2.42.0
+    volumes:
+      - ./monitoring_example/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    networks:
+      - backend
+    restart: unless-stopped
+
+  grafana:
+    image: docker.io/grafana/grafana:8.2.6
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    volumes:
+      - ./monitoring_example/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./monitoring_example/grafana/main.yml:/etc/grafana/provisioning/dashboards/main.yml
+      - ./monitoring_example/grafana/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - backend
+    restart: unless-stopped
+
+    # Disable Grafana login screen for dev/demo.
+    # DO NOT USE THESE SETTINGS IN PRODUCTION.
+    environment:
+      GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+
+networks:
+  backend: {}

--- a/log_config.yml
+++ b/log_config.yml
@@ -1,0 +1,27 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    (): 'tiled.json_log_formatter.JSONFormatter'
+  access:
+    (): 'tiled.json_log_formatter.JSONFormatter'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: INFO
+    handlers:
+      - access
+    propagate: no

--- a/monitoring_example/README.md
+++ b/monitoring_example/README.md
@@ -1,0 +1,13 @@
+# Monitoring example
+
+These are configuration files for monitoring Tiled with Prometheus and Grafana.
+
+To see a complete working example that incorporates these, clone the tiled
+repository and, from the repository root directory, run:
+
+```
+TILED_SINGLE_USER_API_KEY=secret docker-compose up
+```
+
+These configuration files can be used as is or as a jumping off point for
+integrating Tiled into larger systems.

--- a/monitoring_example/README.md
+++ b/monitoring_example/README.md
@@ -1,6 +1,6 @@
 # Monitoring example
 
-These are configuration files for monitoring Tiled with Prometheus and Grafana.
+These are example configuration files for monitoring Tiled with Prometheus and Grafana.
 
 To see a complete working example that incorporates these, clone the tiled
 repository and, from the repository root directory, run:
@@ -9,5 +9,11 @@ repository and, from the repository root directory, run:
 TILED_SINGLE_USER_API_KEY=secret docker-compose up
 ```
 
-These configuration files can be used as is or as a jumping off point for
-integrating Tiled into larger systems.
+**Note that the file `prometheus/prometheus.yml` contains a dummy credential
+(`secret`).** To run the example, it must match the secret set by
+`TILED_SINGLE_USER_API_KEY`. In real single-user deployments, the secret should
+be set to a secure value as described in
+[Tiled's security documentation](https://blueskyproject.io/tiled/explanations/security.html).
+In multi-user deployments, an
+[API key](https://blueskyproject.io/tiled/how-to/api-keys.html) with the
+`metrics` scope should be used.

--- a/monitoring_example/grafana/dashboards/dashboard.json
+++ b/monitoring_example/grafana/dashboards/dashboard.json
@@ -1,0 +1,224 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(tiled_request_duration_seconds_bucket{}[1m]))",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(rate(tiled_request_duration_seconds_bucket{code=\"200\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "200",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(rate(tiled_request_duration_seconds_bucket{code=\"304\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "304",
+          "refId": "B"
+        }
+      ],
+      "title": "Responses Per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum(rate(tiled_request_duration_seconds_bucket[5m])) by (le))",
+          "interval": "",
+          "legendFormat": "95th percentile",
+          "refId": "95th"
+        }
+      ],
+      "title": "Response Time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 32,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Tiled Dashboard",
+  "uid": "Hnvd_TA4z",
+  "version": 1
+}

--- a/monitoring_example/grafana/dashboards/dashboard.json
+++ b/monitoring_example/grafana/dashboards/dashboard.json
@@ -28,6 +28,7 @@
   "panels": [
     {
       "datasource": "Prometheus",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -98,25 +99,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(tiled_request_duration_seconds_bucket{}[1m]))",
-          "interval": "",
-          "legendFormat": "Total",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum(rate(tiled_request_duration_seconds_bucket{code=\"200\"}[1m]))",
+          "expr": "sum by (code) (rate(tiled_request_duration_seconds_count[1m]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "200",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum(rate(tiled_request_duration_seconds_bucket{code=\"304\"}[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "304",
+          "legendFormat": "",
           "refId": "B"
         }
       ],
@@ -195,10 +181,17 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(tiled_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(tiled_request_duration_seconds_bucket[5m])) by (le))",
           "interval": "",
           "legendFormat": "95th percentile",
           "refId": "95th"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum(rate(tiled_request_duration_seconds_bucket[5m])) by (le))",
+          "interval": "",
+          "legendFormat": "50th percentile",
+          "refId": "50th"
         }
       ],
       "title": "Response Time",

--- a/monitoring_example/grafana/main.yml
+++ b/monitoring_example/grafana/main.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/monitoring_example/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring_example/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,6 @@
+datasources:
+- name: Prometheus
+  access: proxy
+  type: prometheus
+  url: http://prometheus:9090
+  isDefault: true

--- a/monitoring_example/prometheus/prometheus.yml
+++ b/monitoring_example/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+# Do we need this?
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'tiled'
+    metrics_path: /api/v1/metrics
+    authorization:  # Set Authorization header to 'Apikey secret'.
+      type: Apikey
+      credentials: secret
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['tiled:8000']

--- a/tiled/json_log_formatter.py
+++ b/tiled/json_log_formatter.py
@@ -1,0 +1,67 @@
+# Source: https://stackoverflow.com/a/70223539
+import json
+import logging
+
+
+class JSONFormatter(logging.Formatter):
+    """
+    Formatter that outputs JSON strings after parsing the LogRecord.
+
+    @param dict fmt_dict: Key: logging format attribute pairs. Defaults to {"message": "message"}.
+    @param str time_format: time.strftime() format string. Default: "%Y-%m-%dT%H:%M:%S"
+    @param str msec_format: Microsecond formatting. Appended at the end. Default: "%s.%03dZ"
+    """
+
+    def __init__(
+        self,
+        fmt_dict: dict = None,
+        time_format: str = "%Y-%m-%dT%H:%M:%S",
+        msec_format: str = "%s.%03dZ",
+    ):
+        self.fmt_dict = fmt_dict if fmt_dict is not None else {"message": "message"}
+        self.default_time_format = time_format
+        self.default_msec_format = msec_format
+        self.datefmt = None
+
+    def usesTime(self) -> bool:
+        """
+        Overwritten to look for the attribute in the format dict values instead of the fmt string.
+        """
+        return "asctime" in self.fmt_dict.values()
+
+    def formatMessage(self, record) -> dict:
+        """
+        Overwritten to return a dictionary of the relevant LogRecord attributes instead of a string.
+        KeyError is raised if an unknown attribute is provided in the fmt_dict.
+        """
+        return {
+            fmt_key: record.__dict__[fmt_val]
+            for fmt_key, fmt_val in self.fmt_dict.items()
+        }
+
+    def format(self, record) -> str:
+        """
+        Mostly the same as the parent's class method,
+        the difference being that a dict is manipulated and dumped as JSON
+        instead of a string.
+        """
+        record.message = record.getMessage()
+
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+
+        message_dict = self.formatMessage(record)
+
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            message_dict["exc_info"] = record.exc_text
+
+        if record.stack_info:
+            message_dict["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(message_dict, default=str)


### PR DESCRIPTION
When errors are logged as multi-line text, it plays badly with system like Splunk that consume each line from the logs as a separate item. Specifically, it becomes difficult to access tracebacks.

Uvicorn supports log configuration involving custom Python objects. It may be convenient for Tiled to ship with a JSON logger to cover this important use case.