### PR TITLE
Use safe JSON serialization for metadata upload.

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -3,6 +3,7 @@ This tests tiled's writing routes with an in-memory store.
 
 Persistent stores are being developed externally to the tiled package.
 """
+from datetime import datetime
 
 import dask.dataframe
 import numpy
@@ -341,3 +342,14 @@ def test_metadata_revisions(tree):
         assert len(ac.metadata_revisions[:]) == 1
         with fail_with_status_code(404):
             ac.metadata_revisions.delete_revision(1)
+
+
+def test_metadata_with_unsafe_objects(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        ac = client.write_array(
+            [1, 2, 3],
+            metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
+        )
+        ac.metadata
+        ac.read()

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -12,7 +12,7 @@ import httpx
 import msgpack
 
 from .._version import get_versions
-from ..utils import DictView, Sentinel
+from ..utils import DictView, Sentinel, safe_json_dump
 from .auth import (
     DEFAULT_TOKEN_CACHE,
     CannotRefreshAuthentication,
@@ -602,7 +602,7 @@ class Context:
         request = self.http_client.build_request(
             "POST",
             path,
-            json=content,
+            content=safe_json_dump(content),
             # Submit CSRF token in both header and cookie.
             # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
             headers={
@@ -622,7 +622,7 @@ class Context:
         request = self.http_client.build_request(
             "PUT",
             path,
-            json=content,
+            content=safe_json_dump(content),
             # Submit CSRF token in both header and cookie.
             # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
             headers={


### PR DESCRIPTION
Sometimes metadata contains a datetime or a numpy array. We already have a robust JSON encoder than makes a best effort for types like these; we just needed to use it for client upload.