### PR TITLE
Improve test coverage on compression, and fix bugs

### DIFF
--- a/tiled/_tests/test_compression.py
+++ b/tiled/_tests/test_compression.py
@@ -1,0 +1,50 @@
+import numpy
+import pytest
+from starlette.testclient import TestClient
+
+from ..adapters.array import ArrayAdapter
+from ..adapters.mapping import MapAdapter
+from ..server.app import build_app
+
+
+@pytest.fixture
+def app():
+    metadata = {str(i): {str(j): j for j in range(100)} for i in range(100)}
+    tree = MapAdapter(
+        {
+            "compresses_well": ArrayAdapter.from_array(
+                numpy.zeros((1000, 1000)), metadata=metadata
+            )
+        },
+    )
+    return build_app(tree, authentication={"single_user_api_key": "secret"})
+    # In this module we use a raw TestClient instead of tiled.client to omit
+    # tiled.client's default headers and other configuration.
+
+
+def test_gzip_supported(app):
+    with TestClient(app=app) as client:
+        client.headers["Authorization"] = "Apikey secret"
+        client.headers["Accept-Encoding"] = "gzip"
+        metadata_response = client.get("/api/v1/search")
+        data_response = client.get(
+            "/api/v1/array/full/compresses_well", headers={"Accept": "text/csv"}
+        )
+    assert metadata_response.status_code == 200
+    assert data_response.status_code == 200
+    assert "gzip" in metadata_response.headers["Content-Encoding"]
+    assert "gzip" in data_response.headers["Content-Encoding"]
+
+
+def test_zstd_preferred(app):
+    with TestClient(app=app) as client:
+        client.headers["Authorization"] = "Apikey secret"
+        client.headers["Accept-Encoding"] = "zstd"
+        metadata_response = client.get("/api/v1/search")
+        data_response = client.get(
+            "/api/v1/array/full/compresses_well", headers={"Accept": "text/csv"}
+        )
+    assert metadata_response.status_code == 200
+    assert data_response.status_code == 200
+    assert "zstd" in metadata_response.headers["Content-Encoding"]
+    assert "zstd" in data_response.headers["Content-Encoding"]

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -207,16 +207,15 @@ compression_registry = CompressionRegistry()
 "Global compression registry. See Registry for usage examples."
 
 
-compression_registry.register(
+for media_type in [
     "application/json",
-    "gzip",
-    lambda buffer: gzip.GzipFile(mode="wb", fileobj=buffer, compresslevel=9),
-)
-compression_registry.register(
     "application/x-msgpack",
-    "gzip",
-    lambda buffer: gzip.GzipFile(mode="wb", fileobj=buffer, compresslevel=9),
-)
+]:
+    compression_registry.register(
+        media_type,
+        "gzip",
+        lambda buffer: gzip.GzipFile(mode="wb", fileobj=buffer, compresslevel=9),
+    )
 for media_type in [
     "application/octet-stream",
     APACHE_ARROW_FILE_MIME_TYPE,

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -216,6 +216,7 @@ for media_type in [
         "gzip",
         lambda buffer: gzip.GzipFile(mode="wb", fileobj=buffer, compresslevel=9),
     )
+
 for media_type in [
     "application/octet-stream",
     APACHE_ARROW_FILE_MIME_TYPE,

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -225,7 +225,7 @@ for media_type in [
     "text/html",
 ]:
     compression_registry.register(
-        "application/octet-stream",
+        media_type,
         "gzip",
         # Use a lower compression level. High compression is extremely slow
         # (~60 seconds) on large array data.

--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -127,9 +127,11 @@ if modules_available("tifffile"):
 def serialize_html(array, metadata):
     "Try to display as image. Fall back to CSV."
     try:
-        png_data = serialization_registry("array", "image/png", array, metadata)
+        png_data = serialization_registry.dispatch("array", "image/png")(
+            array, metadata
+        )
     except Exception:
-        csv_data = serialization_registry("array", "text/csv", array, metadata)
+        csv_data = serialization_registry.dispatch("array", "text/csv")(array, metadata)
         return "<html>" "<body>" f"{csv_data.decode()!s}" "</body>" "</html>"
     else:
         return (

--- a/tiled/server/compression.py
+++ b/tiled/server/compression.py
@@ -54,7 +54,8 @@ class CompressionResponder:
             # modify the outgoing headers correctly.
             self.initial_message = message
             headers = MutableHeaders(raw=self.initial_message["headers"])
-            media_type = headers.get("Content-Type")
+            # Strip off any MIME arguments, as in 'text/plain; charset=utf-8'.
+            media_type, *_ = headers.get("Content-Type", "").split(";", 1)
             for encoding in self.compression_registry.encodings(media_type):
                 if encoding in self.accepted:
                     file_factory = self.compression_registry.dispatch(


### PR DESCRIPTION
In particular, `gzip` is intended to be supported for certain data formats (e.g. plain text) but it was not due to a small bug.