### PR TITLE
Fix broken interaction between API key auth and access control

### DIFF
--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -144,6 +144,16 @@ def test_top_level_access_control(context, enter_password):
         bob_client["b"]
 
 
+def test_access_control_with_api_key_auth(context, enter_password):
+    with enter_password("secret1"):
+        context.authenticate(username="alice")
+    key_info = context.create_api_key()
+    context.logout()
+    context.api_key = key_info["secret"]
+    client = from_context(context)
+    client["a"]["A2"]
+
+
 def test_node_export(enter_password, context):
     "Exporting a node should include only the children we can see."
     with enter_password("secret1"):

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -145,10 +145,13 @@ def test_top_level_access_control(context, enter_password):
 
 
 def test_access_control_with_api_key_auth(context, enter_password):
+    # Log in, create an API key, log out.
     with enter_password("secret1"):
         context.authenticate(username="alice")
     key_info = context.create_api_key()
     context.logout()
+
+    # Use API key auth while exercising the access control code.
     context.api_key = key_info["secret"]
     client = from_context(context)
     client["a"]["A2"]

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -151,10 +151,14 @@ def test_access_control_with_api_key_auth(context, enter_password):
     key_info = context.create_api_key()
     context.logout()
 
-    # Use API key auth while exercising the access control code.
-    context.api_key = key_info["secret"]
-    client = from_context(context)
-    client["a"]["A2"]
+    try:
+        # Use API key auth while exercising the access control code.
+        context.api_key = key_info["secret"]
+        client = from_context(context)
+        client["a"]["A2"]
+    finally:
+        # Clean up Context, which is a module-scopae fixture shared with other tests.
+        context.api_key = None
 
 
 def test_node_export(enter_password, context):

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -285,7 +285,10 @@ async def lookup_valid_api_key(db, secret):
     api_key = (
         await db.execute(
             select(APIKey)
-            .options(selectinload(APIKey.principal).selectinload(Principal.roles))
+            .options(
+                selectinload(APIKey.principal).selectinload(Principal.roles),
+                selectinload(APIKey.principal).selectinload(Principal.identities),
+            )
             .filter(APIKey.first_eight == secret.hex()[:8])
             .filter(APIKey.hashed_secret == hashed_secret)
         )


### PR DESCRIPTION
Access control policies can access `principal.identities`. If these are not eagerly loaded, this triggers database I/O on attribute access, which raises an exception in async SQLAlchemy.

Previously, access control was only tested with bearer (i.e. access/refresh token) auth. Now it is tested with API key auth as well.