### PR TITLE
Fix client version check

### DIFF
--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -1,8 +1,9 @@
 import httpx
 
 from ..adapters.mapping import MapAdapter
-from ..client import Context
+from ..client import Context, from_context
 from ..server.app import build_app
+from .utils import fail_with_status_code
 
 tree = MapAdapter({})
 
@@ -11,3 +12,21 @@ def test_configurable_timeout():
     with Context.from_app(build_app(tree), timeout=httpx.Timeout(17)) as context:
         assert context.http_client.timeout.connect == 17
         assert context.http_client.timeout.read == 17
+
+
+def test_old_client_version():
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        # Too-old user agent should generate a 400.
+        context.http_client.headers["user-agent"] = "python-tiled/0.1.0a77"
+        with fail_with_status_code(400):
+            list(client)
+
+
+def test_gibberish_client_version():
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        # Gibberish user agent should be ignored.
+        # (but, as an implementation detail, generate an error log in the server)
+        context.http_client.headers["user-agent"] = "python-tiled/gibberish"
+        list(client)

--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -14,19 +14,16 @@ def test_configurable_timeout():
         assert context.http_client.timeout.read == 17
 
 
-def test_old_client_version():
+def test_client_version_check():
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
+
         # Too-old user agent should generate a 400.
         context.http_client.headers["user-agent"] = "python-tiled/0.1.0a77"
         with fail_with_status_code(400):
             list(client)
 
-
-def test_gibberish_client_version():
-    with Context.from_app(build_app(tree)) as context:
-        client = from_context(context)
-        # Gibberish user agent should be ignored.
-        # (but, as an implementation detail, generate an error log in the server)
+        # Gibberish user agent should generate a 400.
         context.http_client.headers["user-agent"] = "python-tiled/gibberish"
-        list(client)
+        with fail_with_status_code(400):
+            list(client)


### PR DESCRIPTION
When the client reported an old version, the server hit an unexpected error due to improper sequencing of middlwares. As a result, it responded with `500` instead of the intended `400` with a clear message about the client version being too old.

Mocking an old version like so:

```py
c.context.http_client.headers['user-agent'] = 'python-tiled/0.1.0a10'
c
```

we get this clear error message:

```
ClientError: 400: Python Tiled client reports version 0.1.0a10. Version 0.1.0a78 or higher is needed to communicate with this Tiled server. http://localhost:8000/api/v1/node/search/?page%5Boffset%5D=0&fields=&sort=_
```