### PR TITLE
Prevent orphaning nodes by deleting a non-empty container

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -346,3 +346,31 @@ async def test_delete(tree):
             metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
             key="x",
         )
+
+
+@pytest.mark.asyncio
+async def test_delete_non_empty_node(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        a = client.create_container("a")
+        b = a.create_container("b")
+        c = b.create_container("c")
+        d = c.create_container("d")
+
+        # Cannot delete non-empty nodes
+        assert "a" in client
+        with pytest.raises(Exception):
+            client.delete("a")
+        assert "b" in a
+        with pytest.raises(Exception):
+            a.delete("b")
+        assert "c" in b
+        with pytest.raises(Exception):
+            b.delete("c")
+        assert "d" in c
+        assert not list(d)  # leaf is empty
+        # Delete from the bottom up.
+        c.delete("d")
+        b.delete("c")
+        a.delete("b")
+        client.delete("a")

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -359,13 +359,13 @@ async def test_delete_non_empty_node(tree):
 
         # Cannot delete non-empty nodes
         assert "a" in client
-        with pytest.raises(Exception):
+        with fail_with_status_code(409):
             client.delete("a")
         assert "b" in a
-        with pytest.raises(Exception):
+        with fail_with_status_code(409):
             a.delete("b")
         assert "c" in b
-        with pytest.raises(Exception):
+        with fail_with_status_code(409):
             b.delete("c")
         assert "d" in c
         assert not list(d)  # leaf is empty

--- a/tiled/catalog/node.py
+++ b/tiled/catalog/node.py
@@ -15,6 +15,7 @@ from ..server.schemas import (
     Revision,
     SortingItem,
 )
+from ..utils import NoteToClient
 from . import orm
 from .utils import safe_path
 
@@ -96,7 +97,7 @@ class Node(NodeAttributes):
                 await db.execute(select(func.count(orm.Node.key)).where(is_child))
             ).scalar()
             if num_children:
-                raise NotImplementedError("Cannot delete node that has children")
+                raise NoteToClient("Cannot delete node that has children")
             for data_source in self.data_sources:
                 if data_source.management != Management.external:
                     # TODO Handle case where the same Asset is associated

--- a/tiled/catalog/node.py
+++ b/tiled/catalog/node.py
@@ -91,6 +91,12 @@ class Node(NodeAttributes):
 
     async def delete(self):
         async with self._context.session() as db:
+            is_child = orm.Node.ancestors == self.ancestors + [self.key]
+            num_children = (
+                await db.execute(select(func.count(orm.Node.key)).where(is_child))
+            ).scalar()
+            if num_children:
+                raise NotImplementedError("Cannot delete node that has children")
             for data_source in self.data_sources:
                 if data_source.management != Management.external:
                     # TODO Handle case where the same Asset is associated

--- a/tiled/catalog/node.py
+++ b/tiled/catalog/node.py
@@ -15,7 +15,7 @@ from ..server.schemas import (
     Revision,
     SortingItem,
 )
-from ..utils import NoteToClient
+from ..utils import Conflicts
 from . import orm
 from .utils import safe_path
 
@@ -97,7 +97,9 @@ class Node(NodeAttributes):
                 await db.execute(select(func.count(orm.Node.key)).where(is_child))
             ).scalar()
             if num_children:
-                raise NoteToClient("Cannot delete node that has children")
+                raise Conflicts(
+                    "Cannot delete container that is not empty. Delete contents first."
+                )
             for data_source in self.data_sources:
                 if data_source.management != Management.external:
                     # TODO Handle case where the same Asset is associated

--- a/tiled/client/__init__.py
+++ b/tiled/client/__init__.py
@@ -1,3 +1,4 @@
+from ..utils import tree  # noqa: F401
 from .constructors import from_context, from_profile, from_uri  # noqa: F401
 from .container import ASCENDING, DESCENDING  # noqa: F401
 from .context import Context  # noqa: F401

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -25,7 +25,7 @@ from ..config import construct_build_app_kwargs
 from ..media_type_registration import (
     compression_registry as default_compression_registry,
 )
-from ..utils import SHARE_TILED_PATH, NoteToClient, UnsupportedQueryType
+from ..utils import SHARE_TILED_PATH, Conflicts, UnsupportedQueryType
 from ..validation_registration import validation_registry as default_validation_registry
 from . import schemas
 from .authentication import get_current_principal
@@ -271,10 +271,10 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             async def tiled_ui_settings():
                 return ui_settings
 
-    @app.exception_handler(NoteToClient)
-    async def note_to_client_exception_handler(request: Request, exc: NoteToClient):
-        note = exc.args[0]
-        return JSONResponse(status_code=400, content={"detail": note})
+    @app.exception_handler(Conflicts)
+    async def conflicts_exception_handler(request: Request, exc: Conflicts):
+        message = exc.args[0]
+        return JSONResponse(status_code=400, content={"detail": message})
 
     @app.exception_handler(UnsupportedQueryType)
     async def unsupported_query_type_exception_handler(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -274,7 +274,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
     @app.exception_handler(Conflicts)
     async def conflicts_exception_handler(request: Request, exc: Conflicts):
         message = exc.args[0]
-        return JSONResponse(status_code=400, content={"detail": message})
+        return JSONResponse(status_code=409, content={"detail": message})
 
     @app.exception_handler(UnsupportedQueryType)
     async def unsupported_query_type_exception_handler(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -25,7 +25,7 @@ from ..config import construct_build_app_kwargs
 from ..media_type_registration import (
     compression_registry as default_compression_registry,
 )
-from ..utils import SHARE_TILED_PATH, UnsupportedQueryType
+from ..utils import SHARE_TILED_PATH, NoteToClient, UnsupportedQueryType
 from ..validation_registration import validation_registry as default_validation_registry
 from . import schemas
 from .authentication import get_current_principal
@@ -271,8 +271,15 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             async def tiled_ui_settings():
                 return ui_settings
 
+    @app.exception_handler(NoteToClient)
+    async def note_to_client_exception_handler(request: Request, exc: NoteToClient):
+        note = exc.args[0]
+        return JSONResponse(status_code=400, content={"detail": note})
+
     @app.exception_handler(UnsupportedQueryType)
-    async def unicorn_exception_handler(request: Request, exc: UnsupportedQueryType):
+    async def unsupported_query_type_exception_handler(
+        request: Request, exc: UnsupportedQueryType
+    ):
         query_type = exc.args[0]
         return JSONResponse(
             status_code=400,

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -545,6 +545,11 @@ class UnsupportedQueryType(TypeError):
     pass
 
 
+class NoteToClient(Exception):
+    "A generic way to pass an error message from server-side code to client"
+    pass
+
+
 # Arrow obtained an official MIME type 2021-06-23.
 # https://www.iana.org/assignments/media-types/application/vnd.apache.arrow.file
 APACHE_ARROW_FILE_MIME_TYPE = "application/vnd.apache.arrow.file"

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -545,8 +545,8 @@ class UnsupportedQueryType(TypeError):
     pass
 
 
-class NoteToClient(Exception):
-    "A generic way to pass an error message from server-side code to client"
+class Conflicts(Exception):
+    "Prompts the server to send 409 Conflicts with message"
     pass
 
 


### PR DESCRIPTION
Eventually we will probably need to add a way to do the equivalent of `rm -rf` to a container, but we'll want to be very careful about it. For now, all you get is `rmdir` (i.e. directory must be empty first by explicitly deleting the contents).