### PR TITLE
Tweak config to get better error message.

### DIFF
--- a/docs/source/how-to/docker.md
+++ b/docs/source/how-to/docker.md
@@ -13,6 +13,22 @@ It is best practice to use a specific tag instead of `latest`.
 See the [list of tiled image versions on GitHub](https://github.com/bluesky/tiled/pkgs/container/tiled)
 for tags.
 
+```{note}
+
+Some of the examples below set an environment variable
+`TILED_SINGLE_USER_API_KEY` to `secret`, as a placeholder. For actual use, use
+a difficult-to-guess secret. Two equally good ways to generate a secure
+secret...
+
+With ``openssl``:
+
+    openssl rand -hex 32
+
+With ``python``:
+
+    python -c "import secrets; print(secrets.token_hex(32))"
+
+```
 
 ## Example: A writable catalog
 

--- a/example_configs/single_catalog_single_user.yml
+++ b/example_configs/single_catalog_single_user.yml
@@ -2,7 +2,6 @@ authentication:
   # The default is false. Set to true to enable any HTTP client that can
   # connect to _read_. An API key is still required to write.
   allow_anonymous_access: false
-  single_user_api_key: ${TILED_SINGLE_USER_API_KEY}
 trees:
   - path: /
     tree: catalog


### PR DESCRIPTION
## Before

If you forget to specify `-e TILED_SINGLE_USER_API_KEY=...` tiled ends up getting `"${TILED_SINGLE_USER_API_KEY}"` as the API key, and then only fails because we insist of API keys being alphanumeric. This is a result of how [`os.path.expandvars`](https://docs.python.org/3/library/os.path.html#os.path.expandvars) works:

> References to non-existing variables are left unchanged

```
Using configuration from /deploy/config

    Navigate a web browser or connect a Tiled client to:

    http://0.0.0.0:8000?api_key=${TILED_SINGLE_USER_API_KEY}


INFO:     Started server process [1]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/opt/venv/lib/python3.10/site-packages/starlette/routing.py", line 677, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/opt/venv/lib/python3.10/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/opt/venv/lib/python3.10/site-packages/starlette/routing.py", line 654, in startup
    await handler()
  File "/opt/venv/lib/python3.10/site-packages/tiled/server/app.py", line 467, in startup_event
    raise ValueError(
ValueError: 
The API key must only contain alphanumeric characters. We enforce this because
pasting other characters into a URL, as in ?api_key=..., can result in
confusing behavior due to ambiguous encodings.

Here are two ways to generate a good API key:

# With openssl:
openssl rand -hex 32

# With Python:
python -c "import secrets; print(secrets.token_hex(32))"
```

## After

If you forget to specify `-e TILED_SINGLE_USER_API_KEY=...` the API key ends up unset. Because we passed the CLI flag `--scalable` to `tiled serve config ...` in the Docker `CMD`, Tiled balks with a clear error message:

```
Using configuration from /deploy/config
Traceback (most recent call last):

  File "/opt/venv/bin/tiled", line 8, in <module>
    sys.exit(main())

  File "/opt/venv/lib/python3.10/site-packages/tiled/commandline/_serve.py", line 424, in serve_config
    web_app = build_app_from_config(

  File "/opt/venv/lib/python3.10/site-packages/tiled/server/app.py", line 840, in build_app_from_config
    return build_app(scalable=scalable, **kwargs)

  File "/opt/venv/lib/python3.10/site-packages/tiled/server/app.py", line 182, in build_app
    raise UnscalableConfig(

tiled.server.app.UnscalableConfig: 
In a scaled (multi-process) deployment, when Tiled is configured for
single-user access (i.e. without an Authenticator) a single-user API key must
be provided via configuration like

authentication:
  single_user_api_key: SECRET
  ...

or via the environment variable TILED_SINGLE_USER_API_KEY.
```