### PR TITLE
Simplify some APIs

### DIFF
--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -119,7 +119,7 @@ Tiled currently includes two clients for each structure family:
    tiled.client.base.BaseClient.logout
    tiled.client.base.BaseClient.new_variation
    tiled.client.base.BaseClient.specs
-   tiled.client.base.BaseStructureClient.structure
+   tiled.client.base.BaseClient.structure
 ```
 
 

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -39,7 +39,7 @@ class ParquetDatasetAdapter:
         return DataFrameAdapter(partitions, self._structure)
 
     @classmethod
-    def init_storage(cls, directory, npartitions):
+    def init_storage(cls, directory, structure):
         from ..server.schemas import Asset
 
         directory.mkdir()
@@ -49,7 +49,7 @@ class ParquetDatasetAdapter:
                 data_uri=f"{data_uri}/partition-{i}.parquet",
                 is_directory=False,
             )
-            for i in range(npartitions)
+            for i in range(structure.npartitions)
         ]
         return assets
 

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -42,13 +42,13 @@ class SparseBlocksParquetAdapter:
     def init_storage(
         cls,
         directory,
-        chunks,
+        structure,
     ):
         from ..server.schemas import Asset
 
         directory.mkdir()
 
-        num_blocks = (range(len(n)) for n in chunks)
+        num_blocks = (range(len(n)) for n in structure.chunks)
         block_uris = []
         for block in itertools.product(*num_blocks):
             filepath = directory / f"block-{'.'.join(map(str, block))}.parquet"

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -28,19 +28,19 @@ def read_zarr(filepath, **kwargs):
 
 class ZarrArrayAdapter(ArrayAdapter):
     @classmethod
-    def init_storage(cls, directory, dtype, shape, chunks):
+    def init_storage(cls, directory, structure):
         from ..server.schemas import Asset
 
-        # Zarr requires evently-sized chunks within each dimension.
+        # Zarr requires evenly-sized chunks within each dimension.
         # Use the first chunk along each dimension.
-        zarr_chunks = tuple(dim[0] for dim in chunks)
-        shape = tuple(dim[0] * len(dim) for dim in chunks)
+        zarr_chunks = tuple(dim[0] for dim in structure.chunks)
+        shape = tuple(dim[0] * len(dim) for dim in structure.chunks)
         storage = zarr.storage.DirectoryStore(str(directory))
         zarr.storage.init_array(
             storage,
             shape=shape,
             chunks=zarr_chunks,
-            dtype=dtype,
+            dtype=structure.data_type.to_numpy_dtype(),
         )
         data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
         return [

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -4,11 +4,11 @@ import dask
 import dask.array
 import numpy
 
-from .base import BaseStructureClient
+from .base import BaseClient
 from .utils import export_util, handle_error, params_from_slice
 
 
-class _DaskArrayClient(BaseStructureClient):
+class _DaskArrayClient(BaseClient):
     "Client-side wrapper around an array-like that returns dask arrays"
 
     def __init__(self, *args, item, **kwargs):

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -3,7 +3,7 @@ import dask.dataframe
 
 from ..serialization.table import deserialize_arrow, serialize_arrow
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE, UNCHANGED
-from .base import BaseStructureClient
+from .base import BaseClient
 from .utils import (
     MSGPACK_MIME_TYPE,
     ClientError,
@@ -13,7 +13,7 @@ from .utils import (
 )
 
 
-class _DaskDataFrameClient(BaseStructureClient):
+class _DaskDataFrameClient(BaseClient):
     "Client-side wrapper around an dataframe-like that returns dask dataframes"
 
     def new_variation(self, structure=UNCHANGED, **kwargs):

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -4,11 +4,11 @@ from ndindex import ndindex
 
 from ..serialization.table import deserialize_arrow, serialize_arrow
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE
-from .base import BaseStructureClient
+from .base import BaseClient
 from .utils import export_util, handle_error, params_from_slice
 
 
-class SparseClient(BaseStructureClient):
+class SparseClient(BaseClient):
     @property
     def dims(self):
         return self.structure().dims


### PR DESCRIPTION
Some nice minor simplifications here

* Remove `BaseStructureClient`; all we need is `BaseClient`.
* Simplify `init_storage` API to take the argument `structure` rather than various individual attributes of structure, which may change over time, or be different across different adapters.