### PR TITLE
Fix support for registering container formats.

### DIFF
--- a/tiled/_tests/test_container_files.py
+++ b/tiled/_tests/test_container_files.py
@@ -1,0 +1,63 @@
+import h5py
+import pandas
+import pytest
+import zarr
+
+from ..catalog import in_memory
+from ..catalog.register import register
+from ..client import Context, from_context, tree
+from ..server.app import build_app
+
+
+@pytest.mark.asyncio
+async def test_excel(tmpdir):
+    df = pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df.to_excel(tmpdir / "spreadsheet.xlsx")
+    catalog = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(catalog)) as context:
+        client = from_context(context)
+        await register(catalog, tmpdir)
+        tree(client)
+        client["spreadsheet"]["Sheet1"].read()
+
+
+@pytest.mark.asyncio
+async def test_zarr_array(tmpdir):
+    z = zarr.open(str(tmpdir / "za.zarr"), "w", shape=(3,), chunks=(3,), dtype="i4")
+    z[:] = [1, 2, 3]
+    catalog = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(catalog)) as context:
+        client = from_context(context)
+        await register(catalog, tmpdir)
+        tree(client)
+        client["za"].read()
+
+
+@pytest.mark.asyncio
+async def test_zarr_group(tmpdir):
+    root = zarr.open(str(tmpdir / "zg.zarr"), "w")
+    root.create_dataset("x", data=[1, 2, 3])
+    root.create_dataset("y", data=[4, 5, 6])
+    catalog = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(catalog)) as context:
+        client = from_context(context)
+        await register(catalog, tmpdir)
+        tree(client)
+        client["zg"].export(str(tmpdir / "stuff.h5"))
+        client["zg"]["x"].read()
+        client["zg"]["y"].read()
+
+
+@pytest.mark.asyncio
+async def test_hdf5(tmpdir):
+    with h5py.File(str(tmpdir / "h.h5"), "w") as file:
+        file["x"] = [1, 2, 3]
+        group = file.create_group("g")
+        group["y"] = [4, 5, 6]
+    catalog = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(catalog)) as context:
+        client = from_context(context)
+        await register(catalog, tmpdir)
+        tree(client)
+        client["h"]["x"].read()
+        client["h"]["g"]["y"].read()

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -8,7 +8,7 @@ from .dataframe import DataFrameAdapter
 
 class ExcelAdapter(MapAdapter):
     @classmethod
-    def from_file(cls, file, *, specs=None, access_policy=None):
+    def from_file(cls, file, **kwargs):
         """
         Read the sheets in an Excel file.
 
@@ -52,4 +52,4 @@ class ExcelAdapter(MapAdapter):
                 cache.discard(cache_key)  # parsed sheet content
                 cache.discard_dask(ddf.__dask_keys__())  # dask tasks
             mapping[sheet_name] = DataFrameAdapter.from_dask_dataframe(ddf)
-        return cls(mapping, specs=specs, access_policy=access_policy)
+        return cls(mapping, **kwargs)

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -49,7 +49,9 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
 
     structure_family = StructureFamily.container
 
-    def __init__(self, node, *, metadata=None, specs=None, access_policy=None):
+    def __init__(
+        self, node, *, structure=None, metadata=None, specs=None, access_policy=None
+    ):
         self._node = node
         self._access_policy = access_policy
         self.specs = specs or []
@@ -61,6 +63,7 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         cls,
         file,
         *,
+        structure=None,
         metadata=None,
         swmr=SWMR_DEFAULT,
         libver="latest",
@@ -77,6 +80,9 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
     @property
     def access_policy(self):
         return self._access_policy
+
+    def structure(self):
+        return None
 
     def metadata(self):
         d = dict(self._node.attrs)

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -54,6 +54,7 @@ class MapAdapter(collections.abc.Mapping, IndexersMixin):
         self,
         mapping,
         *,
+        structure=None,
         metadata=None,
         sorting=None,
         specs=None,
@@ -82,6 +83,10 @@ class MapAdapter(collections.abc.Mapping, IndexersMixin):
         must_revalidate : bool
             Whether the client should strictly refresh stale cache items.
         """
+        if structure is not None:
+            raise ValueError(
+                f"structure is expected to be None for containers, not {structure}"
+            )
         self._mapping = mapping
         if sorting is None:
             # This is a special case that means, "the given ordering".


### PR DESCRIPTION
This addresses some of the items in #538.

It adds unit tests for registering HDF5 and Zarr files. Zarr was not supported before, and HDF5 support had been broken but had no tests to catch the regression.