### PR TITLE
Satisfy expected API of decoders.

### DIFF
--- a/tiled/client/decoders.py
+++ b/tiled/client/decoders.py
@@ -14,6 +14,7 @@ if modules_available("blosc"):
 
         def decode(self, data: bytes) -> bytes:
             self._data.append(data)
+            return b""
 
         def flush(self) -> bytes:
             # Hide this here to defer the numpy import that it triggers.


### PR DESCRIPTION
httpx expects `Decoder.decode(data)` to always return `bytes`, not `None`.