### PR TITLE
Special-case prompting for auth in Jupyter

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -724,7 +724,14 @@ class Context:
 
         if not prompt_for_reauthentication:
             raise CannotPrompt(
-                "Authentication is needed but the client cannot prompt for it."
+                """Authentication is needed but Tiled has detected that it is running
+in a 'headless' context where it cannot prompt the user to provide
+credentials in the stdin. Options:
+
+- If Tiled has detected this wrongly, pass prompt_for_reauthentication=True
+  to force it to prompt.
+- Provide an API key in the environment variable TILED_API_KEY for Tiled to use.
+"""
             )
         self.http_client.auth = None
         mode = spec["mode"]

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -802,7 +802,7 @@ and enter the code: {verification['user_code']}
             print(confirmation_message.format(id=username))
         return spec, username
 
-    def login(self, username=None, provider=None):
+    def login(self, username=None, provider=None, prompt_for_reauthentication=UNSET):
         """
         Depending on the server's authentication method, this will prompt for username/password:
 
@@ -819,7 +819,9 @@ and enter the code: {verification['user_code']}
 
         and enter the code: XXXX-XXXX
         """
-        self.authenticate(username, provider)
+        self.authenticate(
+            username, provider, prompt_for_reauthentication=prompt_for_reauthentication
+        )
         # For programmatic access to the return values, use authenticate().
         # This returns None in order to provide a clean UX in an interpreter.
         return None


### PR DESCRIPTION
In Jupyter, `sys.__stdin__.isatty()` is `False`, and currently we are raising an error because it seems we cannot prompt for a password or a user code.

This PR adds a special case for Jupyter, because it has its own mechanism for prompting.