### PR TITLE
CI: Use pip cache.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install
       shell: bash -l {0}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
+      with:
+        cache: 'pip'
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,9 +27,10 @@ jobs:
         fetch-depth: 1000  # should be enough to reach the most recent tag
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install
       shell: bash -l {0}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,9 +19,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install
       shell: bash -l {0}
@@ -52,9 +53,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install
       run: |


### PR DESCRIPTION
The Windows build takes more than 6 minutes to install the depdencies---longer than a Linux makes takes the run end-to-end sometimes. Apparently `v4` of the `setup-python` GH Action supports pip caching. I hope that will help.