### PR TITLE
add dummy file name for some tiffseq

### DIFF
--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -7,7 +7,7 @@ import tifffile as tf
 from ..adapters.mapping import MapAdapter
 from ..adapters.tiff import TiffAdapter, TiffSequenceAdapter
 from ..catalog import in_memory
-from ..catalog.register import register
+from ..catalog.register import register, TIFF_SEQUENCE_EMPTY_NAME_ROOT
 from ..client import Context, from_context
 from ..server.app import build_app
 
@@ -129,7 +129,7 @@ a,b,c
         # Single image is its own node.
         assert client["single_image"].shape == (3, 5)
         # Each sequence is grouped into a node.
-        assert client["_"].shape == (10, 3, 5)
+        assert client[TIFF_SEQUENCE_EMPTY_NAME_ROOT].shape == (10, 3, 5)
         assert client["image"].shape == (10, 3, 5)
         assert client["other_image"].shape == (10, 3, 5)
         assert client["other_image2_"].shape == (10, 3, 5)

--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -7,7 +7,7 @@ import tifffile as tf
 from ..adapters.mapping import MapAdapter
 from ..adapters.tiff import TiffAdapter, TiffSequenceAdapter
 from ..catalog import in_memory
-from ..catalog.register import register, TIFF_SEQUENCE_EMPTY_NAME_ROOT
+from ..catalog.register import TIFF_SEQUENCE_EMPTY_NAME_ROOT, register
 from ..client import Context, from_context
 from ..server.app import build_app
 

--- a/tiled/_tests/test_tiff.py
+++ b/tiled/_tests/test_tiff.py
@@ -129,6 +129,7 @@ a,b,c
         # Single image is its own node.
         assert client["single_image"].shape == (3, 5)
         # Each sequence is grouped into a node.
+        assert client["_"].shape == (10, 3, 5)
         assert client["image"].shape == (10, 3, 5)
         assert client["other_image"].shape == (10, 3, 5)
         assert client["other_image2_"].shape == (10, 3, 5)

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -349,6 +349,8 @@ async def tiff_sequence(
             match = TIFF_SEQUENCE_STEM_PATTERN.match(file.name)
             if match:
                 sequence_name, _sequence_number = match.groups()
+                if sequence_name == '':
+                    sequence_name = '_'
                 sequences[sequence_name].append(file)
                 continue
         unhandled_files.append(file)

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -322,7 +322,8 @@ async def register_single_item(
 # Matches filename with (optional) prefix characters followed by digits \d
 # and then the file extension .tif or .tiff.
 TIFF_SEQUENCE_STEM_PATTERN = re.compile(r"^(.*?)(\d+)\.(?:tif|tiff)$")
-TIFF_SEQUENCE_EMPTY_NAME_ROOT = '_'
+TIFF_SEQUENCE_EMPTY_NAME_ROOT = "_"
+
 
 async def tiff_sequence(
     catalog,
@@ -349,7 +350,7 @@ async def tiff_sequence(
             match = TIFF_SEQUENCE_STEM_PATTERN.match(file.name)
             if match:
                 sequence_name, _sequence_number = match.groups()
-                if sequence_name == '':
+                if sequence_name == "":
                     sequence_name = TIFF_SEQUENCE_EMPTY_NAME_ROOT
                 sequences[sequence_name].append(file)
                 continue

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -322,7 +322,7 @@ async def register_single_item(
 # Matches filename with (optional) prefix characters followed by digits \d
 # and then the file extension .tif or .tiff.
 TIFF_SEQUENCE_STEM_PATTERN = re.compile(r"^(.*?)(\d+)\.(?:tif|tiff)$")
-TIFF_SEQUENCE_EMPTY_NAME_ROOT = "_"
+TIFF_SEQUENCE_EMPTY_NAME_ROOT = "_unnamed"
 
 
 async def tiff_sequence(

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -322,7 +322,7 @@ async def register_single_item(
 # Matches filename with (optional) prefix characters followed by digits \d
 # and then the file extension .tif or .tiff.
 TIFF_SEQUENCE_STEM_PATTERN = re.compile(r"^(.*?)(\d+)\.(?:tif|tiff)$")
-
+TIFF_SEQUENCE_EMPTY_NAME_ROOT = '_'
 
 async def tiff_sequence(
     catalog,
@@ -350,7 +350,7 @@ async def tiff_sequence(
             if match:
                 sequence_name, _sequence_number = match.groups()
                 if sequence_name == '':
-                    sequence_name = '_'
+                    sequence_name = TIFF_SEQUENCE_EMPTY_NAME_ROOT
                 sequences[sequence_name].append(file)
                 continue
         unhandled_files.append(file)


### PR DESCRIPTION
This addresses a bug with the tiff sequence code.

When the files of a tiffsequence don't start with letters, just numbers, a hash was used for the key for that node. 

So:
```
tiff_files
  - 001.tiff
  - 002.tiff
  - a001.tiff
  - a002.tiff
  - b001.tiff
  - b002.tiff
```
would result in 

```
['d3a7b120-91f8-41ef-a1ff-f3e312f23525',
 'a',
 'b']
```

The unit test wasn't expecting a random name for this node, so it didn't test for it.


This PR detects that case and adds an `_` in as the key name. On a call with @taxe10 and @danielballan, we debated this default root name for only a couple seconds. I'm happy to hear better ideas.