### PR TITLE
Move node_modules to root-level gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ docs/source/reference/generated/
 /tiled.egg-info
 /web-frontend/dist
 
+/web-frontend/node_modules
+
 # pytest
 .pytest_cache/
 

--- a/web-frontend/.gitignore
+++ b/web-frontend/.gitignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
Hatchling relies on the `.gitignore` to decide which files from the source tree to include in the `sdist`. It looks at only the `.gitignore` in the repository root. We had listed `node_modules/` in a separate `.gitignore under the subdirectory `web-frontend/`. That _is_ respected by git, but it is not respected by hatchling.

As a result, ever since the front-end was incorporated in the Python build process (v0.1.0a97, July 1), our `sdist` has been shipping with `node_modules`! This made it quite large (~79 MB). The `bdist` is not so large. Perhaps it culled these files out, as they are not actually placed anywhere in the distribution. Since we typically end up installing from `bdist`, the giant `sdist` went unnoticed until now.

This PR consolidates into one `.gitignore`, and it results in artifacts of more reasonable size.

This was caught because on the packages in `node_modules` included a soft link to a file in `/tmp`, outside the source tree, raising this error which prompted further investigation:

```
tarfile.LinkOutsideDestinationError: 'tiled-0.1.0a106.dev11+ge754b17/web-frontend/node_modules/.bin/acorn' would link to '/tmp/acorn/bin/acorn', which is outside the destination
```

Example: https://github.com/bluesky/tiled/actions/runs/6088044609/job/16517865937#step:3:111