### PR TITLE
Make LDAPAuthenticator tests explicitly opt in.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,6 +39,7 @@ jobs:
       shell: bash -l {0}
       run: |
         set -vxeuo pipefail
+        export TILED_TEST_LDAP=1  # Opt in to LDAPAuthenticator tests.
         coverage run -m pytest -v
         coverage report
 
@@ -69,7 +70,6 @@ jobs:
       run: |
         set TILED_BUILD_SKIP_UI=1
         python -m pip install .[dev]
-        pip uninstall --yes ldap3  # to skip LDAPAuthenticator test
         python -m pip list
 
     - name: Test with pytest

--- a/tiled/_tests/test_authenticators.py
+++ b/tiled/_tests/test_authenticators.py
@@ -1,8 +1,13 @@
 import asyncio
+import os
 
 import pytest
 
 from ..authenticators import LDAPAuthenticator
+
+# Set this if there is an LDAP container running for testing.
+# See continuous_integration/docker-configs/ldap-docker-compose.yml
+TILED_TEST_LDAP = os.getenv("TILED_TEST_LDAP")
 
 
 # fmt: off
@@ -26,7 +31,8 @@ def test_LDAPAuthenticator_01(use_tls, use_ssl, ldap_server_address, ldap_server
     TODO: The test could be extended with enabled TLS or SSL, but it requires configuration
     of the LDAP server.
     """
-    pytest.importorskip("ldap3")
+    if not TILED_TEST_LDAP:
+        pytest.skip("Run an LDAP container and set TILED_TEST_LDAP to run")
     authenticator = LDAPAuthenticator(
         ldap_server_address,
         ldap_server_port,


### PR DESCRIPTION
We currently skip the tests in `ldap3` is not installed, but this means the developer workflow is:

```
pip install -e .[dev]
pytest   # LDAP tests run and fail unless the LDAP docker is running
pip uninstall ldap3
pytest
```

Better, I think, to do what we do with the PostgreSQL tests and make this opt _in_ if the developer has set up the necessary external service.