### PR TITLE
Fix import object

### DIFF
--- a/example_configs/custom_export_formats/custom_exporters.py
+++ b/example_configs/custom_export_formats/custom_exporters.py
@@ -4,7 +4,7 @@ import io
 
 from PIL import Image
 
-from tiled.structures.image_serializer_helpers import img_as_ubyte
+from tiled.serialization.image_serializer_helpers import img_as_ubyte
 
 
 def smiley_separated_variables(array, metadata):

--- a/tiled/_tests/test_import_object.py
+++ b/tiled/_tests/test_import_object.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from ..config import parse_configs
+from ..server.app import build_app_from_config
+
+here = Path(__file__).parent.absolute()
+
+
+def test_config_imports_custom_python_module():
+    "Configs can import from Python modules located in their same directory."
+    config_path = here / ".." / ".." / "example_configs" / "custom_export_formats"
+    parsed_config = parse_configs(config_path)
+    build_app_from_config(parsed_config, source_filepath=config_path)

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -252,7 +252,9 @@ def serve_config(
 
     # This config was already validated when it was parsed. Do not re-validate.
     logger.info(f"Using configuration from {Path(config_path).absolute()}")
-    web_app = build_app_from_config(parsed_config, scalable=scalable)
+    web_app = build_app_from_config(
+        parsed_config, source_filepath=config_path, scalable=scalable
+    )
     print_admin_api_key_if_generated(
         web_app, host=uvicorn_kwargs["host"], port=uvicorn_kwargs["port"]
     )

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -752,9 +752,9 @@ Back up the database, and then run:
     return app
 
 
-def build_app_from_config(config, scalable=False):
+def build_app_from_config(config, source_filepath=None, scalable=False):
     "Convenience function that calls build_app(...) given config as dict."
-    kwargs = construct_build_app_kwargs(config)
+    kwargs = construct_build_app_kwargs(config, source_filepath=source_filepath)
     return build_app(scalable=scalable, **kwargs)
 
 


### PR DESCRIPTION
Tiled temporarily adds the directory containing the YAML config file(s) to `sys.path` during server setup, so that _ad hoc_ Python functions and classes can be defined there. It has worked out well to use statically-analyzable YAML for _most_ things but provide an easy escape hatch / escalation pathway for extensions.

In #416 I accidentally broke this feature and no tests were covering it. This PR fixes it and covers it with a test.

