### PR TITLE
Support confirmation_message for all Authenticators.

### DIFF
--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -7,6 +7,7 @@ authentication:
         alice: ${ALICE_PASSWORD}
         bob: ${BOB_PASSWORD}
         cara: ${CARA_PASSWORD}
+      confirmation_message: "You have logged in as {id}."
   tiled_admins:
     - provider: toy
       id: alice

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -29,6 +29,9 @@ class DummyAuthenticator:
 
     mode = Mode.password
 
+    def __init__(self, confirmation_message=""):
+        self.confirmation_message = confirmation_message
+
     async def authenticate(self, username: str, password: str) -> UserSessionState:
         return UserSessionState(username, {})
 
@@ -53,8 +56,9 @@ properties:
     used to avoid placing passwords directly in configuration.
 """
 
-    def __init__(self, users_to_passwords):
+    def __init__(self, users_to_passwords, confirmation_message=""):
         self._users_to_passwords = users_to_passwords
+        self.confirmation_message = confirmation_message
 
     async def authenticate(self, username: str, password: str) -> UserSessionState:
         true_password = self._users_to_passwords.get(username)
@@ -77,12 +81,13 @@ properties:
     description: PAM service. Default is 'login'.
 """
 
-    def __init__(self, service="login"):
+    def __init__(self, service="login", confirmation_message=""):
         if not modules_available("pamela"):
             raise ModuleNotFoundError(
                 "This PAMAuthenticator requires the module 'pamela' to be installed."
             )
         self.service = service
+        self.confirmation_message = confirmation_message
         # TODO Try to open a PAM session.
 
     async def authenticate(self, username: str, password: str) -> UserSessionState:

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -51,9 +51,12 @@ additionalProperties: false
 properties:
   users_to_password:
     type: object
-  description: |
-    Mapping usernames to password. Environment variable expansion should be
-    used to avoid placing passwords directly in configuration.
+    description: |
+      Mapping usernames to password. Environment variable expansion should be
+      used to avoid placing passwords directly in configuration.
+  confirmation_message:
+    type: string
+    description: May be displayed by client after successful login.
 """
 
     def __init__(self, users_to_passwords, confirmation_message=""):
@@ -79,6 +82,9 @@ properties:
   service:
     type: string
     description: PAM service. Default is 'login'.
+  confirmation_message:
+    type: string
+    description: May be displayed by client after successful login.
 """
 
     def __init__(self, service="login", confirmation_message=""):
@@ -141,6 +147,9 @@ properties:
         - kty
         - n
         - use
+  confirmation_message:
+    type: string
+    description: May be displayed by client after successful login.
 """
 
     def __init__(

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -263,7 +263,7 @@ class SAMLAuthenticator:
         self,
         saml_settings,  # See EXAMPLE_SAML_SETTINGS below.
         attribute_name,  # which SAML attribute to use as 'id' for Idenity
-        confirmation_message=None,
+        confirmation_message="",
     ):
         self.saml_settings = saml_settings
         self.attribute_name = attribute_name
@@ -494,6 +494,8 @@ class LDAPAuthenticator:
 
         This can be useful in an heterogeneous environment, when supplying a UNIX username
         to authenticate against AD.
+    confirmation_message: str
+        May be displayed by client after successful login.
 
     Examples
     --------
@@ -558,6 +560,7 @@ class LDAPAuthenticator:
         attributes=None,
         auth_state_attributes=None,
         use_lookup_dn_username=True,
+        confirmation_message="",
     ):
         self.use_ssl = use_ssl
         self.use_tls = use_tls
@@ -599,6 +602,7 @@ class LDAPAuthenticator:
         self.server_port = (
             server_port if server_port is not None else self._server_port_default()
         )
+        self.confirmation_message = confirmation_message
 
     def _server_port_default(self):
         if self.use_ssl:


### PR DESCRIPTION
This is important because it can be used as a hook to comply with policies requiring a `NOTICE TO USERS` on login.

Covered by existing tests, also tested interactively:

```
$ ALICE_PASSWORD=secret tiled serve config example_configs/toy_authentication.yml 
```


```py
In [1]: from tiled.client import from_profile, show_logs

In [2]: c = from_profile('local')
Username: alice
Password: 
You have logged in as alice.
```

Server logs:

```
Using configuration from /home/dallan/Repos/bnl/tiled/example_configs/toy_authentication.yml
INFO:     Started server process [3719697]
INFO:     Waiting for application startup.
OBJECT CACHE: Will use up to 4_997_044_838 bytes (15% of total physical RAM)
Transient in-memory database initialized.
Ensuring that principal with identity {'provider': 'toy', 'id': 'alice'} has role 'admin'
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:41000 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:41000 - "GET /api/v1/metadata/ HTTP/1.1" 401 Unauthorized
INFO:     127.0.0.1:41000 - "POST /api/v1/auth/provider/toy/token HTTP/1.1" 200 OK
INFO:     127.0.0.1:41000 - "GET /api/v1/metadata/ HTTP/1.1" 200 OK
```