### PR TITLE
Fix zstandard decoding.

### DIFF
--- a/tiled/client/decoders.py
+++ b/tiled/client/decoders.py
@@ -34,9 +34,10 @@ if modules_available("zstandard"):
     class ZStandardDecoder:
         def __init__(self):
             self._context = zstandard.ZstdDecompressor()
+            self._obj = self._context.decompressobj()
 
         def decode(self, data: bytes) -> bytes:
-            return self._context.decompress(data)
+            return self._obj.decompress(data)
 
         def flush(self) -> bytes:
             return b""


### PR DESCRIPTION
The `ZStandardDecoder` was using a `zstandard` API that [required at least 1 full ZStandard frame](https://python-zstandard.readthedocs.io/en/latest/decompressor.html#zstandard.ZstdDecompressor.decompress). But httpx will feed it arbitrary chunks of bytes, which may well not correspond to ZStandard frames. If the data is small enough that it happens to be sent in one chunk, this does not come up. But for responses that span multiple chunks, we get:

```
ZstdError: decompression error: did not decompress full frame
```

(A work-around: uninstall `zstandard`, and then the client won't try to use it.)

Therefore we need a more tolerant API. The `zstandard` docs emphasize that this is less efficient---it costs extra memory allocations---but it's the only API they offer that works for our use case, I believe. In any case, this is only applied to metadata responses, not large data payloads, so the stakes are low.

I could not figure out how to finesse a unit test. Sending a large payload didn't work; it seemed to be processed in one chunk regardless of size. I'll open an issue. I don't think that should block merging this critical fix.

On `main` branch:

```py
In [1]: from tiled.client import from_profile

In [2]: c = from_profile('demo')

In [3]: c['rsoxs']['raw']
...
ZstdError: decompression error: did not decompress full frame
```

With this PR:

```py
In [1]: from tiled.client import from_profile

In [2]: c = from_profile('demo')

In [3]: c['rsoxs']['raw']
Out[3]: <Catalog {40000, 40001, 40002, 40003, 40004, 40005, 40006, ...} ~107 entries>
```