### PR TITLE
Fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: "3.2"
 services:
   tiled:
-    build:
-      contenxt: .
+    image: ghcr.io/bluesky/tiled:v0.1.0a96
     volumes:
       - type: bind
         source: ./example_configs/


### PR DESCRIPTION
While we iterate on #461, a small fix:

* `context` was misspelled, so this was straight broken
* While we're at it, for this use case it's better to just point to an image rather than build it. Developers can always edit this file to build it if they want.