### PR TITLE
Update docker-compose to use catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,13 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
 
+COPY ./entrypoint /usr/local/bin/entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENV TILED_CATALOG_DB="/storage/catalog.db"
+
 WORKDIR /deploy
 
 EXPOSE 8000
 
-CMD ["tiled", "serve", "catalog", "/storage/catalog.db", "--write", "/storage/data", "--host", "0.0.0.0", "--port", "8000", "--scalable"]
+# Invoke the shell (bash -c ...) to enable variable expansion of ${TILED_CATALOG_DB}.
+CMD ["bash", "-c", "tiled serve catalog --write /storage/data --host 0.0.0.0 --port 8000 --scalable ${TILED_CATALOG_DB}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ FROM python:3.10-slim as builder
 # We need git at build time in order for versioneer to work, which in turn is
 # needed for the server to correctly report the library_version in the /api/v1/
 # route.
-RUN apt-get -y update && apt-get install -y git
+# We need gcc to compile thriftpy2, a secondary dependency.
+RUN apt-get -y update && apt-get install -y git gcc
 
 WORKDIR /code
 
@@ -28,7 +29,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Copy requirements over first so this layer is cached and we don't have to
 # reinstall dependencies when only the tiled source has changed.
 COPY requirements-server.txt requirements-formats.txt requirements-dataframe.txt requirements-array.txt requirements-xarray.txt requirements-sparse.txt requirements-compression.txt /code/
-RUN pip install --upgrade --no-cache-dir pip wheel
+RUN pip install --upgrade --no-cache-dir cython pip wheel
 RUN pip install --upgrade --no-cache-dir \
   -r /code/requirements-array.txt \
   -r /code/requirements-compression.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /deploy
 
 EXPOSE 8000
 
-CMD ["tiled", "serve", "config", "--host", "0.0.0.0", "--port", "8000", "--scalable", "/deploy"]
+CMD ["tiled", "serve", "catalog", "/storage/catalog.db", "--write", "/storage/data", "--host", "0.0.0.0", "--port", "8000", "--scalable"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,9 @@ services:
       context: .
     volumes:
       - type: bind
-        source: ./example_configs/
-        target: /deploy
+        source: ./storage
+        target: /storage
     environment:
-      - TILED_CONFIG=/deploy/small_single_user_demo.yml
       - TILED_SINGLE_USER_API_KEY=${TILED_SINGLE_USER_API_KEY}
     ports:
       - 8000:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
   tiled:
     build:
-      contenxt: .
+      context: .
     volumes:
       - type: bind
         source: ./example_configs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         target: /storage
     environment:
       - TILED_SINGLE_USER_API_KEY=${TILED_SINGLE_USER_API_KEY}
+      - TILED_INIT_CATALOG_DB=${TILED_INIT_CATALOG_DB}
     ports:
       - 8000:8000
     restart: unless-stopped

--- a/docs/source/how-to/metrics.md
+++ b/docs/source/how-to/metrics.md
@@ -7,13 +7,25 @@ can be visualized in dashboards using, for example,
 
 ![Grafana Dashboard with Tiled metrics](../_static/grafana-screenshot.png)
 
+## Try Tiled with the Dashboard
+
 Tiled ships with some example configuration to make it easy to try this.
 
 1. Install [Podman](https://podman.io/) (recommended) or Docker (also works).
 
 2. Install `podman-compose` or `docker-compose`. Either can be installed using `pip install`.
 
-3. Run `TILED_SINGLE_USER_API_KEY=secret podman-compose up`.
+3. For the first use, run:
+
+   ```
+   TILED_INIT_CATALOG_DB=1 TILED_SINGLE_USER_API_KEY=secret podman-compose up
+   ```
+
+   The `TILED_INIT_CATALOG_DB` parameter creates and initializes a database
+   at the path `./storage/catalog.db` that Tiled uses to store metadata.
+
+   If you restart the container later, omit `TILED_INIT_CATALOG_DB`; the
+   catalog database is already initialized.
 
 4. Open Grafana by navigating a web browser to
    [http://localhost:3000/d/Hnvd_TA4z/tiled-dashboard](http://localhost:3000/d/Hnvd_TA4z/tiled-dashboard).

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ ! -z "${TILED_INIT_CATALOG_DB}" ]
+then
+	echo "Initializing catalog database: ${TILED_CATALOG_DB}"
+	tiled catalog init "${TILED_CATALOG_DB}"
+	echo "Initialized catalog database: ${TILED_CATALOG_DB}"
+fi
+
+exec "$@"

--- a/entrypoint
+++ b/entrypoint
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+# Initialize the catalog database if TILED_INIT_CATALOG_DB is set.
+# This approach is inspired by the way the official MongoDB container works.
 if [ ! -z "${TILED_INIT_CATALOG_DB}" ]
 then
 	echo "Initializing catalog database: ${TILED_CATALOG_DB}"


### PR DESCRIPTION
We have an awesome `docker-compose.yml` with tiled+prometheus+grafana, documented here https://blueskyproject.io/tiled/how-to/metrics.html.

This has had an annoying extra step: we need the user to provide some data to serve, or thread a toy config file in, which is not a very realistic scenario or useful in production. But now, with the writable catalog in Tiled, we can launch empty instance and just tell the user to write some data in. This is something that could be useful to just deploy as is.

Question: How to deal with the fact that the database needs to be initialized at some point? How do people normally handle this? We could make it a two-step process:

1. Run the tiled container with the `CMD` `tiled catalog init ...` to initialize the database.
    ```
    mkdir storage
    podman run -v /storage:./storage:rw tiled tiled catalog init /storage/catalog.db
    ```

2. `podman-compose up`

Is that the best we can do?

Secondary question: Should we ship the `docker-compose.yml` such that it _builds_ the current repo or should we hard-code a tagged version of pre-built tiled? Or should we ship _both_ and if so what should we call them?