### PR TITLE
Sketch support for writing, reading sliced AwkwardArrays.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,8 @@ exclude =
     dist,
     versioneer.py,
     tiled/_version.py,
-    docs/source/conf.py
-    share
-    web-frontend
+    tiled/serialization/_zipfile_py39.py,
+    docs/source/conf.py,
+    share,
+    web-frontend,
 max-line-length = 115

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tiled puts an emphasis on **structures** rather than formats, including:
 * N-dimensional strided arrays (i.e. numpy-like arrays)
 * Sparse arrays
 * Tabular data (e.g. pandas-like "dataframes")
+* Nested, variable-sized data (as implemented by [AwkwardArray](https://awkward-array.org/))
 * Hierarchical structures thereof (e.g. xarrays, HDF5-compatible structures like NeXus)
 
 Tiled implements extensible **access control enforcement** based on web security

--- a/docs/source/explanations/structures.md
+++ b/docs/source/explanations/structures.md
@@ -10,10 +10,11 @@ potentially any language.
 The structure families are:
 
 * array --- a strided array, like a [numpy](https://numpy.org) array
+* awkward --- nested, variable-sized data (as implemented by [AwkwardArray](https://awkward-array.org/))
+* container --- a of other structures, akin to a dictionary or a directory
 * sparse --- a sparse array (i.e. an array which is mostly zeros)
 * table --- tabular data, as in [Apache Arrow](https://arrow.apache.org) or
   [pandas](https://pandas.pydata.org/)
-* container --- a of other structures, akin to a dictionary or a directory
 
 Support for sparse arrays and [Awkward Array](https://awkward-array.org/) are
 planned.
@@ -178,6 +179,70 @@ $ http :8000/api/v1/metadata/structured_data/pets | jq .data.attributes.structur
     ]
   }
 }
+```
+
+### Awkward
+
+[AwkwardArrays](https://awkward-array.org/) express nested, variable-sized
+data, including arbitrary-length lists, records, mixed types, and missing data.
+This often comes up in the context of event-based data, such as is used in
+high-energy physics, neutron experiments, quantum computing, and very high-rate
+detectors.
+
+AwkwardArrays are specified by:
+
+* An outer `length` (always an integer)
+* A JSON `form` (specified by AwkwardArray, giving the internal layout)
+* Named buffers of bytes, whose names match information in the `form`
+
+The first two are included in the structure.
+
+```
+$ http :8000/api/v1/metadata/awkward_array | jq .data.attributes.structure
+```
+
+```json
+{
+  "length": 3,
+  "form": {
+    "class": "ListOffsetArray",
+    "offsets": "i64",
+    "content": {
+      "class": "RecordArray",
+      "fields": [
+        "x",
+        "y"
+      ],
+      "contents": [
+        {
+          "class": "NumpyArray",
+          "primitive": "float64",
+          "inner_shape": [],
+          "parameters": {},
+          "form_key": "node2"
+        },
+        {
+          "class": "ListOffsetArray",
+          "offsets": "i64",
+          "content": {
+            "class": "NumpyArray",
+            "primitive": "int64",
+            "inner_shape": [],
+            "parameters": {},
+            "form_key": "node4"
+          },
+          "parameters": {},
+          "form_key": "node3"
+        }
+      ],
+      "parameters": {},
+      "form_key": "node1"
+    },
+    "parameters": {},
+    "form_key": "node0"
+  }
+}
+
 ```
 
 ### Sparse Array

--- a/docs/source/explanations/structures.md
+++ b/docs/source/explanations/structures.md
@@ -57,7 +57,7 @@ a string label for each dimension.
 This `(10, 10)`-shaped array fits in a single `(10, 10)`-shaped chunk.
 
 ```
-$ http :8000/metadata/small_image | jq .data.attributes.structure
+$ http :8000/api/v1/metadata/small_image | jq .data.attributes.structure
 ```
 
 ```json
@@ -91,7 +91,7 @@ This `(10000, 10000)`-shaped array is subdivided into 4 × 4 = 16 chunks,
 which is why the size of each chunk is given explicitly.
 
 ```
-$ http :8000/metadata/big_image | jq .data.attributes.structure
+$ http :8000/api/v1/metadata/big_image | jq .data.attributes.structure
 ```
 
 ```json
@@ -130,7 +130,7 @@ This is a 1D array where each item has internal structure,
 as in numpy's [strucuted data types](https://numpy.org/doc/stable/user/basics.rec.html)
 
 ```
-$ http :8000/metadata/structured_data/pets | jq .data.attributes.structure
+$ http :8000/api/v1/metadata/structured_data/pets | jq .data.attributes.structure
 ```
 
 ```json
@@ -227,7 +227,7 @@ order, but we cannot make requests like "rows 100-200". (Dask has the same
 limitation, for the same reason.)
 
 ```
-$ http :8000/metadata/long_table | jq .data.attributes.structure
+$ http :8000/api/v1/metadata/long_table | jq .data.attributes.structure
 ```
 
 ```json

--- a/docs/source/explanations/structures.md
+++ b/docs/source/explanations/structures.md
@@ -16,9 +16,6 @@ The structure families are:
 * table --- tabular data, as in [Apache Arrow](https://arrow.apache.org) or
   [pandas](https://pandas.pydata.org/)
 
-Support for sparse arrays and [Awkward Array](https://awkward-array.org/) are
-planned.
-
 ## How structure is encoded
 
 Tiled can describe a structure---its shape, chunking, labels, and so on---for

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -89,6 +89,30 @@ structure_families, and specs of its children along with their counts.
    tiled.client.container.Container.distinct
 ```
 
+And, finally, there are convenience methods for writing:
+
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.client.container.Container.create_container
+   tiled.client.container.Container.write_array
+   tiled.client.container.Container.write_awkward
+   tiled.client.container.Container.write_dataframe
+   tiled.client.container.Container.write_sparse
+```
+
+and a low-level method for creating a new node to write into:
+
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.client.container.Container.new
+```
+
 ## Structure Clients
 
 For each *structure family* ("array", "table", etc.) there is a client
@@ -133,6 +157,32 @@ Tiled currently includes two clients for each structure family:
    tiled.client.array.DaskArrayClient.read_block
    tiled.client.array.DaskArrayClient.read
    tiled.client.array.DaskArrayClient.export
+   tiled.client.array.DaskArrayClient.write
+   tiled.client.array.DaskArrayClient.write_block
+```
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.client.array.ArrayClient
+   tiled.client.array.ArrayClient.read_block
+   tiled.client.array.ArrayClient.read
+   tiled.client.array.ArrayClient.export
+   tiled.client.array.ArrayClient.write
+   tiled.client.array.ArrayClient.write_block
+```
+
+### Awkward
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.client.awkward.AwkwardClient
+   tiled.client.awkward.AwkwardClient.read
+   tiled.client.awkward.AwkwardClient.write
+   tiled.client.awkward.AwkwardClient.export
 ```
 
 ```{eval-rst}
@@ -154,6 +204,8 @@ Tiled currently includes two clients for each structure family:
    tiled.client.sparse.SparseClient
    tiled.client.sparse.SparseClient.read
    tiled.client.sparse.SparseClient.export
+   tiled.client.sparse.SparseClient.write
+   tiled.client.sparse.SparseClient.write_block
 ```
 
 ### DataFrame
@@ -166,6 +218,8 @@ Tiled currently includes two clients for each structure family:
    tiled.client.dataframe.DaskDataFrameClient.read_partition
    tiled.client.dataframe.DaskDataFrameClient.read
    tiled.client.dataframe.DaskDataFrameClient.export
+   tiled.client.dataframe.DaskDataFrameClient.write
+   tiled.client.dataframe.DaskDataFrameClient.write_partition
 ```
 
 ```{eval-rst}
@@ -175,7 +229,9 @@ Tiled currently includes two clients for each structure family:
    tiled.client.dataframe.DataFrameClient
    tiled.client.dataframe.DataFrameClient.read_partition
    tiled.client.dataframe.DataFrameClient.read
-   tiled.client.dataframe.DaskDataFrameClient.export
+   tiled.client.dataframe.DataFrameClient.export
+   tiled.client.dataframe.DataFrameClient.write
+   tiled.client.dataframe.DataFrameClient.write_partition
 ```
 
 ### Xarray Dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ all = [
     "anyio",
     "asyncpg",
     "appdirs",
-    "awkward >=2.4.0",
+    "awkward >=2.4.3",
     "blosc",
     "cachetools",
     "cachey",
@@ -103,7 +103,7 @@ array = [
 # This is the "kichen sink" fully-featured client dependency set.
 client = [
     "appdirs",
-    "awkward >=2.4.0",
+    "awkward >=2.4.3",
     "blosc",
     "click !=8.1.0",
     "dask[array]",
@@ -219,7 +219,7 @@ server = [
     "anyio",
     "appdirs",
     "asyncpg",
-    "awkward >=2.4.0",
+    "awkward >=2.4.3",
     "blosc",
     "cachetools",
     "cachey",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ all = [
     "anyio",
     "asyncpg",
     "appdirs",
+    "awkward",
     "blosc",
     "cachetools",
     "cachey",
@@ -102,6 +103,7 @@ array = [
 # This is the "kichen sink" fully-featured client dependency set.
 client = [
     "appdirs",
+    "awkward",
     "blosc",
     "click !=8.1.0",
     "dask[array]",
@@ -215,8 +217,9 @@ server = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "asyncpg",
     "appdirs",
+    "asyncpg",
+    "awkward",
     "blosc",
     "cachetools",
     "cachey",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,7 @@ exclude = '''
   )/
   | versioneer.py
   | tiled/_version.py
+  | tiled/serialization/_zipfile_py39.py
   | docs/source/conf.py
   | share
   | web-frontend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ all = [
     "anyio",
     "asyncpg",
     "appdirs",
-    "awkward",
+    "awkward >=2.4.0",
     "blosc",
     "cachetools",
     "cachey",
@@ -103,7 +103,7 @@ array = [
 # This is the "kichen sink" fully-featured client dependency set.
 client = [
     "appdirs",
-    "awkward",
+    "awkward >=2.4.0",
     "blosc",
     "click !=8.1.0",
     "dask[array]",
@@ -219,7 +219,7 @@ server = [
     "anyio",
     "appdirs",
     "asyncpg",
-    "awkward",
+    "awkward >=2.4.0",
     "blosc",
     "cachetools",
     "cachey",

--- a/tiled/_tests/test_awkward.py
+++ b/tiled/_tests/test_awkward.py
@@ -1,0 +1,41 @@
+import awkward
+
+from ..catalog import in_memory
+from ..client import Context, from_context, record_history
+from ..server.app import build_app
+
+
+def test_awkward(tmpdir):
+    catalog = in_memory(writable_storage=tmpdir)
+    app = build_app(catalog)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+
+        # Write data into catalog. It will be stored as directory of buffers
+        # named like 'node0-offsets' and 'node2-data'.
+        array = awkward.Array(
+            [
+                [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}],
+                [],
+                [{"x": 3.3, "y": [1, 2, 3]}],
+            ]
+        )
+        aac = client.write_awkward(array, key="test")
+
+        # Read the data back out from the AwkwardArrrayClient, progressively sliced.
+        assert awkward.almost_equal(aac.read(), array)
+        assert awkward.almost_equal(aac[:], array)
+        assert awkward.almost_equal(aac[0], array[0])
+        assert awkward.almost_equal(aac[0, "y"], array[0, "y"])
+        assert awkward.almost_equal(aac[0, "y", :1], array[0, "y", :1])
+
+        # When sliced, the serer sends less data.
+        with record_history() as h:
+            aac[:]
+        assert len(h.responses) == 1  # sanity check
+        full_response_size = len(h.responses[0].content)
+        with record_history() as h:
+            aac[0, "y"]
+        assert len(h.responses) == 1  # sanity check
+        sliced_response_size = len(h.responses[0].content)
+        assert sliced_response_size < full_response_size

--- a/tiled/adapters/awkward.py
+++ b/tiled/adapters/awkward.py
@@ -1,0 +1,61 @@
+import awkward
+import awkward.forms
+
+from ..structures.awkward import AwkwardStructure
+from ..structures.core import StructureFamily
+
+
+class AwkwardAdapter:
+    structure_family = StructureFamily.awkward
+
+    def __init__(
+        self,
+        container,
+        structure,
+        metadata=None,
+        specs=None,
+        access_policy=None,
+    ):
+        self.container = container
+        self._metadata = metadata or {}
+        self._structure = structure
+        self.specs = list(specs or [])
+        self.access_policy = access_policy
+
+    @classmethod
+    def from_array(cls, array, metadata=None, specs=None, access_policy=None):
+        form, length, container = awkward.to_buffers(array)
+        structure = AwkwardStructure(length=length, form=form.to_dict())
+        return cls(
+            container,
+            structure,
+            metadata=metadata,
+            specs=specs,
+            access_policy=access_policy,
+        )
+
+    def metadata(self):
+        return self._metadata
+
+    def read_buffers(self, form_keys=None):
+        form = awkward.forms.from_dict(self._structure.form)
+        keys = [
+            key
+            for key in form.expected_from_buffers()
+            if (form_keys is None)
+            or any(key.startswith(form_key) for form_key in form_keys)
+        ]
+        buffers = {}
+        for key in keys:
+            buffers[key] = self.container[key]
+        return buffers
+
+    def read(self):
+        return dict(self.container)
+
+    def write(self, container):
+        for form_key, value in container.items():
+            container[form_key] = value
+
+    def structure(self):
+        return self._structure

--- a/tiled/adapters/awkward.py
+++ b/tiled/adapters/awkward.py
@@ -55,7 +55,7 @@ class AwkwardAdapter:
 
     def write(self, container):
         for form_key, value in container.items():
-            container[form_key] = value
+            self.container[form_key] = value
 
     def structure(self):
         return self._structure

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -1,0 +1,59 @@
+"""
+A directory containing awkward buffers, one file per form key.
+"""
+from urllib import parse
+
+from ..structures.core import StructureFamily
+
+
+class AwkwardBuffersAdapter:
+    structure_family = StructureFamily.awkward
+
+    def __init__(
+        self,
+        directory,
+        structure,
+        metadata=None,
+        specs=None,
+        access_policy=None,
+    ):
+        self.directory = directory
+        self._metadata = metadata or {}
+        self._structure = structure
+        self.specs = list(specs or [])
+        self.access_policy = access_policy
+
+    def metadata(self):
+        return self._metadata
+
+    @classmethod
+    def init_storage(cls, directory, structure):
+        from ..server.schemas import Asset
+
+        directory.mkdir()
+        data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
+        return [Asset(data_uri=data_uri, is_directory=True)]
+
+    def write(self, data):
+        for form_key, value in data.items():
+            with open(self.directory / form_key, "wb") as file:
+                file.write(value)
+
+    def read(self, form_keys=None):
+        selected_suffixed_form_keys = []
+        if form_keys is None:
+            # Read all.
+            selected_suffixed_form_keys.extend(self._structure.suffixed_form_keys)
+        else:
+            for form_key in form_keys:
+                for suffixed_form_key in self._structure.suffixed_form_keys:
+                    if suffixed_form_key.startswith(form_key):
+                        selected_suffixed_form_keys.append(suffixed_form_key)
+        buffers = {}
+        for form_key in selected_suffixed_form_keys:
+            with open(self.directory / form_key, "rb") as file:
+                buffers[form_key] = file.read()
+        return buffers
+
+    def structure(self):
+        return self._structure

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -3,7 +3,8 @@ A directory containing awkward buffers, one file per form key.
 """
 from urllib import parse
 
-from ..structures.awkward import suffixed_form_keys
+import awkward.forms
+
 from ..structures.core import StructureFamily
 
 
@@ -41,9 +42,10 @@ class AwkwardBuffersAdapter:
                 file.write(value)
 
     def read(self, form_keys=None):
+        form = awkward.forms.from_dict(self._structure.form)
         selected_suffixed_form_keys = [
             suffixed_fk
-            for suffixed_fk in suffixed_form_keys(self._structure.form)
+            for suffixed_fk in form.expected_from_buffers()
             if (form_keys is None)
             or any(suffixed_fk.startswith(fk) for fk in form_keys)
         ]

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -3,6 +3,7 @@ A directory containing awkward buffers, one file per form key.
 """
 from urllib import parse
 
+from ..structures.awkward import suffixed_form_keys
 from ..structures.core import StructureFamily
 
 
@@ -40,19 +41,16 @@ class AwkwardBuffersAdapter:
                 file.write(value)
 
     def read(self, form_keys=None):
-        selected_suffixed_form_keys = []
-        if form_keys is None:
-            # Read all.
-            selected_suffixed_form_keys.extend(self._structure.suffixed_form_keys)
-        else:
-            for form_key in form_keys:
-                for suffixed_form_key in self._structure.suffixed_form_keys:
-                    if suffixed_form_key.startswith(form_key):
-                        selected_suffixed_form_keys.append(suffixed_form_key)
+        selected_suffixed_form_keys = [
+            suffixed_fk
+            for suffixed_fk in suffixed_form_keys(self._structure.form)
+            if (form_keys is None)
+            or any(suffixed_fk.startswith(fk) for fk in form_keys)
+        ]
         buffers = {}
-        for form_key in selected_suffixed_form_keys:
-            with open(self.directory / form_key, "rb") as file:
-                buffers[form_key] = file.read()
+        for suffixed_form_key in selected_suffixed_form_keys:
+            with open(self.directory / suffixed_form_key, "rb") as file:
+                buffers[suffixed_form_key] = file.read()
         return buffers
 
     def structure(self):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -829,6 +829,11 @@ class CatalogAwkwardAdapter(CatalogNodeAdapter):
     async def read(self, *args, **kwargs):
         return await ensure_awaitable((await self.get_adapter()).read, *args, **kwargs)
 
+    async def read_buffers(self, *args, **kwargs):
+        return await ensure_awaitable(
+            (await self.get_adapter()).read_buffers, *args, **kwargs
+        )
+
     async def write(self, *args, **kwargs):
         return await ensure_awaitable((await self.get_adapter()).write, *args, **kwargs)
 

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,10 +5,10 @@ from .base import Base
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "83889e049ddc"
+REQUIRED_REVISION = "0b033e7fbe30"
 
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["83889e049ddc", "6825c778aa3c"]
+ALL_REVISIONS = ["0b033e7fbe30", "83889e049ddc", "6825c778aa3c"]
 
 
 async def initialize_database(engine):

--- a/tiled/catalog/migrations/versions/0b033e7fbe30_add_awkward_to_structurefamily_enum.py
+++ b/tiled/catalog/migrations/versions/0b033e7fbe30_add_awkward_to_structurefamily_enum.py
@@ -1,0 +1,33 @@
+"""Add 'awkward' to structurefamily enum.
+
+Revision ID: 0b033e7fbe30
+Revises: 83889e049ddc
+Create Date: 2023-08-08 21:10:20.181470
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0b033e7fbe30"
+down_revision = "83889e049ddc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    if connection.engine.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.execute(
+                sa.text(
+                    "ALTER TYPE structurefamily ADD VALUE IF NOT EXISTS 'awkward' AFTER 'array'"
+                )
+            )
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -8,6 +8,7 @@ from ..utils import OneShotCachedMap
 # for importing Readers that we will not actually use.
 PARQUET_MIMETYPE = "application/x-parquet"
 SPARSE_BLOCKS_PARQUET_MIMETYPE = "application/x-parquet-sparse"  # HACK!
+ZIP_MIMETYPE = "application/zip"
 ZARR_MIMETYPE = "application/x-zarr"
 DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
     {
@@ -38,6 +39,9 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ZARR_MIMETYPE: lambda: importlib.import_module(
             "...adapters.zarr", __name__
         ).read_zarr,
+        ZIP_MIMETYPE: lambda: importlib.import_module(
+            "...adapters.awkward_buffers", __name__
+        ).AwkwardBuffersAdapter,
     }
 )
 

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -41,7 +41,7 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ).read_zarr,
         ZIP_MIMETYPE: lambda: importlib.import_module(
             "...adapters.awkward_buffers", __name__
-        ).AwkwardBuffersAdapter,
+        ).AwkwardBuffersAdapter.from_directory,
     }
 )
 

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -29,7 +29,7 @@ class AwkwardArrayClient(BaseClient):
         )
         proxy_array = awkward.Array(typetracer)
         # TODO Ask awkward to promote _touch_data to a public method.
-        ak.typetracer.touch_data(proxy_array[slice])
+        awkward.typetracer.touch_data(proxy_array[slice])
         form_keys_touched = set(report.data_touched)
         projected_form = project_form(form, form_keys_touched)
         # The order is not important, but sort so that the request is deterministic.

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -36,7 +36,7 @@ class AwkwardArrayClient(BaseClient):
         params = {"form_key": sorted(list(form_keys_touched))}
         content = handle_error(
             self.context.http_client.get(
-                self.item["links"]["full"],
+                self.item["links"]["buffers"],
                 headers={"Accept": "application/zip"},
                 params=params,
             )

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -44,7 +44,10 @@ class AwkwardClient(BaseClient):
         ).read()
         container = from_zipped_buffers(content, projected_form, structure.length)
         projected_array = awkward.from_buffers(
-            projected_form, structure.length, container
+            projected_form,
+            structure.length,
+            container,
+            allow_noncanonical_form=True,
         )
         return projected_array[slice]
 

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -30,7 +30,6 @@ class AwkwardArrayClient(BaseClient):
             form,
         )
         proxy_array = awkward.Array(typetracer)
-        # TODO Ask awkward to promote _touch_data to a public method.
         awkward.typetracer.touch_data(proxy_array[slice])
         form_keys_touched = set(report.data_touched)
         projected_form = project_form(form, form_keys_touched)

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -6,7 +6,7 @@ from .base import BaseClient
 from .utils import export_util, handle_error
 
 
-class AwkwardArrayClient(BaseClient):
+class AwkwardClient(BaseClient):
     def __repr__(self):
         # TODO Include some summary of the structure. Probably
         # lift __repr__ code from awkward itself here.

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -1,0 +1,52 @@
+import awkward
+
+from ..serialization.awkward import from_zipped_buffers, to_zipped_buffers
+from ..structures.awkward import project_form
+from .base import BaseClient
+from .utils import handle_error
+
+
+class AwkwardArrayClient(BaseClient):
+    def __repr__(self):
+        # TODO Include some summary of the structure. Probably
+        # lift __repr__ code from awkward itself here.
+        return f"<{type(self).__name__}>"
+
+    def write(self, container):
+        handle_error(
+            self.context.http_client.put(
+                self.item["links"]["full"],
+                content=bytes(to_zipped_buffers(container, {})),
+                headers={"Content-Type": "application/zip"},
+            )
+        )
+
+    def read(self, slice=...):
+        structure = self.structure()
+        form = awkward.forms.from_dict(structure.form)
+        typetracer, report = awkward.typetracer.typetracer_with_report(
+            form,
+            forget_length=True,
+        )
+        proxy_array = awkward.Array(typetracer)
+        # TODO Ask awkward to promote _touch_data to a public method.
+        proxy_array[slice].layout._touch_data(recursive=True)
+        form_keys_touched = set(report.data_touched)
+        projected_form = project_form(form, form_keys_touched)
+        # The order is not important, but sort so that the request is deterministic.
+        params = {"form_key": sorted(list(form_keys_touched))}
+        content = handle_error(
+            self.context.http_client.get(
+                self.item["links"]["full"],
+                headers={"Accept": "application/zip"},
+                params=params,
+            )
+        ).read()
+        container = from_zipped_buffers(content)
+        projected_array = awkward.from_buffers(
+            projected_form, structure.length, container
+        )
+        return projected_array[slice]
+
+    def __getitem__(self, slice):
+        return self.read(slice=slice)

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -29,7 +29,7 @@ class AwkwardArrayClient(BaseClient):
         )
         proxy_array = awkward.Array(typetracer)
         # TODO Ask awkward to promote _touch_data to a public method.
-        proxy_array[slice].layout._touch_data(recursive=True)
+        ak.typetracer.touch_data(proxy_array[slice])
         form_keys_touched = set(report.data_touched)
         projected_form = project_form(form, form_keys_touched)
         # The order is not important, but sort so that the request is deterministic.

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -3,7 +3,7 @@ import awkward
 from ..serialization.awkward import from_zipped_buffers, to_zipped_buffers
 from ..structures.awkward import project_form
 from .base import BaseClient
-from .utils import export_util, handle_error, params_from_slice
+from .utils import export_util, handle_error
 
 
 class AwkwardArrayClient(BaseClient):
@@ -52,7 +52,7 @@ class AwkwardArrayClient(BaseClient):
     def __getitem__(self, slice):
         return self.read(slice=slice)
 
-    def export(self, filepath, *, format=None, slice=None, template_vars=None):
+    def export(self, filepath, *, format=None):
         """
         Download data in some format and write to a file.
 
@@ -64,30 +64,23 @@ class AwkwardArrayClient(BaseClient):
             If format is None and `file` is a filepath, the format is inferred
             from the name, like 'table.csv' implies format="text/csv". The format
             may be given as a file extension ("csv") or a media type ("text/csv").
-        slice : List[slice], optional
-            List of slice objects. A convenient way to generate these is shown
-            in the examples.
-        template_vars: dict, optional
-            Used internally.
 
         Examples
         --------
 
-        Export all.
+        Export as Parquet.
 
-        >>> a.export("numbers.csv")
+        >>> a.export("awkward.parquet")
 
-        Export an N-dimensional slice.
+        Export as JSON.
 
-        >>> import numpy
-        >>> a.export("numbers.csv", slice=numpy.s_[:10, 50:100])
+        >>> a.export("awkward.json")
+
         """
-        template_vars = template_vars or {}
-        params = params_from_slice(slice)
         return export_util(
             filepath,
             format,
             self.context.http_client.get,
-            self.item["links"]["full"].format(**template_vars),
-            params=params,
+            self.item["links"]["full"],
+            params={},
         )

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -26,7 +26,6 @@ class AwkwardArrayClient(BaseClient):
         form = awkward.forms.from_dict(structure.form)
         typetracer, report = awkward.typetracer.typetracer_with_report(
             form,
-            forget_length=True,
         )
         proxy_array = awkward.Array(typetracer)
         # TODO Ask awkward to promote _touch_data to a public method.

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -261,6 +261,9 @@ STRUCTURE_TYPES = OneShotCachedMap(
         StructureFamily.array: lambda: importlib.import_module(
             "...structures.array", BaseClient.__module__
         ).ArrayStructure,
+        StructureFamily.awkward: lambda: importlib.import_module(
+            "...structures.awkward", BaseClient.__module__
+        ).AwkwardStructure,
         StructureFamily.table: lambda: importlib.import_module(
             "...structures.table", BaseClient.__module__
         ).TableStructure,

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -761,7 +761,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         from ..structures.awkward import AwkwardStructure
 
-        form, length, container = awkward.to_buffers(array)
+        packed = awkward.to_packed(array)
+        form, length, container = awkward.to_buffers(packed)
         structure = AwkwardStructure(
             length=length,
             form=form.to_dict(),

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -967,9 +967,7 @@ DEFAULT_STRUCTURE_CLIENT_DISPATCH = {
         {
             "container": _Wrap(Container),
             "array": _LazyLoad(("..array", Container.__module__), "ArrayClient"),
-            "awkward": _LazyLoad(
-                ("..awkward", Container.__module__), "AwkwardArrayClient"
-            ),
+            "awkward": _LazyLoad(("..awkward", Container.__module__), "AwkwardClient"),
             "dataframe": _LazyLoad(
                 ("..dataframe", Container.__module__), "DataFrameClient"
             ),
@@ -986,8 +984,8 @@ DEFAULT_STRUCTURE_CLIENT_DISPATCH = {
         {
             "container": _Wrap(Container),
             "array": _LazyLoad(("..array", Container.__module__), "DaskArrayClient"),
-            # TODO Create DaskAwkwardArrayClient
-            # "awkward": _LazyLoad(("..awkward", Container.__module__), "DaskAwkwardArrayClient"),
+            # TODO Create DaskAwkwardClient
+            # "awkward": _LazyLoad(("..awkward", Container.__module__), "DaskAwkwardClient"),
             "dataframe": _LazyLoad(
                 ("..dataframe", Container.__module__), "DaskDataFrameClient"
             ),

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -765,7 +765,6 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         structure = AwkwardStructure(
             length=length,
             form=form.to_dict(),
-            suffixed_form_keys=list(container),
         )
         client = self.new(
             StructureFamily.awkward,

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -146,7 +146,7 @@ DEFAULT_TIMEOUT_PARAMS = {
 def params_from_slice(slice):
     "Generate URL query param ?slice=... from Python slice object."
     params = {}
-    if slice is not None:
+    if (slice is not None) and (slice is not ...):
         if isinstance(slice, (int, builtins.slice)):
             slice = [slice]
         slices = []

--- a/tiled/examples/generated.py
+++ b/tiled/examples/generated.py
@@ -3,12 +3,14 @@ import string
 import sys
 from datetime import timedelta
 
+import awkward
 import numpy
 import pandas
 import sparse
 import xarray
 
 from tiled.adapters.array import ArrayAdapter
+from tiled.adapters.awkward import AwkwardAdapter
 from tiled.adapters.dataframe import DataFrameAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.adapters.sparse import COOAdapter
@@ -34,6 +36,9 @@ lon = [[-99.83, -99.32], [-99.79, -99.23]]
 lat = [[42.25, 42.21], [42.63, 42.59]]
 sparse_arr = numpy.random.random((100, 100))
 sparse_arr[sparse_arr < 0.9] = 0  # fill most of the array with zeros
+awkward_arr = awkward.Array(
+    [[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}], [], [{"x": 3.3, "y": [1, 2, 3]}]]
+)
 
 print("Done generating example data.", file=sys.stderr)
 
@@ -42,6 +47,7 @@ mapping = {
     "small_image": ArrayAdapter.from_array(data["small_image"]),
     "medium_image": ArrayAdapter.from_array(data["medium_image"]),
     "sparse_image": COOAdapter.from_coo(sparse.COO(sparse_arr)),
+    "awkward_array": AwkwardAdapter.from_array(awkward_arr),
     "tiny_image": ArrayAdapter.from_array(data["tiny_image"]),
     "tiny_cube": ArrayAdapter.from_array(data["tiny_cube"]),
     "tiny_hypercube": ArrayAdapter.from_array(data["tiny_hypercube"]),

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -35,6 +35,9 @@ class SerializationRegistry:
     DEFAULT_ALIASES = {
         "h5": "application/x-hdf5",
         "hdf5": "application/x-hdf5",
+        "parquet": "application/x-parquet",
+        "arrow": APACHE_ARROW_FILE_MIME_TYPE,
+        "feather": APACHE_ARROW_FILE_MIME_TYPE,
         "nc": "application/netcdf",
         "text": "text/plain",
         "txt": "text/plain",

--- a/tiled/serialization/__init__.py
+++ b/tiled/serialization/__init__.py
@@ -14,6 +14,10 @@ def register_builtin_serializers():
         from ..serialization import array as _array  # noqa: F401
 
         del _array
+    if modules_available("awkward"):
+        from ..serialization import awkward as _awkward  # noqa: F401
+
+        del _awkward
     if modules_available("pandas", "pyarrow", "dask.dataframe"):
         from ..serialization import table as _table  # noqa: F401
 

--- a/tiled/serialization/_zipfile_py39.py
+++ b/tiled/serialization/_zipfile_py39.py
@@ -1,0 +1,2597 @@
+"""
+Read and write ZIP files.
+
+XXX references to utf-8 need further investigation.
+"""
+import binascii
+import contextlib
+import importlib.util
+import io
+import itertools
+import os
+import posixpath
+import shutil
+import stat
+import struct
+import sys
+import threading
+import time
+
+try:
+    import zlib  # We may need its compression method
+
+    crc32 = zlib.crc32
+except ImportError:
+    zlib = None
+    crc32 = binascii.crc32
+
+try:
+    import bz2  # We may need its compression method
+except ImportError:
+    bz2 = None
+
+try:
+    import lzma  # We may need its compression method
+except ImportError:
+    lzma = None
+
+__all__ = [
+    "BadZipFile",
+    "BadZipfile",
+    "error",
+    "ZIP_STORED",
+    "ZIP_DEFLATED",
+    "ZIP_BZIP2",
+    "ZIP_LZMA",
+    "is_zipfile",
+    "ZipInfo",
+    "ZipFile",
+    "PyZipFile",
+    "LargeZipFile",
+    "Path",
+]
+
+
+class BadZipFile(Exception):
+    pass
+
+
+class LargeZipFile(Exception):
+    """
+    Raised when writing a zipfile, the zipfile requires ZIP64 extensions
+    and those extensions are disabled.
+    """
+
+
+error = BadZipfile = BadZipFile  # Pre-3.2 compatibility names
+
+
+ZIP64_LIMIT = (1 << 31) - 1
+ZIP_FILECOUNT_LIMIT = (1 << 16) - 1
+ZIP_MAX_COMMENT = (1 << 16) - 1
+
+# constants for Zip file compression methods
+ZIP_STORED = 0
+ZIP_DEFLATED = 8
+ZIP_BZIP2 = 12
+ZIP_LZMA = 14
+# Other ZIP compression methods not supported
+
+DEFAULT_VERSION = 20
+ZIP64_VERSION = 45
+BZIP2_VERSION = 46
+LZMA_VERSION = 63
+# we recognize (but not necessarily support) all features up to that version
+MAX_EXTRACT_VERSION = 63
+
+# Below are some formats and associated data for reading/writing headers using
+# the struct module.  The names and structures of headers/records are those used
+# in the PKWARE description of the ZIP file format:
+#     http://www.pkware.com/documents/casestudies/APPNOTE.TXT
+# (URL valid as of January 2008)
+
+# The "end of central directory" structure, magic number, size, and indices
+# (section V.I in the format document)
+structEndArchive = b"<4s4H2LH"
+stringEndArchive = b"PK\005\006"
+sizeEndCentDir = struct.calcsize(structEndArchive)
+
+_ECD_SIGNATURE = 0
+_ECD_DISK_NUMBER = 1
+_ECD_DISK_START = 2
+_ECD_ENTRIES_THIS_DISK = 3
+_ECD_ENTRIES_TOTAL = 4
+_ECD_SIZE = 5
+_ECD_OFFSET = 6
+_ECD_COMMENT_SIZE = 7
+# These last two indices are not part of the structure as defined in the
+# spec, but they are used internally by this module as a convenience
+_ECD_COMMENT = 8
+_ECD_LOCATION = 9
+
+# The "central directory" structure, magic number, size, and indices
+# of entries in the structure (section V.F in the format document)
+structCentralDir = "<4s4B4HL2L5H2L"
+stringCentralDir = b"PK\001\002"
+sizeCentralDir = struct.calcsize(structCentralDir)
+
+# indexes of entries in the central directory structure
+_CD_SIGNATURE = 0
+_CD_CREATE_VERSION = 1
+_CD_CREATE_SYSTEM = 2
+_CD_EXTRACT_VERSION = 3
+_CD_EXTRACT_SYSTEM = 4
+_CD_FLAG_BITS = 5
+_CD_COMPRESS_TYPE = 6
+_CD_TIME = 7
+_CD_DATE = 8
+_CD_CRC = 9
+_CD_COMPRESSED_SIZE = 10
+_CD_UNCOMPRESSED_SIZE = 11
+_CD_FILENAME_LENGTH = 12
+_CD_EXTRA_FIELD_LENGTH = 13
+_CD_COMMENT_LENGTH = 14
+_CD_DISK_NUMBER_START = 15
+_CD_INTERNAL_FILE_ATTRIBUTES = 16
+_CD_EXTERNAL_FILE_ATTRIBUTES = 17
+_CD_LOCAL_HEADER_OFFSET = 18
+
+# The "local file header" structure, magic number, size, and indices
+# (section V.A in the format document)
+structFileHeader = "<4s2B4HL2L2H"
+stringFileHeader = b"PK\003\004"
+sizeFileHeader = struct.calcsize(structFileHeader)
+
+_FH_SIGNATURE = 0
+_FH_EXTRACT_VERSION = 1
+_FH_EXTRACT_SYSTEM = 2
+_FH_GENERAL_PURPOSE_FLAG_BITS = 3
+_FH_COMPRESSION_METHOD = 4
+_FH_LAST_MOD_TIME = 5
+_FH_LAST_MOD_DATE = 6
+_FH_CRC = 7
+_FH_COMPRESSED_SIZE = 8
+_FH_UNCOMPRESSED_SIZE = 9
+_FH_FILENAME_LENGTH = 10
+_FH_EXTRA_FIELD_LENGTH = 11
+
+# The "Zip64 end of central directory locator" structure, magic number, and size
+structEndArchive64Locator = "<4sLQL"
+stringEndArchive64Locator = b"PK\x06\x07"
+sizeEndCentDir64Locator = struct.calcsize(structEndArchive64Locator)
+
+# The "Zip64 end of central directory" record, magic number, size, and indices
+# (section V.G in the format document)
+structEndArchive64 = "<4sQ2H2L4Q"
+stringEndArchive64 = b"PK\x06\x06"
+sizeEndCentDir64 = struct.calcsize(structEndArchive64)
+
+_CD64_SIGNATURE = 0
+_CD64_DIRECTORY_RECSIZE = 1
+_CD64_CREATE_VERSION = 2
+_CD64_EXTRACT_VERSION = 3
+_CD64_DISK_NUMBER = 4
+_CD64_DISK_NUMBER_START = 5
+_CD64_NUMBER_ENTRIES_THIS_DISK = 6
+_CD64_NUMBER_ENTRIES_TOTAL = 7
+_CD64_DIRECTORY_SIZE = 8
+_CD64_OFFSET_START_CENTDIR = 9
+
+_DD_SIGNATURE = 0x08074B50
+
+_EXTRA_FIELD_STRUCT = struct.Struct("<HH")
+
+
+def _strip_extra(extra, xids):
+    # Remove Extra Fields with specified IDs.
+    unpack = _EXTRA_FIELD_STRUCT.unpack
+    modified = False
+    buffer = []
+    start = i = 0
+    while i + 4 <= len(extra):
+        xid, xlen = unpack(extra[i : i + 4])
+        j = i + 4 + xlen
+        if xid in xids:
+            if i != start:
+                buffer.append(extra[start:i])
+            start = j
+            modified = True
+        i = j
+    if not modified:
+        return extra
+    return b"".join(buffer)
+
+
+def _check_zipfile(fp):
+    try:
+        if _EndRecData(fp):
+            return True  # file has correct magic number
+    except OSError:
+        pass
+    return False
+
+
+def is_zipfile(filename):
+    """Quickly see if a file is a ZIP file by checking the magic number.
+
+    The filename argument may be a file or file-like object too.
+    """
+    result = False
+    try:
+        if hasattr(filename, "read"):
+            result = _check_zipfile(fp=filename)
+        else:
+            with open(filename, "rb") as fp:
+                result = _check_zipfile(fp)
+    except OSError:
+        pass
+    return result
+
+
+def _EndRecData64(fpin, offset, endrec):
+    """
+    Read the ZIP64 end-of-archive records and use that to update endrec
+    """
+    try:
+        fpin.seek(offset - sizeEndCentDir64Locator, 2)
+    except OSError:
+        # If the seek fails, the file is not large enough to contain a ZIP64
+        # end-of-archive record, so just return the end record we were given.
+        return endrec
+
+    data = fpin.read(sizeEndCentDir64Locator)
+    if len(data) != sizeEndCentDir64Locator:
+        return endrec
+    sig, diskno, reloff, disks = struct.unpack(structEndArchive64Locator, data)
+    if sig != stringEndArchive64Locator:
+        return endrec
+
+    if diskno != 0 or disks > 1:
+        raise BadZipFile("zipfiles that span multiple disks are not supported")
+
+    # Assume no 'zip64 extensible data'
+    fpin.seek(offset - sizeEndCentDir64Locator - sizeEndCentDir64, 2)
+    data = fpin.read(sizeEndCentDir64)
+    if len(data) != sizeEndCentDir64:
+        return endrec
+    (
+        sig,
+        sz,
+        create_version,
+        read_version,
+        disk_num,
+        disk_dir,
+        dircount,
+        dircount2,
+        dirsize,
+        diroffset,
+    ) = struct.unpack(structEndArchive64, data)
+    if sig != stringEndArchive64:
+        return endrec
+
+    # Update the original endrec using data from the ZIP64 record
+    endrec[_ECD_SIGNATURE] = sig
+    endrec[_ECD_DISK_NUMBER] = disk_num
+    endrec[_ECD_DISK_START] = disk_dir
+    endrec[_ECD_ENTRIES_THIS_DISK] = dircount
+    endrec[_ECD_ENTRIES_TOTAL] = dircount2
+    endrec[_ECD_SIZE] = dirsize
+    endrec[_ECD_OFFSET] = diroffset
+    return endrec
+
+
+def _EndRecData(fpin):
+    """Return data from the "End of Central Directory" record, or None.
+
+    The data is a list of the nine items in the ZIP "End of central dir"
+    record followed by a tenth item, the file seek offset of this record."""
+
+    # Determine file size
+    fpin.seek(0, 2)
+    filesize = fpin.tell()
+
+    # Check to see if this is ZIP file with no archive comment (the
+    # "end of central directory" structure should be the last item in the
+    # file if this is the case).
+    try:
+        fpin.seek(-sizeEndCentDir, 2)
+    except OSError:
+        return None
+    data = fpin.read()
+    if (
+        len(data) == sizeEndCentDir
+        and data[0:4] == stringEndArchive
+        and data[-2:] == b"\000\000"
+    ):
+        # the signature is correct and there's no comment, unpack structure
+        endrec = struct.unpack(structEndArchive, data)
+        endrec = list(endrec)
+
+        # Append a blank comment and record start offset
+        endrec.append(b"")
+        endrec.append(filesize - sizeEndCentDir)
+
+        # Try to read the "Zip64 end of central directory" structure
+        return _EndRecData64(fpin, -sizeEndCentDir, endrec)
+
+    # Either this is not a ZIP file, or it is a ZIP file with an archive
+    # comment.  Search the end of the file for the "end of central directory"
+    # record signature. The comment is the last item in the ZIP file and may be
+    # up to 64K long.  It is assumed that the "end of central directory" magic
+    # number does not appear in the comment.
+    maxCommentStart = max(filesize - (1 << 16) - sizeEndCentDir, 0)
+    fpin.seek(maxCommentStart, 0)
+    data = fpin.read()
+    start = data.rfind(stringEndArchive)
+    if start >= 0:
+        # found the magic number; attempt to unpack and interpret
+        recData = data[start : start + sizeEndCentDir]
+        if len(recData) != sizeEndCentDir:
+            # Zip file is corrupted.
+            return None
+        endrec = list(struct.unpack(structEndArchive, recData))
+        commentSize = endrec[_ECD_COMMENT_SIZE]  # as claimed by the zip file
+        comment = data[start + sizeEndCentDir : start + sizeEndCentDir + commentSize]
+        endrec.append(comment)
+        endrec.append(maxCommentStart + start)
+
+        # Try to read the "Zip64 end of central directory" structure
+        return _EndRecData64(fpin, maxCommentStart + start - filesize, endrec)
+
+    # Unable to find a valid end of central directory structure
+    return None
+
+
+class ZipInfo(object):
+    """Class with attributes describing each file in the ZIP archive."""
+
+    __slots__ = (
+        "orig_filename",
+        "filename",
+        "date_time",
+        "compress_type",
+        "_compresslevel",
+        "comment",
+        "extra",
+        "create_system",
+        "create_version",
+        "extract_version",
+        "reserved",
+        "flag_bits",
+        "volume",
+        "internal_attr",
+        "external_attr",
+        "header_offset",
+        "CRC",
+        "compress_size",
+        "file_size",
+        "_raw_time",
+    )
+
+    def __init__(self, filename="NoName", date_time=(1980, 1, 1, 0, 0, 0)):
+        self.orig_filename = filename  # Original file name in archive
+
+        # Terminate the file name at the first null byte.  Null bytes in file
+        # names are used as tricks by viruses in archives.
+        null_byte = filename.find(chr(0))
+        if null_byte >= 0:
+            filename = filename[0:null_byte]
+        # This is used to ensure paths in generated ZIP files always use
+        # forward slashes as the directory separator, as required by the
+        # ZIP format specification.
+        if os.sep != "/" and os.sep in filename:
+            filename = filename.replace(os.sep, "/")
+
+        self.filename = filename  # Normalized file name
+        self.date_time = date_time  # year, month, day, hour, min, sec
+
+        if date_time[0] < 1980:
+            raise ValueError("ZIP does not support timestamps before 1980")
+
+        # Standard values:
+        self.compress_type = ZIP_STORED  # Type of compression for the file
+        self._compresslevel = None  # Level for the compressor
+        self.comment = b""  # Comment for each file
+        self.extra = b""  # ZIP extra data
+        if sys.platform == "win32":
+            self.create_system = 0  # System which created ZIP archive
+        else:
+            # Assume everything else is unix-y
+            self.create_system = 3  # System which created ZIP archive
+        self.create_version = DEFAULT_VERSION  # Version which created ZIP archive
+        self.extract_version = DEFAULT_VERSION  # Version needed to extract archive
+        self.reserved = 0  # Must be zero
+        self.flag_bits = 0  # ZIP flag bits
+        self.volume = 0  # Volume number of file header
+        self.internal_attr = 0  # Internal attributes
+        self.external_attr = 0  # External file attributes
+        self.compress_size = 0  # Size of the compressed file
+        self.file_size = 0  # Size of the uncompressed file
+        # Other attributes are set by class ZipFile:
+        # header_offset         Byte offset to the file header
+        # CRC                   CRC-32 of the uncompressed file
+
+    def __repr__(self):
+        result = ["<%s filename=%r" % (self.__class__.__name__, self.filename)]
+        if self.compress_type != ZIP_STORED:
+            result.append(
+                " compress_type=%s"
+                % compressor_names.get(self.compress_type, self.compress_type)
+            )
+        hi = self.external_attr >> 16
+        lo = self.external_attr & 0xFFFF
+        if hi:
+            result.append(" filemode=%r" % stat.filemode(hi))
+        if lo:
+            result.append(" external_attr=%#x" % lo)
+        isdir = self.is_dir()
+        if not isdir or self.file_size:
+            result.append(" file_size=%r" % self.file_size)
+        if (not isdir or self.compress_size) and (
+            self.compress_type != ZIP_STORED or self.file_size != self.compress_size
+        ):
+            result.append(" compress_size=%r" % self.compress_size)
+        result.append(">")
+        return "".join(result)
+
+    def FileHeader(self, zip64=None):
+        """Return the per-file header as a bytes object."""
+        dt = self.date_time
+        dosdate = (dt[0] - 1980) << 9 | dt[1] << 5 | dt[2]
+        dostime = dt[3] << 11 | dt[4] << 5 | (dt[5] // 2)
+        if self.flag_bits & 0x08:
+            # Set these to zero because we write them after the file data
+            CRC = compress_size = file_size = 0
+        else:
+            CRC = self.CRC
+            compress_size = self.compress_size
+            file_size = self.file_size
+
+        extra = self.extra
+
+        min_version = 0
+        if zip64 is None:
+            zip64 = file_size > ZIP64_LIMIT or compress_size > ZIP64_LIMIT
+        if zip64:
+            fmt = "<HHQQ"
+            extra = extra + struct.pack(
+                fmt, 1, struct.calcsize(fmt) - 4, file_size, compress_size
+            )
+        if file_size > ZIP64_LIMIT or compress_size > ZIP64_LIMIT:
+            if not zip64:
+                raise LargeZipFile("Filesize would require ZIP64 extensions")
+            # File is larger than what fits into a 4 byte integer,
+            # fall back to the ZIP64 extension
+            file_size = 0xFFFFFFFF
+            compress_size = 0xFFFFFFFF
+            min_version = ZIP64_VERSION
+
+        if self.compress_type == ZIP_BZIP2:
+            min_version = max(BZIP2_VERSION, min_version)
+        elif self.compress_type == ZIP_LZMA:
+            min_version = max(LZMA_VERSION, min_version)
+
+        self.extract_version = max(min_version, self.extract_version)
+        self.create_version = max(min_version, self.create_version)
+        filename, flag_bits = self._encodeFilenameFlags()
+        header = struct.pack(
+            structFileHeader,
+            stringFileHeader,
+            self.extract_version,
+            self.reserved,
+            flag_bits,
+            self.compress_type,
+            dostime,
+            dosdate,
+            CRC,
+            compress_size,
+            file_size,
+            len(filename),
+            len(extra),
+        )
+        return header + filename + extra
+
+    def _encodeFilenameFlags(self):
+        try:
+            return self.filename.encode("ascii"), self.flag_bits
+        except UnicodeEncodeError:
+            return self.filename.encode("utf-8"), self.flag_bits | 0x800
+
+    def _decodeExtra(self):
+        # Try to decode the extra field.
+        extra = self.extra
+        unpack = struct.unpack
+        while len(extra) >= 4:
+            tp, ln = unpack("<HH", extra[:4])
+            if ln + 4 > len(extra):
+                raise BadZipFile("Corrupt extra field %04x (size=%d)" % (tp, ln))
+            if tp == 0x0001:
+                data = extra[4 : ln + 4]
+                # ZIP64 extension (large files and/or large archives)
+                try:
+                    if self.file_size in (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF):
+                        field = "File size"
+                        (self.file_size,) = unpack("<Q", data[:8])
+                        data = data[8:]
+                    if self.compress_size == 0xFFFF_FFFF:
+                        field = "Compress size"
+                        (self.compress_size,) = unpack("<Q", data[:8])
+                        data = data[8:]
+                    if self.header_offset == 0xFFFF_FFFF:
+                        field = "Header offset"
+                        (self.header_offset,) = unpack("<Q", data[:8])
+                except struct.error:
+                    raise BadZipFile(
+                        f"Corrupt zip64 extra field. " f"{field} not found."
+                    ) from None
+
+            extra = extra[ln + 4 :]
+
+    @classmethod
+    def from_file(cls, filename, arcname=None, *, strict_timestamps=True):
+        """Construct an appropriate ZipInfo for a file on the filesystem.
+
+        filename should be the path to a file or directory on the filesystem.
+
+        arcname is the name which it will have within the archive (by default,
+        this will be the same as filename, but without a drive letter and with
+        leading path separators removed).
+        """
+        if isinstance(filename, os.PathLike):
+            filename = os.fspath(filename)
+        st = os.stat(filename)
+        isdir = stat.S_ISDIR(st.st_mode)
+        mtime = time.localtime(st.st_mtime)
+        date_time = mtime[0:6]
+        if not strict_timestamps and date_time[0] < 1980:
+            date_time = (1980, 1, 1, 0, 0, 0)
+        elif not strict_timestamps and date_time[0] > 2107:
+            date_time = (2107, 12, 31, 23, 59, 59)
+        # Create ZipInfo instance to store file information
+        if arcname is None:
+            arcname = filename
+        arcname = os.path.normpath(os.path.splitdrive(arcname)[1])
+        while arcname[0] in (os.sep, os.altsep):
+            arcname = arcname[1:]
+        if isdir:
+            arcname += "/"
+        zinfo = cls(arcname, date_time)
+        zinfo.external_attr = (st.st_mode & 0xFFFF) << 16  # Unix attributes
+        if isdir:
+            zinfo.file_size = 0
+            zinfo.external_attr |= 0x10  # MS-DOS directory flag
+        else:
+            zinfo.file_size = st.st_size
+
+        return zinfo
+
+    def is_dir(self):
+        """Return True if this archive member is a directory."""
+        return self.filename[-1] == "/"
+
+
+# ZIP encryption uses the CRC32 one-byte primitive for scrambling some
+# internal keys. We noticed that a direct implementation is faster than
+# relying on binascii.crc32().
+
+_crctable = None
+
+
+def _gen_crc(crc):
+    for j in range(8):
+        if crc & 1:
+            crc = (crc >> 1) ^ 0xEDB88320
+        else:
+            crc >>= 1
+    return crc
+
+
+# ZIP supports a password-based form of encryption. Even though known
+# plaintext attacks have been found against it, it is still useful
+# to be able to get data out of such a file.
+#
+# Usage:
+#     zd = _ZipDecrypter(mypwd)
+#     plain_bytes = zd(cypher_bytes)
+
+
+def _ZipDecrypter(pwd):
+    key0 = 305419896
+    key1 = 591751049
+    key2 = 878082192
+
+    global _crctable
+    if _crctable is None:
+        _crctable = list(map(_gen_crc, range(256)))
+    crctable = _crctable
+
+    def crc32(ch, crc):
+        """Compute the CRC32 primitive on one byte."""
+        return (crc >> 8) ^ crctable[(crc ^ ch) & 0xFF]
+
+    def update_keys(c):
+        nonlocal key0, key1, key2
+        key0 = crc32(c, key0)
+        key1 = (key1 + (key0 & 0xFF)) & 0xFFFFFFFF
+        key1 = (key1 * 134775813 + 1) & 0xFFFFFFFF
+        key2 = crc32(key1 >> 24, key2)
+
+    for p in pwd:
+        update_keys(p)
+
+    def decrypter(data):
+        """Decrypt a bytes object."""
+        result = bytearray()
+        append = result.append
+        for c in data:
+            k = key2 | 2
+            c ^= ((k * (k ^ 1)) >> 8) & 0xFF
+            update_keys(c)
+            append(c)
+        return bytes(result)
+
+    return decrypter
+
+
+class LZMACompressor:
+    def __init__(self):
+        self._comp = None
+
+    def _init(self):
+        props = lzma._encode_filter_properties({"id": lzma.FILTER_LZMA1})
+        self._comp = lzma.LZMACompressor(
+            lzma.FORMAT_RAW,
+            filters=[lzma._decode_filter_properties(lzma.FILTER_LZMA1, props)],
+        )
+        return struct.pack("<BBH", 9, 4, len(props)) + props
+
+    def compress(self, data):
+        if self._comp is None:
+            return self._init() + self._comp.compress(data)
+        return self._comp.compress(data)
+
+    def flush(self):
+        if self._comp is None:
+            return self._init() + self._comp.flush()
+        return self._comp.flush()
+
+
+class LZMADecompressor:
+    def __init__(self):
+        self._decomp = None
+        self._unconsumed = b""
+        self.eof = False
+
+    def decompress(self, data):
+        if self._decomp is None:
+            self._unconsumed += data
+            if len(self._unconsumed) <= 4:
+                return b""
+            (psize,) = struct.unpack("<H", self._unconsumed[2:4])
+            if len(self._unconsumed) <= 4 + psize:
+                return b""
+
+            self._decomp = lzma.LZMADecompressor(
+                lzma.FORMAT_RAW,
+                filters=[
+                    lzma._decode_filter_properties(
+                        lzma.FILTER_LZMA1, self._unconsumed[4 : 4 + psize]
+                    )
+                ],
+            )
+            data = self._unconsumed[4 + psize :]
+            del self._unconsumed
+
+        result = self._decomp.decompress(data)
+        self.eof = self._decomp.eof
+        return result
+
+
+compressor_names = {
+    0: "store",
+    1: "shrink",
+    2: "reduce",
+    3: "reduce",
+    4: "reduce",
+    5: "reduce",
+    6: "implode",
+    7: "tokenize",
+    8: "deflate",
+    9: "deflate64",
+    10: "implode",
+    12: "bzip2",
+    14: "lzma",
+    18: "terse",
+    19: "lz77",
+    97: "wavpack",
+    98: "ppmd",
+}
+
+
+def _check_compression(compression):
+    if compression == ZIP_STORED:
+        pass
+    elif compression == ZIP_DEFLATED:
+        if not zlib:
+            raise RuntimeError("Compression requires the (missing) zlib module")
+    elif compression == ZIP_BZIP2:
+        if not bz2:
+            raise RuntimeError("Compression requires the (missing) bz2 module")
+    elif compression == ZIP_LZMA:
+        if not lzma:
+            raise RuntimeError("Compression requires the (missing) lzma module")
+    else:
+        raise NotImplementedError("That compression method is not supported")
+
+
+def _get_compressor(compress_type, compresslevel=None):
+    if compress_type == ZIP_DEFLATED:
+        if compresslevel is not None:
+            return zlib.compressobj(compresslevel, zlib.DEFLATED, -15)
+        return zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+    elif compress_type == ZIP_BZIP2:
+        if compresslevel is not None:
+            return bz2.BZ2Compressor(compresslevel)
+        return bz2.BZ2Compressor()
+    # compresslevel is ignored for ZIP_LZMA
+    elif compress_type == ZIP_LZMA:
+        return LZMACompressor()
+    else:
+        return None
+
+
+def _get_decompressor(compress_type):
+    _check_compression(compress_type)
+    if compress_type == ZIP_STORED:
+        return None
+    elif compress_type == ZIP_DEFLATED:
+        return zlib.decompressobj(-15)
+    elif compress_type == ZIP_BZIP2:
+        return bz2.BZ2Decompressor()
+    elif compress_type == ZIP_LZMA:
+        return LZMADecompressor()
+    else:
+        descr = compressor_names.get(compress_type)
+        if descr:
+            raise NotImplementedError(
+                "compression type %d (%s)" % (compress_type, descr)
+            )
+        else:
+            raise NotImplementedError("compression type %d" % (compress_type,))
+
+
+class _SharedFile:
+    def __init__(self, file, pos, close, lock, writing):
+        self._file = file
+        self._pos = pos
+        self._close = close
+        self._lock = lock
+        self._writing = writing
+        self.seekable = file.seekable
+
+    def tell(self):
+        return self._pos
+
+    def seek(self, offset, whence=0):
+        with self._lock:
+            if self._writing():
+                raise ValueError(
+                    "Can't reposition in the ZIP file while "
+                    "there is an open writing handle on it. "
+                    "Close the writing handle before trying to read."
+                )
+            self._file.seek(offset, whence)
+            self._pos = self._file.tell()
+            return self._pos
+
+    def read(self, n=-1):
+        with self._lock:
+            if self._writing():
+                raise ValueError(
+                    "Can't read from the ZIP file while there "
+                    "is an open writing handle on it. "
+                    "Close the writing handle before trying to read."
+                )
+            self._file.seek(self._pos)
+            data = self._file.read(n)
+            self._pos = self._file.tell()
+            return data
+
+    def close(self):
+        if self._file is not None:
+            fileobj = self._file
+            self._file = None
+            self._close(fileobj)
+
+
+# Provide the tell method for unseekable stream
+class _Tellable:
+    def __init__(self, fp):
+        self.fp = fp
+        self.offset = 0
+
+    def write(self, data):
+        n = self.fp.write(data)
+        self.offset += n
+        return n
+
+    def tell(self):
+        return self.offset
+
+    def flush(self):
+        self.fp.flush()
+
+    def close(self):
+        self.fp.close()
+
+
+class ZipExtFile(io.BufferedIOBase):
+    """File-like object for reading an archive member.
+    Is returned by ZipFile.open().
+    """
+
+    # Max size supported by decompressor.
+    MAX_N = 1 << 31 - 1
+
+    # Read from compressed files in 4k blocks.
+    MIN_READ_SIZE = 4096
+
+    # Chunk size to read during seek
+    MAX_SEEK_READ = 1 << 24
+
+    def __init__(self, fileobj, mode, zipinfo, pwd=None, close_fileobj=False):
+        self._fileobj = fileobj
+        self._pwd = pwd
+        self._close_fileobj = close_fileobj
+
+        self._compress_type = zipinfo.compress_type
+        self._compress_left = zipinfo.compress_size
+        self._left = zipinfo.file_size
+
+        self._decompressor = _get_decompressor(self._compress_type)
+
+        self._eof = False
+        self._readbuffer = b""
+        self._offset = 0
+
+        self.newlines = None
+
+        self.mode = mode
+        self.name = zipinfo.filename
+
+        if hasattr(zipinfo, "CRC"):
+            self._expected_crc = zipinfo.CRC
+            self._running_crc = crc32(b"")
+        else:
+            self._expected_crc = None
+
+        self._seekable = False
+        try:
+            if fileobj.seekable():
+                self._orig_compress_start = fileobj.tell()
+                self._orig_compress_size = zipinfo.compress_size
+                self._orig_file_size = zipinfo.file_size
+                self._orig_start_crc = self._running_crc
+                self._seekable = True
+        except AttributeError:
+            pass
+
+        self._decrypter = None
+        if pwd:
+            if zipinfo.flag_bits & 0x8:
+                # compare against the file type from extended local headers
+                check_byte = (zipinfo._raw_time >> 8) & 0xFF
+            else:
+                # compare against the CRC otherwise
+                check_byte = (zipinfo.CRC >> 24) & 0xFF
+            h = self._init_decrypter()
+            if h != check_byte:
+                raise RuntimeError("Bad password for file %r" % zipinfo.orig_filename)
+
+    def _init_decrypter(self):
+        self._decrypter = _ZipDecrypter(self._pwd)
+        # The first 12 bytes in the cypher stream is an encryption header
+        #  used to strengthen the algorithm. The first 11 bytes are
+        #  completely random, while the 12th contains the MSB of the CRC,
+        #  or the MSB of the file time depending on the header type
+        #  and is used to check the correctness of the password.
+        header = self._fileobj.read(12)
+        self._compress_left -= 12
+        return self._decrypter(header)[11]
+
+    def __repr__(self):
+        result = ["<%s.%s" % (self.__class__.__module__, self.__class__.__qualname__)]
+        if not self.closed:
+            result.append(" name=%r mode=%r" % (self.name, self.mode))
+            if self._compress_type != ZIP_STORED:
+                result.append(
+                    " compress_type=%s"
+                    % compressor_names.get(self._compress_type, self._compress_type)
+                )
+        else:
+            result.append(" [closed]")
+        result.append(">")
+        return "".join(result)
+
+    def readline(self, limit=-1):
+        """Read and return a line from the stream.
+
+        If limit is specified, at most limit bytes will be read.
+        """
+
+        if limit < 0:
+            # Shortcut common case - newline found in buffer.
+            i = self._readbuffer.find(b"\n", self._offset) + 1
+            if i > 0:
+                line = self._readbuffer[self._offset : i]
+                self._offset = i
+                return line
+
+        return io.BufferedIOBase.readline(self, limit)
+
+    def peek(self, n=1):
+        """Returns buffered bytes without advancing the position."""
+        if n > len(self._readbuffer) - self._offset:
+            chunk = self.read(n)
+            if len(chunk) > self._offset:
+                self._readbuffer = chunk + self._readbuffer[self._offset :]
+                self._offset = 0
+            else:
+                self._offset -= len(chunk)
+
+        # Return up to 512 bytes to reduce allocation overhead for tight loops.
+        return self._readbuffer[self._offset : self._offset + 512]
+
+    def readable(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        return True
+
+    def read(self, n=-1):
+        """Read and return up to n bytes.
+        If the argument is omitted, None, or negative, data is read and returned until EOF is reached.
+        """
+        if self.closed:
+            raise ValueError("read from closed file.")
+        if n is None or n < 0:
+            buf = self._readbuffer[self._offset :]
+            self._readbuffer = b""
+            self._offset = 0
+            while not self._eof:
+                buf += self._read1(self.MAX_N)
+            return buf
+
+        end = n + self._offset
+        if end < len(self._readbuffer):
+            buf = self._readbuffer[self._offset : end]
+            self._offset = end
+            return buf
+
+        n = end - len(self._readbuffer)
+        buf = self._readbuffer[self._offset :]
+        self._readbuffer = b""
+        self._offset = 0
+        while n > 0 and not self._eof:
+            data = self._read1(n)
+            if n < len(data):
+                self._readbuffer = data
+                self._offset = n
+                buf += data[:n]
+                break
+            buf += data
+            n -= len(data)
+        return buf
+
+    def _update_crc(self, newdata):
+        # Update the CRC using the given data.
+        if self._expected_crc is None:
+            # No need to compute the CRC if we don't have a reference value
+            return
+        self._running_crc = crc32(newdata, self._running_crc)
+        # Check the CRC if we're at the end of the file
+        if self._eof and self._running_crc != self._expected_crc:
+            raise BadZipFile("Bad CRC-32 for file %r" % self.name)
+
+    def read1(self, n):
+        """Read up to n bytes with at most one read() system call."""
+
+        if n is None or n < 0:
+            buf = self._readbuffer[self._offset :]
+            self._readbuffer = b""
+            self._offset = 0
+            while not self._eof:
+                data = self._read1(self.MAX_N)
+                if data:
+                    buf += data
+                    break
+            return buf
+
+        end = n + self._offset
+        if end < len(self._readbuffer):
+            buf = self._readbuffer[self._offset : end]
+            self._offset = end
+            return buf
+
+        n = end - len(self._readbuffer)
+        buf = self._readbuffer[self._offset :]
+        self._readbuffer = b""
+        self._offset = 0
+        if n > 0:
+            while not self._eof:
+                data = self._read1(n)
+                if n < len(data):
+                    self._readbuffer = data
+                    self._offset = n
+                    buf += data[:n]
+                    break
+                if data:
+                    buf += data
+                    break
+        return buf
+
+    def _read1(self, n):
+        # Read up to n compressed bytes with at most one read() system call,
+        # decrypt and decompress them.
+        if self._eof or n <= 0:
+            return b""
+
+        # Read from file.
+        if self._compress_type == ZIP_DEFLATED:
+            ## Handle unconsumed data.
+            data = self._decompressor.unconsumed_tail
+            if n > len(data):
+                data += self._read2(n - len(data))
+        else:
+            data = self._read2(n)
+
+        if self._compress_type == ZIP_STORED:
+            self._eof = self._compress_left <= 0
+        elif self._compress_type == ZIP_DEFLATED:
+            n = max(n, self.MIN_READ_SIZE)
+            data = self._decompressor.decompress(data, n)
+            self._eof = (
+                self._decompressor.eof
+                or self._compress_left <= 0
+                and not self._decompressor.unconsumed_tail
+            )
+            if self._eof:
+                data += self._decompressor.flush()
+        else:
+            data = self._decompressor.decompress(data)
+            self._eof = self._decompressor.eof or self._compress_left <= 0
+
+        data = data[: self._left]
+        self._left -= len(data)
+        if self._left <= 0:
+            self._eof = True
+        self._update_crc(data)
+        return data
+
+    def _read2(self, n):
+        if self._compress_left <= 0:
+            return b""
+
+        n = max(n, self.MIN_READ_SIZE)
+        n = min(n, self._compress_left)
+
+        data = self._fileobj.read(n)
+        self._compress_left -= len(data)
+        if not data:
+            raise EOFError
+
+        if self._decrypter is not None:
+            data = self._decrypter(data)
+        return data
+
+    def close(self):
+        try:
+            if self._close_fileobj:
+                self._fileobj.close()
+        finally:
+            super().close()
+
+    def seekable(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        return self._seekable
+
+    def seek(self, offset, whence=0):
+        if self.closed:
+            raise ValueError("seek on closed file.")
+        if not self._seekable:
+            raise io.UnsupportedOperation("underlying stream is not seekable")
+        curr_pos = self.tell()
+        if whence == 0:  # Seek from start of file
+            new_pos = offset
+        elif whence == 1:  # Seek from current position
+            new_pos = curr_pos + offset
+        elif whence == 2:  # Seek from EOF
+            new_pos = self._orig_file_size + offset
+        else:
+            raise ValueError(
+                "whence must be os.SEEK_SET (0), " "os.SEEK_CUR (1), or os.SEEK_END (2)"
+            )
+
+        if new_pos > self._orig_file_size:
+            new_pos = self._orig_file_size
+
+        if new_pos < 0:
+            new_pos = 0
+
+        read_offset = new_pos - curr_pos
+        buff_offset = read_offset + self._offset
+
+        if buff_offset >= 0 and buff_offset < len(self._readbuffer):
+            # Just move the _offset index if the new position is in the _readbuffer
+            self._offset = buff_offset
+            read_offset = 0
+        elif read_offset < 0:
+            # Position is before the current position. Reset the ZipExtFile
+            self._fileobj.seek(self._orig_compress_start)
+            self._running_crc = self._orig_start_crc
+            self._compress_left = self._orig_compress_size
+            self._left = self._orig_file_size
+            self._readbuffer = b""
+            self._offset = 0
+            self._decompressor = _get_decompressor(self._compress_type)
+            self._eof = False
+            read_offset = new_pos
+            if self._decrypter is not None:
+                self._init_decrypter()
+
+        while read_offset > 0:
+            read_len = min(self.MAX_SEEK_READ, read_offset)
+            self.read(read_len)
+            read_offset -= read_len
+
+        return self.tell()
+
+    def tell(self):
+        if self.closed:
+            raise ValueError("tell on closed file.")
+        if not self._seekable:
+            raise io.UnsupportedOperation("underlying stream is not seekable")
+        filepos = (
+            self._orig_file_size - self._left - len(self._readbuffer) + self._offset
+        )
+        return filepos
+
+
+class _ZipWriteFile(io.BufferedIOBase):
+    def __init__(self, zf, zinfo, zip64):
+        self._zinfo = zinfo
+        self._zip64 = zip64
+        self._zipfile = zf
+        self._compressor = _get_compressor(zinfo.compress_type, zinfo._compresslevel)
+        self._file_size = 0
+        self._compress_size = 0
+        self._crc = 0
+
+    @property
+    def _fileobj(self):
+        return self._zipfile.fp
+
+    def writable(self):
+        return True
+
+    def write(self, data):
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+
+        # Accept any data that supports the buffer protocol
+        if isinstance(data, (bytes, bytearray)):
+            nbytes = len(data)
+        else:
+            data = memoryview(data)
+            nbytes = data.nbytes
+        self._file_size += nbytes
+
+        self._crc = crc32(data, self._crc)
+        if self._compressor:
+            data = self._compressor.compress(data)
+            self._compress_size += len(data)
+        self._fileobj.write(data)
+        return nbytes
+
+    def close(self):
+        if self.closed:
+            return
+        try:
+            super().close()
+            # Flush any data from the compressor, and update header info
+            if self._compressor:
+                buf = self._compressor.flush()
+                self._compress_size += len(buf)
+                self._fileobj.write(buf)
+                self._zinfo.compress_size = self._compress_size
+            else:
+                self._zinfo.compress_size = self._file_size
+            self._zinfo.CRC = self._crc
+            self._zinfo.file_size = self._file_size
+
+            # Write updated header info
+            if self._zinfo.flag_bits & 0x08:
+                # Write CRC and file sizes after the file data
+                fmt = "<LLQQ" if self._zip64 else "<LLLL"
+                self._fileobj.write(
+                    struct.pack(
+                        fmt,
+                        _DD_SIGNATURE,
+                        self._zinfo.CRC,
+                        self._zinfo.compress_size,
+                        self._zinfo.file_size,
+                    )
+                )
+                self._zipfile.start_dir = self._fileobj.tell()
+            else:
+                if not self._zip64:
+                    if self._file_size > ZIP64_LIMIT:
+                        raise RuntimeError(
+                            "File size unexpectedly exceeded ZIP64 limit"
+                        )
+                    if self._compress_size > ZIP64_LIMIT:
+                        raise RuntimeError(
+                            "Compressed size unexpectedly exceeded ZIP64 limit"
+                        )
+                # Seek backwards and write file header (which will now include
+                # correct CRC and file sizes)
+
+                # Preserve current position in file
+                self._zipfile.start_dir = self._fileobj.tell()
+                self._fileobj.seek(self._zinfo.header_offset)
+                self._fileobj.write(self._zinfo.FileHeader(self._zip64))
+                self._fileobj.seek(self._zipfile.start_dir)
+
+            # Successfully written: Add file to our caches
+            self._zipfile.filelist.append(self._zinfo)
+            self._zipfile.NameToInfo[self._zinfo.filename] = self._zinfo
+        finally:
+            self._zipfile._writing = False
+
+
+class ZipFile:
+    """Class with methods to open, read, write, close, list zip files.
+
+    z = ZipFile(file, mode="r", compression=ZIP_STORED, allowZip64=True,
+                compresslevel=None)
+
+    file: Either the path to the file, or a file-like object.
+          If it is a path, the file will be opened and closed by ZipFile.
+    mode: The mode can be either read 'r', write 'w', exclusive create 'x',
+          or append 'a'.
+    compression: ZIP_STORED (no compression), ZIP_DEFLATED (requires zlib),
+                 ZIP_BZIP2 (requires bz2) or ZIP_LZMA (requires lzma).
+    allowZip64: if True ZipFile will create files with ZIP64 extensions when
+                needed, otherwise it will raise an exception when this would
+                be necessary.
+    compresslevel: None (default for the given compression type) or an integer
+                   specifying the level to pass to the compressor.
+                   When using ZIP_STORED or ZIP_LZMA this keyword has no effect.
+                   When using ZIP_DEFLATED integers 0 through 9 are accepted.
+                   When using ZIP_BZIP2 integers 1 through 9 are accepted.
+
+    """
+
+    fp = None  # Set here since __del__ checks it
+    _windows_illegal_name_trans_table = None
+
+    def __init__(
+        self,
+        file,
+        mode="r",
+        compression=ZIP_STORED,
+        allowZip64=True,
+        compresslevel=None,
+        *,
+        strict_timestamps=True,
+    ):
+        """Open the ZIP file with mode read 'r', write 'w', exclusive create 'x',
+        or append 'a'."""
+        if mode not in ("r", "w", "x", "a"):
+            raise ValueError("ZipFile requires mode 'r', 'w', 'x', or 'a'")
+
+        _check_compression(compression)
+
+        self._allowZip64 = allowZip64
+        self._didModify = False
+        self.debug = 0  # Level of printing: 0 through 3
+        self.NameToInfo = {}  # Find file info given name
+        self.filelist = []  # List of ZipInfo instances for archive
+        self.compression = compression  # Method of compression
+        self.compresslevel = compresslevel
+        self.mode = mode
+        self.pwd = None
+        self._comment = b""
+        self._strict_timestamps = strict_timestamps
+
+        # Check if we were passed a file-like object
+        if isinstance(file, os.PathLike):
+            file = os.fspath(file)
+        if isinstance(file, str):
+            # No, it's a filename
+            self._filePassed = 0
+            self.filename = file
+            modeDict = {
+                "r": "rb",
+                "w": "w+b",
+                "x": "x+b",
+                "a": "r+b",
+                "r+b": "w+b",
+                "w+b": "wb",
+                "x+b": "xb",
+            }
+            filemode = modeDict[mode]
+            while True:
+                try:
+                    self.fp = io.open(file, filemode)
+                except OSError:
+                    if filemode in modeDict:
+                        filemode = modeDict[filemode]
+                        continue
+                    raise
+                break
+        else:
+            self._filePassed = 1
+            self.fp = file
+            self.filename = getattr(file, "name", None)
+        self._fileRefCnt = 1
+        self._lock = threading.RLock()
+        self._seekable = True
+        self._writing = False
+
+        try:
+            if mode == "r":
+                self._RealGetContents()
+            elif mode in ("w", "x"):
+                # set the modified flag so central directory gets written
+                # even if no files are added to the archive
+                self._didModify = True
+                try:
+                    self.start_dir = self.fp.tell()
+                except (AttributeError, OSError):
+                    self.fp = _Tellable(self.fp)
+                    self.start_dir = 0
+                    self._seekable = False
+                else:
+                    # Some file-like objects can provide tell() but not seek()
+                    try:
+                        self.fp.seek(self.start_dir)
+                    except (AttributeError, OSError):
+                        self._seekable = False
+            elif mode == "a":
+                try:
+                    # See if file is a zip file
+                    self._RealGetContents()
+                    # seek to start of directory and overwrite
+                    self.fp.seek(self.start_dir)
+                except BadZipFile:
+                    # file is not a zip file, just append
+                    self.fp.seek(0, 2)
+
+                    # set the modified flag so central directory gets written
+                    # even if no files are added to the archive
+                    self._didModify = True
+                    self.start_dir = self.fp.tell()
+            else:
+                raise ValueError("Mode must be 'r', 'w', 'x', or 'a'")
+        except:
+            fp = self.fp
+            self.fp = None
+            self._fpclose(fp)
+            raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def __repr__(self):
+        result = ["<%s.%s" % (self.__class__.__module__, self.__class__.__qualname__)]
+        if self.fp is not None:
+            if self._filePassed:
+                result.append(" file=%r" % self.fp)
+            elif self.filename is not None:
+                result.append(" filename=%r" % self.filename)
+            result.append(" mode=%r" % self.mode)
+        else:
+            result.append(" [closed]")
+        result.append(">")
+        return "".join(result)
+
+    def _RealGetContents(self):
+        """Read in the table of contents for the ZIP file."""
+        fp = self.fp
+        try:
+            endrec = _EndRecData(fp)
+        except OSError:
+            raise BadZipFile("File is not a zip file")
+        if not endrec:
+            raise BadZipFile("File is not a zip file")
+        if self.debug > 1:
+            print(endrec)
+        size_cd = endrec[_ECD_SIZE]  # bytes in central directory
+        offset_cd = endrec[_ECD_OFFSET]  # offset of central directory
+        self._comment = endrec[_ECD_COMMENT]  # archive comment
+
+        # "concat" is zero, unless zip was concatenated to another file
+        concat = endrec[_ECD_LOCATION] - size_cd - offset_cd
+        if endrec[_ECD_SIGNATURE] == stringEndArchive64:
+            # If Zip64 extension structures are present, account for them
+            concat -= sizeEndCentDir64 + sizeEndCentDir64Locator
+
+        if self.debug > 2:
+            inferred = concat + offset_cd
+            print("given, inferred, offset", offset_cd, inferred, concat)
+        # self.start_dir:  Position of start of central directory
+        self.start_dir = offset_cd + concat
+        fp.seek(self.start_dir, 0)
+        data = fp.read(size_cd)
+        fp = io.BytesIO(data)
+        total = 0
+        while total < size_cd:
+            centdir = fp.read(sizeCentralDir)
+            if len(centdir) != sizeCentralDir:
+                raise BadZipFile("Truncated central directory")
+            centdir = struct.unpack(structCentralDir, centdir)
+            if centdir[_CD_SIGNATURE] != stringCentralDir:
+                raise BadZipFile("Bad magic number for central directory")
+            if self.debug > 2:
+                print(centdir)
+            filename = fp.read(centdir[_CD_FILENAME_LENGTH])
+            flags = centdir[5]
+            if flags & 0x800:
+                # UTF-8 file names extension
+                filename = filename.decode("utf-8")
+            else:
+                # Historical ZIP filename encoding
+                filename = filename.decode("cp437")
+            # Create ZipInfo instance to store file information
+            x = ZipInfo(filename)
+            x.extra = fp.read(centdir[_CD_EXTRA_FIELD_LENGTH])
+            x.comment = fp.read(centdir[_CD_COMMENT_LENGTH])
+            x.header_offset = centdir[_CD_LOCAL_HEADER_OFFSET]
+            (
+                x.create_version,
+                x.create_system,
+                x.extract_version,
+                x.reserved,
+                x.flag_bits,
+                x.compress_type,
+                t,
+                d,
+                x.CRC,
+                x.compress_size,
+                x.file_size,
+            ) = centdir[1:12]
+            if x.extract_version > MAX_EXTRACT_VERSION:
+                raise NotImplementedError(
+                    "zip file version %.1f" % (x.extract_version / 10)
+                )
+            x.volume, x.internal_attr, x.external_attr = centdir[15:18]
+            # Convert date/time code to (year, month, day, hour, min, sec)
+            x._raw_time = t
+            x.date_time = (
+                (d >> 9) + 1980,
+                (d >> 5) & 0xF,
+                d & 0x1F,
+                t >> 11,
+                (t >> 5) & 0x3F,
+                (t & 0x1F) * 2,
+            )
+
+            x._decodeExtra()
+            x.header_offset = x.header_offset + concat
+            self.filelist.append(x)
+            self.NameToInfo[x.filename] = x
+
+            # update total bytes read from central directory
+            total = (
+                total
+                + sizeCentralDir
+                + centdir[_CD_FILENAME_LENGTH]
+                + centdir[_CD_EXTRA_FIELD_LENGTH]
+                + centdir[_CD_COMMENT_LENGTH]
+            )
+
+            if self.debug > 2:
+                print("total", total)
+
+    def namelist(self):
+        """Return a list of file names in the archive."""
+        return [data.filename for data in self.filelist]
+
+    def infolist(self):
+        """Return a list of class ZipInfo instances for files in the
+        archive."""
+        return self.filelist
+
+    def printdir(self, file=None):
+        """Print a table of contents for the zip file."""
+        print("%-46s %19s %12s" % ("File Name", "Modified    ", "Size"), file=file)
+        for zinfo in self.filelist:
+            date = "%d-%02d-%02d %02d:%02d:%02d" % zinfo.date_time[:6]
+            print("%-46s %s %12d" % (zinfo.filename, date, zinfo.file_size), file=file)
+
+    def testzip(self):
+        """Read all the files and check the CRC."""
+        chunk_size = 2**20
+        for zinfo in self.filelist:
+            try:
+                # Read by chunks, to avoid an OverflowError or a
+                # MemoryError with very large embedded files.
+                with self.open(zinfo.filename, "r") as f:
+                    while f.read(chunk_size):  # Check CRC-32
+                        pass
+            except BadZipFile:
+                return zinfo.filename
+
+    def getinfo(self, name):
+        """Return the instance of ZipInfo given 'name'."""
+        info = self.NameToInfo.get(name)
+        if info is None:
+            raise KeyError("There is no item named %r in the archive" % name)
+
+        return info
+
+    def setpassword(self, pwd):
+        """Set default password for encrypted files."""
+        if pwd and not isinstance(pwd, bytes):
+            raise TypeError("pwd: expected bytes, got %s" % type(pwd).__name__)
+        if pwd:
+            self.pwd = pwd
+        else:
+            self.pwd = None
+
+    @property
+    def comment(self):
+        """The comment text associated with the ZIP file."""
+        return self._comment
+
+    @comment.setter
+    def comment(self, comment):
+        if not isinstance(comment, bytes):
+            raise TypeError("comment: expected bytes, got %s" % type(comment).__name__)
+        # check for valid comment length
+        if len(comment) > ZIP_MAX_COMMENT:
+            import warnings
+
+            warnings.warn(
+                "Archive comment is too long; truncating to %d bytes" % ZIP_MAX_COMMENT,
+                stacklevel=2,
+            )
+            comment = comment[:ZIP_MAX_COMMENT]
+        self._comment = comment
+        self._didModify = True
+
+    def read(self, name, pwd=None):
+        """Return file bytes for name."""
+        with self.open(name, "r", pwd) as fp:
+            return fp.read()
+
+    def open(self, name, mode="r", pwd=None, *, force_zip64=False):
+        """Return file-like object for 'name'.
+
+        name is a string for the file name within the ZIP file, or a ZipInfo
+        object.
+
+        mode should be 'r' to read a file already in the ZIP file, or 'w' to
+        write to a file newly added to the archive.
+
+        pwd is the password to decrypt files (only used for reading).
+
+        When writing, if the file size is not known in advance but may exceed
+        2 GiB, pass force_zip64 to use the ZIP64 format, which can handle large
+        files.  If the size is known in advance, it is best to pass a ZipInfo
+        instance for name, with zinfo.file_size set.
+        """
+        if mode not in {"r", "w"}:
+            raise ValueError('open() requires mode "r" or "w"')
+        if pwd and not isinstance(pwd, bytes):
+            raise TypeError("pwd: expected bytes, got %s" % type(pwd).__name__)
+        if pwd and (mode == "w"):
+            raise ValueError("pwd is only supported for reading files")
+        if not self.fp:
+            raise ValueError("Attempt to use ZIP archive that was already closed")
+
+        # Make sure we have an info object
+        if isinstance(name, ZipInfo):
+            # 'name' is already an info object
+            zinfo = name
+        elif mode == "w":
+            zinfo = ZipInfo(name)
+            zinfo.compress_type = self.compression
+            zinfo._compresslevel = self.compresslevel
+        else:
+            # Get info object for name
+            zinfo = self.getinfo(name)
+
+        if mode == "w":
+            return self._open_to_write(zinfo, force_zip64=force_zip64)
+
+        if self._writing:
+            raise ValueError(
+                "Can't read from the ZIP file while there "
+                "is an open writing handle on it. "
+                "Close the writing handle before trying to read."
+            )
+
+        # Open for reading:
+        self._fileRefCnt += 1
+        zef_file = _SharedFile(
+            self.fp,
+            zinfo.header_offset,
+            self._fpclose,
+            self._lock,
+            lambda: self._writing,
+        )
+        try:
+            # Skip the file header:
+            fheader = zef_file.read(sizeFileHeader)
+            if len(fheader) != sizeFileHeader:
+                raise BadZipFile("Truncated file header")
+            fheader = struct.unpack(structFileHeader, fheader)
+            if fheader[_FH_SIGNATURE] != stringFileHeader:
+                raise BadZipFile("Bad magic number for file header")
+
+            fname = zef_file.read(fheader[_FH_FILENAME_LENGTH])
+            if fheader[_FH_EXTRA_FIELD_LENGTH]:
+                zef_file.read(fheader[_FH_EXTRA_FIELD_LENGTH])
+
+            if zinfo.flag_bits & 0x20:
+                # Zip 2.7: compressed patched data
+                raise NotImplementedError("compressed patched data (flag bit 5)")
+
+            if zinfo.flag_bits & 0x40:
+                # strong encryption
+                raise NotImplementedError("strong encryption (flag bit 6)")
+
+            if fheader[_FH_GENERAL_PURPOSE_FLAG_BITS] & 0x800:
+                # UTF-8 filename
+                fname_str = fname.decode("utf-8")
+            else:
+                fname_str = fname.decode("cp437")
+
+            if fname_str != zinfo.orig_filename:
+                raise BadZipFile(
+                    "File name in directory %r and header %r differ."
+                    % (zinfo.orig_filename, fname)
+                )
+
+            # check for encrypted flag & handle password
+            is_encrypted = zinfo.flag_bits & 0x1
+            if is_encrypted:
+                if not pwd:
+                    pwd = self.pwd
+                if not pwd:
+                    raise RuntimeError(
+                        "File %r is encrypted, password "
+                        "required for extraction" % name
+                    )
+            else:
+                pwd = None
+
+            return ZipExtFile(zef_file, mode, zinfo, pwd, True)
+        except:
+            zef_file.close()
+            raise
+
+    def _open_to_write(self, zinfo, force_zip64=False):
+        if force_zip64 and not self._allowZip64:
+            raise ValueError(
+                "force_zip64 is True, but allowZip64 was False when opening "
+                "the ZIP file."
+            )
+        if self._writing:
+            raise ValueError(
+                "Can't write to the ZIP file while there is "
+                "another write handle open on it. "
+                "Close the first handle before opening another."
+            )
+
+        # Size and CRC are overwritten with correct data after processing the file
+        zinfo.compress_size = 0
+        zinfo.CRC = 0
+
+        zinfo.flag_bits = 0x00
+        if zinfo.compress_type == ZIP_LZMA:
+            # Compressed data includes an end-of-stream (EOS) marker
+            zinfo.flag_bits |= 0x02
+        if not self._seekable:
+            zinfo.flag_bits |= 0x08
+
+        if not zinfo.external_attr:
+            zinfo.external_attr = 0o600 << 16  # permissions: ?rw-------
+
+        # Compressed size can be larger than uncompressed size
+        zip64 = self._allowZip64 and (
+            force_zip64 or zinfo.file_size * 1.05 > ZIP64_LIMIT
+        )
+
+        if self._seekable:
+            self.fp.seek(self.start_dir)
+        zinfo.header_offset = self.fp.tell()
+
+        self._writecheck(zinfo)
+        self._didModify = True
+
+        self.fp.write(zinfo.FileHeader(zip64))
+
+        self._writing = True
+        return _ZipWriteFile(self, zinfo, zip64)
+
+    def extract(self, member, path=None, pwd=None):
+        """Extract a member from the archive to the current working directory,
+        using its full name. Its file information is extracted as accurately
+        as possible. `member' may be a filename or a ZipInfo object. You can
+        specify a different directory using `path'.
+        """
+        if path is None:
+            path = os.getcwd()
+        else:
+            path = os.fspath(path)
+
+        return self._extract_member(member, path, pwd)
+
+    def extractall(self, path=None, members=None, pwd=None):
+        """Extract all members from the archive to the current working
+        directory. `path' specifies a different directory to extract to.
+        `members' is optional and must be a subset of the list returned
+        by namelist().
+        """
+        if members is None:
+            members = self.namelist()
+
+        if path is None:
+            path = os.getcwd()
+        else:
+            path = os.fspath(path)
+
+        for zipinfo in members:
+            self._extract_member(zipinfo, path, pwd)
+
+    @classmethod
+    def _sanitize_windows_name(cls, arcname, pathsep):
+        """Replace bad characters and remove trailing dots from parts."""
+        table = cls._windows_illegal_name_trans_table
+        if not table:
+            illegal = ':<>|"?*'
+            table = str.maketrans(illegal, "_" * len(illegal))
+            cls._windows_illegal_name_trans_table = table
+        arcname = arcname.translate(table)
+        # remove trailing dots
+        arcname = (x.rstrip(".") for x in arcname.split(pathsep))
+        # rejoin, removing empty parts.
+        arcname = pathsep.join(x for x in arcname if x)
+        return arcname
+
+    def _extract_member(self, member, targetpath, pwd):
+        """Extract the ZipInfo object 'member' to a physical
+        file on the path targetpath.
+        """
+        if not isinstance(member, ZipInfo):
+            member = self.getinfo(member)
+
+        # build the destination pathname, replacing
+        # forward slashes to platform specific separators.
+        arcname = member.filename.replace("/", os.path.sep)
+
+        if os.path.altsep:
+            arcname = arcname.replace(os.path.altsep, os.path.sep)
+        # interpret absolute pathname as relative, remove drive letter or
+        # UNC path, redundant separators, "." and ".." components.
+        arcname = os.path.splitdrive(arcname)[1]
+        invalid_path_parts = ("", os.path.curdir, os.path.pardir)
+        arcname = os.path.sep.join(
+            x for x in arcname.split(os.path.sep) if x not in invalid_path_parts
+        )
+        if os.path.sep == "\\":
+            # filter illegal characters on Windows
+            arcname = self._sanitize_windows_name(arcname, os.path.sep)
+
+        targetpath = os.path.join(targetpath, arcname)
+        targetpath = os.path.normpath(targetpath)
+
+        # Create all upper directories if necessary.
+        upperdirs = os.path.dirname(targetpath)
+        if upperdirs and not os.path.exists(upperdirs):
+            os.makedirs(upperdirs)
+
+        if member.is_dir():
+            if not os.path.isdir(targetpath):
+                os.mkdir(targetpath)
+            return targetpath
+
+        with self.open(member, pwd=pwd) as source, open(targetpath, "wb") as target:
+            shutil.copyfileobj(source, target)
+
+        return targetpath
+
+    def _writecheck(self, zinfo):
+        """Check for errors before writing a file to the archive."""
+        if zinfo.filename in self.NameToInfo:
+            import warnings
+
+            warnings.warn("Duplicate name: %r" % zinfo.filename, stacklevel=3)
+        if self.mode not in ("w", "x", "a"):
+            raise ValueError("write() requires mode 'w', 'x', or 'a'")
+        if not self.fp:
+            raise ValueError("Attempt to write ZIP archive that was already closed")
+        _check_compression(zinfo.compress_type)
+        if not self._allowZip64:
+            requires_zip64 = None
+            if len(self.filelist) >= ZIP_FILECOUNT_LIMIT:
+                requires_zip64 = "Files count"
+            elif zinfo.file_size > ZIP64_LIMIT:
+                requires_zip64 = "Filesize"
+            elif zinfo.header_offset > ZIP64_LIMIT:
+                requires_zip64 = "Zipfile size"
+            if requires_zip64:
+                raise LargeZipFile(requires_zip64 + " would require ZIP64 extensions")
+
+    def write(self, filename, arcname=None, compress_type=None, compresslevel=None):
+        """Put the bytes from filename into the archive under the name
+        arcname."""
+        if not self.fp:
+            raise ValueError("Attempt to write to ZIP archive that was already closed")
+        if self._writing:
+            raise ValueError(
+                "Can't write to ZIP archive while an open writing handle exists"
+            )
+
+        zinfo = ZipInfo.from_file(
+            filename, arcname, strict_timestamps=self._strict_timestamps
+        )
+
+        if zinfo.is_dir():
+            zinfo.compress_size = 0
+            zinfo.CRC = 0
+        else:
+            if compress_type is not None:
+                zinfo.compress_type = compress_type
+            else:
+                zinfo.compress_type = self.compression
+
+            if compresslevel is not None:
+                zinfo._compresslevel = compresslevel
+            else:
+                zinfo._compresslevel = self.compresslevel
+
+        if zinfo.is_dir():
+            with self._lock:
+                if self._seekable:
+                    self.fp.seek(self.start_dir)
+                zinfo.header_offset = self.fp.tell()  # Start of header bytes
+                if zinfo.compress_type == ZIP_LZMA:
+                    # Compressed data includes an end-of-stream (EOS) marker
+                    zinfo.flag_bits |= 0x02
+
+                self._writecheck(zinfo)
+                self._didModify = True
+
+                self.filelist.append(zinfo)
+                self.NameToInfo[zinfo.filename] = zinfo
+                self.fp.write(zinfo.FileHeader(False))
+                self.start_dir = self.fp.tell()
+        else:
+            with open(filename, "rb") as src, self.open(zinfo, "w") as dest:
+                shutil.copyfileobj(src, dest, 1024 * 8)
+
+    def writestr(self, zinfo_or_arcname, data, compress_type=None, compresslevel=None):
+        """Write a file into the archive.  The contents is 'data', which
+        may be either a 'str' or a 'bytes' instance; if it is a 'str',
+        it is encoded as UTF-8 first.
+        'zinfo_or_arcname' is either a ZipInfo instance or
+        the name of the file in the archive."""
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        if not isinstance(zinfo_or_arcname, ZipInfo):
+            zinfo = ZipInfo(
+                filename=zinfo_or_arcname, date_time=time.localtime(time.time())[:6]
+            )
+            zinfo.compress_type = self.compression
+            zinfo._compresslevel = self.compresslevel
+            if zinfo.filename[-1] == "/":
+                zinfo.external_attr = 0o40775 << 16  # drwxrwxr-x
+                zinfo.external_attr |= 0x10  # MS-DOS directory flag
+            else:
+                zinfo.external_attr = 0o600 << 16  # ?rw-------
+        else:
+            zinfo = zinfo_or_arcname
+
+        if not self.fp:
+            raise ValueError("Attempt to write to ZIP archive that was already closed")
+        if self._writing:
+            raise ValueError(
+                "Can't write to ZIP archive while an open writing handle exists."
+            )
+
+        if compress_type is not None:
+            zinfo.compress_type = compress_type
+
+        if compresslevel is not None:
+            zinfo._compresslevel = compresslevel
+
+        zinfo.file_size = len(data)  # Uncompressed size
+        with self._lock:
+            with self.open(zinfo, mode="w") as dest:
+                dest.write(data)
+
+    def __del__(self):
+        """Call the "close()" method in case the user forgot."""
+        self.close()
+
+    def close(self):
+        """Close the file, and for mode 'w', 'x' and 'a' write the ending
+        records."""
+        if self.fp is None:
+            return
+
+        if self._writing:
+            raise ValueError(
+                "Can't close the ZIP file while there is "
+                "an open writing handle on it. "
+                "Close the writing handle before closing the zip."
+            )
+
+        try:
+            if self.mode in ("w", "x", "a") and self._didModify:  # write ending records
+                with self._lock:
+                    if self._seekable:
+                        self.fp.seek(self.start_dir)
+                    self._write_end_record()
+        finally:
+            fp = self.fp
+            self.fp = None
+            self._fpclose(fp)
+
+    def _write_end_record(self):
+        for zinfo in self.filelist:  # write central directory
+            dt = zinfo.date_time
+            dosdate = (dt[0] - 1980) << 9 | dt[1] << 5 | dt[2]
+            dostime = dt[3] << 11 | dt[4] << 5 | (dt[5] // 2)
+            extra = []
+            if zinfo.file_size > ZIP64_LIMIT or zinfo.compress_size > ZIP64_LIMIT:
+                extra.append(zinfo.file_size)
+                extra.append(zinfo.compress_size)
+                file_size = 0xFFFFFFFF
+                compress_size = 0xFFFFFFFF
+            else:
+                file_size = zinfo.file_size
+                compress_size = zinfo.compress_size
+
+            if zinfo.header_offset > ZIP64_LIMIT:
+                extra.append(zinfo.header_offset)
+                header_offset = 0xFFFFFFFF
+            else:
+                header_offset = zinfo.header_offset
+
+            extra_data = zinfo.extra
+            min_version = 0
+            if extra:
+                # Append a ZIP64 field to the extra's
+                extra_data = _strip_extra(extra_data, (1,))
+                extra_data = (
+                    struct.pack("<HH" + "Q" * len(extra), 1, 8 * len(extra), *extra)
+                    + extra_data
+                )
+
+                min_version = ZIP64_VERSION
+
+            if zinfo.compress_type == ZIP_BZIP2:
+                min_version = max(BZIP2_VERSION, min_version)
+            elif zinfo.compress_type == ZIP_LZMA:
+                min_version = max(LZMA_VERSION, min_version)
+
+            extract_version = max(min_version, zinfo.extract_version)
+            create_version = max(min_version, zinfo.create_version)
+            filename, flag_bits = zinfo._encodeFilenameFlags()
+            centdir = struct.pack(
+                structCentralDir,
+                stringCentralDir,
+                create_version,
+                zinfo.create_system,
+                extract_version,
+                zinfo.reserved,
+                flag_bits,
+                zinfo.compress_type,
+                dostime,
+                dosdate,
+                zinfo.CRC,
+                compress_size,
+                file_size,
+                len(filename),
+                len(extra_data),
+                len(zinfo.comment),
+                0,
+                zinfo.internal_attr,
+                zinfo.external_attr,
+                header_offset,
+            )
+            self.fp.write(centdir)
+            self.fp.write(filename)
+            self.fp.write(extra_data)
+            self.fp.write(zinfo.comment)
+
+        pos2 = self.fp.tell()
+        # Write end-of-zip-archive record
+        centDirCount = len(self.filelist)
+        centDirSize = pos2 - self.start_dir
+        centDirOffset = self.start_dir
+        requires_zip64 = None
+        if centDirCount > ZIP_FILECOUNT_LIMIT:
+            requires_zip64 = "Files count"
+        elif centDirOffset > ZIP64_LIMIT:
+            requires_zip64 = "Central directory offset"
+        elif centDirSize > ZIP64_LIMIT:
+            requires_zip64 = "Central directory size"
+        if requires_zip64:
+            # Need to write the ZIP64 end-of-archive records
+            if not self._allowZip64:
+                raise LargeZipFile(requires_zip64 + " would require ZIP64 extensions")
+            zip64endrec = struct.pack(
+                structEndArchive64,
+                stringEndArchive64,
+                44,
+                45,
+                45,
+                0,
+                0,
+                centDirCount,
+                centDirCount,
+                centDirSize,
+                centDirOffset,
+            )
+            self.fp.write(zip64endrec)
+
+            zip64locrec = struct.pack(
+                structEndArchive64Locator, stringEndArchive64Locator, 0, pos2, 1
+            )
+            self.fp.write(zip64locrec)
+            centDirCount = min(centDirCount, 0xFFFF)
+            centDirSize = min(centDirSize, 0xFFFFFFFF)
+            centDirOffset = min(centDirOffset, 0xFFFFFFFF)
+
+        endrec = struct.pack(
+            structEndArchive,
+            stringEndArchive,
+            0,
+            0,
+            centDirCount,
+            centDirCount,
+            centDirSize,
+            centDirOffset,
+            len(self._comment),
+        )
+        self.fp.write(endrec)
+        self.fp.write(self._comment)
+        if self.mode == "a":
+            self.fp.truncate()
+        self.fp.flush()
+
+    def _fpclose(self, fp):
+        assert self._fileRefCnt > 0
+        self._fileRefCnt -= 1
+        if not self._fileRefCnt and not self._filePassed:
+            fp.close()
+
+
+class PyZipFile(ZipFile):
+    """Class to create ZIP archives with Python library files and packages."""
+
+    def __init__(
+        self, file, mode="r", compression=ZIP_STORED, allowZip64=True, optimize=-1
+    ):
+        ZipFile.__init__(
+            self, file, mode=mode, compression=compression, allowZip64=allowZip64
+        )
+        self._optimize = optimize
+
+    def writepy(self, pathname, basename="", filterfunc=None):
+        """Add all files from "pathname" to the ZIP archive.
+
+        If pathname is a package directory, search the directory and
+        all package subdirectories recursively for all *.py and enter
+        the modules into the archive.  If pathname is a plain
+        directory, listdir *.py and enter all modules.  Else, pathname
+        must be a Python *.py file and the module will be put into the
+        archive.  Added modules are always module.pyc.
+        This method will compile the module.py into module.pyc if
+        necessary.
+        If filterfunc(pathname) is given, it is called with every argument.
+        When it is False, the file or directory is skipped.
+        """
+        pathname = os.fspath(pathname)
+        if filterfunc and not filterfunc(pathname):
+            if self.debug:
+                label = "path" if os.path.isdir(pathname) else "file"
+                print("%s %r skipped by filterfunc" % (label, pathname))
+            return
+        dir, name = os.path.split(pathname)
+        if os.path.isdir(pathname):
+            initname = os.path.join(pathname, "__init__.py")
+            if os.path.isfile(initname):
+                # This is a package directory, add it
+                if basename:
+                    basename = "%s/%s" % (basename, name)
+                else:
+                    basename = name
+                if self.debug:
+                    print("Adding package in", pathname, "as", basename)
+                fname, arcname = self._get_codename(initname[0:-3], basename)
+                if self.debug:
+                    print("Adding", arcname)
+                self.write(fname, arcname)
+                dirlist = sorted(os.listdir(pathname))
+                dirlist.remove("__init__.py")
+                # Add all *.py files and package subdirectories
+                for filename in dirlist:
+                    path = os.path.join(pathname, filename)
+                    root, ext = os.path.splitext(filename)
+                    if os.path.isdir(path):
+                        if os.path.isfile(os.path.join(path, "__init__.py")):
+                            # This is a package directory, add it
+                            self.writepy(
+                                path, basename, filterfunc=filterfunc
+                            )  # Recursive call
+                    elif ext == ".py":
+                        if filterfunc and not filterfunc(path):
+                            if self.debug:
+                                print("file %r skipped by filterfunc" % path)
+                            continue
+                        fname, arcname = self._get_codename(path[0:-3], basename)
+                        if self.debug:
+                            print("Adding", arcname)
+                        self.write(fname, arcname)
+            else:
+                # This is NOT a package directory, add its files at top level
+                if self.debug:
+                    print("Adding files from directory", pathname)
+                for filename in sorted(os.listdir(pathname)):
+                    path = os.path.join(pathname, filename)
+                    root, ext = os.path.splitext(filename)
+                    if ext == ".py":
+                        if filterfunc and not filterfunc(path):
+                            if self.debug:
+                                print("file %r skipped by filterfunc" % path)
+                            continue
+                        fname, arcname = self._get_codename(path[0:-3], basename)
+                        if self.debug:
+                            print("Adding", arcname)
+                        self.write(fname, arcname)
+        else:
+            if pathname[-3:] != ".py":
+                raise RuntimeError('Files added with writepy() must end with ".py"')
+            fname, arcname = self._get_codename(pathname[0:-3], basename)
+            if self.debug:
+                print("Adding file", arcname)
+            self.write(fname, arcname)
+
+    def _get_codename(self, pathname, basename):
+        """Return (filename, archivename) for the path.
+
+        Given a module name path, return the correct file path and
+        archive name, compiling if necessary.  For example, given
+        /python/lib/string, return (/python/lib/string.pyc, string).
+        """
+
+        def _compile(file, optimize=-1):
+            import py_compile
+
+            if self.debug:
+                print("Compiling", file)
+            try:
+                py_compile.compile(file, doraise=True, optimize=optimize)
+            except py_compile.PyCompileError as err:
+                print(err.msg)
+                return False
+            return True
+
+        file_py = pathname + ".py"
+        file_pyc = pathname + ".pyc"
+        pycache_opt0 = importlib.util.cache_from_source(file_py, optimization="")
+        pycache_opt1 = importlib.util.cache_from_source(file_py, optimization=1)
+        pycache_opt2 = importlib.util.cache_from_source(file_py, optimization=2)
+        if self._optimize == -1:
+            # legacy mode: use whatever file is present
+            if (
+                os.path.isfile(file_pyc)
+                and os.stat(file_pyc).st_mtime >= os.stat(file_py).st_mtime
+            ):
+                # Use .pyc file.
+                arcname = fname = file_pyc
+            elif (
+                os.path.isfile(pycache_opt0)
+                and os.stat(pycache_opt0).st_mtime >= os.stat(file_py).st_mtime
+            ):
+                # Use the __pycache__/*.pyc file, but write it to the legacy pyc
+                # file name in the archive.
+                fname = pycache_opt0
+                arcname = file_pyc
+            elif (
+                os.path.isfile(pycache_opt1)
+                and os.stat(pycache_opt1).st_mtime >= os.stat(file_py).st_mtime
+            ):
+                # Use the __pycache__/*.pyc file, but write it to the legacy pyc
+                # file name in the archive.
+                fname = pycache_opt1
+                arcname = file_pyc
+            elif (
+                os.path.isfile(pycache_opt2)
+                and os.stat(pycache_opt2).st_mtime >= os.stat(file_py).st_mtime
+            ):
+                # Use the __pycache__/*.pyc file, but write it to the legacy pyc
+                # file name in the archive.
+                fname = pycache_opt2
+                arcname = file_pyc
+            else:
+                # Compile py into PEP 3147 pyc file.
+                if _compile(file_py):
+                    if sys.flags.optimize == 0:
+                        fname = pycache_opt0
+                    elif sys.flags.optimize == 1:
+                        fname = pycache_opt1
+                    else:
+                        fname = pycache_opt2
+                    arcname = file_pyc
+                else:
+                    fname = arcname = file_py
+        else:
+            # new mode: use given optimization level
+            if self._optimize == 0:
+                fname = pycache_opt0
+                arcname = file_pyc
+            else:
+                arcname = file_pyc
+                if self._optimize == 1:
+                    fname = pycache_opt1
+                elif self._optimize == 2:
+                    fname = pycache_opt2
+                else:
+                    msg = "invalid value for 'optimize': {!r}".format(self._optimize)
+                    raise ValueError(msg)
+            if not (
+                os.path.isfile(fname)
+                and os.stat(fname).st_mtime >= os.stat(file_py).st_mtime
+            ):
+                if not _compile(file_py, optimize=self._optimize):
+                    fname = arcname = file_py
+        archivename = os.path.split(arcname)[1]
+        if basename:
+            archivename = "%s/%s" % (basename, archivename)
+        return (fname, archivename)
+
+
+def _parents(path):
+    """
+    Given a path with elements separated by
+    posixpath.sep, generate all parents of that path.
+
+    >>> list(_parents('b/d'))
+    ['b']
+    >>> list(_parents('/b/d/'))
+    ['/b']
+    >>> list(_parents('b/d/f/'))
+    ['b/d', 'b']
+    >>> list(_parents('b'))
+    []
+    >>> list(_parents(''))
+    []
+    """
+    return itertools.islice(_ancestry(path), 1, None)
+
+
+def _ancestry(path):
+    """
+    Given a path with elements separated by
+    posixpath.sep, generate all elements of that path
+
+    >>> list(_ancestry('b/d'))
+    ['b/d', 'b']
+    >>> list(_ancestry('/b/d/'))
+    ['/b/d', '/b']
+    >>> list(_ancestry('b/d/f/'))
+    ['b/d/f', 'b/d', 'b']
+    >>> list(_ancestry('b'))
+    ['b']
+    >>> list(_ancestry(''))
+    []
+    """
+    path = path.rstrip(posixpath.sep)
+    while path and path != posixpath.sep:
+        yield path
+        path, tail = posixpath.split(path)
+
+
+_dedupe = dict.fromkeys
+"""Deduplicate an iterable in original order"""
+
+
+def _difference(minuend, subtrahend):
+    """
+    Return items in minuend not in subtrahend, retaining order
+    with O(1) lookup.
+    """
+    return itertools.filterfalse(set(subtrahend).__contains__, minuend)
+
+
+class CompleteDirs(ZipFile):
+    """
+    A ZipFile subclass that ensures that implied directories
+    are always included in the namelist.
+    """
+
+    @staticmethod
+    def _implied_dirs(names):
+        parents = itertools.chain.from_iterable(map(_parents, names))
+        as_dirs = (p + posixpath.sep for p in parents)
+        return _dedupe(_difference(as_dirs, names))
+
+    def namelist(self):
+        names = super(CompleteDirs, self).namelist()
+        return names + list(self._implied_dirs(names))
+
+    def _name_set(self):
+        return set(self.namelist())
+
+    def resolve_dir(self, name):
+        """
+        If the name represents a directory, return that name
+        as a directory (with the trailing slash).
+        """
+        names = self._name_set()
+        dirname = name + "/"
+        dir_match = name not in names and dirname in names
+        return dirname if dir_match else name
+
+    @classmethod
+    def make(cls, source):
+        """
+        Given a source (filename or zipfile), return an
+        appropriate CompleteDirs subclass.
+        """
+        if isinstance(source, CompleteDirs):
+            return source
+
+        if not isinstance(source, ZipFile):
+            return cls(source)
+
+        # Only allow for FastPath when supplied zipfile is read-only
+        if "r" not in source.mode:
+            cls = CompleteDirs
+
+        res = cls.__new__(cls)
+        vars(res).update(vars(source))
+        return res
+
+
+class FastLookup(CompleteDirs):
+    """
+    ZipFile subclass to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+
+    def namelist(self):
+        with contextlib.suppress(AttributeError):
+            return self.__names
+        self.__names = super(FastLookup, self).namelist()
+        return self.__names
+
+    def _name_set(self):
+        with contextlib.suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super(FastLookup, self)._name_set()
+        return self.__lookup
+
+
+class Path:
+    """
+    A pathlib-compatible interface for zip files.
+
+    Consider a zip file with this structure::
+
+        .
+        ├── a.txt
+        └── b
+            ├── c.txt
+            └── d
+                └── e.txt
+
+    >>> data = io.BytesIO()
+    >>> zf = ZipFile(data, 'w')
+    >>> zf.writestr('a.txt', 'content of a')
+    >>> zf.writestr('b/c.txt', 'content of c')
+    >>> zf.writestr('b/d/e.txt', 'content of e')
+    >>> zf.filename = 'abcde.zip'
+
+    Path accepts the zipfile object itself or a filename
+
+    >>> root = Path(zf)
+
+    From there, several path operations are available.
+
+    Directory iteration (including the zip file itself):
+
+    >>> a, b = root.iterdir()
+    >>> a
+    Path('abcde.zip', 'a.txt')
+    >>> b
+    Path('abcde.zip', 'b/')
+
+    name property:
+
+    >>> b.name
+    'b'
+
+    join with divide operator:
+
+    >>> c = b / 'c.txt'
+    >>> c
+    Path('abcde.zip', 'b/c.txt')
+    >>> c.name
+    'c.txt'
+
+    Read text:
+
+    >>> c.read_text()
+    'content of c'
+
+    existence:
+
+    >>> c.exists()
+    True
+    >>> (b / 'missing.txt').exists()
+    False
+
+    Coercion to string:
+
+    >>> str(c)
+    'abcde.zip/b/c.txt'
+    """
+
+    __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
+
+    def __init__(self, root, at=""):
+        self.root = FastLookup.make(root)
+        self.at = at
+
+    def open(self, mode="r", *args, **kwargs):
+        """
+        Open this entry as text or binary following the semantics
+        of ``pathlib.Path.open()`` by passing arguments through
+        to io.TextIOWrapper().
+        """
+        pwd = kwargs.pop("pwd", None)
+        zip_mode = mode[0]
+        stream = self.root.open(self.at, zip_mode, pwd=pwd)
+        if "b" in mode:
+            if args or kwargs:
+                raise ValueError("encoding args invalid for binary operation")
+            return stream
+        return io.TextIOWrapper(stream, *args, **kwargs)
+
+    @property
+    def name(self):
+        return posixpath.basename(self.at.rstrip("/"))
+
+    def read_text(self, *args, **kwargs):
+        with self.open("r", *args, **kwargs) as strm:
+            return strm.read()
+
+    def read_bytes(self):
+        with self.open("rb") as strm:
+            return strm.read()
+
+    def _is_child(self, path):
+        return posixpath.dirname(path.at.rstrip("/")) == self.at.rstrip("/")
+
+    def _next(self, at):
+        return Path(self.root, at)
+
+    def is_dir(self):
+        return not self.at or self.at.endswith("/")
+
+    def is_file(self):
+        return not self.is_dir()
+
+    def exists(self):
+        return self.at in self.root._name_set()
+
+    def iterdir(self):
+        if not self.is_dir():
+            raise ValueError("Can't listdir a file")
+        subs = map(self._next, self.root.namelist())
+        return filter(self._is_child, subs)
+
+    def __str__(self):
+        return posixpath.join(self.root.filename, self.at)
+
+    def __repr__(self):
+        return self.__repr.format(self=self)
+
+    def joinpath(self, add):
+        next = posixpath.join(self.at, add)
+        return self._next(self.root.resolve_dir(next))
+
+    __truediv__ = joinpath
+
+    @property
+    def parent(self):
+        parent_at = posixpath.dirname(self.at.rstrip("/"))
+        if parent_at:
+            parent_at += "/"
+        return self._next(parent_at)
+
+
+def main(args=None):
+    import argparse
+
+    description = "A simple command-line interface for zipfile module."
+    parser = argparse.ArgumentParser(description=description)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-l", "--list", metavar="<zipfile>", help="Show listing of a zipfile"
+    )
+    group.add_argument(
+        "-e",
+        "--extract",
+        nargs=2,
+        metavar=("<zipfile>", "<output_dir>"),
+        help="Extract zipfile into target dir",
+    )
+    group.add_argument(
+        "-c",
+        "--create",
+        nargs="+",
+        metavar=("<name>", "<file>"),
+        help="Create zipfile from sources",
+    )
+    group.add_argument(
+        "-t", "--test", metavar="<zipfile>", help="Test if a zipfile is valid"
+    )
+    args = parser.parse_args(args)
+
+    if args.test is not None:
+        src = args.test
+        with ZipFile(src, "r") as zf:
+            badfile = zf.testzip()
+        if badfile:
+            print("The following enclosed file is corrupted: {!r}".format(badfile))
+        print("Done testing")
+
+    elif args.list is not None:
+        src = args.list
+        with ZipFile(src, "r") as zf:
+            zf.printdir()
+
+    elif args.extract is not None:
+        src, curdir = args.extract
+        with ZipFile(src, "r") as zf:
+            zf.extractall(curdir)
+
+    elif args.create is not None:
+        zip_name = args.create.pop(0)
+        files = args.create
+
+        def addToZip(zf, path, zippath):
+            if os.path.isfile(path):
+                zf.write(path, zippath, ZIP_DEFLATED)
+            elif os.path.isdir(path):
+                if zippath:
+                    zf.write(path, zippath)
+                for nm in sorted(os.listdir(path)):
+                    addToZip(zf, os.path.join(path, nm), os.path.join(zippath, nm))
+            # else: ignore
+
+        with ZipFile(zip_name, "w") as zf:
+            for path in files:
+                zippath = os.path.basename(path)
+                if not zippath:
+                    zippath = os.path.basename(os.path.dirname(path))
+                if zippath in ("", os.curdir, os.pardir):
+                    zippath = ""
+                addToZip(zf, path, zippath)
+
+
+if __name__ == "__main__":
+    main()

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -3,6 +3,9 @@ import sys
 
 import awkward
 
+from ..structures.core import StructureFamily
+from ..utils import modules_available
+
 if sys.version_info < (3, 9):
     # Python 3.8 has a bug in zipfile that is not easily matched. Import
     # zipfile from a copy of the Python 3.9.17 version, vendored in the tiled
@@ -12,9 +15,10 @@ else:
     import zipfile
 
 from ..media_type_registration import deserialization_registry, serialization_registry
+from ..utils import APACHE_ARROW_FILE_MIME_TYPE
 
 
-@serialization_registry.register("awkward", "application/zip")
+@serialization_registry.register(StructureFamily.awkward, "application/zip")
 def to_zipped_buffers(components, metadata):
     (form, length, container) = components
     file = io.BytesIO()
@@ -28,7 +32,7 @@ def to_zipped_buffers(components, metadata):
     return file.getbuffer()
 
 
-@deserialization_registry.register("awkward", "application/zip")
+@deserialization_registry.register(StructureFamily.awkward, "application/zip")
 def from_zipped_buffers(buffer, form, length):
     file = io.BytesIO(buffer)
     with zipfile.ZipFile(file, "r") as zip:
@@ -39,10 +43,41 @@ def from_zipped_buffers(buffer, form, length):
     return container
 
 
-@serialization_registry.register("awkward", "application/json")
+@serialization_registry.register(StructureFamily.awkward, "application/json")
 def to_json(components, metadata):
     (form, length, container) = components
     file = io.StringIO()
     array = awkward.from_buffers(form, length, container)
     awkward.to_json(array, file)
     return file.getvalue()
+
+
+if modules_available("pyarrow"):
+
+    @serialization_registry.register(
+        StructureFamily.awkward, APACHE_ARROW_FILE_MIME_TYPE
+    )
+    def to_arrow(components, metadata):
+        import pyarrow
+
+        (form, length, container) = components
+        array = awkward.from_buffers(form, length, container)
+        table = awkward.to_arrow_table(array)
+        sink = pyarrow.BufferOutputStream()
+        with pyarrow.ipc.new_file(sink, table.schema) as writer:
+            writer.write_table(table)
+        return memoryview(sink.getvalue())
+
+    # There seems to be no official Parquet MIME type.
+    # https://issues.apache.org/jira/browse/PARQUET-1889
+    @serialization_registry.register(StructureFamily.awkward, "application/x-parquet")
+    def to_parquet(components, metadata):
+        import pyarrow.parquet
+
+        (form, length, container) = components
+        array = awkward.from_buffers(form, length, container)
+        table = awkward.to_arrow_table(array)
+        sink = pyarrow.BufferOutputStream()
+        with pyarrow.parquet.ParquetWriter(sink, table.schema) as writer:
+            writer.write_table(table)
+        return memoryview(sink.getvalue())

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -1,6 +1,8 @@
 import io
 import sys
 
+import awkward
+
 if sys.version_info < (3, 9):
     # Python 3.8 has a bug in zipfile that is not easily matched. Import
     # zipfile from a copy of the Python 3.9.17 version, vendored in the tiled
@@ -13,7 +15,8 @@ from ..media_type_registration import deserialization_registry, serialization_re
 
 
 @serialization_registry.register("awkward", "application/zip")
-def to_zipped_buffers(container, metadata):
+def to_zipped_buffers(components, metadata):
+    (form, length, container) = components
     file = io.BytesIO()
     # Pack multiple buffers into a zipfile, uncompressed. This enables
     # multiple buffers in a single response, with random access. The
@@ -26,11 +29,20 @@ def to_zipped_buffers(container, metadata):
 
 
 @deserialization_registry.register("awkward", "application/zip")
-def from_zipped_buffers(buffer):
+def from_zipped_buffers(buffer, form, length):
     file = io.BytesIO(buffer)
     with zipfile.ZipFile(file, "r") as zip:
         form_keys = zip.namelist()
-        buffers = {}
+        container = {}
         for form_key in form_keys:
-            buffers[form_key] = zip.read(form_key)
-    return buffers
+            container[form_key] = zip.read(form_key)
+    return container
+
+
+@serialization_registry.register("awkward", "application/json")
+def to_json(components, metadata):
+    (form, length, container) = components
+    file = io.StringIO()
+    array = awkward.from_buffers(form, length, container)
+    awkward.to_json(array, file)
+    return file.getvalue()

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -1,5 +1,13 @@
 import io
-import zipfile
+import sys
+
+if sys.version_info < (3, 9):
+    # Python 3.8 has a bug in zipfile that is not easily matched. Import
+    # zipfile from a copy of the Python 3.9.17 version, vendored in the tiled
+    # source.
+    from . import _zipfile_py39 as zipfile
+else:
+    import zipfile
 
 from ..media_type_registration import deserialization_registry, serialization_registry
 

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -1,0 +1,28 @@
+import io
+import zipfile
+
+from ..media_type_registration import deserialization_registry, serialization_registry
+
+
+@serialization_registry.register("awkward", "application/zip")
+def to_zipped_buffers(container, metadata):
+    file = io.BytesIO()
+    # Pack multiple buffers into a zipfile, uncompressed. This enables
+    # multiple buffers in a single response, with random access. The
+    # entire payload *may* be compressed using Tiled's normal compression
+    # mechanisms.
+    with zipfile.ZipFile(file, "w", compresslevel=zipfile.ZIP_STORED) as zip:
+        for form_key, buffer in container.items():
+            zip.writestr(form_key, buffer)
+    return file.getbuffer()
+
+
+@deserialization_registry.register("awkward", "application/zip")
+def from_zipped_buffers(buffer):
+    file = io.BytesIO(buffer)
+    with zipfile.ZipFile(file, "r") as zip:
+        form_keys = zip.namelist()
+        buffers = {}
+        for form_key in form_keys:
+            buffers[form_key] = zip.read(form_key)
+    return buffers

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -527,6 +527,8 @@ async def construct_resource(
                 links[
                     "partition"
                 ] = f"{base_url}/table/partition/{path_str}?partition={{index}}"
+            elif entry.structure_family == StructureFamily.awkward:
+                links["buffers"] = f"{base_url}/awkward/buffers/{path_str}"
             if schemas.EntryFields.structure in fields:
                 attributes["structure"] = structure
         else:

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -243,6 +243,7 @@ async def construct_entries_response(
 
 DEFAULT_MEDIA_TYPES = {
     StructureFamily.array: {"*/*": "application/octet-stream", "image/*": "image/png"},
+    StructureFamily.awkward: {"*/*": "application/zip"},
     StructureFamily.table: {"*/*": APACHE_ARROW_FILE_MIME_TYPE},
     StructureFamily.container: {"*/*": "application/x-hdf5"},
     StructureFamily.sparse: {"*/*": APACHE_ARROW_FILE_MIME_TYPE},
@@ -708,8 +709,9 @@ class WrongTypeForRoute(Exception):
 
 
 FULL_LINKS = {
-    StructureFamily.container: {"full": "{base_url}/node/full/{path}"},
     StructureFamily.array: {"full": "{base_url}/array/full/{path}"},
+    StructureFamily.awkward: {"full": "{base_url}/awkward/full/{path}"},
+    StructureFamily.container: {"full": "{base_url}/node/full/{path}"},
     StructureFamily.table: {"full": "{base_url}/node/full/{path}"},
     StructureFamily.sparse: {"full": "{base_url}/array/full/{path}"},
 }

--- a/tiled/server/pydantic_awkward.py
+++ b/tiled/server/pydantic_awkward.py
@@ -1,10 +1,12 @@
+from typing import List
+
 import pydantic
 
 
 class AwkwardStructure(pydantic.BaseModel):
     length: int
     form: dict
-    suffixed_form_keys: list[str]
+    suffixed_form_keys: List[str]
 
     @classmethod
     def from_json(cls, structure):

--- a/tiled/server/pydantic_awkward.py
+++ b/tiled/server/pydantic_awkward.py
@@ -1,0 +1,11 @@
+import pydantic
+
+
+class AwkwardStructure(pydantic.BaseModel):
+    length: int
+    form: dict
+    suffixed_form_keys: list[str]
+
+    @classmethod
+    def from_json(cls, structure):
+        return cls(**structure)

--- a/tiled/server/pydantic_awkward.py
+++ b/tiled/server/pydantic_awkward.py
@@ -1,12 +1,9 @@
-from typing import List
-
 import pydantic
 
 
 class AwkwardStructure(pydantic.BaseModel):
     length: int
     form: dict
-    suffixed_form_keys: List[str]
 
     @classmethod
     def from_json(cls, structure):

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -604,14 +604,13 @@ async def node_full(
 
 
 @router.get(
-    "/awkward/full/{path:path}",
+    "/awkward/buffers/{path:path}",
     response_model=schemas.Response,
-    name="full awkward array",
+    name="AwkwardArray buffers",
 )
-async def awkward_full(
+async def awkward_buffers(
     request: Request,
     entry=SecureEntry(scopes=["read:data"]),
-    # slice=Depends(slice_),
     form_key: Optional[List[str]] = Query(None, min_length=1),
     format: Optional[str] = None,
     filename: Optional[str] = None,
@@ -625,7 +624,7 @@ async def awkward_full(
     if structure_family != StructureFamily.awkward:
         raise HTTPException(
             status_code=404,
-            detail=f"Cannot read {entry.structure_family} structure with /awkwrad/full route.",
+            detail=f"Cannot read {entry.structure_family} structure with /awkward/buffers route.",
         )
     with record_timing(request.state.metrics, "read"):
         # The plural vs. singular mismatch is due to the way query parameters
@@ -741,6 +740,7 @@ async def post_metadata(
         links["full"] = f"{base_url}/node/full/{path_str}"
         links["search"] = f"{base_url}/search/{path_str}"
     elif body.structure_family == StructureFamily.awkward:
+        links["buffers"] = f"{base_url}/awkward/buffers/{path_str}"
         links["full"] = f"{base_url}/awkward/full/{path_str}"
     else:
         raise NotImplementedError(body.structure_family)

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -12,6 +12,7 @@ import pydantic.generics
 
 from ..structures.core import StructureFamily
 from .pydantic_array import ArrayStructure
+from .pydantic_awkward import AwkwardStructure
 from .pydantic_sparse import SparseStructure
 from .pydantic_table import TableStructure
 
@@ -122,7 +123,13 @@ class Revision(pydantic.BaseModel):
 class DataSource(pydantic.BaseModel):
     id: Optional[int] = None
     structure: Optional[
-        Union[ArrayStructure, TableStructure, NodeStructure, SparseStructure]
+        Union[
+            ArrayStructure,
+            AwkwardStructure,
+            TableStructure,
+            NodeStructure,
+            SparseStructure,
+        ]
     ] = None
     mimetype: Optional[str] = None
     parameters: dict = {}
@@ -147,7 +154,13 @@ class NodeAttributes(pydantic.BaseModel):
     specs: Optional[Specs]
     metadata: Optional[Dict]  # free-form, user-specified dict
     structure: Optional[
-        Union[ArrayStructure, TableStructure, NodeStructure, SparseStructure]
+        Union[
+            ArrayStructure,
+            AwkwardStructure,
+            TableStructure,
+            NodeStructure,
+            SparseStructure,
+        ]
     ]
     sorting: Optional[List[SortingItem]]
     data_sources: Optional[List[DataSource]]
@@ -174,6 +187,11 @@ class ArrayLinks(pydantic.BaseModel):
     block: str
 
 
+class AwkwardLinks(pydantic.BaseModel):
+    self: str
+    full: str
+
+
 class DataFrameLinks(pydantic.BaseModel):
     self: str
     full: str
@@ -189,6 +207,7 @@ class SparseLinks(pydantic.BaseModel):
 resource_links_type_by_structure_family = {
     StructureFamily.container: ContainerLinks,
     StructureFamily.array: ArrayLinks,
+    StructureFamily.awkward: AwkwardLinks,
     StructureFamily.table: DataFrameLinks,
     StructureFamily.sparse: SparseLinks,
 }

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -189,6 +189,7 @@ class ArrayLinks(pydantic.BaseModel):
 
 class AwkwardLinks(pydantic.BaseModel):
     self: str
+    buffers: str
     full: str
 
 

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+import awkward
+
+
+@dataclass
+class AwkwardStructure:
+    length: int
+    form: dict
+    suffixed_form_keys: list[str]
+
+    @classmethod
+    def from_json(cls, structure):
+        return cls(**structure)
+
+
+def project_form(form, form_keys_touched):
+    # See https://github.com/bluesky/tiled/issues/450
+    if isinstance(form, awkward.forms.RecordForm):
+        if form.fields is None:
+            original_fields = [None] * len(form.contents)
+        else:
+            original_fields = form.fields
+
+        fields = []
+        contents = []
+        for field, content in zip(original_fields, form.contents):
+            projected = project_form(content, form_keys_touched)
+            if projected is not None:
+                fields.append(field)
+                contents.append(content)
+
+        if form.fields is None:
+            fields = None
+
+        return form.copy(fields=fields, contents=contents)
+
+    elif isinstance(form, awkward.forms.UnionForm):
+        raise NotImplementedError
+
+    elif isinstance(form, (awkward.forms.NumpyForm, awkward.forms.EmptyForm)):
+        if form.form_key in form_keys_touched:
+            return form.copy()
+        else:
+            return None
+
+    else:
+        if form.form_key in form_keys_touched:
+            return form.copy(content=project_form(form.content, form_keys_touched))
+        else:
+            return None

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 import awkward
 
@@ -7,7 +8,7 @@ import awkward
 class AwkwardStructure:
     length: int
     form: dict
-    suffixed_form_keys: list[str]
+    suffixed_form_keys: List[str]
 
     @classmethod
     def from_json(cls, structure):

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -42,6 +42,10 @@ def project_form(form, form_keys_touched):
         elif len(step2) == 1:
             return step2[0]
         else:
+            raise NotImplementedError(
+                "Certain UnionForms are not yet supported. "
+                "See https://github.com/scikit-hep/awkward/issues/2666"
+            )
             return awkward.forms.UnionForm.simplified(
                 form.tags,
                 form.index,

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -65,33 +65,3 @@ def project_form(form, form_keys_touched):
             return form.copy(content=project_form(form.content, form_keys_touched))
         else:
             return None
-
-
-ATTRIBUTES_BY_CLASS = {
-    "NumpyArray": ["data"],
-    "EmptyArray": [],
-    "ListOffsetArray": ["offsets"],
-    "ListArray": ["starts", "stops"],
-    "RegularArray": [],
-    "IndexedArray": ["index"],
-    "IndexedOptionArray": ["index"],
-    "ByteMaskedArray": ["mask"],
-    "BitMaskedArray": ["mask"],
-    "UnmaskedArray": [],
-    "RecordArray": [],
-    "UnionArray": ["tags", "index"],
-}
-
-
-def suffixed_form_keys(form):
-    "Given a form, extract suffixed form keys like 'node0-data'."
-    result = []
-    attributes = ATTRIBUTES_BY_CLASS[form["class"]]
-    for attribute in attributes:
-        result.append(f"{form['form_key']}-{attribute}")
-    if "content" in form:
-        result.extend(suffixed_form_keys(form["content"]))
-    elif "contents" in form:
-        for content in form["contents"]:
-            result.extend(suffixed_form_keys(content))
-    return result

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 
 import awkward
 
@@ -8,7 +7,6 @@ import awkward
 class AwkwardStructure:
     length: int
     form: dict
-    suffixed_form_keys: List[str]
 
     @classmethod
     def from_json(cls, structure):
@@ -50,3 +48,33 @@ def project_form(form, form_keys_touched):
             return form.copy(content=project_form(form.content, form_keys_touched))
         else:
             return None
+
+
+ATTRIBUTES_BY_CLASS = {
+    "NumpyArray": ["data"],
+    "EmptyArray": [],
+    "ListOffsetArray": ["offsets"],
+    "ListArray": ["starts", "stops"],
+    "RegularArray": [],
+    "IndexedArray": ["index"],
+    "IndexedOptionArray": ["index"],
+    "ByteMaskedArray": ["mask"],
+    "BitMaskedArray": ["mask"],
+    "UnmaskedArray": [],
+    "RecordArray": [],
+    "UnionArray": ["tags", "index"],
+}
+
+
+def suffixed_form_keys(form):
+    "Given a form, extract suffixed form keys like 'node0-data'."
+    result = []
+    attributes = ATTRIBUTES_BY_CLASS[form["class"]]
+    for attribute in attributes:
+        result.append(f"{form['form_key']}-{attribute}")
+    if "content" in form:
+        result.extend(suffixed_form_keys(form["content"]))
+    elif "contents" in form:
+        for content in form["contents"]:
+            result.extend(suffixed_form_keys(content))
+    return result

--- a/tiled/structures/awkward.py
+++ b/tiled/structures/awkward.py
@@ -35,7 +35,20 @@ def project_form(form, form_keys_touched):
         return form.copy(fields=fields, contents=contents)
 
     elif isinstance(form, awkward.forms.UnionForm):
-        raise NotImplementedError
+        step1 = [project_form(x, form_keys_touched) for x in form.contents]
+        step2 = [x for x in step1 if x is not None]
+        if len(step2) == 0:
+            return None
+        elif len(step2) == 1:
+            return step2[0]
+        else:
+            return awkward.forms.UnionForm.simplified(
+                form.tags,
+                form.index,
+                step2,
+                parameters=form.parameters,
+                form_key=form.form_key,
+            )
 
     elif isinstance(form, (awkward.forms.NumpyForm, awkward.forms.EmptyForm)):
         if form.form_key in form_keys_touched:

--- a/tiled/structures/core.py
+++ b/tiled/structures/core.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 
 class StructureFamily(str, enum.Enum):
+    awkward = "awkward"
     container = "container"
     array = "array"
     sparse = "sparse"


### PR DESCRIPTION
First crack at #450. This uses the `project_form` approach that @jpivarski sketched back in May.

To take this PR branch for a spin...

```
pip install -e .[server,client]
```

Start a Tiled server. Using a stable API key (instead of random cryptographic) is nice for development.

```
TILED_SINGLE_USER_API_KEY=secret tiled serve catalog --temp
```

Use it from the Python client.

```py
import awkward as ak
from tiled.client import from_uri

c = from_uri("http://localhost:8000", api_key="secret")
array = ak.Array(
    [[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}], [], [{"x": 3.3, "y": [1, 2, 3]}]]
)

# This sends two requests: (1) metadata and structure as JSON (2) zipped buffers
# The buffers could (later) be chunked across multiple requests / parallelized as we do for plain arrays.
c.write_awkward(array, key="test")

# This could be in a separate process to fully illustrate sharing the data between processes...
aac = c["test"]
aac.read()
aac[:]  # equivalent to read()
aac[0, "y", 1:]  # fetches only the form keys it needs, fewer bytes transferred
```

It may be more interesting to use `metadata` to make the data findable, instead of or in addition to giving it a `key`. (If the `key` is unspecified, a UUID4 key is provided by the server.)

```py
c.write_awkward(array, metadata={"color": "blue"})
from tiled.queries import Key
c.search(Key("color") == "blue")
c.search(Key("color") == "blue").values().first().read()
```

The messages written to stderr by the server at startup include the location of the temp dir being used. There, we can find the buffers:

```
$ ls /tmp/tmphxumip5h/data
total 27
drwxrwxr-x 3 dallan dallan 3 Aug  8 23:06 ./
drwxrwxr-x 3 dallan dallan 4 Aug  8 23:06 ../
drwxrwxr-x 2 dallan dallan 6 Aug  8 23:06 test/
$ ls /tmp/tmphxumip5h/data/test/
total 38
drwxrwxr-x 2 dallan dallan  6 Aug  8 23:06 ./
drwxrwxr-x 3 dallan dallan  3 Aug  8 23:06 ../
-rw-rw-r-- 1 dallan dallan 32 Aug  8 23:06 node0-offsets
-rw-rw-r-- 1 dallan dallan 24 Aug  8 23:06 node2-data
-rw-rw-r-- 1 dallan dallan 32 Aug  8 23:06 node3-offsets
-rw-rw-r-- 1 dallan dallan 48 Aug  8 23:06 node4-data
```

and the SQLite database:

```
$ sqlite3 /tmp/tmphxumip5h/catalog.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> .mode columns
sqlite> select * from nodes;
id  key                                   ancestors  structure_family  metadata          specs  time_created         time_updated       
--  ------------------------------------  ---------  ----------------  ----------------  -----  -------------------  -------------------
1   test                                  []         awkward           {}                []     2023-08-09 03:06:50  2023-08-09 03:06:50
2   14c2ccde-3b0b-4f31-b5b2-b772b7932a26  []         awkward           {"color":"blue"}  []     2023-08-09 03:09:49  2023-08-09 03:09:49
sqlite> select * from data_sources;
id  node_id  structure                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          mimetype         parameters  management  time_created         time_updated       
--  -------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------  ----------  ----------  -------------------  -------------------
1   1        {"length":3,"form":{"class":"ListOffsetArray","offsets":"i64","content":{"class":"RecordArray","fields":["x","y"],"contents":[{"class":"NumpyArray","primitive":"float64","inner_shape":[],"parameters":{},"form_key":"node2"},{"class":"ListOffsetArray","offsets":"i64","content":{"class":"NumpyArray","primitive":"int64","inner_shape":[],"parameters":{},"form_key":"node4"},"parameters":{},"form_key":"node3"}],"parameters":{},"form_key":"node1"},"parameters":{},"form_key":"node0"},"suffixed_form_keys":["node0-offsets","node2-data","node3-offsets","node4-data"]}  application/zip  {}          writable    2023-08-09 03:06:50  2023-08-09 03:06:50
2   2        {"length":3,"form":{"class":"ListOffsetArray","offsets":"i64","content":{"class":"RecordArray","fields":["x","y"],"contents":[{"class":"NumpyArray","primitive":"float64","inner_shape":[],"parameters":{},"form_key":"node2"},{"class":"ListOffsetArray","offsets":"i64","content":{"class":"NumpyArray","primitive":"int64","inner_shape":[],"parameters":{},"form_key":"node4"},"parameters":{},"form_key":"node3"}],"parameters":{},"form_key":"node1"},"parameters":{},"form_key":"node0"},"suffixed_form_keys":["node0-offsets","node2-data","node3-offsets","node4-data"]}  application/zip  {}          writable    2023-08-09 03:09:49  2023-08-09 03:09:49
sqlite> select * from assets;
id  data_uri                                                                    is_directory  hash_type  hash_content  size  time_created         time_updated       
--  --------------------------------------------------------------------------  ------------  ---------  ------------  ----  -------------------  -------------------
1   file://localhost/tmp/tmphxumip5h/data/test                                  1                                            2023-08-09 03:06:50  2023-08-09 03:06:50
2   file://localhost/tmp/tmphxumip5h/data/14c2ccde-3b0b-4f31-b5b2-b772b7932a26  1                                            2023-08-09 03:09:49  2023-08-09 03:09:49
```

The writing feature in general has only been around since early summer, so there are sure to be bugs, but it's a start. More context, including how to start a server with persistent storage, is [in the docs](https://blueskyproject.io/tiled/tutorials/writing.html).

One question: Is there a clever way to associate the "form keys" like `node0` with their suffixed variants like `node0-offsets`? To get something working, I opted to store `suffixed_form_keys` (list of strings) alongside the JSON `form` and the `length`. That works fine, but there may be a better way.