### PR TITLE
Replace `btree` with `btree_gin` indexes for PostgreSQL to allow larger metadata and faster nested search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         export TILED_TEST_POSTGRESQL_URI=postgresql+asyncpg://postgres:secret@localhost:5432
         # Opt in to LDAPAuthenticator tests.
         export TILED_TEST_LDAP=1
-        coverage run -m pytest -v
+        coverage run -m pytest -v -m "not slow"
         coverage report
 
   windows_checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,13 @@ jobs:
       shell: bash -l {0}
       run: |
         set -vxeuo pipefail
-        # Provide test suite with a PostgreSQL database to use.
-        export TILED_TEST_POSTGRESQL_URI=postgresql+asyncpg://postgres:secret@localhost:5432
-        # Opt in to LDAPAuthenticator tests.
-        export TILED_TEST_LDAP=1
         coverage run -m pytest -v -m "not slow"
         coverage report
+      env:
+        # Provide test suite with a PostgreSQL database to use.
+        TILED_TEST_POSTGRESQL_URI: postgresql+asyncpg://postgres:secret@localhost:5432
+        # Opt in to LDAPAuthenticator tests.
+        TILED_TEST_LDAP: 1
 
   windows_checks:
     runs-on: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,10 +319,3 @@ exclude = '''
   | web-frontend
 )
 '''
-
-[tool.pytest.ini_options]
-addopts = [ "--strict-markers" ]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "serial",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,3 +319,10 @@ exclude = '''
   | web-frontend
 )
 '''
+
+[tool.pytest.ini_options]
+addopts = [ "--strict-markers" ]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "serial",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ log_cli = 1
 log_cli_level = WARNING
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S
+addopts = --strict-markers
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,6 @@ log_cli = 1
 log_cli_level = WARNING
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S
-addopts = --strict-markers
+addopts = --strict-markers -m 'not slow'
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -155,7 +155,11 @@ async def test_search(a):
     assert await d.search(Eq("letter", "c")).keys_range(0, 5) == ["c"]
     assert await d.search(Eq("number", 12)).keys_range(0, 5) == ["c"]
 
+# @pytest_asyncio.fixture
+# @pytest.mark.asyncio
+# async def large_database():
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(a):
     for i in range(10000):

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -158,7 +158,7 @@ async def test_search(a):
 
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(a):
-    for i in range(1500):
+    for i in range(2500):
         await a.create_node(
             metadata={
                 "number": i,

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -156,11 +156,6 @@ async def test_search(a):
     assert await d.search(Eq("number", 12)).keys_range(0, 5) == ["c"]
 
 
-# @pytest_asyncio.fixture
-# @pytest.mark.asyncio
-# async def large_database():
-
-
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(a):

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -155,9 +155,11 @@ async def test_search(a):
     assert await d.search(Eq("letter", "c")).keys_range(0, 5) == ["c"]
     assert await d.search(Eq("number", 12)).keys_range(0, 5) == ["c"]
 
+
 # @pytest_asyncio.fixture
 # @pytest.mark.asyncio
 # async def large_database():
+
 
 @pytest.mark.slow
 @pytest.mark.asyncio

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -158,7 +158,7 @@ async def test_search(a):
 
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(a):
-    for i in range(10):
+    for i in range(1500):
         await a.create_node(
             metadata={
                 "number": i,

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -158,7 +158,7 @@ async def test_search(a):
 
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(a):
-    for i in range(2500):
+    for i in range(10000):
         await a.create_node(
             metadata={
                 "number": i,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -946,7 +946,7 @@ def binary_op(query, tree, operation):
     elif (dialect_name == "postgresql") and (operation == operator.eq):
         condition = orm.Node.metadata_.op("@>")(
             type_coerce(
-                {keys[0]: reduce(lambda x, y: {y: x}, keys[1:][::-1], query.value)},
+                key_array_to_json(keys, query.value),
                 orm.Node.metadata_.type,
             )
         )
@@ -1104,6 +1104,29 @@ class Collision(Conflicts):
 def json_serializer(obj):
     "The PostgreSQL JSON serializer requires str, not bytes."
     return safe_json_dump(obj).decode()
+
+
+def key_array_to_json(keys, value):
+    """Take JSON accessor information as an array of keys and value (['foo','bar'], 'baz') and convert to JSON object({'foo' : { 'bar' : 'baz'}}).
+
+    Parameters
+    ----------
+    keys : iterable
+        An array of keys to be created in the object.
+    value : string
+        Value assigned to the final key.
+
+    Returns
+    -------
+    json
+        JSON object for use in postgresql queries.
+
+    Examples
+    --------
+    >>> key_array_to_json(['x','y','z'], 1)
+    {'x': {'y': {'z': 1}}
+    """
+    return {keys[0]: reduce(lambda x, y: {y: x}, keys[1:][::-1], value)}
 
 
 STRUCTURES = {

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import sys
 import uuid
-from functools import partial
+from functools import partial, reduce
 from pathlib import Path
 from urllib.parse import quote_plus, urlparse
 
@@ -938,9 +938,18 @@ def _prepare_structure(structure_family, structure):
 
 def binary_op(query, tree, operation):
     dialect_name = tree.engine.url.get_dialect().name
-    attr = orm.Node.metadata_[query.key.split(".")]
+    keys = query.key.split(".")
+    attr = orm.Node.metadata_[keys]
     if dialect_name == "sqlite":
         condition = operation(_get_value(attr, type(query.value)), query.value)
+    # specific case where GIN optomized index can be used to speed up POSTGRES equals queries
+    elif dialect_name == "postgresql" and operation == operator.eq:
+        condition = orm.Node.metadata_.op("@>")(
+            type_coerce(
+                {keys[0]: reduce(lambda x, y: {y: x}, keys[1:][::-1], query.value)},
+                orm.Node.metadata_.type,
+            )
+        )
     else:
         condition = operation(attr, type_coerce(query.value, orm.Node.metadata_.type))
     return tree.new_variation(conditions=tree.conditions + [condition])

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1107,7 +1107,7 @@ def json_serializer(obj):
 
 
 def key_array_to_json(keys, value):
-    """Take JSON accessor information as an array of keys and value (['foo','bar'], 'baz') and convert to JSON object({'foo' : { 'bar' : 'baz'}}).
+    """Take JSON accessor information as an array of keys and value
 
     Parameters
     ----------

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -943,7 +943,7 @@ def binary_op(query, tree, operation):
     if dialect_name == "sqlite":
         condition = operation(_get_value(attr, type(query.value)), query.value)
     # specific case where GIN optomized index can be used to speed up POSTGRES equals queries
-    elif dialect_name == "postgresql" and operation == operator.eq:
+    elif (dialect_name == "postgresql") and (operation == operator.eq):
         condition = orm.Node.metadata_.op("@>")(
             type_coerce(
                 {keys[0]: reduce(lambda x, y: {y: x}, keys[1:][::-1], query.value)},

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -16,6 +16,9 @@ async def initialize_database(engine):
     from . import orm  # noqa: F401
 
     async with engine.connect() as connection:
+        # Install extensions
+        if (engine.dialect.name == "postgresql"):
+            await connection.execute(text("create extension btree_gin;"))
         # Create all tables.
         await connection.run_sync(Base.metadata.create_all)
         if engine.dialect.name == "sqlite":

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,10 +5,10 @@ from .base import Base
 
 # This is the alembic revision ID of the database revision
 # required by this version of Tiled.
-REQUIRED_REVISION = "0b033e7fbe30"
+REQUIRED_REVISION = "3db11ff95b6c"
 
 # This is list of all valid revisions (from current to oldest).
-ALL_REVISIONS = ["0b033e7fbe30", "83889e049ddc", "6825c778aa3c"]
+ALL_REVISIONS = ["3db11ff95b6c", "0b033e7fbe30", "83889e049ddc", "6825c778aa3c"]
 
 
 async def initialize_database(engine):

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -17,7 +17,7 @@ async def initialize_database(engine):
 
     async with engine.connect() as connection:
         # Install extensions
-        if (engine.dialect.name == "postgresql"):
+        if engine.dialect.name == "postgresql":
             await connection.execute(text("create extension btree_gin;"))
         # Create all tables.
         await connection.run_sync(Base.metadata.create_all)

--- a/tiled/catalog/migrations/versions/3db11ff95b6c_changing_top_level_metadata_to_btree_gin.py
+++ b/tiled/catalog/migrations/versions/3db11ff95b6c_changing_top_level_metadata_to_btree_gin.py
@@ -1,0 +1,36 @@
+"""Changing top_level_metadata to btree_gin
+
+Revision ID: 3db11ff95b6c
+Revises: 0b033e7fbe30
+Create Date: 2023-11-01 15:16:48.554420
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "3db11ff95b6c"
+down_revision = "0b033e7fbe30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.execute(sa.text("create extension IF NOT EXISTS btree_gin;"))
+            op.drop_index("top_level_metadata", table_name="nodes")
+            op.create_index(
+                "top_level_metadata",
+                "nodes",
+                ["ancestors", "time_created", "id", "metadata"],
+                postgresql_using="gin",
+            )
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/migrations/versions/3db11ff95b6c_changing_top_level_metadata_to_btree_gin.py
+++ b/tiled/catalog/migrations/versions/3db11ff95b6c_changing_top_level_metadata_to_btree_gin.py
@@ -5,9 +5,8 @@ Revises: 0b033e7fbe30
 Create Date: 2023-11-01 15:16:48.554420
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "3db11ff95b6c"

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -90,7 +90,7 @@ class Node(Timestamped, Base):
             "time_created",
             "id",
             "metadata",
-            postgresql_using="btree",
+            postgresql_using="gin",
         ),
         # This is used by ORDER BY with the default sorting.
         # Index("ancestors_time_created", "ancestors", "time_created"),


### PR DESCRIPTION
### The title explains it all, this PR is intended to have the following effects:

- Enable the pg ingestion of real bluesky runs from existing beamline datasets which can occasionally have very large metadata, previously when attempting to do this using the default `btree` index type the operation would fail with an error.
- Enable the `eq` binary operation for queries like `.search(Key("start.purpose") == "test")` to utilize the new index for rapid traversals, greatly reducing the time needed to query when searching for nested strings in metadata objects.

### Caveats:
- Currently the btree_gin index is not being invoked for all other binary operations including `ne`,`lt`,`le`,`gt`,`ge` leading to slow seq scans in those conditions. Hypothetically this can be achieved but there is no known way currently.
- The `eq` operator is technically being converted to the postgresql `@>` operator which is technically an `IN`, this may have unintended side effects.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205786328204581