### PR TITLE
Enrich data source / asset association

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       shell: bash -l {0}
       run: source continuous_integration/scripts/start_LDAP.sh
 
+    - name: Download SQLite example data.
+      shell: bash -l {0}
+      run: source continuous_integration/scripts/download_sqlite_data.sh
+
     - name: Start PostgreSQL service in container.
       shell: bash -l {0}
       run: source continuous_integration/scripts/start_postgres.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         set -vxeuo pipefail
         tiled catalog upgrade-database sqlite+aiosqlite:///tiled_test_db_sqlite.db
-        tiled catalog upgrade-database postgresql+asyncpg://postgres:secret@localhost:5432
+        tiled catalog upgrade-database postgresql+asyncpg://postgres:secret@localhost:5432/tiled-example-data
 
     - name: Test with pytest
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
       shell: bash -l {0}
       run: source continuous_integration/scripts/start_postgres.sh
 
+
+    - name: Ensure example data is migrated to current catalog database schema.
+      # The example data is expected to be kept up to date to the latest Tiled
+      # release, but this CI run may include some unreleased schema changes,
+      # so we run a migration here.
+      shell: bash -l {0}
+      run: |
+        set -vxeuo pipefail
+        tiled catalog upgrade-database sqlite+aiosqlite:///tiled_test_db_sqlite.db
+        tiled catalog upgrade-database postgresql+asyncpg://postgres:secret@localhost:5432
+
     - name: Test with pytest
       shell: bash -l {0}
       run: |

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -200,9 +200,10 @@ async def test_metadata_index_is_used(example_data_adapter):
 @pytest.mark.asyncio
 async def test_write_array_external(a, tmpdir):
     arr = numpy.ones((5, 3))
-    filepath = tmpdir / "file.tiff"
-    tifffile.imwrite(str(filepath), arr)
-    ad = TiffAdapter(str(filepath))
+    filepath = str(tmpdir / "file.tiff")
+    data_uri = ensure_uri(filepath)
+    tifffile.imwrite(filepath, arr)
+    ad = TiffAdapter(data_uri)
     structure = asdict(ad.structure())
     await a.create_node(
         key="x",
@@ -216,9 +217,9 @@ async def test_write_array_external(a, tmpdir):
                 management="external",
                 assets=[
                     Asset(
-                        parameter="filepath",
+                        parameter="data_uri",
                         num=None,
-                        data_uri=str(ensure_uri(filepath)),
+                        data_uri=str(data_uri),
                         is_directory=False,
                     )
                 ],
@@ -232,9 +233,10 @@ async def test_write_array_external(a, tmpdir):
 @pytest.mark.asyncio
 async def test_write_dataframe_external_direct(a, tmpdir):
     df = pandas.DataFrame(numpy.ones((5, 3)), columns=list("abc"))
-    filepath = tmpdir / "file.csv"
+    filepath = str(tmpdir / "file.csv")
+    data_uri = ensure_uri(filepath)
     df.to_csv(filepath, index=False)
-    dfa = read_csv(filepath)
+    dfa = read_csv(data_uri)
     structure = asdict(dfa.structure())
     await a.create_node(
         key="x",
@@ -248,9 +250,9 @@ async def test_write_dataframe_external_direct(a, tmpdir):
                 management="external",
                 assets=[
                     Asset(
-                        parameter="filepath",
+                        parameter="data_uri",
                         num=None,
-                        data_uri=str(ensure_uri(filepath)),
+                        data_uri=data_uri,
                         is_directory=False,
                     )
                 ],

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -21,8 +21,8 @@ from ..catalog.utils import ensure_uri
 from ..client import Context, from_context
 from ..client.xarray import write_xarray_dataset
 from ..queries import Eq, Key
-from ..server.app import build_app, build_app_from_config
-from ..server.schemas import Asset, DataSource, DataSourceAssetAssociation
+from ..server.app import build_app
+from ..server.schemas import Asset, DataSource
 from ..structures.core import StructureFamily
 from .utils import enter_password
 
@@ -212,12 +212,11 @@ async def test_write_array_external(a, tmpdir):
                 parameters={},
                 management="external",
                 assets=[
-                    DataSourceAssetAssociation(
+                    Asset(
                         parameter="filepath",
                         num=None,
-                        asset=Asset(
-                            data_uri=str(ensure_uri(filepath)), is_directory=False
-                        ),
+                        data_uri=str(ensure_uri(filepath)),
+                        is_directory=False,
                     )
                 ],
             )
@@ -244,7 +243,14 @@ async def test_write_dataframe_external_direct(a, tmpdir):
                 structure=structure,
                 parameters={},
                 management="external",
-                assets=[Asset(data_uri=str(ensure_uri(filepath)), is_directory=False)],
+                assets=[
+                    Asset(
+                        parameter="filepath",
+                        num=None,
+                        data_uri=str(ensure_uri(filepath)),
+                        is_directory=False,
+                    )
+                ],
             )
         ],
     )

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -22,7 +22,7 @@ from ..client import Context, from_context
 from ..client.xarray import write_xarray_dataset
 from ..queries import Eq, Key
 from ..server.app import build_app, build_app_from_config
-from ..server.schemas import Asset, DataSource
+from ..server.schemas import Asset, DataSource, DataSourceAssetAssociation
 from ..structures.core import StructureFamily
 from .utils import enter_password
 
@@ -211,7 +211,15 @@ async def test_write_array_external(a, tmpdir):
                 structure=structure,
                 parameters={},
                 management="external",
-                assets=[Asset(data_uri=str(ensure_uri(filepath)), is_directory=False)],
+                assets=[
+                    DataSourceAssetAssociation(
+                        parameter="filepath",
+                        num=None,
+                        asset=Asset(
+                            data_uri=str(ensure_uri(filepath)), is_directory=False
+                        ),
+                    )
+                ],
             )
         ],
     )

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -499,6 +499,7 @@ async def test_access_control(tmpdir):
         "duplicate-int",
     ],
 )
+@pytest.mark.asyncio
 async def test_constraints_on_parameter_and_num(a, assets):
     "Test constraints enforced by database on 'parameter' and 'num'."
     arr_adapter = ArrayAdapter.from_array([1, 2, 3])

--- a/tiled/_tests/test_directory_walker.py
+++ b/tiled/_tests/test_directory_walker.py
@@ -170,6 +170,7 @@ async def test_tiff_seq_custom_sorting(tmpdir):
     for i in ordering:
         file = Path(tmpdir, f"image{i:05}.tif")
         files.append(file)
+        # data is a block of ones
         tifffile.imwrite(file, i * data)
 
     settings = Settings.init()
@@ -182,6 +183,11 @@ async def test_tiff_seq_custom_sorting(tmpdir):
             settings,
         )
         client = from_context(context)
+        # We are being a bit clever here.
+        # Each image in this image series has pixels with a constant value, and
+        # that value matches the image's position in the sequence enumerated by
+        # `ordering`. We pick out one pixel and check that its value matches
+        # the corresponding value in `ordering`.
         actual = list(client["image"][:, 0, 0])
         assert actual == ordering
 

--- a/tiled/_tests/test_directory_walker.py
+++ b/tiled/_tests/test_directory_walker.py
@@ -250,6 +250,20 @@ async def test_image_file_with_sidecar_metadata_file(tmpdir):
 
 @pytest.mark.asyncio
 async def test_hdf5_virtual_datasets(tmpdir):
+    # A virtual database comprises one master file and N data files. The master
+    # file must be handed to the Adapter for opening. The data files are not
+    # handled directly by the Adapter but they still ought to be tracked as
+    # Assets for purposes of data movement, accounting for data size, etc.
+    # This is why they are Assets with parameter=NULL/None, Assets not used
+    # directly by the Adapter.
+
+    # One could do one-dataset-per-directory. But like TIFF series in practice
+    # they are often mixed, so we address that general case and track them at
+    # the per-file level.
+
+    # Contrast this to Zarr, where the files involves are always bundled by
+    # directory. We track Zarr at the directory level.
+
     layout = h5py.VirtualLayout(shape=(4, 100), dtype="i4")
 
     data_filepaths = []

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -2,11 +2,11 @@
 A directory containing awkward buffers, one file per form key.
 """
 import collections.abc
-from urllib import parse
 
 import awkward.forms
 
 from ..structures.core import StructureFamily
+from ..utils import path_from_uri
 from .awkward import AwkwardAdapter
 
 
@@ -37,23 +37,26 @@ class AwkwardBuffersAdapter(AwkwardAdapter):
     structure_family = StructureFamily.awkward
 
     @classmethod
-    def init_storage(cls, directory, structure):
+    def init_storage(cls, data_uri, structure):
         from ..server.schemas import Asset
 
+        directory = path_from_uri(data_uri)
         directory.mkdir(parents=True, exist_ok=True)
-        data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
         return [Asset(data_uri=data_uri, is_directory=True, parameter="directory")]
 
     @classmethod
     def from_directory(
         cls,
-        directory,
+        data_uri,
         structure,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
         form = awkward.forms.from_dict(structure.form)
+        directory = path_from_uri(data_uri)
+        if not directory.is_dir():
+            raise ValueError(f"Not a directory: {directory}")
         container = DirectoryContainer(directory, form)
         return cls(
             container,

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -42,7 +42,7 @@ class AwkwardBuffersAdapter(AwkwardAdapter):
 
         directory = path_from_uri(data_uri)
         directory.mkdir(parents=True, exist_ok=True)
-        return [Asset(data_uri=data_uri, is_directory=True, parameter="directory")]
+        return [Asset(data_uri=data_uri, is_directory=True, parameter="data_uri")]
 
     @classmethod
     def from_directory(

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -42,7 +42,7 @@ class AwkwardBuffersAdapter(AwkwardAdapter):
 
         directory.mkdir(parents=True, exist_ok=True)
         data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
-        return [Asset(data_uri=data_uri, is_directory=True)]
+        return [Asset(data_uri=data_uri, is_directory=True, parameter="directory")]
 
     @classmethod
     def from_directory(

--- a/tiled/adapters/csv.py
+++ b/tiled/adapters/csv.py
@@ -5,7 +5,7 @@ from .dataframe import DataFrameAdapter
 
 
 def read_csv(
-    *args,
+    filepath,
     structure=None,
     metadata=None,
     specs=None,
@@ -25,7 +25,7 @@ def read_csv(
     >>> read_csv("myfiles.*.csv")
     >>> read_csv("s3://bucket/myfiles.*.csv")
     """
-    ddf = dask.dataframe.read_csv(*args, **kwargs)
+    ddf = dask.dataframe.read_csv(filepath, **kwargs)
     # If an instance has previously been created using the same parameters,
     # then we are here because the caller wants a *fresh* view on this data.
     # Therefore, we should clear any cached data.

--- a/tiled/adapters/csv.py
+++ b/tiled/adapters/csv.py
@@ -1,11 +1,12 @@
 import dask.dataframe
 
 from ..server.object_cache import NO_CACHE, get_object_cache
+from ..utils import path_from_uri
 from .dataframe import DataFrameAdapter
 
 
 def read_csv(
-    filepath,
+    data_uri,
     structure=None,
     metadata=None,
     specs=None,
@@ -25,6 +26,7 @@ def read_csv(
     >>> read_csv("myfiles.*.csv")
     >>> read_csv("s3://bucket/myfiles.*.csv")
     """
+    filepath = path_from_uri(data_uri)
     ddf = dask.dataframe.read_csv(filepath, **kwargs)
     # If an instance has previously been created using the same parameters,
     # then we are here because the caller wants a *fresh* view on this data.

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -8,7 +8,7 @@ from .dataframe import DataFrameAdapter
 
 class ExcelAdapter(MapAdapter):
     @classmethod
-    def from_file(cls, filepath, **kwargs):
+    def from_file(cls, file, **kwargs):
         """
         Read the sheets in an Excel file.
 
@@ -18,16 +18,28 @@ class ExcelAdapter(MapAdapter):
         Examples
         --------
 
-        >>> ExcelAdapter.from_file("path/to/excel_file.xlsx")
+        Given a file object
+
+        >>> file = open("path/to/excel_file.xlsx")
+        >>> ExcelAdapter.from_file(file)
+
+        Given a pandas.ExcelFile object
+
+        >>> import pandas
+        >>> ef = pandas.ExcelFile(filepath)
+        >>> ExcelAdapter.from_file(ef)
         """
-        excel_file = pandas.ExcelFile(filepath)
+        if isinstance(file, pandas.ExcelFile):
+            excel_file = file
+        else:
+            excel_file = pandas.ExcelFile(file)
         # If an instance has previously been created using the same parameters,
         # then we are here because the caller wants a *fresh* view on this data.
         # Therefore, we should clear any cached data.
         cache = get_object_cache()
         mapping = {}
         for sheet_name in excel_file.sheet_names:
-            cache_key = (cls.__module__, cls.__qualname__, filepath, sheet_name)
+            cache_key = (cls.__module__, cls.__qualname__, file, sheet_name)
             ddf = dask.dataframe.from_pandas(
                 with_object_cache(cache_key, excel_file.parse, sheet_name),
                 npartitions=1,  # TODO Be smarter about this.
@@ -37,3 +49,21 @@ class ExcelAdapter(MapAdapter):
                 cache.discard_dask(ddf.__dask_keys__())  # dask tasks
             mapping[sheet_name] = DataFrameAdapter.from_dask_dataframe(ddf)
         return cls(mapping, **kwargs)
+
+    @classmethod
+    def from_filepath(cls, filepath, **kwargs):
+        """
+        Read the sheets in an Excel file.
+
+        This maps the Excel file, which may contain one of more spreadsheets,
+        onto a tree of tabular structures.
+
+        Examples
+        --------
+
+        Given a file path
+
+        >>> ExcelAdapter.from_file("path/to/excel_file.xlsx")
+        """
+        file = pandas.ExcelFile(filepath)
+        return cls.from_file(file)

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -8,7 +8,7 @@ from .dataframe import DataFrameAdapter
 
 class ExcelAdapter(MapAdapter):
     @classmethod
-    def from_file(cls, file, **kwargs):
+    def from_file(cls, filepath, **kwargs):
         """
         Read the sheets in an Excel file.
 
@@ -18,32 +18,16 @@ class ExcelAdapter(MapAdapter):
         Examples
         --------
 
-        Given a file path
-
         >>> ExcelAdapter.from_file("path/to/excel_file.xlsx")
-
-        Given a file object
-
-        >>> file = open("path/to/excel_file.xlsx")
-        >>> ExcelAdapter.from_file(file)
-
-        Given a pandas.ExcelFile object
-
-        >>> import pandas
-        >>> ef = pandas.ExcelFile(file)
-        >>> ExcelAdapter.from_file(ef)
         """
-        if isinstance(file, pandas.ExcelFile):
-            excel_file = file
-        else:
-            excel_file = pandas.ExcelFile(file)
+        excel_file = pandas.ExcelFile(filepath)
         # If an instance has previously been created using the same parameters,
         # then we are here because the caller wants a *fresh* view on this data.
         # Therefore, we should clear any cached data.
         cache = get_object_cache()
         mapping = {}
         for sheet_name in excel_file.sheet_names:
-            cache_key = (cls.__module__, cls.__qualname__, file, sheet_name)
+            cache_key = (cls.__module__, cls.__qualname__, filepath, sheet_name)
             ddf = dask.dataframe.from_pandas(
                 with_object_cache(cache_key, excel_file.parse, sheet_name),
                 npartitions=1,  # TODO Be smarter about this.

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -52,7 +52,7 @@ class ExcelAdapter(MapAdapter):
         return cls(mapping, **kwargs)
 
     @classmethod
-    def from_filepath(cls, filepath, **kwargs):
+    def from_uri(cls, data_uri, **kwargs):
         """
         Read the sheets in an Excel file.
 
@@ -66,5 +66,5 @@ class ExcelAdapter(MapAdapter):
 
         >>> ExcelAdapter.from_file("path/to/excel_file.xlsx")
         """
-        file = pandas.ExcelFile(filepath)
+        file = pandas.ExcelFile(data_uri)
         return cls.from_file(file)

--- a/tiled/adapters/excel.py
+++ b/tiled/adapters/excel.py
@@ -26,6 +26,7 @@ class ExcelAdapter(MapAdapter):
         Given a pandas.ExcelFile object
 
         >>> import pandas
+        >>> filepath = "path/to/excel_file.xlsx"
         >>> ef = pandas.ExcelFile(filepath)
         >>> ExcelAdapter.from_file(ef)
         """

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -31,7 +31,7 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
     From the root node of a file given a filepath
 
     >>> import h5py
-    >>> HDF5Adapter.from_filepath("path/to/file.h5")
+    >>> HDF5Adapter.from_uri("file://localhost/path/to/file.h5")
 
     From the root node of a file given an h5py.File object
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -8,7 +8,7 @@ import numpy
 from ..adapters.utils import IndexersMixin
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..structures.core import StructureFamily
-from ..utils import node_repr
+from ..utils import node_repr, path_from_uri
 from .array import ArrayAdapter
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
@@ -73,9 +73,9 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         return cls(file, metadata=metadata, specs=specs, access_policy=access_policy)
 
     @classmethod
-    def from_filepath(
+    def from_uri(
         cls,
-        filepath,
+        data_uri,
         *,
         structure=None,
         metadata=None,
@@ -84,6 +84,7 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         specs=None,
         access_policy=None,
     ):
+        filepath = path_from_uri(data_uri)
         file = h5py.File(filepath, "r", swmr=swmr, libver=libver)
         return cls.from_file(file)
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -31,7 +31,7 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
     From the root node of a file given a filepath
 
     >>> import h5py
-    >>> HDF5Adapter.from_file("path/to/file.h5")
+    >>> HDF5Adapter.from_filepath("path/to/file.h5")
 
     From the root node of a file given an h5py.File object
 
@@ -70,9 +70,22 @@ class HDF5Adapter(collections.abc.Mapping, IndexersMixin):
         specs=None,
         access_policy=None,
     ):
-        if not isinstance(file, h5py.File):
-            file = h5py.File(file, "r", swmr=swmr, libver=libver)
         return cls(file, metadata=metadata, specs=specs, access_policy=access_policy)
+
+    @classmethod
+    def from_filepath(
+        cls,
+        filepath,
+        *,
+        structure=None,
+        metadata=None,
+        swmr=SWMR_DEFAULT,
+        libver="latest",
+        specs=None,
+        access_policy=None,
+    ):
+        file = h5py.File(filepath, "r", swmr=swmr, libver=libver)
+        return cls.from_file(file)
 
     def __repr__(self):
         return node_repr(self, list(self))

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -49,7 +49,7 @@ class ParquetDatasetAdapter:
             Asset(
                 data_uri=f"{data_uri}/partition-{i}.parquet",
                 is_directory=False,
-                parameter="uris",
+                parameter="data_uris",
                 num=i,
             )
             for i in range(structure.npartitions)

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -12,13 +12,13 @@ class ParquetDatasetAdapter:
 
     def __init__(
         self,
-        *partition_paths,
+        uris,
         structure,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
-        self.partition_paths = sorted(partition_paths)
+        self.partition_paths = uris
         self._metadata = metadata or {}
         self._structure = structure
         self.specs = list(specs or [])
@@ -48,6 +48,8 @@ class ParquetDatasetAdapter:
             Asset(
                 data_uri=f"{data_uri}/partition-{i}.parquet",
                 is_directory=False,
+                parameter="uris",
+                num=i,
             )
             for i in range(structure.npartitions)
         ]

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -23,7 +23,7 @@ class SparseBlocksParquetAdapter:
 
     def __init__(
         self,
-        *block_uris,
+        block_uris,
         structure,
         metadata=None,
         specs=None,
@@ -58,8 +58,10 @@ class SparseBlocksParquetAdapter:
             Asset(
                 data_uri=uri,
                 is_directory=False,
+                parameter="block_uris",
+                num=i,
             )
-            for uri in block_uris
+            for i, uri in enumerate(block_uris)
         ]
         return assets
 

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -12,7 +12,7 @@ from ..utils import path_from_uri
 def load_block(uri):
     # TODO This can be done without pandas.
     # Better to use a plain I/O library.
-    df = pandas.read_parquet(uri)
+    df = pandas.read_parquet(path_from_uri(uri))
     coords = df[df.columns[:-1]].values.T
     data = df["data"].values
     return coords, data
@@ -66,13 +66,13 @@ class SparseBlocksParquetAdapter:
 
     def write_block(self, data, block):
         uri = self.blocks[block]
-        data.to_parquet(uri)
+        data.to_parquet(path_from_uri(uri))
 
     def write(self, data):
         if len(self.blocks) > 1:
             raise NotImplementedError
         uri = self.blocks[(0,) * len(self._structure.shape)]
-        data.to_parquet(uri)
+        data.to_parquet(path_from_uri(uri))
 
     def read(self, slice=...):
         all_coords = []

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -25,14 +25,14 @@ class TableAdapter:
     @classmethod
     def from_pandas(
         cls,
-        *args,
+        data_uri,
         metadata=None,
         specs=None,
         access_policy=None,
         npartitions=1,
         **kwargs,
     ):
-        ddf = dask.dataframe.from_pandas(*args, npartitions=npartitions, **kwargs)
+        ddf = dask.dataframe.from_pandas(data_uri, npartitions=npartitions, **kwargs)
         if specs is None:
             specs = [Spec("dataframe")]
         return cls.from_dask_dataframe(

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -5,7 +5,6 @@ import pandas
 from ..server.object_cache import get_object_cache
 from ..structures.core import Spec, StructureFamily
 from ..structures.table import TableStructure
-from ..utils import path_from_uri
 from .array import ArrayAdapter
 
 
@@ -26,15 +25,14 @@ class TableAdapter:
     @classmethod
     def from_pandas(
         cls,
-        data_uri,
+        *args,
         metadata=None,
         specs=None,
         access_policy=None,
         npartitions=1,
         **kwargs,
     ):
-        filepath = path_from_uri(data_uri)
-        ddf = dask.dataframe.from_pandas(filepath, npartitions=npartitions, **kwargs)
+        ddf = dask.dataframe.from_pandas(*args, npartitions=npartitions, **kwargs)
         if specs is None:
             specs = [Spec("dataframe")]
         return cls.from_dask_dataframe(

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -5,6 +5,7 @@ import pandas
 from ..server.object_cache import get_object_cache
 from ..structures.core import Spec, StructureFamily
 from ..structures.table import TableStructure
+from ..utils import path_from_uri
 from .array import ArrayAdapter
 
 
@@ -32,7 +33,8 @@ class TableAdapter:
         npartitions=1,
         **kwargs,
     ):
-        ddf = dask.dataframe.from_pandas(data_uri, npartitions=npartitions, **kwargs)
+        filepath = path_from_uri(data_uri)
+        ddf = dask.dataframe.from_pandas(filepath, npartitions=npartitions, **kwargs)
         if specs is None:
             specs = [Spec("dataframe")]
         return cls.from_dask_dataframe(

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -83,7 +83,7 @@ class TiffSequenceAdapter:
     structure_family = "array"
 
     @classmethod
-    def from_files(
+    def from_filepaths(
         cls,
         filepaths,
         structure=None,

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -85,13 +85,13 @@ class TiffSequenceAdapter:
     @classmethod
     def from_files(
         cls,
-        *files,
+        filepaths,
         structure=None,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
-        seq = tifffile.TiffSequence(sorted(files))
+        seq = tifffile.TiffSequence(filepaths)
         return cls(
             seq,
             structure=structure,

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -22,15 +22,15 @@ class TiffAdapter:
 
     def __init__(
         self,
-        path,
+        filepath,
         *,
         structure=None,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
-        self._file = tifffile.TiffFile(path)
-        self._cache_key = (type(self).__module__, type(self).__qualname__, path)
+        self._file = tifffile.TiffFile(filepath)
+        self._cache_key = (type(self).__module__, type(self).__qualname__, filepath)
         self.specs = specs or []
         self._provided_metadata = metadata or {}
         self.access_policy = access_policy

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -6,6 +6,7 @@ import tifffile
 from ..server.object_cache import with_object_cache
 from ..structures.array import ArrayStructure, BuiltinDtype
 from ..structures.core import StructureFamily
+from ..utils import path_from_uri
 
 
 class TiffAdapter:
@@ -22,13 +23,14 @@ class TiffAdapter:
 
     def __init__(
         self,
-        filepath,
+        data_uri,
         *,
         structure=None,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
+        filepath = path_from_uri(data_uri)
         self._file = tifffile.TiffFile(filepath)
         self._cache_key = (type(self).__module__, type(self).__qualname__, filepath)
         self.specs = specs or []
@@ -85,12 +87,13 @@ class TiffSequenceAdapter:
     @classmethod
     def from_filepaths(
         cls,
-        filepaths,
+        data_uris,
         structure=None,
         metadata=None,
         specs=None,
         access_policy=None,
     ):
+        filepaths = [path_from_uri(data_uri) for data_uri in data_uris]
         seq = tifffile.TiffSequence(filepaths)
         return cls(
             seq,

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -30,6 +30,8 @@ class TiffAdapter:
         specs=None,
         access_policy=None,
     ):
+        if not isinstance(data_uri, str):
+            raise Exception
         filepath = path_from_uri(data_uri)
         self._file = tifffile.TiffFile(filepath)
         self._cache_key = (type(self).__module__, type(self).__qualname__, filepath)
@@ -85,7 +87,7 @@ class TiffSequenceAdapter:
     structure_family = "array"
 
     @classmethod
-    def from_filepaths(
+    def from_uris(
         cls,
         data_uris,
         structure=None,

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -15,13 +15,16 @@ from .array import ArrayAdapter, slice_and_shape_from_block_and_chunks
 INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 
 
-def read_zarr(data_uri, **kwargs):
+def read_zarr(data_uri, structure=None, **kwargs):
     filepath = path_from_uri(data_uri)
     zarr_obj = zarr.open(filepath)  # Group or Array
     if isinstance(zarr_obj, zarr.hierarchy.Group):
         adapter = ZarrGroupAdapter(zarr_obj, **kwargs)
     else:
-        adapter = ZarrArrayAdapter(zarr_obj, **kwargs)
+        if structure is None:
+            adapter = ZarrArrayAdapter.from_array(zarr_obj, **kwargs)
+        else:
+            adapter = ZarrArrayAdapter(zarr_obj, structure=structure, **kwargs)
     return adapter
 
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -48,6 +48,7 @@ class ZarrArrayAdapter(ArrayAdapter):
             Asset(
                 data_uri=data_uri,
                 is_directory=True,
+                parameter="filepath",
             )
         ]
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -1,7 +1,6 @@
 import builtins
 import collections.abc
 import os
-from urllib import parse
 
 import zarr.core
 import zarr.hierarchy
@@ -16,7 +15,8 @@ from .array import ArrayAdapter, slice_and_shape_from_block_and_chunks
 INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 
 
-def read_zarr(filepath, **kwargs):
+def read_zarr(data_uri, **kwargs):
+    filepath = path_from_uri(data_uri)
     zarr_obj = zarr.open(filepath)  # Group or Array
     if isinstance(zarr_obj, zarr.hierarchy.Group):
         adapter = ZarrGroupAdapter(zarr_obj, **kwargs)
@@ -43,12 +43,11 @@ class ZarrArrayAdapter(ArrayAdapter):
             chunks=zarr_chunks,
             dtype=structure.data_type.to_numpy_dtype(),
         )
-        data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
         return [
             Asset(
                 data_uri=data_uri,
                 is_directory=True,
-                parameter="filepath",
+                parameter="data_uri",
             )
         ]
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -392,6 +392,8 @@ class CatalogNodeAdapter:
                 )
             parameters = collections.defaultdict(list)
             for asset in data_source.assets:
+                if asset.parameter is None:
+                    continue
                 data_uri = httpx.URL(asset.data_uri)
                 if data_uri.scheme != "file":
                     raise NotImplementedError(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1069,12 +1069,14 @@ CatalogNodeAdapter.register_query(SpecsQuery, specs)
 
 
 def in_memory(
+    *,
     metadata=None,
     specs=None,
     access_policy=None,
     writable_storage=None,
     readable_storage=None,
     echo=DEFAULT_ECHO,
+    adapters_by_mimetype=None,
 ):
     uri = "sqlite+aiosqlite:///:memory:"
     return from_uri(
@@ -1085,6 +1087,7 @@ def in_memory(
         writable_storage=writable_storage,
         readable_storage=readable_storage,
         echo=echo,
+        adapters_by_mimetype=adapters_by_mimetype,
     )
 
 

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -3,12 +3,15 @@ from sqlalchemy import text
 from ..alembic_utils import DatabaseUpgradeNeeded, UninitializedDatabase, check_database
 from .base import Base
 
-# This is the alembic revision ID of the database revision
-# required by this version of Tiled.
-REQUIRED_REVISION = "3db11ff95b6c"
-
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["3db11ff95b6c", "0b033e7fbe30", "83889e049ddc", "6825c778aa3c"]
+ALL_REVISIONS = [
+    "a66028395cab",
+    "3db11ff95b6c",
+    "0b033e7fbe30",
+    "83889e049ddc",
+    "6825c778aa3c",
+]
+REQUIRED_REVISION = ALL_REVISIONS[0]
 
 
 async def initialize_database(engine):

--- a/tiled/catalog/migrations/versions/a66028395cab_enrich_datasource_asset_association.py
+++ b/tiled/catalog/migrations/versions/a66028395cab_enrich_datasource_asset_association.py
@@ -163,6 +163,7 @@ def upgrade():
         # SQLite does not supported adding constraints to an existing table.
         # We invoke its 'copy and move' functionality.
         with op.batch_alter_table(DataSourceAssetAssociation.__tablename__) as batch_op:
+            # Gotcha: This does not take table_name because it is bound into batch_op.
             batch_op.create_unique_constraint(
                 "parameter_num_unique_constraint",
                 [
@@ -213,6 +214,7 @@ def upgrade():
         # PostgreSQL
         op.create_unique_constraint(
             "parameter_num_unique_constraint",
+            DataSourceAssetAssociation.__tablename__,
             [
                 "data_source_id",
                 "parameter",

--- a/tiled/catalog/migrations/versions/a66028395cab_enrich_datasource_asset_association.py
+++ b/tiled/catalog/migrations/versions/a66028395cab_enrich_datasource_asset_association.py
@@ -1,0 +1,122 @@
+"""Enrich DataSource-Asset association.
+
+Revision ID: a66028395cab
+Revises: 3db11ff95b6c
+Create Date: 2024-01-21 15:17:20.571763
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.authn_database.orm import (  # unique_parameter_num_null_check,
+    DataSourceAssetAssociation,
+    JSONVariant,
+)
+
+# revision identifiers, used by Alembic.
+revision = "a66028395cab"
+down_revision = "3db11ff95b6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    data_sources = sa.Table(
+        "data_sources",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer),
+        sa.Column("node_id", sa.Integer),
+        sa.Column("mimetype", sa.Unicode),
+        sa.Column("structure", JSONVariant),
+    )
+    data_source_asset_association = sa.Table(
+        DataSourceAssetAssociation.__tablename__,
+        sa.MetaData(),
+        sa.Column("asset_id", sa.Integer),
+        sa.Column("data_source_id", sa.Integer),
+        sa.Column("parameter", sa.Unicode(255)),
+        sa.Column("num", sa.Integer),
+    )
+
+    # Rename some MIME types.
+
+    # While Awkward data is typically _transmitted_ in a ZIP archive,
+    # it is stored as directory of buffers, with no ZIP involved.
+    # Thus using 'application/zip' in the database was a mistake.
+    connection.execute(
+        data_sources.update()
+        .where(mimetype="application/zip")
+        .values(mimtype="application/x-awkward-buffers")
+    )
+    # The format is standard parquet. We will use a MIME type
+    # parameter to let Tiled know to use the Adapter for sparse
+    # data, as opposed to the Adapter for tabular data.
+    connection.execute(
+        data_sources.update()
+        .where(mimetype="application/x-parquet-sparse")
+        .values(mimtype="application/x-parquet;structure=sparse")
+    )
+
+    # Add columns 'parameter' and 'num' to association table.
+    op.add_column(
+        DataSourceAssetAssociation.__tablename__,
+        sa.Column("parameter", sa.Unicode(255), nullable=True),
+    )
+    op.add_column(
+        DataSourceAssetAssociation.__tablename__,
+        sa.Column("num", sa.Integer, nullable=True),
+    )
+
+    # First populate the columns to bring them into compliance with
+    # constraints. Then, apply constraints.
+
+    connection.execute(
+        data_source_asset_association.update()
+        .where(
+            sa.not_(
+                sa._or(
+                    data_sources.mimetype == "multipart/related;type=image/tiff",
+                    data_sources.mimetype == "application/x-parquet",
+                    data_sources.mimetype == "application/x-parquet;structure=sparse",
+                )
+            )
+        )
+        .values(parameter="data_uri")
+    )
+    connection.execute(
+        data_source_asset_association.update()
+        .where(
+            sa._or(
+                data_sources.mimetype == "multipart/related;type=image/tiff",
+                data_sources.mimetype == "application/x-parquet",
+                data_sources.mimetype == "application/x-parquet;structure=sparse",
+            )
+        )
+        .values(parameter="data_uris")  # plural
+    )
+    # results = connection.execute(
+    #     sa.select(
+    #         data_sources.c.id,
+    #         data_sources.c.structure,
+    #         nodes.c.structure_family,
+    #     ).select_from(joined)
+    # ).fetchall()
+
+    # Create unique constraint and triggers.
+    # op.create_unique_constraint(
+    #     constraint_name="parameter_num_unique_constraint",
+    #     table_name=DataSourceAssetAssociation.__tablename__,
+    #     columns=[
+    #         "data_source_id",
+    #         "parameter",
+    #         "num",
+    #     ],
+    # )
+    # unique_parameter_num_null_check(data_source_asset_association, connection)
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -7,9 +7,9 @@ from ..utils import OneShotCachedMap
 # OneShotCachedMap is used to defer imports. We don't want to pay up front
 # for importing Readers that we will not actually use.
 PARQUET_MIMETYPE = "application/x-parquet"
-SPARSE_BLOCKS_PARQUET_MIMETYPE = "application/x-parquet-sparse"  # HACK!
-ZIP_MIMETYPE = "application/zip"
+SPARSE_BLOCKS_PARQUET_MIMETYPE = "application/x-parquet;structure=sparse"
 ZARR_MIMETYPE = "application/x-zarr"
+AWKWARD_BUFFERS_MIMETYPE = "application/x-awkward-buffers"
 DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
     {
         "image/tiff": lambda: importlib.import_module(
@@ -39,7 +39,7 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ZARR_MIMETYPE: lambda: importlib.import_module(
             "...adapters.zarr", __name__
         ).read_zarr,
-        ZIP_MIMETYPE: lambda: importlib.import_module(
+        AWKWARD_BUFFERS_MIMETYPE: lambda: importlib.import_module(
             "...adapters.awkward_buffers", __name__
         ).AwkwardBuffersAdapter.from_directory,
     }

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -17,16 +17,16 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ).TiffAdapter,
         "multipart/related;type=image/tiff": lambda: importlib.import_module(
             "...adapters.tiff", __name__
-        ).TiffSequenceAdapter.from_files,
+        ).TiffSequenceAdapter.from_filepaths,
         "text/csv": lambda: importlib.import_module(
             "...adapters.csv", __name__
         ).read_csv,
         XLSX_MIME_TYPE: lambda: importlib.import_module(
             "...adapters.excel", __name__
-        ).ExcelAdapter.from_file,
+        ).ExcelAdapter.from_filepath,
         "application/x-hdf5": lambda: importlib.import_module(
             "...adapters.hdf5", __name__
-        ).HDF5Adapter.from_file,
+        ).HDF5Adapter.from_filepath,
         "application/x-netcdf": lambda: importlib.import_module(
             "...adapters.netcdf", __name__
         ).read_netcdf,

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -23,7 +23,7 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ).read_csv,
         XLSX_MIME_TYPE: lambda: importlib.import_module(
             "...adapters.excel", __name__
-        ).ExcelAdapter.from_filepath,
+        ).ExcelAdapter.from_uri,
         "application/x-hdf5": lambda: importlib.import_module(
             "...adapters.hdf5", __name__
         ).HDF5Adapter.from_filepath,

--- a/tiled/catalog/mimetypes.py
+++ b/tiled/catalog/mimetypes.py
@@ -17,7 +17,7 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ).TiffAdapter,
         "multipart/related;type=image/tiff": lambda: importlib.import_module(
             "...adapters.tiff", __name__
-        ).TiffSequenceAdapter.from_filepaths,
+        ).TiffSequenceAdapter.from_uris,
         "text/csv": lambda: importlib.import_module(
             "...adapters.csv", __name__
         ).read_csv,
@@ -26,7 +26,7 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         ).ExcelAdapter.from_uri,
         "application/x-hdf5": lambda: importlib.import_module(
             "...adapters.hdf5", __name__
-        ).HDF5Adapter.from_filepath,
+        ).HDF5Adapter.from_uri,
         "application/x-netcdf": lambda: importlib.import_module(
             "...adapters.netcdf", __name__
         ).read_netcdf,

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -139,7 +139,6 @@ class DataSourceAssetAssociation(Base):
     __table_args__ = (
         UniqueConstraint(
             "data_source_id",
-            "asset_id",
             "parameter",
             "num",
             name="parameter_num_unique_constraint",

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -156,7 +156,7 @@ def unique_parameter_num_null_check(target, connection, **kw):
         connection.execute(
             text(
                 """
-CREATE TRIGGER cannot_insert_num_null_if_num_int_exists
+CREATE TRIGGER cannot_insert_num_null_if_num_exists
 BEFORE INSERT ON data_source_asset_association
 WHEN NEW.num IS NULL
 BEGIN
@@ -213,7 +213,7 @@ $$ LANGUAGE plpgsql;"""
         connection.execute(
             text(
                 """
-CREATE TRIGGER cannot_insert_num_null_if_num_int_exists
+CREATE TRIGGER cannot_insert_num_null_if_num_exists
 BEFORE INSERT ON data_source_asset_association
 FOR EACH ROW
 WHEN (NEW.num IS NULL)

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -176,13 +176,13 @@ class DataSource(Timestamped, Base):
     assets: Mapped[List["Asset"]] = relationship(
         secondary="data_source_asset_association",
         back_populates="data_sources",
+        cascade="all, delete",
+        lazy="selectin",
         viewonly=True,
     )
     # association between Asset -> Association -> DataSource
     asset_associations: Mapped[List["DataSourceAssetAssociation"]] = relationship(
         back_populates="data_source",
-        cascade="all, delete",
-        lazy="selectin",
     )
 
 
@@ -211,7 +211,6 @@ class Asset(Timestamped, Base):
     # association between DataSource -> Association -> Asset
     data_source_associations: Mapped[List["DataSourceAssetAssociation"]] = relationship(
         back_populates="asset",
-        passive_deletes=True,
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -135,9 +135,6 @@ class DataSourceAssetAssociation(Base):
         back_populates="data_source_associations", lazy="selectin"
     )
 
-    # TODO We should additionally ensure that, if there is a row with some
-    # parameter P and num NULL, that there can be no rows with parameter P and
-    # num <INT>. This may be possible with a trigger.
     __table_args__ = (
         UniqueConstraint(
             "data_source_id",
@@ -145,6 +142,8 @@ class DataSourceAssetAssociation(Base):
             "num",
             name="parameter_num_unique_constraint",
         ),
+        # Below, in unique_parameter_num_null_check, additional constraints
+        # are applied, via triggers.
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -194,7 +194,7 @@ END"""
         connection.execute(
             text(
                 """
-CREATE OR REPLACE FUNCTION test_parameter_exists()
+CREATE OR REPLACE FUNCTION raise_if_parameter_exists()
 RETURNS TRIGGER AS $$
 BEGIN
     IF EXISTS (
@@ -217,13 +217,13 @@ CREATE TRIGGER cannot_insert_num_null_if_num_int_exists
 BEFORE INSERT ON data_source_asset_association
 FOR EACH ROW
 WHEN (NEW.num IS NULL)
-EXECUTE FUNCTION test_parameter_exists();"""
+EXECUTE FUNCTION raise_if_parameter_exists();"""
             )
         )
         connection.execute(
             text(
                 """
-CREATE OR REPLACE FUNCTION test_not_null_parameter_exists()
+CREATE OR REPLACE FUNCTION raise_if_null_parameter_exists()
 RETURNS TRIGGER AS $$
 BEGIN
     IF EXISTS (
@@ -247,7 +247,7 @@ CREATE TRIGGER cannot_insert_num_int_if_num_null_exists
 BEFORE INSERT ON data_source_asset_association
 FOR EACH ROW
 WHEN (NEW.num IS NOT NULL)
-EXECUTE FUNCTION test_not_null_parameter_exists();"""
+EXECUTE FUNCTION raise_if_null_parameter_exists();"""
             )
         )
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -220,6 +220,36 @@ WHEN (NEW.num IS NULL)
 EXECUTE FUNCTION test_parameter_exists();"""
             )
         )
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION test_not_null_parameter_exists()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM data_source_asset_association
+        WHERE parameter = NEW.parameter
+        AND data_source_id = NEW.data_source_id
+        AND num IS NULL
+    ) THEN
+        RAISE EXCEPTION 'Can only insert INTEGER num if no NULL row exists for the same parameter';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER cannot_insert_num_int_if_num_null_exists
+BEFORE INSERT ON data_source_asset_association
+FOR EACH ROW
+WHEN (NEW.num IS NOT NULL)
+EXECUTE FUNCTION test_not_null_parameter_exists();"""
+            )
+        )
 
 
 class DataSource(Timestamped, Base):

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -102,7 +102,7 @@ class DataSourceAssetAssociation(Base):
     """
     This describes which Assets are used by which DataSources, and how.
 
-    The 'parameter' describes which argument to pass the asset to in when
+    The 'parameter' describes which argument to pass the asset into when
     constructing the Adapter. If 'parameter' is NULL then the asset is an
     indirect dependency, such as a HDF5 data file backing an HDF5 'master'
     file.

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -216,6 +216,7 @@ $$ LANGUAGE plpgsql;"""
 CREATE TRIGGER cannot_insert_num_null_if_num_int_exists
 BEFORE INSERT ON data_source_asset_association
 FOR EACH ROW
+WHEN (NEW.num IS NULL)
 EXECUTE FUNCTION test_parameter_exists();"""
             )
         )

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -188,6 +188,7 @@ class DataSource(Timestamped, Base):
     asset_associations: Mapped[List["DataSourceAssetAssociation"]] = relationship(
         back_populates="data_source",
         lazy="selectin",
+        order_by=[DataSourceAssetAssociation.parameter, DataSourceAssetAssociation.num],
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -129,13 +129,17 @@ class DataSourceAssetAssociation(Base):
     data_source: Mapped["DataSource"] = relationship(
         back_populates="asset_associations"
     )
-    asset: Mapped["Asset"] = relationship(back_populates="data_source_associations")
+    asset: Mapped["Asset"] = relationship(
+        back_populates="data_source_associations", lazy="selectin"
+    )
 
     # TODO We should additionally ensure that, if there is a row with some
     # parameter P and num NULL, that there can be no rows with parameter P and
     # num <INT>. This may be possible with a trigger.
     __table_args__ = (
         UniqueConstraint(
+            "data_source_id",
+            "asset_id",
             "parameter",
             "num",
             name="parameter_num_unique_constraint",
@@ -183,6 +187,7 @@ class DataSource(Timestamped, Base):
     # association between Asset -> Association -> DataSource
     asset_associations: Mapped[List["DataSourceAssetAssociation"]] = relationship(
         back_populates="data_source",
+        lazy="selectin",
     )
 
 

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -291,7 +291,7 @@ async def register_single_item(
     adapter_factory = settings.adapters_by_mimetype[mimetype]
     logger.info("    Resolved mimetype '%s' with adapter for '%s'", mimetype, item)
     try:
-        adapter = await anyio.to_thread.run_sync(adapter_factory, item)
+        adapter = await anyio.to_thread.run_sync(adapter_factory, ensure_uri(item))
     except Exception:
         logger.exception("    SKIPPED: Error constructing adapter for '%s':", item)
         return
@@ -310,9 +310,9 @@ async def register_single_item(
                 management=Management.external,
                 assets=[
                     Asset(
-                        data_uri=str(ensure_uri(str(item.absolute()))),
+                        data_uri=ensure_uri(item),
                         is_directory=is_directory,
-                        parameter="filepath",
+                        parameter="data_uri",
                     )
                 ],
             )
@@ -369,7 +369,7 @@ async def register_tiff_sequence(catalog, name, sequence, settings):
     adapter_class = settings.adapters_by_mimetype[TIFF_SEQ_MIMETYPE]
     key = settings.key_from_filename(name)
     try:
-        adapter = adapter_class(sequence)
+        adapter = adapter_class([ensure_uri(filepath) for filepath in sequence])
     except Exception:
         logger.exception("    SKIPPED: Error constructing adapter for '%s'", name)
         return
@@ -387,9 +387,9 @@ async def register_tiff_sequence(catalog, name, sequence, settings):
                 management=Management.external,
                 assets=[
                     Asset(
-                        data_uri=str(ensure_uri(str(item.absolute()))),
+                        data_uri=ensure_uri(item),
                         is_directory=False,
-                        parameter="filepaths",
+                        parameter="data_uris",
                         num=i,
                     )
                     for i, item in enumerate(sequence)

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -309,10 +309,14 @@ async def register_single_item(
                 parameters={},
                 management=Management.external,
                 assets=[
-                    Asset(
-                        data_uri=str(ensure_uri(str(item.absolute()))),
-                        is_directory=is_directory,
-                    )
+                    {
+                        "parameter": "filepath",
+                        "num": None,
+                        "asset": Asset(
+                            data_uri=str(ensure_uri(str(item.absolute()))),
+                            is_directory=is_directory,
+                        ),
+                    }
                 ],
             )
         ],

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -309,14 +309,11 @@ async def register_single_item(
                 parameters={},
                 management=Management.external,
                 assets=[
-                    {
-                        "parameter": "filepath",
-                        "num": None,
-                        "asset": Asset(
-                            data_uri=str(ensure_uri(str(item.absolute()))),
-                            is_directory=is_directory,
-                        ),
-                    }
+                    Asset(
+                        data_uri=str(ensure_uri(str(item.absolute()))),
+                        is_directory=is_directory,
+                        parameter="filepath",
+                    )
                 ],
             )
         ],
@@ -365,7 +362,7 @@ async def tiff_sequence(
         adapter_class = settings.adapters_by_mimetype[mimetype]
         key = settings.key_from_filename(name)
         try:
-            adapter = adapter_class(*sequence)
+            adapter = adapter_class(sequence)
         except Exception:
             logger.exception("    SKIPPED: Error constructing adapter for '%s'", name)
             return
@@ -385,8 +382,10 @@ async def tiff_sequence(
                         Asset(
                             data_uri=str(ensure_uri(str(item.absolute()))),
                             is_directory=False,
+                            parameter="filepaths",
+                            num=i,
                         )
-                        for item in sorted(sequence)
+                        for i, item in enumerate(sorted(sequence))
                     ],
                 )
             ],

--- a/tiled/catalog/utils.py
+++ b/tiled/catalog/utils.py
@@ -1,27 +1,8 @@
 import re
-import sys
 from pathlib import Path
-from urllib import parse
-
-import httpx
+from urllib.parse import urlparse, urlunparse
 
 SCHEME_PATTERN = re.compile(r"^[a-z0-9+]+:\/\/.*$")
-
-
-def safe_path(uri):
-    """
-    Acceess the path of a URI and return it as a Path object.
-
-    Ideally we could just do uri.path, but Windows paths confuse
-    HTTP URI parsers because of the drive (e.g. C:) and return
-    something like /C:/x/y/z with an extraneous leading slash.
-    """
-    raw_path = httpx.URL(uri).path
-    if sys.platform == "win32" and raw_path[0] == "/":
-        path = raw_path[1:]
-    else:
-        path = raw_path
-    return Path(path)
 
 
 def ensure_uri(uri_or_path):
@@ -29,15 +10,15 @@ def ensure_uri(uri_or_path):
     if not SCHEME_PATTERN.match(str(uri_or_path)):
         # Interpret this as a filepath.
         path = uri_or_path
-        uri_str = parse.urlunparse(
+        uri_str = urlunparse(
             ("file", "localhost", str(Path(path).absolute()), "", "", None)
         )
     else:
         # Interpret this as a URI.
         uri_str = uri_or_path
-    uri = httpx.URL(uri_str)
-    # Ensure that, if the scheme is file, it meets the techincal standard for
-    # file URIs, like file://localhost/..., not the shorthand file:///...
-    if uri.scheme == "file":
-        uri = uri.copy_with(host="localhost")
-    return uri
+        parsed = urlparse(uri_str)
+        if parsed.netloc == "":
+            mutable = list(parsed)
+            mutable[1] = "localhost"
+            uri_str = urlunparse(mutable)
+    return uri_str

--- a/tiled/catalog/utils.py
+++ b/tiled/catalog/utils.py
@@ -21,4 +21,4 @@ def ensure_uri(uri_or_path):
             mutable = list(parsed)
             mutable[1] = "localhost"
             uri_str = urlunparse(mutable)
-    return uri_str
+    return str(uri_str)

--- a/tiled/examples/generate_files.py
+++ b/tiled/examples/generate_files.py
@@ -10,7 +10,11 @@ TIFF_PATHS = [
     ("a.tif",),
     ("b.tif",),
     ("c.tif",),
-    ("more", "d.tif"),
+    ("more", "A0001.tif"),
+    ("more", "A0002.tif"),
+    ("more", "A0003.tif"),
+    ("more", "B0001.tif"),
+    ("more", "B0002.tif"),
     ("more", "even_more", "e.tif"),
     ("more", "even_more", "f.tif"),
 ]

--- a/tiled/examples/xdi.py
+++ b/tiled/examples/xdi.py
@@ -13,10 +13,12 @@ import pandas as pd
 
 from tiled.adapters.dataframe import DataFrameAdapter
 from tiled.structures.core import Spec
+from tiled.utils import path_from_uri
 
 
-def read_xdi(filepath, structure=None, metadata=None, specs=None, access_policy=None):
+def read_xdi(data_uri, structure=None, metadata=None, specs=None, access_policy=None):
     "Read XDI-formatted file."
+    filepath = path_from_uri(data_uri)
     with open(filepath, "r") as file:
         metadata = {}
         fields = collections.defaultdict(dict)

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -88,11 +88,19 @@ Specs = pydantic.conlist(Spec, max_items=20)
 class Asset(pydantic.BaseModel):
     data_uri: str
     is_directory: bool
+    parameter: Optional[str]
+    num: Optional[int] = None
     id: Optional[int] = None
 
     @classmethod
     def from_orm(cls, orm):
-        return cls(id=orm.id, data_uri=orm.data_uri, is_directory=orm.is_directory)
+        return cls(
+            data_uri=orm.asset.data_uri,
+            is_directory=orm.asset.is_directory,
+            parameter=orm.parameter,
+            num=orm.num,
+            id=orm.asset.id,
+        )
 
 
 class Management(str, enum.Enum):
@@ -120,20 +128,6 @@ class Revision(pydantic.BaseModel):
         )
 
 
-class DataSourceAssetAssociation(pydantic.BaseModel):
-    parameter: str
-    num: Optional[int]
-    asset: Asset
-
-    @classmethod
-    def from_orm(cls, orm):
-        return cls(
-            parameter=orm.parameter,
-            num=orm.num,
-            asset=Asset.from_orm(orm.asset),
-        )
-
-
 class DataSource(pydantic.BaseModel):
     id: Optional[int] = None
     structure: Optional[
@@ -147,7 +141,7 @@ class DataSource(pydantic.BaseModel):
     ] = None
     mimetype: Optional[str] = None
     parameters: dict = {}
-    assets: List[DataSourceAssetAssociation] = []
+    assets: List[Asset] = []
     management: Management = Management.writable
 
     @classmethod
@@ -157,10 +151,7 @@ class DataSource(pydantic.BaseModel):
             structure=orm.structure,
             mimetype=orm.mimetype,
             parameters=orm.parameters,
-            assets=[
-                DataSourceAssetAssociation.from_orm(assoc)
-                for assoc in orm.assets_associations
-            ],
+            assets=[Asset.from_orm(assoc) for assoc in orm.asset_associations],
             management=orm.management,
         )
 

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -120,6 +120,20 @@ class Revision(pydantic.BaseModel):
         )
 
 
+class DataSourceAssetAssociation(pydantic.BaseModel):
+    parameter: str
+    num: Optional[int]
+    asset: Asset
+
+    @classmethod
+    def from_orm(cls, orm):
+        return cls(
+            parameter=orm.parameter,
+            num=orm.num,
+            asset=Asset.from_orm(orm.asset),
+        )
+
+
 class DataSource(pydantic.BaseModel):
     id: Optional[int] = None
     structure: Optional[
@@ -133,7 +147,7 @@ class DataSource(pydantic.BaseModel):
     ] = None
     mimetype: Optional[str] = None
     parameters: dict = {}
-    assets: List[Asset] = []
+    assets: List[DataSourceAssetAssociation] = []
     management: Management = Management.writable
 
     @classmethod
@@ -143,7 +157,10 @@ class DataSource(pydantic.BaseModel):
             structure=orm.structure,
             mimetype=orm.mimetype,
             parameters=orm.parameters,
-            assets=[Asset.from_orm(asset) for asset in orm.assets],
+            assets=[
+                DataSourceAssetAssociation.from_orm(assoc)
+                for assoc in orm.assets_associations
+            ],
             management=orm.management,
         )
 

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -8,9 +8,12 @@ import importlib.util
 import inspect
 import operator
 import os
+import platform
 import sys
 import threading
+from pathlib import Path
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 import anyio
 
@@ -654,3 +657,15 @@ async def ensure_awaitable(func, *args, **kwargs):
         return await func(*args, **kwargs)
     else:
         return await anyio.to_thread.run_sync(func, *args, **kwargs)
+
+
+def path_from_uri(uri):
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        raise ValueError(f"Only 'file' URIs are supported. URI: {uri}")
+    if platform.system() == "Windows":
+        # We slice because we need "C:/..." not "/C:/...".
+        path = Path(parsed.path[1:])
+    else:
+        path = Path(parsed.path)
+    return path

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -660,6 +660,16 @@ async def ensure_awaitable(func, *args, **kwargs):
 
 
 def path_from_uri(uri):
+    """
+    Give a URI, return a Path.
+
+    If the URI has a scheme other than 'file', raise ValueError.
+
+    >>> path_from_uri('file://localhost/a/b/c')  # POSIX-style
+    '/a/b/c'
+    >>> path_from_uri('file://localhost/C:/a/b/c')  # Windows-style
+    'C:/a/b/c'
+    """
     parsed = urlparse(uri)
     if parsed.scheme != "file":
         raise ValueError(f"Only 'file' URIs are supported. URI: {uri}")


### PR DESCRIPTION
## Status Quo

The DataSource gives us a `mimetype`, which identifies (via a registry) which Adapter to use to read/write this data. The DataSource additionally provides some optional `parameters` to configure the Adapter.

Through a many-to-many association table, each DataSource is associated with an unordered set of Assets. This might be one file (e.g. a CSV), a group of files (e.g. a TIFF sequence), or a directory with some internal structure (Zarr). When there are multiple Assets in a DataSource, they are passed to the Adapter's first argument as variadic args: `adapter(*asset_paths, **parameters)`.

It is left to the Adapter to deal with:
* Do these asset paths need to be sorted?
* Do these asset paths have different roles and/or formats?
* Are some of these assets indirect dependencies that the Adapter should not directly use?

This is messy and limiting. It makes mess of use cases like:

* TIFF sequences that may not be in alphanumeric sort order
* Data file with sidecar metadata file, like an image file with some associated YAML metadata
* HDF5 "master" files with underling "data" files that _should_ be tracked as dependencies of the DataSource, for the purposes of export or calculating size, but are not directly needed by the Adapter

## This PR

This adds to the `Asset` schema two fields:

* `parameter` -- string corresponding to the Adapter's parameter name that this Asset should be pasesd to
* `num` -- int giving a position in a list (like a TIFF sequence number) if the parameter expects a list

If the `parameter` is `None`, the Asset is an indirect dependency and not passed to the Adapter. If `num` is `None`, that indicates that there is only one Asset for the given parameter, to be passed to the Adapter as a scalar; if `num` is a integer, a list is given, sorted in ascending order.

At the database level, these columns go in to the datasource--asset association table. At the HTTP API and Python object level, these fields are just flattened (denormalized) into the Asset for simplicity.

## TO DO

- [ ] ~Developer docs on this and on the catalog database schema generally~ deferred to https://github.com/bluesky/tiled/issues/576
- [x] Tests that cover the use cases sketched above
- [x] Tests that verify the ordering is respected
- [x] All Adapters should accept a URI as input. (They may also accept a filepath.)
- [x] Database migration to update existing deployments