### PR TITLE
User code UX tweaks

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -758,9 +758,11 @@ class Context:
                 f"""
 You have {int(verification['expires_in']) // 60} minutes visit this URL
 
-{authorization_uri}
+  {authorization_uri}
 
-and enter the code: {verification['user_code']}
+and enter the code:
+
+  {verification['user_code']}
 
 """
             )

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -570,12 +570,12 @@ def build_device_code_user_code_submit_route(authenticator, provider):
         action = (
             f"{get_base_url(request)}/auth/provider/{provider}/device_code?code={code}"
         )
-        normalized_user_code = user_code.upper().replace("-", "")
+        normalized_user_code = user_code.upper().replace("-", "").strip()
         pending_session = await lookup_valid_pending_session_by_user_code(
             db, normalized_user_code
         )
         if pending_session is None:
-            message = "Invalid user_code. It may have been mistyped, or the pending request may have expired."
+            message = "Invalid user code. It may have been mistyped, or the pending request may have expired."
             return templates.TemplateResponse(
                 "device_code_form.html",
                 {


### PR DESCRIPTION
- Ignore extraneous whitespace (e.g. from copy/paste)
- Spell it "user code" not `user_code` in human-facing HTML.