### PR TITLE
Add Python 3.11 to CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
       fail-fast: false
     steps:
 
@@ -73,7 +74,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
     steps:
 


### PR DESCRIPTION
This was held up by the delayed numba release.