### PR TITLE
Handle case where __stdin__ is closed.

### DIFF
--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from pathlib import Path
 
 import httpx
@@ -7,8 +9,10 @@ import yaml
 from ..adapters.mapping import MapAdapter
 from ..client import Context, from_context, from_profile
 from ..config import ConfigError
+from ..client.context import CannotPrompt
+from ..config import ConfigError
 from ..profiles import load_profiles, paths
-from ..server.app import build_app
+from ..server.app import build_app, build_app_from_config
 from .utils import fail_with_status_code
 
 tree = MapAdapter({})
@@ -76,3 +80,36 @@ def test_direct_config_error(tmpdir):
             from_profile("test")
     finally:
         paths.remove(profile_dir)
+
+
+def test_stdin_closed(monkeypatch):
+    "When stdin is closed do not prompt for authentication."
+    # https://github.com/bluesky/tiled/pull/427
+    __stdin__ = types.SimpleNamespace(closed=True)
+    monkeypatch.setattr(sys, "__stdin__", __stdin__)
+    config = {
+        "authentication": {
+            "secret_keys": ["SECRET"],
+            "providers": [
+                {
+                    "provider": "toy",
+                    "authenticator": "tiled.authenticators:DictionaryAuthenticator",
+                    "args": {
+                        "users_to_passwords": {"alice": "secret1", "bob": "secret2"}
+                    },
+                }
+            ],
+        },
+        "database": {
+            "uri": "sqlite+aiosqlite://",  # in memory
+        },
+        "trees": [
+            {
+                "tree": f"{__name__}:tree",
+                "path": "/",
+            },
+        ],
+    }
+    with Context.from_app(build_app_from_config(config)) as context:
+        with pytest.raises(CannotPrompt):
+            from_context(context)

--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -8,7 +8,6 @@ import yaml
 
 from ..adapters.mapping import MapAdapter
 from ..client import Context, from_context, from_profile
-from ..config import ConfigError
 from ..client.context import CannotPrompt
 from ..config import ConfigError
 from ..profiles import load_profiles, paths
@@ -51,10 +50,10 @@ def test_direct(tmpdir):
     }
     with open(tmpdir / "example.yml", "w") as file:
         file.write(yaml.dump(profile_content))
-    load_profiles.cache_clear()
     profile_dir = Path(tmpdir)
     try:
-        paths.insert(0, profile_dir)
+        paths.append(profile_dir)
+        load_profiles.cache_clear()
         from_profile("test")
     finally:
         paths.remove(profile_dir)
@@ -72,10 +71,10 @@ def test_direct_config_error(tmpdir):
     }
     with open(tmpdir / "example.yml", "w") as file:
         file.write(yaml.dump(profile_content))
-    load_profiles.cache_clear()
     profile_dir = Path(tmpdir)
     try:
-        paths.insert(0, profile_dir)
+        paths.append(profile_dir)
+        load_profiles.cache_clear()
         with pytest.raises(ConfigError):
             from_profile("test")
     finally:

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -724,6 +724,10 @@ class Context:
                 # No need to log in again.
                 return
 
+        if not prompt_for_reauthentication:
+            raise CannotPrompt(
+                "Authentication is needed but the client cannot prompt for it."
+            )
         self.http_client.auth = None
         mode = spec["mode"]
         auth_endpoint = spec["links"]["auth_endpoint"]
@@ -970,3 +974,7 @@ class Admin:
         )
         handle_error(response)
         return response.json()
+
+
+class CannotPrompt(Exception):
+    pass

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -681,7 +681,9 @@ class Context:
         if prompt_for_reauthentication is UNSET:
             prompt_for_reauthentication = PROMPT_FOR_REAUTHENTICATION
         if prompt_for_reauthentication is None:
-            prompt_for_reauthentication = sys.__stdin__.isatty()
+            prompt_for_reauthentication = (
+                not sys.__stdin__.closed
+            ) and sys.__stdin__.isatty()
         providers = self.server_info["authentication"]["providers"]
         spec = _choose_identity_provider(providers, provider)
         provider = spec["provider"]


### PR DESCRIPTION
This addresses an issue we saw "in the wild" with queueserver at BMM. Needs unit tests with mock.