### PR TITLE
In db migration, provide default value for existing rows.

### DIFF
--- a/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
+++ b/tiled/authn_database/migrations/versions/c7bd2573716d_add_session_state_column.py
@@ -19,7 +19,8 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        Session.__tablename__, sa.Column("state", JSONVariant, nullable=False)
+        Session.__tablename__,
+        sa.Column("state", JSONVariant, nullable=False, server_default="{}"),
     )
 
 


### PR DESCRIPTION
We tested the migration on an _empty_ database. If we had tested it on a non-empty database we would have found:

```
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.NotNullViolationError'>: column "state" contains null values
[SQL: ALTER TABLE sessions ADD COLUMN state JSONB NOT NULL]
```

The existing rows have no `state` column that, thus, the `state` columns ends up `NULL` and violates the `NOT NULL` constraint. This PR provides default value, `"{}"`, and the migration works.