### PR TITLE
Fixed search error in the documentation frontend

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx_click",
     "sphinx_copybutton",
     "myst_parser",
+    "sphinxcontrib.jquery",
 ]
 
 # Configuration options for plot_directive. See:
@@ -208,7 +209,6 @@ import yaml
 
 
 def generate_schema_documentation(header, schema, target):
-
     # header
     with open(header, "r") as f:
         header_md = f.readlines()


### PR DESCRIPTION
This PR solve a search error in the documentation frontend, where any time a query was requested from the search bar, the website stayed hanging and never showed the results; it showed the searching message indefinitely and the error message in the browser was "Uncaught ReferenceError: jQuery is not defined".

