### PR TITLE
Elide getitem requests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
-codecov
 coverage
 flake8
 ldap3

--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -7,10 +7,11 @@ import pytest
 import yaml
 
 from ..adapters.mapping import MapAdapter
-from ..client import Context, from_context, from_profile
+from ..client import Context, from_context, from_profile, record_history
 from ..client.context import CannotPrompt
 from ..config import ConfigError
 from ..profiles import load_profiles, paths
+from ..queries import Key
 from ..server.app import build_app, build_app_from_config
 from .utils import fail_with_status_code
 
@@ -112,3 +113,54 @@ def test_stdin_closed(monkeypatch):
     with Context.from_app(build_app_from_config(config)) as context:
         with pytest.raises(CannotPrompt):
             from_context(context)
+
+
+def test_jump_down_tree():
+    tree = MapAdapter({}, metadata={"number": 1})
+    for number, letter in enumerate(list("abcde"), start=2):
+        tree = MapAdapter({letter: tree}, metadata={"number": number})
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+    assert (
+        client["e"]["d"]["c"]["b"]["a"].metadata["number"]
+        == client["e", "d", "c", "b", "a"].metadata["number"]
+        == 1
+    )
+    assert (
+        client["e"]["d"]["c"]["b"].metadata["number"]
+        == client["e", "d", "c", "b"].metadata["number"]
+        == 2
+    )
+    assert (
+        client["e"]["d"]["c"].metadata["number"]
+        == client["e", "d", "c"].metadata["number"]
+        == 3
+    )
+    assert (
+        client["e"]["d"].metadata["number"] == client["e", "d"].metadata["number"] == 4
+    )
+
+    assert client["e"]["d", "c", "b"]["a"].metadata["number"] == 1
+    assert client["e"]["d", "c", "b", "a"].metadata["number"] == 1
+    assert client["e", "d", "c", "b"]["a"].metadata["number"] == 1
+    assert (
+        client.search(Key("number") == 5)["e", "d", "c", "b", "a"].metadata["number"]
+        == 1
+    )
+    assert (
+        client["e"].search(Key("number") == 4)["d", "c", "b", "a"].metadata["number"]
+        == 1
+    )
+    with pytest.raises(KeyError):
+        client.search(Key("number") == 4)["e", "d", "c", "b", "a"]
+        client["e"].search(Key("number") == 3)["d", "c", "b", "a"].metadata[
+            "number"
+        ] == 1
+
+    with record_history() as h:
+        client["e", "d", "c", "b", "a"]
+    assert len(h.requests) == 1
+
+    with record_history() as h:
+        client["e"]["d"]["c"]["b"]["a"]
+    assert len(h.requests) == 5

--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -151,11 +151,33 @@ def test_jump_down_tree():
         client["e"].search(Key("number") == 4)["d", "c", "b", "a"].metadata["number"]
         == 1
     )
-    with pytest.raises(KeyError):
+
+    # Check that a reasonable KeyError is raised.
+    # Notice that we do not binary search to find _exactly_ where the problem is.
+    with pytest.raises(KeyError) as exc_info:
+        client["e", "d", "c", "b"]["X"]
+    assert exc_info.value.args[0] == "X"
+    with pytest.raises(KeyError) as exc_info:
+        client["e", "d", "c", "b", "X"]
+    assert exc_info.value.args[0] == ("e", "d", "c", "b", "X")
+    with pytest.raises(KeyError) as exc_info:
+        client["e", "d", "X", "b", "a"]
+    assert exc_info.value.args[0] == ("e", "d", "X", "b", "a")
+
+    # Check that jumping raises if a key along the path is not in the search
+    # resuts.
+    with pytest.raises(KeyError) as exc_info:
+        client.search(Key("number") == 4)["e"]
+    assert exc_info.value.args[0] == "e"
+    with pytest.raises(KeyError) as exc_info:
         client.search(Key("number") == 4)["e", "d", "c", "b", "a"]
-        client["e"].search(Key("number") == 3)["d", "c", "b", "a"].metadata[
-            "number"
-        ] == 1
+    assert exc_info.value.args[0] == "e"
+    with pytest.raises(KeyError) as exc_info:
+        client["e"].search(Key("number") == 3)["d"]
+    assert exc_info.value.args[0] == "d"
+    with pytest.raises(KeyError) as exc_info:
+        client["e"].search(Key("number") == 3)["d", "c", "b", "a"]
+    assert exc_info.value.args[0] == "d"
 
     with record_history() as h:
         client["e", "d", "c", "b", "a"]

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -287,7 +287,9 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                 len(data) == 1
             ), "The key lookup query must never result more than one result."
             (item,) = data
-            return client_for_item(self.context, self.structure_clients, item)[tail]
+            result = client_for_item(self.context, self.structure_clients, item)
+            if tail:
+                result = result[tail]
         else:
             # Straightforwardly look up the key under this node.
             # There is no search filter in place, so if it is there
@@ -319,7 +321,8 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                         raise
                     item = content["data"]
                     break
-            return client_for_item(self.context, self.structure_clients, item)
+            result = client_for_item(self.context, self.structure_clients, item)
+        return result
 
     def __delitem__(self, key):
         self._cached_len = None

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -311,7 +311,11 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                         )
                     except ClientError as err:
                         if err.response.status_code == 404:
-                            raise KeyError(key)
+                            # If this is a scalar lookup, raise KeyError("X") not KeyError(("X",)).
+                            err_arg = keys[i:]
+                            if len(err_arg) == 1:
+                                (err_arg,) = err_arg
+                            raise KeyError(err_arg)
                         raise
                     item = content["data"]
                     break

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -245,7 +245,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                 yield item["id"]
             next_page_url = content["links"]["next"]
 
-    def __getitem__(self, key, _ignore_inlined_contents=False):
+    def __getitem__(self, keys, _ignore_inlined_contents=False):
         # These are equivalent:
         #
         # >>> node['a']['b']['c']
@@ -255,24 +255,19 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         # The last two are equivalent at a Python level;
         # both call node.__getitem__(('a', 'b', 'c')).
         #
-        # TODO Elide this into a single request to the server rather than
+        # We elide this into a single request to the server rather than
         # a chain of requests. This is not totally straightforward because
         # of this use case:
         #
         # >>> node.search(...)['a', 'b']
         #
         # which must only return a result if 'a' is contained in the search results.
-        # There are also some open design questions on the server side about
-        # how search and tree-traversal will relate, so we'll wait to make this
-        # optimization until that is fully worked out.
-        if isinstance(key, tuple):
-            child = self
-            for k in key:
-                child = child[k]
-            return child
+        if not isinstance(keys, tuple):
+            keys = (keys,)
 
         if self._queries:
             # Lookup this key *within the search results* of this Node.
+            key, *tail = keys
             content = self.context.get_json(
                 self.item["links"]["search"],
                 params={
@@ -292,6 +287,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
                 len(data) == 1
             ), "The key lookup query must never result more than one result."
             (item,) = data
+            return client_for_item(self.context, self.structure_clients, item)[tail]
         else:
             # Straightforwardly look up the key under this node.
             # There is no search filter in place, so if it is there
@@ -300,24 +296,26 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
             # Sometimes Nodes will in-line their contents (child nodes)
             # to reduce latency. This is how we handle xarray Datasets efficiently,
             # for example. Use that, if present.
-            item = (self.item["attributes"]["structure"]["contents"] or {}).get(key)
-            if (item is None) or _ignore_inlined_contents:
-                # The item was not inlined, either because nothing was inlined
-                # or because it was added after we fetched the inlined contents.
-                # Make a request for it.
-                try:
-                    self_link = self.item["links"]["self"]
-                    if self_link.endswith("/"):
-                        self_link = self_link[:-1]
-                    content = self.context.get_json(
-                        self_link + f"/{key}",
-                    )
-                except ClientError as err:
-                    if err.response.status_code == 404:
-                        raise KeyError(key)
-                    raise
-                item = content["data"]
-        return client_for_item(self.context, self.structure_clients, item)
+            for i, key in enumerate(keys):
+                item = (self.item["attributes"]["structure"]["contents"] or {}).get(key)
+                if (item is None) or _ignore_inlined_contents:
+                    # The item was not inlined, either because nothing was inlined
+                    # or because it was added after we fetched the inlined contents.
+                    # Make a request for it.
+                    try:
+                        self_link = self.item["links"]["self"]
+                        if self_link.endswith("/"):
+                            self_link = self_link[:-1]
+                        content = self.context.get_json(
+                            self_link + "".join(f"/{key}" for key in keys[i:]),
+                        )
+                    except ClientError as err:
+                        if err.response.status_code == 404:
+                            raise KeyError(key)
+                        raise
+                    item = content["data"]
+                    break
+            return client_for_item(self.context, self.structure_clients, item)
 
     def __delitem__(self, key):
         self._cached_len = None

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -264,10 +264,10 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         # which must only return a result if 'a' is contained in the search results.
         if not isinstance(keys, tuple):
             keys = (keys,)
-
         if self._queries:
             # Lookup this key *within the search results* of this Node.
             key, *tail = keys
+            tail = tuple(tail)  # list -> tuple
             content = self.context.get_json(
                 self.item["links"]["search"],
                 params={


### PR DESCRIPTION
For a long time we have supported

```py
c['x', 'y', 'z']
```

as an alias for

```py
c['x']['y']['z']
```

However, we have not been taking advantage of the opportunity to elide the former into a single HTTP request that "jumps" down the tree, instead of making separate HTTP requests at each jump. (Why? We deferred this work because of the subtlety of the implementation and some lingering questions about the meaning of paths in Tiled which have since been settled.)

This is expected to give good savings on latency.