### PR TITLE
Allow digits in tiff-sequence file names

### DIFF
--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -61,6 +61,28 @@ def test_tiff_sequence_block(client, block_input, correct_shape):
 
 
 @pytest.mark.asyncio
+async def test_tiff_sequence_order(tmpdir):
+    """
+    directory/
+      00001.tif
+      00002.tif
+      ...
+      00010.tif
+    """
+    data = numpy.ones((4, 5))
+    num_files = 10
+    for i in range(num_files):
+        tf.imwrite(Path(tmpdir / f"image{i:05}.tif"), data * i)
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(adapter)) as context:
+        await register(adapter, tmpdir)
+        client = from_context(context)
+        for i in range(num_files):
+            numpy.testing.assert_equal(client["image"][i], data * i)
+
+
+@pytest.mark.asyncio
 async def test_tiff_sequence_with_directory_walker(tmpdir):
     """
     directory/

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -91,7 +91,7 @@ class TiffSequenceAdapter:
         specs=None,
         access_policy=None,
     ):
-        seq = tifffile.TiffSequence(files)
+        seq = tifffile.TiffSequence(sorted(files))
         return cls(
             seq,
             structure=structure,

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -317,9 +317,9 @@ async def register_single_item(
     )
 
 
-# Matches filename with (optional) non-digits \D followed by digits \d
+# Matches filename with (optional) prefix characters followed by digits \d
 # and then the file extension .tif or .tiff.
-TIFF_SEQUENCE_STEM_PATTERN = re.compile(r"^(\D*)(\d+)\.(?:tif|tiff)$")
+TIFF_SEQUENCE_STEM_PATTERN = re.compile(r"^(.*?)(\d+)\.(?:tif|tiff)$")
 
 
 async def tiff_sequence(


### PR DESCRIPTION
Expands possible file name patters recognized as a tiff sequence to those including numbers, e.g.  `run2_20230823_0001.tiff`,`run2_20230823_0002.tiff`, ... to be registered as a node `run2_20230823_`

Sequences not containing any prefix (`0000.tif`, `0001.tif`, ...) or with a prefix containing just non-digits are still treated as before.