### PR TITLE
Support more query types in the SQL-backed Catalog

### DIFF
--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -50,7 +50,7 @@ mapping["specs_foo_bar_baz"] = ArrayAdapter.from_array(
 @pytest.fixture(scope="module")
 def event_loop():
     # https://stackoverflow.com/a/56238383/1221924
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     yield loop
     loop.close()
 

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -4,7 +4,7 @@ import uuid
 
 import httpx
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from ..client import context
@@ -49,29 +49,6 @@ async def temp_postgres(uri):
         )  # close the automatically-started transaction
         await connection.execute(text(f"DROP DATABASE {database_name};"))
         await connection.commit()
-
-
-@contextlib.contextmanager
-def temp_postgres_sync(uri):
-    if uri.endswith("/"):
-        uri = uri[:-1]
-    # Create a fresh database.
-    engine = create_engine(uri)
-    database_name = f"tiled_test_disposable_{uuid.uuid4().hex}"
-    with engine.connect() as connection:
-        connection.execute(
-            text("COMMIT")
-        )  # close the automatically-started transaction
-        connection.execute(text(f"CREATE DATABASE {database_name};"))
-        connection.commit()
-    yield f"{uri}/{database_name}"
-    # Drop the database.
-    with engine.connect() as connection:
-        connection.execute(
-            text("COMMIT")
-        )  # close the automatically-started transaction
-        connection.execute(text(f"DROP DATABASE {database_name};"))
-        connection.commit()
 
 
 @contextlib.contextmanager

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -32,7 +32,7 @@ from ..serialization.dataframe import XLSX_MIME_TYPE
 from ..server.schemas import Management, Node
 from ..server.utils import ensure_awaitable
 from ..structures.core import StructureFamily
-from ..utils import UNCHANGED, OneShotCachedMap, import_object
+from ..utils import UNCHANGED, OneShotCachedMap, UnsupportedQueryType, import_object
 from . import orm
 from .base import Base
 from .explain import ExplainAsyncSession
@@ -684,17 +684,18 @@ def contains(query, tree):
     if dialect_name == "sqlite":
         condition = _get_value(attr, type(query.value)).contains(query.value)
     else:
-        condition = attr.contains(type_coerce(query.value, orm.Node.metadata_.type))
+        raise UnsupportedQueryType("Contains")
     return tree.new_variation(conditions=tree.conditions + [condition])
 
 
-# def specs(query, tree):
-#     conditions = []
-#     for spec in query.include:
-#         conditions.append(func.json_contains(orm.Node.specs, spec))
-#     for spec in query.exclude:
-#         conditions.append(not_(func.json_contains(orm.Node.specs.contains, spec)))
-#     return tree.new_variation(conditions=tree.conditions + conditions)
+def specs(query, tree):
+    raise UnsupportedQueryType("Specs")
+    # conditions = []
+    # for spec in query.include:
+    #     conditions.append(func.json_contains(orm.Node.specs, spec))
+    # for spec in query.exclude:
+    #     conditions.append(not_(func.json_contains(orm.Node.specs.contains, spec)))
+    # return tree.new_variation(conditions=tree.conditions + conditions)
 
 
 def in_or_not_in(query, tree, method):
@@ -703,9 +704,7 @@ def in_or_not_in(query, tree, method):
     if dialect_name == "sqlite":
         condition = getattr(_get_value(attr, type(query.value[0])), method)(query.value)
     else:
-        condition = getattr(attr, method)(
-            type_coerce(query.value, orm.Node.metadata_.type)
-        )
+        raise UnsupportedQueryType("In/NotIn")
     return tree.new_variation(conditions=tree.conditions + [condition])
 
 

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -187,6 +187,7 @@ def serve_catalog(
         database = f"sqlite+aiosqlite:///{Path(directory, SQLITE_CATALOG_FILENAME)}"
         if write is None:
             write = directory / DATA_SUBDIRECTORY
+            write.mkdir()
         # TODO Hook into server lifecycle hooks to delete this at shutdown.
 
     tree_kwargs = {}

--- a/tiled/query_registration.py
+++ b/tiled/query_registration.py
@@ -7,7 +7,7 @@ This intentionally only uses built-in dataclasses, not pydantic models.
 import inspect
 from dataclasses import fields
 
-from .utils import DictView
+from .utils import DictView, UnsupportedQueryType
 
 
 class QueryRegistry:
@@ -123,7 +123,7 @@ class QueryTranslationRegistry:
             if base in lk:
                 lk[class_] = lk[base]
                 return lk[base]
-        raise TypeError(f"No dispatch for {class_}")
+        raise UnsupportedQueryType(class_.__name__)
 
     def __call__(self, arg, *args, **kwargs):
         """

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -723,7 +723,7 @@ def resolve_media_type(request):
     return media_type
 
 
-def json_or_msgpack(request, content, expires=None, headers=None):
+def json_or_msgpack(request, content, expires=None, headers=None, status_code=200):
     media_type = resolve_media_type(request)
     with record_timing(request.state.metrics, "tok"):
         etag = md5(str(content).encode()).hexdigest()
@@ -735,9 +735,14 @@ def json_or_msgpack(request, content, expires=None, headers=None):
         # If the client already has this content, confirm that.
         return Response(status_code=304, headers=headers)
     if media_type == "application/x-msgpack":
-        return MsgpackResponse(content, headers=headers, metrics=request.state.metrics)
+        return MsgpackResponse(
+            content,
+            headers=headers,
+            metrics=request.state.metrics,
+            status_code=status_code,
+        )
     return NumpySafeJSONResponse(
-        content, headers=headers, metrics=request.state.metrics
+        content, headers=headers, metrics=request.state.metrics, status_code=status_code
     )
 
 

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -540,6 +540,10 @@ class UnsupportedShape(SerializationError):
     pass
 
 
+class UnsupportedQueryType(TypeError):
+    pass
+
+
 # Arrow obtained an official MIME type 2021-06-23.
 # https://www.iana.org/assignments/media-types/application/vnd.apache.arrow.file
 APACHE_ARROW_FILE_MIME_TYPE = "application/vnd.apache.arrow.file"


### PR DESCRIPTION
This add support for more query types and raises a clearer error for those types that are still not supported.

```py
In [8]: c.write_dataframe(pandas.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), metadata={"color": "green", "barcode": 12})
Out[8]: <DataFrameClient ['x', 'y']>

In [9]: c
Out[9]: <Node {'473bd2da-ecf8-46e8-b6e5-2878ac0b1955'}>

In [10]: c.search(Key("barcode") > 12)
Out[10]: <Node {}>

In [11]: c.search(Key("barcode") > 11)
Out[11]: <Node {'473bd2da-ecf8-46e8-b6e5-2878ac0b1955'}>

In [12]: from tiled.queries import In

In [13]: c.search(In("color", {"green", "blue"}))
Out[13]: <Node {'473bd2da-ecf8-46e8-b6e5-2878ac0b1955'}>

In [14]: c.search(In("color", {"red", "blue"}))
Out[14]: <Node {}>

In [15]: c.search(FullText("green"))
...
ClientError: 400: The query type 'FullText' is not supported on this node. http://127.0.0.1:8000/api/v1/node/search/?page%5Boffset%5D=0&fields=&filter%5Bfulltext%5D%5Bcondition%5D%5Btext%5D=green&filter%5Bfulltext%5D%5Bcondition%5D%5Bcase_sensitive%5D=false&sort=
```

Two unrelated fixes lumped into this PR:
* When SQLite database is initialized, it is placed into [Write-Ahead Logging (WAL) mode](https://www.sqlite.org/wal.html).
* `tiled serve catalog --temp` failed to actually `mkdir` the data directory it wants to use; that's fixed now.

Closes #447 