### PR TITLE
Make container structure just None.

### DIFF
--- a/docs/source/reference/service.md
+++ b/docs/source/reference/service.md
@@ -102,7 +102,6 @@ See {doc}`../explanations/structures` for more context.
    tiled.structures.array.BuiltinDtype
    tiled.structures.array.Endianness
    tiled.structures.array.Kind
-   tiled.structures.container.ContainerStructure
    tiled.structures.core.Spec
    tiled.structures.core.StructureFamily
    tiled.structures.table.TableStructure

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -20,7 +20,6 @@ from ..queries import (
     StructureFamilyQuery,
 )
 from ..query_registration import QueryTranslationRegistry
-from ..structures.container import ContainerStructure
 from ..structures.core import StructureFamily
 from ..utils import UNCHANGED
 from .utils import IndexersMixin
@@ -152,7 +151,7 @@ class MapAdapter(collections.abc.Mapping, IndexersMixin):
         return ItemsView(lambda: len(self), self._items_slice)
 
     def structure(self):
-        return ContainerStructure(count=len(self._mapping))
+        return None
 
     @property
     def metadata_stale_at(self):

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -300,7 +300,7 @@ async def register_single_item(
         data_sources=[
             DataSource(
                 mimetype=mimetype,
-                structure=dataclasses.asdict(adapter.structure()),
+                structure=dict_or_none(adapter.structure()),
                 parameters={},
                 management=Management.external,
                 assets=[
@@ -365,7 +365,7 @@ async def tiff_sequence(
             data_sources=[
                 DataSource(
                     mimetype=mimetype,
-                    structure=dataclasses.asdict(adapter.structure()),
+                    structure=dict_or_none(adapter.structure()),
                     parameters={},
                     management=Management.external,
                     assets=[
@@ -539,3 +539,9 @@ async def create_node_safe(
             "   COLLISION: Multiple files would result in node at '%s'. Skipping all.",
             err.args[0],
         )
+
+
+def dict_or_none(structure):
+    if structure is None:
+        return None
+    return dataclasses.asdict(structure)

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -717,6 +717,8 @@ FULL_LINKS = {
 
 def asdict(dc):
     "Compat for converting dataclass or pydantic.BaseModel to dict."
+    if dc is None:
+        return None
     try:
         return dataclasses.asdict(dc)
     except TypeError:

--- a/tiled/structures/container.py
+++ b/tiled/structures/container.py
@@ -1,6 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class ContainerStructure:
-    count: int


### PR DESCRIPTION
We briefly had this reporting `{"count": N}` but that should not be stored at rest because we don't want have to cascade updates if a node grows a child.