### PR TITLE
Test AwkwardClient.read() for long URL

### DIFF
--- a/tiled/_tests/test_awkward.py
+++ b/tiled/_tests/test_awkward.py
@@ -125,7 +125,7 @@ def test_export_parquet(tmpdir, client):
 
 
 def test_large_number_of_form_keys(client):
-    "Specifically, test that too many form_keys to fit in a URL."
+    "Request should succeed even when too many form_keys to fit in a URL."
     # https://github.com/bluesky/tiled/pull/577
 
     # The HTTP spec itself has no limit, but tools impose a pragmatic one.
@@ -142,3 +142,5 @@ def test_large_number_of_form_keys(client):
     form_keys = json.loads(request.read())
     form_key_length = len(str(form_keys))
     assert form_key_length > URL_LENGTH_LIMIT
+    url_length = len(str(request.url))
+    assert url_length <= URL_LENGTH_LIMIT


### PR DESCRIPTION
This is a belated addition to PR #577.

In addition to checking that `form_keys` are too long to fit in a URL, let's also check that we did not supply the corresponding excessive URL with the request.

We might want to use this pattern for other complementary GET/POST routes, and this test would act as an example for those client tests.