### PR TITLE
Bump Python version in container to 3.11

### DIFF
--- a/.github/workflows/build-and-validate-image.yml
+++ b/.github/workflows/build-and-validate-image.yml
@@ -9,7 +9,7 @@ jobs:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
 
      - name: Install Container Canary
        run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
         export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
         echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1000  # should be enough to reach the most recent tag
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install && npm run build
 
 # We cannot upgrade to Python 3.11 until numba supports it.
 # The `sparse` library relies on numba.
-FROM python:3.10-slim as builder
+FROM python:3.11-slim as builder
 
 # We need git at build time in order for versioneer to work, which in turn is
 # needed for the server to correctly report the library_version in the /api/v1/
@@ -40,7 +40,7 @@ RUN TILED_BUILD_SKIP_UI=1 pip install '.[server]'
 # RUN pip install '.[client,dev]'
 # RUN pytest -v
 
-FROM python:3.10-slim as runner
+FROM python:3.11-slim as runner
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 # in ENTRYPOINT or CMD.
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip install --upgrade --no-cache-dir cython pip wheel
+RUN pip install --upgrade --no-cache-dir "cython<3" pip wheel
 
 COPY --from=web_frontend_builder /code/dist /code/share/tiled/ui
 COPY . .


### PR DESCRIPTION
* Update Python 3.10 -> 3.11.
* Pin back cython. See #526.
* Update GHA `checkout` v2 -> v3.