### PR TITLE
Improve error message when `TILED_SINGLE_USER_API_KEY` is set but empty.

### DIFF
--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -418,23 +418,33 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         # Validate the single-user API key.
         settings = app.dependency_overrides[get_settings]()
         single_user_api_key = settings.single_user_api_key
+        API_KEY_MSG = """
+Here are two ways to generate a good API key:
+
+# With openssl:
+openssl rand -hex 32
+
+# With Python:
+python -c "import secrets; print(secrets.token_hex(32))"
+
+"""
         if single_user_api_key is not None:
+            if not single_user_api_key:
+                raise ValueError(
+                    """
+The single-user API key is set to an empty value. Perhaps the environment
+variable TILED_SINGLE_USER_API_KEY is set to an empty string.
+"""
+                    + API_KEY_MSG
+                )
             if not single_user_api_key.isalnum():
                 raise ValueError(
                     """
-    The API key must only contain alphanumeric characters. We enforce this because
-    pasting other characters into a URL, as in ?api_key=..., can result in
-    confusing behavior due to ambiguous encodings.
-
-    The API key can be as long as you like. Here are two ways to generate a valid
-    one:
-
-    # With openssl:
-    openssl rand -hex 32
-
-    # With Python:
-    python -c "import secrets; print(secrets.token_hex(32))"
-    """
+The API key must only contain alphanumeric characters. We enforce this because
+pasting other characters into a URL, as in ?api_key=..., can result in
+confusing behavior due to ambiguous encodings.
+"""
+                    + API_KEY_MSG
                 )
 
         # Run startup tasks collected from trees (adapters).


### PR DESCRIPTION
It reports that the API key contains nonalphanumeric characters, when in fact the problem is that it is an empty string. This fixes that.

## With an empty API key:

```bash
$ TILED_SINGLE_USER_API_KEY="" tiled serve catalog --temp
Creating catalog database at /tmp/tmpaaseory2/catalog.db
Creating writable catalog data directory at /tmp/tmpaaseory2/data
INFO:     Started server process [246763]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 677, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 654, in startup
    await handler()
  File "/home/dallan/Repos/bnl/tiled/tiled/server/app.py", line 433, in startup_event
    raise ValueError(
ValueError: 
The single-user API key is set to an empty value. Perhaps the environment
variable TILED_SINGLE_USER_API_KEY is set to an empty string.

Here are two ways to generate a good API key:

# With openssl:
openssl rand -hex 32

# With Python:
python -c "import secrets; print(secrets.token_hex(32))"



ERROR:    Application startup failed. Exiting.
```

## With nonalphanumeric characters in API key

```bash
$ TILED_SINGLE_USER_API_KEY="@?#" tiled serve catalog --temp
Creating catalog database at /tmp/tmptwkshoae/catalog.db
Creating writable catalog data directory at /tmp/tmptwkshoae/data
INFO:     Started server process [246565]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 677, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/home/dallan/micromamba/envs/py310/lib/python3.10/site-packages/starlette/routing.py", line 654, in startup
    await handler()
  File "/home/dallan/Repos/bnl/tiled/tiled/server/app.py", line 423, in startup_event
    raise ValueError(
ValueError: 
    The API key must only contain alphanumeric characters. We enforce this because
    pasting other characters into a URL, as in ?api_key=..., can result in
    confusing behavior due to ambiguous encodings.

    The API key can be as long as you like. Here are two ways to generate a valid
    one:

    # With openssl:
    openssl rand -hex 32

    # With Python:
    python -c "import secrets; print(secrets.token_hex(32))"
    

ERROR:    Application startup failed. Exiting.
```