### PR TITLE
All removal of cache items that weren't present

### DIFF
--- a/tiled/_tests/test_caches.py
+++ b/tiled/_tests/test_caches.py
@@ -83,10 +83,6 @@ def test_caching_map():
     assert "a" not in cache
     assert "a" not in mapping
     assert "a" not in d
-    with pytest.raises(KeyError):
-        d.remove("a")
-    with pytest.raises(KeyError):
-        d.remove("never existed")
     d.set("a", f)
     assert d["a"] == 5  # f is called here again
     assert counter == 4

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -147,7 +147,7 @@ class OneShotCachedMap(collections.abc.Mapping):
         """
         Remove a key. Raises KeyError if key not present.
         """
-        del self.__mapping[key]
+        self.__mapping.pop(key, None)
         self.evict(key)
 
     def __len__(self):
@@ -229,7 +229,7 @@ class CachingMap(collections.abc.Mapping):
         """
         Remove a key. Raises KeyError if key not present.
         """
-        del self.__mapping[key]
+        self.__mapping.pop(key, None)
         self.evict(key)
 
     def evict(self, key):


### PR DESCRIPTION
Fixes #336 

Changes the documented behavior of `CachingMap` to silently allow removing items.

I also changed `OneShotCachedMap` to follow the same pattern. This was not necessary to get unit tests to work, and I'm a little unsure when the `OneShotCachedmap` is used.