### PR TITLE
URL-encode keys

### DIFF
--- a/tiled/_tests/test_slash.py
+++ b/tiled/_tests/test_slash.py
@@ -1,0 +1,21 @@
+import numpy
+
+from ..adapters.array import ArrayAdapter
+from ..adapters.mapping import MapAdapter
+from ..client import Context, from_context
+from ..server.app import build_app
+
+arr = numpy.ones(3)
+
+
+def test_slash_in_key():
+    tree = MapAdapter(
+        {
+            "x": MapAdapter({"y": ArrayAdapter(1 * arr)}),
+            "x/y": ArrayAdapter(2 * arr),
+        }
+    )
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+    assert client["x", "y"].read()[0] == 1
+    assert client["x/y"].read()[0] == 2

--- a/tiled/client/node.py
+++ b/tiled/client/node.py
@@ -6,6 +6,7 @@ import itertools
 import time
 import warnings
 from dataclasses import asdict
+from urllib.parse import quote_plus
 
 import entrypoints
 
@@ -264,6 +265,7 @@ class Node(BaseClient, collections.abc.Mapping, IndexersMixin):
         # which must only return a result if 'a' is contained in the search results.
         if not isinstance(keys, tuple):
             keys = (keys,)
+        keys = tuple(quote_plus(key) for key in keys)
         if self._queries:
             # Lookup this key *within the search results* of this Node.
             key, *tail = keys

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from hashlib import md5
 from typing import Any
+from urllib.parse import quote_plus
 
 import dateutil.tz
 import jmespath
@@ -186,7 +187,7 @@ def construct_entries_response(
     media_type,
     max_depth,
 ):
-    path_parts = [segment for segment in path.split("/") if segment]
+    path_parts = [quote_plus(segment) for segment in path.split("/") if segment]
     tree = apply_search(tree, filters, query_registry)
     tree = apply_sort(tree, sort)
 
@@ -248,7 +249,7 @@ def construct_revisions_response(
     limit,
     media_type,
 ):
-    path_parts = [segment for segment in path.split("/") if segment]
+    path_parts = [quote_plus(segment) for segment in path.split("/") if segment]
     revisions = entry.revisions[offset : offset + limit]  # noqa: E203
     data = []
     for revision in revisions:
@@ -456,7 +457,7 @@ def construct_resource(
                     for key, direction in entry.sorting
                 ]
         d = {
-            "id": path_parts[-1] if path_parts else "",
+            "id": quote_plus(path_parts[-1]) if path_parts else "",
             "attributes": schemas.NodeAttributes(**attributes),
         }
         if not omit_links:

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import Optional
+from urllib.parse import unquote
 
 import pydantic
 from fastapi import Depends, HTTPException, Query, Request, Security
@@ -52,7 +53,8 @@ def SecureEntry(scopes):
         Walk down the path from the root tree, filtering each intermediate node by
         'read:metadata' and finally filtering by the specified scope.
         """
-        path_parts = [segment for segment in path.split("/") if segment]
+        path_parts = [unquote(segment) for segment in path.split("/") if segment]
+        breakpoint()
         entry = root_tree
         try:
             # Traverse into sub-tree(s). This requires only 'read:metadata' scope.

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -54,7 +54,6 @@ def SecureEntry(scopes):
         'read:metadata' and finally filtering by the specified scope.
         """
         path_parts = [unquote(segment) for segment in path.split("/") if segment]
-        breakpoint()
         entry = root_tree
         try:
             # Traverse into sub-tree(s). This requires only 'read:metadata' scope.


### PR DESCRIPTION
The original motivation for this branch was to enable @dylanmcreynolds' use case where keys from SciCat have slashes in them like `"als/SOMETHING"`.

This seems like something that HTTP spec enables but that ASGI may not, or at least that the ASGI frameworks discourage / make difficult. I am not sure whether we should support it. This PR does not quite manage it.

Leaving this here for consideration and discussion.