### PR TITLE
Fix importable object in direct profile

### DIFF
--- a/tiled/_tests/test_import_object.py
+++ b/tiled/_tests/test_import_object.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
+import yaml
+
+from ..client import from_profile
 from ..config import parse_configs
+from ..profiles import load_profiles, paths
 from ..server.app import build_app_from_config
 
 here = Path(__file__).parent.absolute()
@@ -11,3 +15,22 @@ def test_config_imports_custom_python_module():
     config_path = here / ".." / ".." / "example_configs" / "custom_export_formats"
     parsed_config = parse_configs(config_path)
     build_app_from_config(parsed_config, source_filepath=config_path)
+
+
+def test_direct_profile(tmpdir):
+    profile_content = {
+        "test": {"direct": {"trees": [{"path": "/", "tree": "custom_module:tree"}]}}
+    }
+    with open(tmpdir / "example.yml", "w") as yaml_file:
+        yaml_file.write(yaml.dump(profile_content))
+    with open(tmpdir / "custom_module.py", "w") as py_file:
+        py_file.write(
+            "from tiled.adapters.mapping import MapAdapter; tree = MapAdapter({})"
+        )
+    profile_dir = Path(tmpdir)
+    try:
+        paths.append(profile_dir)
+        load_profiles.cache_clear()
+        from_profile("test")
+    finally:
+        paths.remove(profile_dir)

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -267,7 +267,9 @@ def from_profile(name, structure_clients=None, **kwargs):
             raise ConfigError(
                 f"ValidationError while parsing configuration file {filepath}: {msg}"
             ) from err
-        context = Context.from_app(build_app_from_config(config), **merged)
+        context = Context.from_app(
+            build_app_from_config(config, source_filepath=filepath), **merged
+        )
         return from_context(context)
     else:
         return from_uri(**merged)


### PR DESCRIPTION
This regression was seen in the wild by @mrakitin. It was introduced recently, in #416. The issue related to a previously fixed regression, #425. I believe this is the last instance of this bug.

The test reproduces the issue:

```
FAILED tiled/_tests/test_import_object.py::test_direct_profile - ModuleNotFoundError: No module named 'custom_module'
```

And it is then resolved by the next commit.
