### PR TITLE
Respect `TILED_CONFIG` env var in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ WORKDIR /deploy
 
 EXPOSE 8000
 
-CMD ["tiled", "serve", "config", "--host", "0.0.0.0", "--port", "8000", "--scalable", "/deploy"]
+CMD ["tiled", "serve", "config", "--host", "0.0.0.0", "--port", "8000", "--scalable"]


### PR DESCRIPTION
Closes #494

This is the kind of mistake that I would like to rely on [container-canary](https://github.com/NVIDIA/container-canary) to catch. It seems it only supports [mounting _empty_ volumes](https://github.com/NVIDIA/container-canary#volumes) at the moment, so there is no way to do something like:

```yaml
# This is used to verify that a container image has the basic expected behavior.
# See https://github.com/NVIDIA/container-canary
#
# Run locally like:
#
# canary validate --file canary-validator.yml ghcr.io/bluesky/tiled:latest

apiVersion: container-canary.nvidia.com/v2
kind: Validator
name: tiled
description: Validate that Tiled container image with TILED_CONFIG set is operational.
env:
  - name: TILED_CONFIG
    value: /tmp/arbitrary/config/dir/
ports:
 - port: 8000
   protocol: TCP
volumes:
  - mountPath: /tmp/arbitrary/config/dir/  # <-- will be empty, does not work
checks:
 - name: http
   description: Exposes an HTTP interface on port 8000
   probe:
     httpGet:
       path: /api/v1
       port: 8000
     initialDelaySeconds: 5
     timeoutSeconds: 10
     failureThreshold: 3
 - name: http
   description: Serves a REST API at /api/v1
   probe:
     httpGet:
       path: /api/v1
       port: 8000
     initialDelaySeconds: 5
     timeoutSeconds: 10
     failureThreshold: 3
 - name: http
   description: Serves a UI at /ui/browse
   probe:
     httpGet:
       path: /ui/browse
       port: 8000
     initialDelaySeconds: 5
     timeoutSeconds: 10
     failureThreshold: 3
```