### PR TITLE
Cleanup extraneous print() statements in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,6 @@
 testpaths =
     tiled/_tests
 log_cli = 1
-log_cli_level = INFO
+log_cli_level = WARNING
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 testpaths =
     tiled/_tests
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -78,7 +78,7 @@ def tmpdir_module(request, tmpdir_factory):
     return tmpdir_factory.mktemp(request.module.__name__)
 
 
-# Use this with pytest -s option.
+# Use this with pytest --log-cli-level=INFO option.
 if os.getenv("TILED_DEBUG_LEAKED_THREADS"):
     import logging
     import threading

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -80,13 +80,15 @@ def tmpdir_module(request, tmpdir_factory):
 
 # Use this with pytest -s option.
 if os.getenv("TILED_DEBUG_LEAKED_THREADS"):
+    import logging
     import threading
     import time
 
     def poll_enumerate():
+        logger = logging.getLogger(__name__)
         while True:
             time.sleep(1)
-            print("THREAD COUNT", len(threading.enumerate()))
+            logger.info("THREAD COUNT = %d", len(threading.enumerate()))
 
     thread = threading.Thread(target=poll_enumerate, daemon=True)
     thread.start()

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -78,7 +78,7 @@ def tmpdir_module(request, tmpdir_factory):
     return tmpdir_factory.mktemp(request.module.__name__)
 
 
-# Use this with pytest --log-cli-level=INFO option.
+# Use this with pytest --log-cli-level=25 option.
 if os.getenv("TILED_DEBUG_LEAKED_THREADS"):
     import logging
     import threading
@@ -86,9 +86,10 @@ if os.getenv("TILED_DEBUG_LEAKED_THREADS"):
 
     def poll_enumerate():
         logger = logging.getLogger(__name__)
+        msg_level = int(logging.INFO + logging.WARNING)//2
         while True:
             time.sleep(1)
-            logger.info("THREAD COUNT = %d", len(threading.enumerate()))
+            logger.log(msg_level, "THREAD COUNT = %d", len(threading.enumerate()))
 
     thread = threading.Thread(target=poll_enumerate, daemon=True)
     thread.start()

--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -108,8 +108,12 @@ def test_shape_with_zero(context):
 
 def test_nan_infinity_handler(tmpdir, context):
     client = from_context(context)["inf"]
-    print(f"Metadata: {client['example'].metadata}")
-    print(f"Data: {client['example'].read()}")
+    data = client['example'].read()
+    assert numpy.isnan(data).any()
+    assert numpy.isinf(data).any()
+    metadata = tuple(client['example'].metadata.values())
+    assert numpy.isnan(metadata).any()
+    assert numpy.isinf(metadata).any()
     Path(tmpdir, "testjson").mkdir()
     client["example"].export(Path(tmpdir, "testjson", "test.json"))
 

--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -108,10 +108,10 @@ def test_shape_with_zero(context):
 
 def test_nan_infinity_handler(tmpdir, context):
     client = from_context(context)["inf"]
-    data = client['example'].read()
+    data = client["example"].read()
     assert numpy.isnan(data).any()
     assert numpy.isinf(data).any()
-    metadata = tuple(client['example'].metadata.values())
+    metadata = tuple(client["example"].metadata.values())
     assert numpy.isnan(metadata).any()
     assert numpy.isinf(metadata).any()
     Path(tmpdir, "testjson").mkdir()

--- a/tiled/_tests/test_hdf5.py
+++ b/tiled/_tests/test_hdf5.py
@@ -32,7 +32,7 @@ def example_file_with_vlen_str_in_dataset():
     # Need to do this to make a vlen str dataset
     dt = h5py.string_dtype(encoding="utf-8")
     dset = c.create_dataset("d", (100,), dtype=dt)
-    # print(dset.dtype)
+    assert dset.dtype == "object"
     dset[0] = b"test"
     return file
 

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -144,7 +144,6 @@ class TiffSequenceAdapter:
         of a group of images
         """
 
-        # Print("Inside Adapter:", slice)
         if slice is None:
             return with_object_cache(self._cache_key, self._seq.asarray)
         if isinstance(slice, int):


### PR DESCRIPTION
Closes #589 

* Converted several debug-style print() statements into assertions
* Enable live logging for pytest
* Use logger with custom log level (>INFO && <WARNING) for TILED_DEBUG_LEAKED_THREADS counting
    * Too many INFO log entries from normal use of client and server