### PR TITLE
Various refinements to client HTTP response cache

### DIFF
--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 
 from .. import profiles
 from ..catalog import from_uri, in_memory
-from ..client import context
 from ..server.settings import get_settings
 from .utils import enter_password as utils_enter_password
 from .utils import temp_postgres
@@ -43,10 +42,9 @@ def set_tiled_cache_dir():
     if sys.platform.startswith("win") and sys.version_info >= (3, 10):
         kwargs["ignore_cleanup_errors"] = True
     with tempfile.TemporaryDirectory(**kwargs) as tmpdir:
-        original = context.TILED_CACHE_DIR
-        context.TILED_CACHE_DIR = Path(tmpdir)
+        os.environ["TILED_CACHE_DIR"] = str(tmpdir)
         yield
-        context.TILED_CACHE_DIR = original
+        del os.environ["TILED_CACHE_DIR"]
 
 
 @pytest.fixture

--- a/tiled/_tests/test_client_cache.py
+++ b/tiled/_tests/test_client_cache.py
@@ -22,7 +22,7 @@ tree = MapAdapter(
 @pytest.fixture
 def client():
     app = build_app(tree)
-    with Context.from_app(app) as context:
+    with Context.from_app(app, cache=Cache()) as context:
         yield from_context(context)
 
 

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -196,25 +196,7 @@ def from_profile(name, structure_clients=None, **kwargs):
         if isinstance(cache_config, collections.abc.Mapping):
             # All necessary validation has already been performed
             # in load_profiles().
-            ((key, value),) = cache_config.items()
-            # For back-compat, rename "available_bytes" to "capacity".
-            available_bytes = value.pop("available_bytes", None)
-            if available_bytes:
-                if "capacity" in value:
-                    raise ValueError(
-                        "Cannot specific both 'capacity' and its deprecated alias 'available_bytes'."
-                    )
-                value["capacity"] = available_bytes
-                import warnings
-
-                warnings.warn(
-                    "Profile specifies 'available_bytes'. Use new name 'capacity' instead. "
-                    "Support for the old name, 'available_bytes', will be removed in the future."
-                )
-            if key == "memory":
-                cache = Cache.in_memory(**value)
-            elif key == "disk":
-                cache = Cache.on_disk(**value)
+            cache = Cache(**cache_config)
         else:
             # Interpret this as a Cache object passed in directly.
             cache = cache_config

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -44,7 +44,8 @@ class Transport(httpx.BaseTransport):
 
     def close(self) -> None:
         self.transport.close()
-        self.cache.close()
+        if self.cache is not None:
+            self.cache.close()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         # check if request is cacheable

--- a/tiled/config_schemas/client_profiles.yml
+++ b/tiled/config_schemas/client_profiles.yml
@@ -94,60 +94,43 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      # These properties are mutually exclusive, but encoding this
-      # in jsonschema is complex and therefore in tension with the goal
-      # of this file stated at the top. The mutual exclusion *is* enforced,
-      # but in the Python code that parses the profiles, not here.
-      memory:
-        type: object
-        anyOf:
-          - required:
-            - capacity
-          - required:
-            - available_bytes  # deprecated alias for 'capacity'
-        properties:
-          capacity:
-            type: number
-            description: |
-              Maximum memory (in bytes) that the cache may consume.
+      filepath:
+        type: string
+        description: |
+          Location of cache file on disk.
+          Default location is `$XDG_CACHE_HOME/tiled/http_response_cache.db`.
+      capacity:
+        type: number
+        description: |
+          Maximum size (in bytes) that the cache may allocate for response bodies.
+          The total size of a cache may be slightly higher. Default is 500 MB.
 
-              For readability it is recommended to use `_` for thousands separators.
-              Example:
+          For readability it is recommended to use `_` for thousands separators.
+          Example:
 
-              ```yaml
-              available_bytes: 2_000_000_000  # 2GB
-              ```
+          ```yaml
+          capacity: 500_000_000  # 500 MB
+          ```
 
-          available_bytes:
-            type: number
-            description: Deprecated alias for "capacity"
-      disk:
-        type: object
-        required:
-          - path
-        properties:
-          path:
-            type: string
-            description: |
-              A directory will be created at this path if it does not yet exist.
-              It is safe to reuse an existing cache directory and to share a cache
-              directory between multiple processes.
-              available_bytes:
-          capacity:
-            type: number
-            description: |
-              Maximum storage space (in bytes) that the cache may consume.
+      max_item_size:
+        type: number
+        description: |
+          Maximum size (in bytes) of any individual cached response body.
+          This limit is designed to prevent one a couple very large responses from
+          using up the entire capacity.
 
-              For readability it is recommended to use `_` for thousands separators.
-              Example:
+          For readability it is recommended to use `_` for thousands separators.
+          Example:
 
-              ```yaml
-              available_bytes: 2_000_000_000  # 2GB
-              ```
+          ```yaml
+          capacity: 500_000  # 500 kB
+          ```
 
-          available_bytes:
-            type: number
-            description: Deprecated alias for "capacity"
+      readonly:
+        type: boolean
+        description: |
+          Open the cache in read-only mode.
+          Do not add, remove, or update contents.
   timeout:
     description: |
       Configure timeouts for the HTTP client.

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -103,12 +103,6 @@ def gather_profiles(paths, strict=True):
                                     f"ValidationError while parsing profile {profile_name} "
                                     f"in file {filepath!s}: {original_msg}"
                                 ) from validation_err
-                            if len(profile_content.get("cache", {})) > 1:
-                                raise ProfileError(
-                                    "The profile's 'cache' property contains "
-                                    f"{len(profile_content['cache'])} items: {list(profile_content['cache'])} "
-                                    "At most one is allowed."
-                                )
                 except Exception as err:
                     if strict:
                         raise


### PR DESCRIPTION
- Add a nice repr that shows the filepath of the SQLite storage.
- Move the logic setting the default Cache filepath from Context to Cache.
- Give a nicer error message if user tries to clear cache from a different thread.
- Update client profile schema to the new Cache signature (belatedly!)
- **Do not install a Cache default.** It seems to _work_ robustly, but the performance difference is marginal because the server is not giving us much. We should look at this.