### PR TITLE
Validate server config in 'direct'.

### DIFF
--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -254,9 +254,19 @@ def from_profile(name, structure_clients=None, **kwargs):
     if "direct" in merged:
         # The profile specifies the server in-line.
         # Create an app and use it directly via ASGI.
+        import jsonschema
+
+        from ..config import ConfigError, schema
         from ..server.app import build_app_from_config
 
         config = merged.pop("direct", None)
+        try:
+            jsonschema.validate(instance=config, schema=schema())
+        except jsonschema.ValidationError as err:
+            msg = err.args[0]
+            raise ConfigError(
+                f"ValidationError while parsing configuration file {filepath}: {msg}"
+            ) from err
         context = Context.from_app(build_app_from_config(config), **merged)
         return from_context(context)
     else:


### PR DESCRIPTION
This is a commit I meant to push to #428. Below is the original comment explaining this aspect.

---

I also improved the error reporting. Previously, we did not validate the server-side configuration in-lined in the profile under `direct:`. A broken config like this:

```yaml
test:
  direct:
    # Intentional mistake! Value of `trees:` must be a _list_.
    trees:
      path: /
      tree: tiled.examples.generated_minimal:tree
```

produced unhelpful errors downstream like:

```py
In [1]: from tiled.client import from_profile

In [2]: c = from_profile("test")
...
AttributeError: 'str' object has no attribute 'get'
```

Now, the configuration is validated same as it would be in normal HTTP/TCP server mode, and we get a clearer error:

```py
ConfigError: ValidationError while parsing configuration file /home/dallan/.config/tiled/profiles/test.yml: {'path': '/', 'tree': 'tiled.examples.generated_minimal:tree'} is not of type 'array'
```
