### PR TITLE
Catalog SQL migration for upcoming release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ server = [
     "aiosqlite",
     "alembic",
     "anyio",
+    "asyncpg",
     "appdirs",
     "blosc",
     "cachetools",

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -42,5 +42,16 @@ tiled catalog init {redacted_url}
 """,
         )
     except DatabaseUpgradeNeeded:
-        # No upgrades have been made yet.
-        raise NotImplementedError
+        raise DatabaseUpgradeNeeded(
+            f"""
+
+The catalog found at
+
+{redacted_url}
+
+was created using an older version of Tiled. It needs to be upgraded
+to work with this version. Back up the database, and the run:
+
+tiled catalog upgrade-database {redacted_url}
+""",
+        )

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -3,8 +3,12 @@ from sqlalchemy import text
 from ..alembic_utils import DatabaseUpgradeNeeded, UninitializedDatabase, check_database
 from .base import Base
 
-ALL_REVISIONS = ["6825c778aa3c"]
-REQUIRED_REVISION = "6825c778aa3c"
+# This is the alembic revision ID of the database revision
+# required by this version of Tiled.
+REQUIRED_REVISION = "83889e049ddc"
+
+# This is list of all valid revisions (from current to oldest).
+ALL_REVISIONS = ["83889e049ddc", "6825c778aa3c"]
 
 
 async def initialize_database(engine):

--- a/tiled/catalog/migrations/versions/83889e049ddc_reorganize_structure_and_rename_.py
+++ b/tiled/catalog/migrations/versions/83889e049ddc_reorganize_structure_and_rename_.py
@@ -1,0 +1,84 @@
+"""Reorganize 'structure' and rename 'dataframe' to 'table'.
+
+Revision ID: 83889e049ddc
+Revises: 6825c778aa3c
+Create Date: 2023-08-04 06:38:48.775874
+
+"""
+import base64
+
+import pyarrow
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.serialization.table import deserialize_arrow
+from tiled.structures.table import B64_ENCODED_PREFIX
+
+# revision identifiers, used by Alembic.
+revision = "83889e049ddc"
+down_revision = "6825c778aa3c"
+branch_labels = None
+depends_on = None
+
+# This is a *data migration* only. There are no changes to the SQL schema.
+
+
+def upgrade():
+    connection = op.get_bind()
+    nodes = sa.Table(
+        "nodes",
+        sa.MetaData(),
+        sa.Column("structure_family", sa.String(32)),
+        sa.Column("structure", sa.Unicode(length=100)),
+    )
+    results = connection.execute(
+        sa.select(
+            [
+                nodes.c.id,
+                nodes.c.structure_family,
+                nodes.c.structure,
+            ]
+        )
+    ).fetchall()
+    for id_, structure_family, structure in results:
+        if structure_family == "array":
+            new_structure_family = structure_family
+            # Consolidate "macro" and "micro".
+            new_structure = {}
+            new_structure["shape"] = structure["macro"]["shape"]
+            new_structure["dims"] = structure["macro"]["dims"]
+            new_structure["chunks"] = structure["macro"]["chunks"]
+            new_structure["resizable"] = structure["macro"]["resizable"]
+            new_structure["data_type"] = structure["micro"]
+        if structure_family == "dataframe":
+            # Rename "dataframe" to "table".
+            new_structure_family = "table"
+            # Consolidate "macro" and "micro".
+            new_structure = {}
+            new_structure["columns"] = structure["macro"]["columns"]
+            new_structure["npartitions"] = structure["macro"]["npartitions"]
+            new_structure["resizable"] = structure["macro"]["resizable"]
+            # Re-encode the Arrow schema.
+            meta_bytes = structure["micro"]["meta"]
+            meta = deserialize_arrow(base64.b64decode(meta_bytes))
+            schema_bytes = pyarrow.Table.from_pandas(meta).schema.serialize()
+            schema_b64 = base64.b64encode(schema_bytes).decode("utf-8")
+            data_uri = B64_ENCODED_PREFIX + schema_b64
+            new_structure["arrow_schema"] = data_uri
+        else:
+            new_structure_family = structure_family
+            new_structure = structure
+        connection.execute(
+            nodes.update()
+            .where(nodes.c.id == id_)
+            .values(
+                structure=new_structure,
+                structure_family=new_structure_family,
+            )
+        )
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/migrations/versions/83889e049ddc_reorganize_structure_and_rename_.py
+++ b/tiled/catalog/migrations/versions/83889e049ddc_reorganize_structure_and_rename_.py
@@ -10,6 +10,7 @@ import base64
 import pyarrow
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 from tiled.serialization.table import deserialize_arrow
 from tiled.structures.table import B64_ENCODED_PREFIX
@@ -20,29 +21,45 @@ down_revision = "6825c778aa3c"
 branch_labels = None
 depends_on = None
 
+# Use JSON with SQLite and JSONB with PostgreSQL.
+JSONVariant = sa.JSON().with_variant(JSONB(), "postgresql")
+
 # This is a *data migration* only. There are no changes to the SQL schema.
 
 
 def upgrade():
     connection = op.get_bind()
+
+    # Rename "dataframe" to "table".
     nodes = sa.Table(
         "nodes",
         sa.MetaData(),
-        sa.Column("structure_family", sa.String(32)),
-        sa.Column("structure", sa.Unicode(length=100)),
+        sa.Column("id", sa.Integer),
+        sa.Column("structure_family", sa.Unicode(32)),
     )
+    connection.execute(
+        nodes.update()
+        .where(nodes.c.structure_family == "dataframe")
+        .values(structure_family="table")
+    )
+
+    data_sources = sa.Table(
+        "data_sources",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer),
+        sa.Column("node_id", sa.Integer),
+        sa.Column("structure", JSONVariant),
+    )
+    joined = data_sources.join(nodes, data_sources.c.node_id == nodes.c.id)
     results = connection.execute(
         sa.select(
-            [
-                nodes.c.id,
-                nodes.c.structure_family,
-                nodes.c.structure,
-            ]
-        )
+            data_sources.c.id,
+            data_sources.c.structure,
+            nodes.c.structure_family,
+        ).select_from(joined)
     ).fetchall()
-    for id_, structure_family, structure in results:
+    for id_, structure, structure_family in results:
         if structure_family == "array":
-            new_structure_family = structure_family
             # Consolidate "macro" and "micro".
             new_structure = {}
             new_structure["shape"] = structure["macro"]["shape"]
@@ -50,9 +67,7 @@ def upgrade():
             new_structure["chunks"] = structure["macro"]["chunks"]
             new_structure["resizable"] = structure["macro"]["resizable"]
             new_structure["data_type"] = structure["micro"]
-        if structure_family == "dataframe":
-            # Rename "dataframe" to "table".
-            new_structure_family = "table"
+        elif structure_family == "table":
             # Consolidate "macro" and "micro".
             new_structure = {}
             new_structure["columns"] = structure["macro"]["columns"]
@@ -66,15 +81,11 @@ def upgrade():
             data_uri = B64_ENCODED_PREFIX + schema_b64
             new_structure["arrow_schema"] = data_uri
         else:
-            new_structure_family = structure_family
-            new_structure = structure
+            continue
         connection.execute(
-            nodes.update()
-            .where(nodes.c.id == id_)
-            .values(
-                structure=new_structure,
-                structure_family=new_structure_family,
-            )
+            data_sources.update()
+            .where(data_sources.c.id == id_)
+            .values(structure=new_structure)
         )
 
 


### PR DESCRIPTION
This migration handles the changes from recent PRs:

* Rename structure family `dataframe` to `table`.
* Restructure `structure` JSON, flattening out the `macro` and `micro` sub-keys.
* Encode tabular structure a base64-encoded Arrow schema.