### PR TITLE
Support Adapters that Interact with Services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"

--- a/example_configs/external_service/README.md
+++ b/example_configs/external_service/README.md
@@ -1,0 +1,1 @@
+This is just an initial sketch.

--- a/example_configs/external_service/config.yml
+++ b/example_configs/external_service/config.yml
@@ -1,0 +1,9 @@
+authentication:
+  providers:
+  - provider: example
+    authenticator: custom:Authenticator
+trees:
+- tree: custom:Adapter
+  path: /
+  args:
+    base_url: https://example.com

--- a/example_configs/external_service/custom.py
+++ b/example_configs/external_service/custom.py
@@ -1,0 +1,94 @@
+import numpy
+
+from tiled.adapters.array import ArrayAdapter
+from tiled.authenticators import Mode, UserSessionState
+from tiled.structures.core import StructureFamily
+
+
+class Authenticator:
+    "This accepts any password and stashes it in session state as 'token'."
+    mode = Mode.password
+
+    async def authenticate(self, username: str, password: str) -> UserSessionState:
+        return UserSessionState(username, {"token": password})
+
+
+# This stands in for a secret token issued by the external service.
+SERVICE_ISSUED_TOKEN = "secret"
+
+
+class MockClient:
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    # This API (get_contents, get_metadata, get_data) is just made up and not important.
+    # Could be anything.
+
+    async def get_metadata(self, url, token):
+        # This assert stands in for the mocked service
+        # authenticating a request.
+        assert token == SERVICE_ISSUED_TOKEN
+        return {"metadata": str(url)}
+
+    async def get_contents(self, url, token):
+        # This assert stands in for the mocked service
+        # authenticating a request.
+        assert token == SERVICE_ISSUED_TOKEN
+        return ["a", "b", "c"]
+
+    async def get_data(self, url, token):
+        # This assert stands in for the mocked service
+        # authenticating a request.
+        assert token == SERVICE_ISSUED_TOKEN
+        return numpy.ones((3, 3))
+
+
+class Adapter:
+    """
+    This is the Adapter that should be given to the Tiled service in config.
+
+    The only API it should implement is `with_session_state`, which returns
+    the AuthenticatedAdapter that actually accesses the data.
+    """
+
+    def __init__(self, base_url, metadata=None):
+        self.client = MockClient(base_url)
+        self.metadata = metadata
+
+    def with_session_state(self, state):
+        return AuthenticatedAdapter(self.client, state["token"], metadata=self.metadata)
+
+
+class AuthenticatedAdapter:
+    structure_family = StructureFamily.container
+
+    def __init__(self, client, token, segments=None, metadata=None):
+        self._client = client
+        self._token = token
+        self._segments = segments or []
+        self.metadata = metadata or {}
+
+    async def lookup_adapter(self, segments):
+        # The service URL is probably something based on segments, but not
+        # literally this....
+        metadata_url = "/".join(self._segments + segments)
+        data_url = "/".join(self._segments + segments)
+        metadata = await self._client.get_metadata(metadata_url, token=self._token)
+        data = await self._client.get_data(data_url, token=self._token)
+        # This could alternatively be some file-based adapter with HDF5Adapter
+        # or something custom, or another AuthenticatedAdapter...
+        return ArrayAdapter(data, metadata=metadata)
+
+    # TODO This can be a fast-path.
+    lookup_node = lookup_adapter
+
+    async def keys_range(self, offset, limit):
+        url = ...  # based on self._segments
+        return await self._client.get_contents(url, token=self._token)
+        return ["a", "b", "c"]
+
+    async def items_range(self, offset, limit):
+        # Ideally this would be a batched request to the external service.
+        return [
+            (key, self.lookup_adapter([key])) for key in self._keys_range(offset, limit)
+        ]

--- a/example_configs/simple_oidc/README.md
+++ b/example_configs/simple_oidc/README.md
@@ -8,11 +8,12 @@ use in production.**
    follows.
 
 ```
-docker run --rm -p 9000:9000 -v $(pwd):/config -e CONFIG_FILE=/config/oidc_provider_config.json -e USERS_FILE=/config/users.json qlik/simple-oidc-provider:0.2.4
+docker run --rm -p 9000:9000 -v $(pwd):/config -e CONFIG_FILE=/config/oidc_provider_config.json -e USERS_FILE=/config/users.json docker.io/qlik/simple-oidc-provider:0.2.4
 ```
 
-2. From a web browser or commandline, access `http://localhost:9000`. These
-   contain public keys which _reset every time the container is (re)started_.
+2. From a web browser or commandline, access
+   `http://localhost:9000/keys`. This contains
+   public keys which _reset every time the container is (re)started_.
    Fill them into the Tiled configuration in this directory, `config.yml`,
    under `public_keys:`.
 

--- a/example_configs/simple_oidc/README.md
+++ b/example_configs/simple_oidc/README.md
@@ -12,7 +12,7 @@ docker run --rm -p 9000:9000 -v $(pwd):/config -e CONFIG_FILE=/config/oidc_provi
 ```
 
 2. From a web browser or commandline, access
-   `http://localhost:9000/keys`. This contains
+   `http://localhost:9000/certs`. This contains
    public keys which _reset every time the container is (re)started_.
    Fill them into the Tiled configuration in this directory, `config.yml`,
    under `public_keys:`.

--- a/example_configs/simple_oidc/config.yml
+++ b/example_configs/simple_oidc/config.yml
@@ -1,0 +1,30 @@
+# Must set environment variables:
+# - OIDC_CLIENT_ID
+# - OIDC_CLIENT_SECRET
+# - OIDC_BASE_URL (e.g. http://localhost:9000)
+# and update 'public_keys' section below to match values at http://localhost:9000/certs
+#
+authentication:
+  providers:
+  - provider: simple_oidc
+    authenticator: tiled.authenticators:OIDCAuthenticator
+    args:
+      # These values come from https://orcid.org/developer-tools
+      client_id: ${OIDC_CLIENT_ID}
+      client_secret: ${OIDC_CLIENT_SECRET}
+      # These values come from https://orcid.org/.well-known/openid-configuration
+      # Obtain them directly from ORCID. They may change over time.
+      token_uri: "${OIDC_BASE_URL}/token"
+      authorization_endpoint: "${OIDC_BASE_URL}/auth"
+      public_keys:
+        - kty: "RSA"
+          e: "AQAB"
+          kid: "E4XC5wXCxI2TpmNVuYq_97Z14elH_BtIjp0Wx_Ktyyw"
+          n: "5CGXulzBOt_CuAq-F3COgA8x1GYgsewz-y_fFfcgmbWIVOCqCrvsqu48ee2ZkZacPFuslCndnYVfksVUJVTkc89NIMkIs6a029YGesIecTwMxsa0PSoimCdBaiPidjgU-IfRvvpANkRftrjp6oRhs5JUuw_6qUte0IHxznGyJnzxP6I8LRyuwR2Eep7l-OlQSv4LapPiEA16kZ6CtYFQpkrkThduLaGa09krt0-JmS55ht8TLdQOr5KP8xExkLv89daDnx4U2peQijDph2IsRoVLsg1GtbLJDnZPjqQrwpe5EDxoC1JjfeV4RV7HB6hf80npZGAbRj91dfzPpRxAPw"
+          alg: RS256
+      confirmation_message: "You have logged in with Simple OIDC as {id}."
+trees:
+ # Just some arbitrary example data...
+ # The point of this example is the authenticaiton above.
+ - tree: tiled.examples.generated_minimal:tree
+   path: /

--- a/example_configs/simple_oidc/config.yml
+++ b/example_configs/simple_oidc/config.yml
@@ -19,8 +19,8 @@ authentication:
       public_keys:
         - kty: "RSA"
           e: "AQAB"
-          kid: "E4XC5wXCxI2TpmNVuYq_97Z14elH_BtIjp0Wx_Ktyyw"
-          n: "5CGXulzBOt_CuAq-F3COgA8x1GYgsewz-y_fFfcgmbWIVOCqCrvsqu48ee2ZkZacPFuslCndnYVfksVUJVTkc89NIMkIs6a029YGesIecTwMxsa0PSoimCdBaiPidjgU-IfRvvpANkRftrjp6oRhs5JUuw_6qUte0IHxznGyJnzxP6I8LRyuwR2Eep7l-OlQSv4LapPiEA16kZ6CtYFQpkrkThduLaGa09krt0-JmS55ht8TLdQOr5KP8xExkLv89daDnx4U2peQijDph2IsRoVLsg1GtbLJDnZPjqQrwpe5EDxoC1JjfeV4RV7HB6hf80npZGAbRj91dfzPpRxAPw"
+          kid: "<Enter kid value from simple oidc web page http://localhost:9000/certs>"
+          n: "<Enger n from simple oidc web page http://localhost:9000/certs>"
           alg: RS256
       confirmation_message: "You have logged in with Simple OIDC as {id}."
 trees:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 maintainers = [
   { name = "Brookhaven National Laboratory", email = "dallan@bnl.gov" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 # All dependencies are optional; it depends on whether you are running
 # a client or server (or both) and what data structures you care about.

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -42,9 +42,9 @@ def test_LDAPAuthenticator_01(use_tls, use_ssl, ldap_server_address, ldap_server
     )
 
     async def testing():
-        assert await authenticator.authenticate("user01", "password1") == "user01"
-        assert await authenticator.authenticate("user02", "password2") == "user02"
-        assert await authenticator.authenticate("user02a", "password2") is None
-        assert await authenticator.authenticate("user02", "password2a") is None
+        assert await authenticator.authenticate("user01", "password1").user_name == "user01"
+        assert await authenticator.authenticate("user02", "password2").user_name == "user02"
+        assert await authenticator.authenticate("user02a", "password2").user_name is None
+        assert await authenticator.authenticate("user02", "password2a").user_name is None
 
     asyncio.run(testing())

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -42,9 +42,9 @@ def test_LDAPAuthenticator_01(use_tls, use_ssl, ldap_server_address, ldap_server
     )
 
     async def testing():
-        assert await authenticator.authenticate("user01", "password1").user_name == "user01"
-        assert await authenticator.authenticate("user02", "password2").user_name == "user02"
-        assert await authenticator.authenticate("user02a", "password2").user_name is None
-        assert await authenticator.authenticate("user02", "password2a").user_name is None
+        assert (await authenticator.authenticate("user01", "password1")).user_name == "user01"
+        assert (await authenticator.authenticate("user02", "password2")).user_name == "user02"
+        assert (await authenticator.authenticate("user02a", "password2")).user_name is None
+        assert (await authenticator.authenticate("user02", "password2a")).user_name is None
 
     asyncio.run(testing())

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -44,7 +44,7 @@ def test_LDAPAuthenticator_01(use_tls, use_ssl, ldap_server_address, ldap_server
     async def testing():
         assert (await authenticator.authenticate("user01", "password1")).user_name == "user01"
         assert (await authenticator.authenticate("user02", "password2")).user_name == "user02"
-        assert (await authenticator.authenticate("user02a", "password2")).user_name is None
-        assert (await authenticator.authenticate("user02", "password2a")).user_name is None
+        assert (await authenticator.authenticate("user02a", "password2")) is None
+        assert (await authenticator.authenticate("user02", "password2a")) is None
 
     asyncio.run(testing())

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -12,9 +12,15 @@ from .orm import APIKey, Identity, PendingSession, Principal, Role, Session
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "4a9dfaba4a98"
+REQUIRED_REVISION = "c7bd2573716d"
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["4a9dfaba4a98", "56809bcbfcb0", "722ff4e4fcc7", "481830dd6c11"]
+ALL_REVISIONS = [
+    "c7bd2573716d",
+    "4a9dfaba4a98",
+    "56809bcbfcb0",
+    "722ff4e4fcc7",
+    "481830dd6c11",
+]
 
 
 async def create_default_roles(db):

--- a/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
+++ b/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
@@ -5,11 +5,10 @@ Revises: 4a9dfaba4a98
 Create Date: 2023-07-10 13:57:12.476131
 
 """
-from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
+from alembic import op
 
-from tiled.authn_database.orm import Session, JSONVariant
+from tiled.authn_database.orm import JSONVariant, Session
 
 # revision identifiers, used by Alembic.
 revision = "c7bd2573716d"

--- a/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
+++ b/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
@@ -10,18 +10,19 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
 from tiled.authn_database.orm import Session, JSONVariant
+
 # revision identifiers, used by Alembic.
-revision = 'c7bd2573716d'
-down_revision = '4a9dfaba4a98'
+revision = "c7bd2573716d"
+down_revision = "4a9dfaba4a98"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     op.add_column(
-        Session.__tablename__
-        ,sa.Column('state', JSONVariant, nullable=True))
+        Session.__tablename__, sa.Column("state", JSONVariant, nullable=False)
+    )
 
 
 def downgrade():
-    op.drop_column(Session.__tablename__, 'state')
+    op.drop_column(Session.__tablename__, "state")

--- a/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
+++ b/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
@@ -1,0 +1,27 @@
+"""add session state column
+
+Revision ID: c7bd2573716d
+Revises: 4a9dfaba4a98
+Create Date: 2023-07-10 13:57:12.476131
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from tiled.authn_database.orm import Session, JSONVariant
+# revision identifiers, used by Alembic.
+revision = 'c7bd2573716d'
+down_revision = '4a9dfaba4a98'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        Session.__tablename__
+        ,sa.Column('state', JSONVariant, nullable=True))
+
+
+def downgrade():
+    op.drop_column(Session.__tablename__, 'state')

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Enum,
     ForeignKey,
     Integer,
-    JSON,
     LargeBinary,
     Table,
     Unicode,

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -207,7 +207,7 @@ class Session(Timestamped, Base):
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
     revoked = Column(Boolean, default=False, nullable=False)
     # State allows for custom  authenticator information to be stored in the session.
-    state = Column(JSONVariant, nullable=True)
+    state = Column(JSONVariant, nullable=False)
     principal = relationship("Principal", back_populates="sessions", lazy="joined")
 
 

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Enum,
     ForeignKey,
     Integer,
+    JSON,
     LargeBinary,
     Table,
     Unicode,
@@ -23,7 +24,6 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
-
 
 class JSONList(TypeDecorator):
     """Represents an immutable structure as a JSON-encoded list.

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -2,13 +2,13 @@ import json
 import uuid as uuid_module
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     Column,
     DateTime,
     Enum,
     ForeignKey,
     Integer,
-    JSON,
     LargeBinary,
     Table,
     Unicode,

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -24,6 +24,7 @@ from .base import Base
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
 
+
 class JSONList(TypeDecorator):
     """Represents an immutable structure as a JSON-encoded list.
 
@@ -205,6 +206,7 @@ class Session(Timestamped, Base):
     expiration_time = Column(DateTime(timezone=False), nullable=False)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
     revoked = Column(Boolean, default=False, nullable=False)
+    # State allows for custom  authenticator information to be stored in the session.
     state = Column(JSONVariant, nullable=True)
     principal = relationship("Principal", back_populates="sessions", lazy="joined")
 

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -25,6 +25,7 @@ from .base import Base
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
 
+
 class JSONList(TypeDecorator):
     """Represents an immutable structure as a JSON-encoded list.
 

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -8,10 +8,12 @@ from sqlalchemy import (
     Enum,
     ForeignKey,
     Integer,
+    JSON,
     LargeBinary,
     Table,
     Unicode,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from sqlalchemy.types import TypeDecorator
@@ -19,6 +21,8 @@ from sqlalchemy.types import TypeDecorator
 from ..server.schemas import PrincipalType
 from .base import Base
 
+# Use JSON with SQLite and JSONB with PostgreSQL.
+JSONVariant = JSON().with_variant(JSONB(), "postgresql")
 
 class JSONList(TypeDecorator):
     """Represents an immutable structure as a JSON-encoded list.
@@ -201,7 +205,7 @@ class Session(Timestamped, Base):
     expiration_time = Column(DateTime(timezone=False), nullable=False)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
     revoked = Column(Boolean, default=False, nullable=False)
-
+    state = Column(JSONVariant, nullable=True)
     principal = relationship("Principal", back_populates="sessions", lazy="joined")
 
 

--- a/tiled/commandline/_admin.py
+++ b/tiled/commandline/_admin.py
@@ -62,6 +62,7 @@ def upgrade_database(
     Upgrade the database schema to the latest version.
     """
     import asyncio
+
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from ..alembic_utils import get_current_revision, upgrade

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -432,7 +432,7 @@ async def create_session(
     session = orm.Session(
         principal_id=principal.id,
         expiration_time=utcnow() + settings.session_max_age,
-        state=state,
+        state=state or {},
     )
     db.add(session)
     await db.commit()

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -465,11 +465,6 @@ async def create_tokens_from_session(settings, db, session, provider, state_data
             for identity in principal.identities
         ],
     }
-    if state_data:
-        # add a custom claim for state if exists, this way tiled Adapter
-        # can have access to a state object that were created by Authenticators without
-        # having to store it in the database
-        data["state"] = state_data
     access_token = create_access_token(
         data=data,
         expires_delta=settings.access_token_max_age,

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -366,7 +366,9 @@ async def create_pending_session(db):
     }
 
 
-async def create_session(settings, db, identity_provider, id, state: UserSessionState = None):
+async def create_session(
+    settings, db, identity_provider, id, state: UserSessionState = None
+):
     # Have we seen this Identity before?
     identity = (
         await db.execute(
@@ -405,7 +407,7 @@ async def create_session(settings, db, identity_provider, id, state: UserSession
     session = orm.Session(
         principal_id=principal.id,
         expiration_time=utcnow() + settings.session_max_age,
-        state=state
+        state=state,
     )
     db.add(session)
     await db.commit()
@@ -652,7 +654,9 @@ def build_device_code_token_route(authenticator, provider):
     return route
 
 
-def build_handle_credentials_route(authenticator: UsernamePasswordAuthenticator, provider):
+def build_handle_credentials_route(
+    authenticator: UsernamePasswordAuthenticator, provider
+):
     "Register a handle_credentials route function for this Authenticator."
 
     async def route(
@@ -671,7 +675,13 @@ def build_handle_credentials_route(authenticator: UsernamePasswordAuthenticator,
                 detail="Incorrect username or password",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        session = await create_session(settings, db, provider, user_session_state.user_name, state = user_session_state.state)
+        session = await create_session(
+            settings,
+            db,
+            provider,
+            user_session_state.user_name,
+            state=user_session_state.state,
+        )
         tokens = await create_tokens_from_session(settings, db, session, provider)
         return tokens
 

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -76,9 +76,10 @@ def SecureEntry(scopes, kind=EntryKind.adapter):
         path_parts = [segment for segment in path.split("/") if segment]
         entry = root_tree
 
-        # if the entry/adapter can take a session state, pass it in
+        # If the entry/adapter can take a session state, pass it in.
+        # The entry/adapter may return itself or a different object.
         if hasattr(entry, "with_session_state") and session_state:
-            entry.with_session_state(session_state)
+            entry = entry.with_session_state(session_state)
         try:
             # Traverse into sub-tree(s). This requires only 'read:metadata' scope.
             for i, segment in enumerate(path_parts):

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -3,12 +3,9 @@ from typing import Protocol
 from fastapi import Request
 
 
-
-
 @dataclass
 class UserSessionState:
     """Data transfer class to communicate custom session state infromation."""
-
 
     user_name: str
     state: dict = None

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -3,9 +3,12 @@ from typing import Protocol
 from fastapi import Request
 
 
+
+
 @dataclass
 class UserSessionState:
     """Data transfer class to communicate custom session state infromation."""
+
 
     user_name: str
     state: dict = None

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+@dataclass
+class UserSessionState():
+    user_name: str
+    state: dict = None
+
+
+class UsernamePasswordAuthenticator(Protocol):
+    
+    def authenticate(self, username: str, password: str) -> UserSessionState:
+        pass

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 from typing import Protocol
 
+
 @dataclass
-class UserSessionState():
+class UserSessionState:
+    """Data transfer class to communicate custom state infromation."""
+
     user_name: str
     state: dict = None
 
 
 class UsernamePasswordAuthenticator(Protocol):
-    
     def authenticate(self, username: str, password: str) -> UserSessionState:
         pass

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Protocol
+
 from fastapi import Request
 
 

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from typing import Protocol
+from fastapi import Request
 
 
 @dataclass
 class UserSessionState:
-    """Data transfer class to communicate custom state infromation."""
+    """Data transfer class to communicate custom session state infromation."""
 
     user_name: str
     state: dict = None
@@ -12,4 +13,9 @@ class UserSessionState:
 
 class UsernamePasswordAuthenticator(Protocol):
     def authenticate(self, username: str, password: str) -> UserSessionState:
+        pass
+
+
+class Authenticator(Protocol):
+    def authenticate(self, request: Request) -> UserSessionState:
         pass


### PR DESCRIPTION
Resolves #453

An issue with having an Adapter that interacts with third  party services is a third party service may have its own authentication scheme. That scheme might involve passing a token through Tiled from the client as a password, and then when the Adapter interacts with the third party service, the it somehow needs access to that token from within the same user session. 

This PR implements two parts of this. 

1. It adds the ability for a username/password Authenticator to return a state object back to Tiled.  Tiled stores that dictionary in the session row of the auth database.

2. We will provide a mechanism for Adapters to have access to this state.

The initial commits address the first case but not yet the second, so this PR is preliminary.