### PR TITLE
Respect range requests.

### DIFF
--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -1,5 +1,6 @@
 import builtins
 import hashlib
+import pathlib
 
 import tifffile
 
@@ -63,6 +64,11 @@ class TiffAdapter:
         if slice is not None:
             arr = arr[slice]
         return arr
+
+    def read_raw(self, mimetype):
+        if mimetype != "image/tiff":
+            raise ValueError(f"Unsupported mimetype {mimetype}")
+        return pathlib.Path(self._file.filehandle.path).read_bytes()
 
     def read_block(self, block, slice=None):
         # For simplicity, this adapter always treat a single TIFF file as one

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -737,6 +737,11 @@ class CatalogNodeAdapter:
             )
             await db.commit()
 
+    async def read_raw(self, *args, **kwargs):
+        return await ensure_awaitable(
+            (await self.get_adapter()).read_raw, *args, **kwargs
+        )
+
 
 class CatalogContainerAdapter(CatalogNodeAdapter):
     async def keys_range(self, offset, limit):

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -23,6 +23,7 @@ from .core import (
     WrongTypeForRoute,
     apply_search,
     construct_data_response,
+    construct_direct_read_response,
     construct_entries_response,
     construct_resource,
     construct_revisions_response,
@@ -444,6 +445,17 @@ async def array_full(
     # for some use cases.
     import numpy
 
+    # TODO Refine this filter to include any full slice.
+    if slice == ():
+        response = await construct_direct_read_response(
+            request=request,
+            entry=entry,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+        )
+        if response is not None:
+            return response
     try:
         with record_timing(request.state.metrics, "read"):
             array = await ensure_awaitable(entry.read, slice)


### PR DESCRIPTION
Needs unit tests.

This is needed to support DuckDB `httpfs`, which sets the `Range` header.

```
$ http https://tiled-demo.blueskyproject.io/api/v1/node/full/bmm/raw/f8c83910-4adb-4207-a465-9ff0ff0e9cd2/primary/data/?format=application/x-parquet 'Range: bytes=0-100'
HTTP/1.1 206 Partial Content
Connection: keep-alive
Content-Length: 101
Content-Type: application/x-parquet
Date: Thu, 13 Jul 2023 19:33:38 GMT
Server: nginx/1.18.0 (Ubuntu)
content-range: bytes 0-100/83289
etag: 17c638c79d841b8a5c7c98fe07a4a078
expires: Thu, 13 Jul 2023 20:33:38 GMT
server-timing: read;dur=43.5, tok;dur=0.1, pack;dur=23.5, app;dur=105.4
set-cookie: tiled_csrf=h8wIyssQ2_Mg1J8OhWCofwIIEh0if1zbnFMZ-w5685k; HttpOnly; Path=/; SameSite=lax
```

Via duckdb:

```
import duckdb
db = duckdb.connect(':memory:')
db.execute('install httpfs; load httpfs;')
db.execute('SELECT * FROM read_parquet("https://tiled-demo.blueskyproject.io/api/v1/node/full/bmm/raw/f8c83910-4adb-4207-a465-9ff0ff0e9cd2/primary/data/?format=application/x-parquet")')
```
