### PR TITLE
Version-lock fastapi

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -7,7 +7,7 @@ cachey
 cachetools
 click !=8.1.0
 dask
-fastapi
+fastapi <=0.89.1
 httpx >=0.20.0,!=0.23.1
 jinja2
 jmespath


### PR DESCRIPTION
`fastapi==0.93.0` causes `tiled serve config` to fail with RuntimeError: Cannot add middleware after an application has started error. Version-locking `fastapi` to `0.89.1` seems to fix the issue.

Here's the full error:

```
  File "/Users/mc/miniforge3/envs/py3.9-3/lib/python3.9/site-packages/starlette/routing.py", line 671, in lifespan
    async with self.lifespan_context(app):
  File "/Users/mc/miniforge3/envs/py3.9-3/lib/python3.9/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/Users/mc/miniforge3/envs/py3.9-3/lib/python3.9/site-packages/starlette/routing.py", line 648, in startup
    await handler()
  File "/Users/mc/miniforge3/envs/py3.9-3/lib/python3.9/site-packages/tiled/server/app.py", line 395, in startup_event
    app.add_middleware(
  File "/Users/mc/miniforge3/envs/py3.9-3/lib/python3.9/site-packages/starlette/applications.py", line 135, in add_middleware
    raise RuntimeError("Cannot add middleware after an application has started")
RuntimeError: Cannot add middleware after an application has started

ERROR:    Application startup failed. Exiting.
```

@jmaruland @danielballan 