### PR TITLE
Consistently access metadata as a method across the project

### DIFF
--- a/docs/source/how-to/custom-clients.md
+++ b/docs/source/how-to/custom-clients.md
@@ -26,8 +26,8 @@ Suppose data labeled with the `xdi` spec is guaranteed to have a metadata
 dictionary containing the following two entries:
 
 ```py
-x.metadata["XDI"]["Element"]["Symbol"]
-x.metadata["XDI"]["Element"]["Edge"]
+x.metadata()["XDI"]["Element"]["Symbol"]
+x.metadata()["XDI"]["Element"]["Edge"]
 ```
 
 When the Tiled client encounters this type of data, we would like to hand
@@ -48,7 +48,7 @@ class XDIDatasetClient(tiled.client.dataframe.DataFrameClient):
         assert self.item["attributes"]["structure_family"] == "table"
 
     def __repr__(self):
-        md = self.metadata["XDI"]
+        md = self.metadata()["XDI"]
         return f'<{x.item["id"]} {md["Element"]["Symbol"]} {md["Element"]["Edge"]}>'
 ```
 
@@ -159,7 +159,7 @@ to quickly access certain metadata.
 class CustomClient(...):
     @property
     def element(self):
-        return self.metadata["XDI"]["Element"]["Symbol"]
+        return self.metadata()["XDI"]["Element"]["Symbol"]
 ```
 
 We can add convenience methods that read certain sections of the data and perhaps do

--- a/docs/source/tutorials/navigation.md
+++ b/docs/source/tutorials/navigation.md
@@ -132,15 +132,15 @@ and `(key, value)` pairs ("items").
 [('tiny_image', <ArrayClient>),
 ```
 
-Each item has ``metadata``, which is a simple dict.
+Each item has ``metadata`` method, which returns a simple dict.
 The content of this dict has no special meaning to Tiled; it's the user's
 space to use or not.
 
 ```python
->>> client.metadata  # happens to be empty
+>>> client.metadata()  # happens to be empty
 DictView({})
 
->>> client['short_table'].metadata  # happens to have some stuff
+>>> client['short_table'].metadata()  # happens to have some stuff
 DictView({'animal': 'dog', 'color': 'red'})
 ```
 

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -197,7 +197,7 @@ def test_create_and_update_allowed(enter_password, context):
     # Update
     alice_client["c"]["x"].metadata
     alice_client["c"]["x"].update_metadata(metadata={"added_key": 3})
-    assert alice_client["c"]["x"].metadata["added_key"] == 3
+    assert alice_client["c"]["x"].metadata()["added_key"] == 3
 
     # Create
     alice_client["c"].write_array([1, 2, 3])

--- a/tiled/_tests/test_client.py
+++ b/tiled/_tests/test_client.py
@@ -87,33 +87,35 @@ def test_jump_down_tree():
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
     assert (
-        client["e"]["d"]["c"]["b"]["a"].metadata["number"]
-        == client["e", "d", "c", "b", "a"].metadata["number"]
+        client["e"]["d"]["c"]["b"]["a"].metadata()["number"]
+        == client["e", "d", "c", "b", "a"].metadata()["number"]
         == 1
     )
     assert (
-        client["e"]["d"]["c"]["b"].metadata["number"]
-        == client["e", "d", "c", "b"].metadata["number"]
+        client["e"]["d"]["c"]["b"].metadata()["number"]
+        == client["e", "d", "c", "b"].metadata()["number"]
         == 2
     )
     assert (
-        client["e"]["d"]["c"].metadata["number"]
-        == client["e", "d", "c"].metadata["number"]
+        client["e"]["d"]["c"].metadata()["number"]
+        == client["e", "d", "c"].metadata()["number"]
         == 3
     )
     assert (
-        client["e"]["d"].metadata["number"] == client["e", "d"].metadata["number"] == 4
+        client["e"]["d"].metadata()["number"]
+        == client["e", "d"].metadata()["number"]
+        == 4
     )
 
-    assert client["e"]["d", "c", "b"]["a"].metadata["number"] == 1
-    assert client["e"]["d", "c", "b", "a"].metadata["number"] == 1
-    assert client["e", "d", "c", "b"]["a"].metadata["number"] == 1
+    assert client["e"]["d", "c", "b"]["a"].metadata()["number"] == 1
+    assert client["e"]["d", "c", "b", "a"].metadata()["number"] == 1
+    assert client["e", "d", "c", "b"]["a"].metadata()["number"] == 1
     assert (
-        client.search(Key("number") == 5)["e", "d", "c", "b", "a"].metadata["number"]
+        client.search(Key("number") == 5)["e", "d", "c", "b", "a"].metadata()["number"]
         == 1
     )
     assert (
-        client["e"].search(Key("number") == 4)["d", "c", "b", "a"].metadata["number"]
+        client["e"].search(Key("number") == 4)["d", "c", "b", "a"].metadata()["number"]
         == 1
     )
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -146,7 +146,7 @@ def test_comparison(client):
 
 
 def test_contains(client):
-    if client.metadata["backend"] == "postgresql":
+    if client.metadata()["backend"] == "postgresql":
 
         def cm():
             return fail_with_status_code(400)
@@ -158,7 +158,7 @@ def test_contains(client):
 
 
 def test_full_text(client):
-    if client.metadata["backend"] in {"postgresql", "sqlite"}:
+    if client.metadata()["backend"] in {"postgresql", "sqlite"}:
 
         def cm():
             return fail_with_status_code(400)
@@ -170,7 +170,7 @@ def test_full_text(client):
 
 
 def test_regex(client):
-    if client.metadata["backend"] in {"postgresql", "sqlite"}:
+    if client.metadata()["backend"] in {"postgresql", "sqlite"}:
 
         def cm():
             return fail_with_status_code(400)
@@ -215,7 +215,7 @@ def test_not_and_and_or(client):
     ],
 )
 def test_in(client, query_values):
-    if client.metadata["backend"] == "postgresql":
+    if client.metadata()["backend"] == "postgresql":
 
         def cm():
             return fail_with_status_code(400)
@@ -240,7 +240,7 @@ def test_in(client, query_values):
     ],
 )
 def test_notin(client, query_values):
-    if client.metadata["backend"] == "postgresql":
+    if client.metadata()["backend"] == "postgresql":
 
         def cm():
             return fail_with_status_code(400)
@@ -263,7 +263,7 @@ def test_notin(client, query_values):
     ],
 )
 def test_specs(client, include_values, exclude_values):
-    if client.metadata["backend"] in {"postgresql", "sqlite"}:
+    if client.metadata()["backend"] in {"postgresql", "sqlite"}:
 
         def cm():
             return fail_with_status_code(400)

--- a/tiled/_tests/test_search.py
+++ b/tiled/_tests/test_search.py
@@ -53,8 +53,8 @@ def test_compound_search(client):
 
 def test_key_into_results(client):
     results = client.search(FullText("dog"))
-    assert "apple" in results["a"].metadata
-    assert "banana" in results["b"].metadata
+    assert "apple" in results["a"].metadata()
+    assert "banana" in results["b"].metadata()
     assert "c" not in results  # This *is* in the tree but not among the results.
 
 
@@ -69,4 +69,4 @@ def test_compound_key_into_results():
     with Context.from_app(app) as context:
         client = from_context(context)
         result = client.search(FullText("hot"))["i", "X", "a"]
-        assert "apple" in result.metadata
+        assert "apple" in result.metadata()

--- a/tiled/_tests/test_sort.py
+++ b/tiled/_tests/test_sort.py
@@ -50,19 +50,21 @@ def client():
     ],
 )
 def test_sort(client, key, sorted_list):
-    unsorted = [node.metadata[key] for node in client.values()]
+    unsorted = [node.metadata()[key] for node in client.values()]
     assert unsorted != sorted_list
-    sorted_ascending = [node.metadata[key] for node in client.sort((key, 1)).values()]
+    sorted_ascending = [node.metadata()[key] for node in client.sort((key, 1)).values()]
     assert sorted_ascending == sorted_list
-    sorted_descending = [node.metadata[key] for node in client.sort((key, -1)).values()]
+    sorted_descending = [
+        node.metadata()[key] for node in client.sort((key, -1)).values()
+    ]
     assert sorted_descending == list(reversed(sorted_list))
 
 
 def test_sort_two_columns(client):
     # Sort by (repeated) letter, then by number.
     client_sorted = client.sort(("repeated_letter", 1), ("number", 1))
-    letters_ = [node.metadata["repeated_letter"] for node in client_sorted.values()]
-    numbers_ = [node.metadata["number"] for node in client_sorted.values()]
+    letters_ = [node.metadata()["repeated_letter"] for node in client_sorted.values()]
+    numbers_ = [node.metadata()["number"] for node in client_sorted.values()]
     # Letters are sorted.
     assert letters_ == ["a"] * 5 + ["b"] * 5
     # Numbers *within* each block of letters are sorted

--- a/tiled/_tests/test_validation.py
+++ b/tiled/_tests/test_validation.py
@@ -89,14 +89,14 @@ def test_validators(client):
     metadata = {"id": 1, "foo": "bar"}
     df = pd.DataFrame({"a": np.zeros(10), "b": np.zeros(10)})
     result = client.write_dataframe(df, metadata=metadata, specs=["foo"])
-    assert result.metadata == metadata
+    assert result.metadata() == metadata
     result_df = result.read()
     pd.testing.assert_frame_equal(result_df, df)
 
     metadata_upper = {"ID": 2, "FOO": "bar"}
     metadata_lower, _ = lower_case_dict(metadata_upper)
     result = client.write_dataframe(df, metadata=metadata_upper, specs=["foo"])
-    assert result.metadata == metadata_lower
+    assert result.metadata() == metadata_lower
     result_df = result.read()
     pd.testing.assert_frame_equal(result_df, df)
 

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -50,7 +50,7 @@ def test_write_array_full(tree):
         result_array = result.read()
 
         numpy.testing.assert_equal(result_array, a)
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -78,7 +78,7 @@ def test_write_large_array_full(tree):
             result_array = result.read()
 
             numpy.testing.assert_equal(result_array, a)
-            assert result.metadata == metadata
+            assert result.metadata() == metadata
             assert result.specs == specs
         finally:
             client._SUGGESTED_MAX_UPLOAD_SIZE = original
@@ -104,7 +104,7 @@ def test_write_array_chunked(tree):
         result_array = result.read()
 
         numpy.testing.assert_equal(result_array, a.compute())
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -129,7 +129,7 @@ def test_write_dataframe_full(tree):
         result_dataframe = result.read()
 
         pandas.testing.assert_frame_equal(result_dataframe, df)
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -155,7 +155,7 @@ def test_write_dataframe_partitioned(tree):
         result_dataframe = result.read()
 
         pandas.testing.assert_frame_equal(result_dataframe, df)
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -189,7 +189,7 @@ def test_write_sparse_full(tree, coo):
         result_array = result.read()
 
         numpy.testing.assert_equal(result_array.todense(), coo.todense())
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -226,7 +226,7 @@ def test_write_sparse_chunked(tree):
         )
 
         # numpy.testing.assert_equal(result_array, sparse.COO(coords=[0, 1, ]))
-        assert result.metadata == metadata
+        assert result.metadata() == metadata
         assert result.specs == specs
 
 
@@ -282,12 +282,12 @@ def test_metadata_revisions(tree):
         ac = client.write_array([1, 2, 3], key="revise_me")
         assert len(ac.metadata_revisions[:]) == 0
         ac.update_metadata(metadata={"a": 1})
-        assert ac.metadata["a"] == 1
-        client["revise_me"].metadata["a"] == 1
+        assert ac.metadata()["a"] == 1
+        client["revise_me"].metadata()["a"] == 1
         assert len(ac.metadata_revisions[:]) == 1
         ac.update_metadata(metadata={"a": 2})
-        assert ac.metadata["a"] == 2
-        client["revise_me"].metadata["a"] == 2
+        assert ac.metadata()["a"] == 2
+        client["revise_me"].metadata()["a"] == 2
         assert len(ac.metadata_revisions[:]) == 2
         ac.metadata_revisions.delete_revision(1)
         assert len(ac.metadata_revisions[:]) == 1
@@ -386,7 +386,7 @@ async def test_bytes_in_metadata(tree):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
         client.create_container("a", metadata={"test": b"raw_bytes"})
-        value = client["a"].metadata["test"]
+        value = client["a"].metadata()["test"]
         assert value.startswith("data:application/octet-stream;base64,")
         label, encoded = value.split(",", 1)
         assert base64.b64decode(encoded) == b"raw_bytes"

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -154,7 +154,7 @@ class BaseClient:
         "JSON payload describing this item. Mostly for internal use."
         return self._item
 
-    @property
+    # @property
     def metadata(self):
         "Metadata about this data source."
         # Ensure this is immutable (at the top level) to help the user avoid

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -99,7 +99,7 @@ class DaskDatasetClient(Container):
     def read(self, variables=None, *, optimize_wide_table=True):
         data_vars, coords = self._build_arrays(variables, optimize_wide_table)
         return xarray.Dataset(
-            data_vars=data_vars, coords=coords, attrs=self.metadata["attrs"]
+            data_vars=data_vars, coords=coords, attrs=self.metadata()["attrs"]
         )
 
 


### PR DESCRIPTION
See post-close discussion in #515.

I could not discern whether it was an intentional decision to keep `metadata` as a property in the python client -- perhaps to avoid breaking beamline scripts during the previous operations cycle?

One consequence of the current state is that calling `serialize_json()` for an xarray causes errors that cannot be resolved by simple changes in one module.  Some of the underlying calls expect `metadata` to be a method, while other calls require `metadata` to be a property.

I'm proposing here to consistently treat `metadata` as a method throughout--effectively taking #527 a step farther.

---
This suggestion arose from testing the bug fix in #560.  My recommendation is to apply this PR, followed immediately by #560.