### PR TITLE
Fix up OIDC and add a locally-runnable exampmle

### DIFF
--- a/example_configs/simple_oidc/README.md
+++ b/example_configs/simple_oidc/README.md
@@ -1,0 +1,46 @@
+# Run a local OIDC provider
+
+This example runs a [toy OIDC provider][] (the same authentication mechanism
+used by e.g. Google and GitHub) but running locally with fake users. **Do not
+use in production.**
+
+1. From this directory, start the OIDC provider service in a container as
+   follows.
+
+```
+docker run --rm -p 9000:9000 -v $(pwd):/config -e CONFIG_FILE=/config/oidc_provider_config.json -e USERS_FILE=/config/users.json qlik/simple-oidc-provider:0.2.4
+```
+
+2. From a web browser or commandline, access `http://localhost:9000`. These
+   contain public keys which _reset every time the container is (re)started_.
+   Fill them into the Tiled configuration in this directory, `config.yml`,
+   under `public_keys:`.
+
+3. Start a tiled server, providing the environment variables referenced in the
+   config file. These values can be used exactly as is; they match the values
+   in the file `oidc_provider_config.json` used by the OIDC provider.
+
+   ```
+   OIDC_BASE_URL=http://localhost:9000 OIDC_CLIENT_ID=example_client_id OIDC_CLIENT_SECRET=example_client_secret tiled serve config config.yml
+   ```
+4. Connect from the Python client and initiate log in.
+
+   ```python
+   from tiled.client import from_uri
+   c = from_uri("http://localhost:8000")
+   c.login()
+   ```
+
+5. This will show a URL and may automatically navigate a web browser to it.
+   When prompted to log in to the OIDC provider, use
+
+   ```
+   Username: example@example.com
+   Password: password
+   ```
+
+   This can be customized in the file `users.json` used by the OIDC provider.
+
+6. Follow the prompts from there, and login should succeed.
+
+[toy OIDC provider]: https://hub.docker.com/r/qlik/simple-oidc-provider/

--- a/example_configs/simple_oidc/oidc_provider_config.json
+++ b/example_configs/simple_oidc/oidc_provider_config.json
@@ -1,0 +1,27 @@
+{
+  "idp_name": "http://simple-oidc-provider",
+  "port": 9000,
+  "client_config": [
+    {
+      "client_id": "example_client_id",
+      "client_secret": "example_client_secret",
+      "redirect_uris": [
+        "http://localhost:8000/api/v1/auth/provider/simple_oidc/code",
+        "http://localhost:8000/api/v1/auth/provider/simple_oidc/device_code"
+      ]
+    }
+  ],
+  "claim_mapping": {
+    "openid": [
+      "sub"
+    ],
+    "email": [
+      "email",
+      "email_verified"
+    ],
+    "profile": [
+      "name",
+      "nickname"
+    ]
+  }
+}

--- a/example_configs/simple_oidc/users.json
+++ b/example_configs/simple_oidc/users.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "example",
+    "email": "example@example.com",
+    "email_verified": true,
+    "name": "Example",
+    "nickname": "example",
+    "password": "password",
+    "groups": []
+  }
+]

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -11,6 +11,7 @@ from jose import JWTError, jwk, jwt
 from starlette.responses import RedirectResponse
 
 from .server.authentication import Mode
+from .server.utils import get_root_url
 from .utils import modules_available
 
 logger = logging.getLogger(__name__)
@@ -153,7 +154,10 @@ properties:
 
     async def authenticate(self, request):
         code = request.query_params["code"]
-        redirect_uri = str(httpx.URL(str(request.url)).copy_with(params=[]))
+        # A proxy in the middle may make the request into something like
+        # 'http://localhost:8000/...' so we fix the first part but keep
+        # the original URI path.
+        redirect_uri = f"{get_root_url(request)}{request.url.path}"
         response = await exchange_code(
             self.token_uri, code, self.client_id, self.client_secret, redirect_uri
         )

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import functools
 import logging
 import re
@@ -225,6 +226,7 @@ async def exchange_code(token_uri, auth_code, client_id, client_secret, redirect
         token_url ([type]): [description]
         auth_code ([type]): [description]
     """
+    auth_value = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
     response = httpx.post(
         url=token_uri,
         data={
@@ -234,6 +236,7 @@ async def exchange_code(token_uri, auth_code, client_id, client_secret, redirect
             "code": auth_code,
             "client_secret": client_secret,
         },
+        headers={"Authorization": f"Basic {auth_value}"},
     )
     return response
 

--- a/tiled/database/core.py
+++ b/tiled/database/core.py
@@ -220,8 +220,12 @@ async def lookup_valid_pending_session_by_device_code(db, device_code):
     hashed_device_code = hashlib.sha256(device_code).digest()
     pending_session = (
         await db.execute(
-            select(PendingSession).filter(
-                PendingSession.hashed_device_code == hashed_device_code
+            select(PendingSession)
+            .filter(PendingSession.hashed_device_code == hashed_device_code)
+            .options(
+                selectinload(PendingSession.session)
+                .selectinload(Session.principal)
+                .selectinload(Principal.identities),
             )
         )
     ).scalar()

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -492,10 +492,10 @@ def build_device_code_authorize_route(authenticator, provider):
 
     async def route(
         request: Request,
-        settings: BaseSettings = Depends(get_settings),
+        db=Depends(get_database_session),
     ):
         request.state.endpoint = "auth"
-        pending_session = await create_pending_session(settings)
+        pending_session = await create_pending_session(db)
         verification_uri = f"{get_base_url(request)}/auth/provider/{provider}/token"
         authorization_uri = authenticator.authorization_endpoint.copy_with(
             params={

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -644,7 +644,7 @@ def build_device_code_token_route(authenticator, provider):
         # The pending session can only be used once.
         await db.delete(pending_session)
         await db.commit()
-        tokens = create_tokens_from_session(settings, db, session, provider)
+        tokens = await create_tokens_from_session(settings, db, session, provider)
         return tokens
 
     return route

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -630,7 +630,9 @@ def build_device_code_token_route(authenticator, provider):
         except Exception:
             # Not valid hex, therefore not a valid device_code
             raise HTTPException(status_code=401, detail="Invalid device code")
-        pending_session = lookup_valid_pending_session_by_device_code(db, device_code)
+        pending_session = await lookup_valid_pending_session_by_device_code(
+            db, device_code
+        )
         if pending_session is None:
             raise HTTPException(
                 404,


### PR DESCRIPTION
It turns out that #416 broke our OIDC authentication pathways _badly_, with multiple bugs. (N.B. There are no _security_ issues here; it just fails to run and shows the client status code `500`, as it should in such an event.) This is not used in production at NSLS-II---only as an option on tiled-demo.blueskyproject.io, and it went unnoticed for quite awhile.

This PR adds an example that is fairly easy to run locally, to lower the barrier to interactive testing. More work is needed to turn this into proper unit tests.