### PR TITLE
Fix OpenAPI auth URL.

### DIFF
--- a/tiled/_tests/test_openapi.py
+++ b/tiled/_tests/test_openapi.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ..adapters.mapping import MapAdapter
+from ..client import Context
+from ..server.app import build_app_from_config
+
+# Basic authenticated server config
+tree = MapAdapter({})
+config = {
+    "authentication": {
+        "secret_keys": ["SECRET"],
+        "providers": [
+            {
+                "provider": "toy",
+                "authenticator": "tiled.authenticators:DictionaryAuthenticator",
+                "args": {"users_to_passwords": {"alice": "secret1", "bob": "secret2"}},
+            }
+        ],
+    },
+    "trees": [
+        {
+            "tree": f"{__name__}:tree",
+            "path": "/",
+        },
+    ],
+}
+
+
+@pytest.fixture
+def context():
+    with Context.from_app(build_app_from_config(config)) as context:
+        yield context
+
+
+def test_openapi_username_password_login(context):
+    """
+    Ensure that tokenUrl is a valid path.
+
+    The tokenUrl is set manually because of when in the server lifecycle it is
+    known, and the point of this test is to ensure it does not bit rot to some
+    invalid path, because that has happened before.
+    """
+    response = context.http_client.get("/openapi.json")
+    assert response.status_code == 200
+    openapi = response.json()
+    token_url = openapi["components"]["securitySchemes"]["OAuth2PasswordBearer"][
+        "flows"
+    ]["password"]["tokenUrl"]
+    assert token_url in openapi["paths"]

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -275,7 +275,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         # For the OpenAPI schema, inject a OAuth2PasswordBearer URL.
         first_provider = authentication["providers"][0]["provider"]
         oauth2_scheme.model.flows.password.tokenUrl = (
-            f"/api/auth/provider/{first_provider}/token"
+            f"/api/v1/auth/provider/{first_provider}/token"
         )
         # Authenticators provide Router(s) for their particular flow.
         # Collect them in the authentication_router.


### PR DESCRIPTION
This was broken by #358 when we inserted `/v1` into the URL. Tested manually that this fixes the issue, and added a unit test to avoid letting this bit rot again in the future.