### PR TITLE
Use double quotes in installation instructions

### DIFF
--- a/docs/source/tutorials/installation.rst
+++ b/docs/source/tutorials/installation.rst
@@ -27,42 +27,21 @@ Install Tiled from PyPI using pip.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[all]'
+   python3 -m pip install "tiled[all]"
 
 If you are connecting to an existing to a tiled server as a client, there
 is not need to install all the server-related dependencies.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[client]'  # client only
+   python3 -m pip install "tiled[client]"  # client only
 
 Likewise, if you are deploying a tiled server but not using the client, you can
 skip a couple client-related dependencies.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[server]'  # server only
-
-.. warning::
-
-   We use single quotes in the installation commands, as in:
-
-   .. code:: bash
-
-      python3 -m pip install 'tiled[all]'
-
-   On MacOS, you MUST include the single quotes.
-   On Windows, you MUST NOT include them; you should instead do:
-
-   .. code:: bash
-
-      python3 -m pip install tiled[all]
-
-   On Linux, you may include them or omit them; it works the same either way.
-
-   (This difference between Mac and Linux is not due to the operating system *per
-   se*. It just happens that modern MacOS systems ship with zsh as the default
-   shell, whereas Linux typically ships with bash.)
+   python3 -m pip install "tiled[server]"  # server only
 
 Minimal Installation (fewer dependencies)
 -----------------------------------------
@@ -75,8 +54,8 @@ exploring metadata.
 
 .. code:: bash
 
-   python3 -m pip install 'tiled[minimal-client]'
-   python3 -m pip install 'tiled[minimal-server]'
+   python3 -m pip install "tiled[minimal-client]"
+   python3 -m pip install "tiled[minimal-server]"
 
 See lists of dependencies in `pyproject.toml` in the repository root for
 details.
@@ -90,7 +69,7 @@ To install an editable installation for local development:
 
    git clone https://github.com/bluesky/tiled
    cd tiled
-   pip install -e '.[all]'
+   pip install -e ".[all]"
 
 Web UI
 ------

--- a/share/tiled/templates/index.html
+++ b/share/tiled/templates/index.html
@@ -21,7 +21,7 @@
     <h2 class="subtitle">
       Install and use Tiled's Python client from Python, IPython, or Jupyter.
     </h2>
-    <pre><code>$ pip install tiled[client]
+    <pre><code>$ pip install "tiled[client]"
 $ python
 >>> from tiled.client import from_uri
 >>> client = from_uri("{{ root_url }}")</code></pre>


### PR DESCRIPTION
Usage like:

```
pip intsall "tiled[client]"
```

works in the Linux default shell (bash), Mac default shell (`zsh`), and Windows command prompt. Using no quotes breaks in `zsh` and using single quotes breaks on Windows.