### PR TITLE
Add `--api-key` CLI option

### DIFF
--- a/docs/source/explanations/security.md
+++ b/docs/source/explanations/security.md
@@ -35,8 +35,13 @@ client, a cookie will be set in your client and you won’t need to use the toke
 again. It is valid indefinitely.
 
 For horizontally-scaled deployments where you need multiple instances of the
-server to share the same secret, you can set it via an environment variable like
-so.
+server to share the same secret, you can set it with a CLI option
+
+```
+tiled serve ... --api-key=YOUR_SECRET
+```
+
+or via an environment variable
 
 ```
 TILED_SINGLE_USER_API_KEY=YOUR_SECRET tiled serve ...

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -34,6 +34,14 @@ def serve_directory(
             "this option selected."
         ),
     ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Set the single-user API key. "
+            "By default, a random key is generated at startup and printed."
+        ),
+    ),
     keep_ext: bool = typer.Option(
         False,
         "--keep-ext",
@@ -182,7 +190,10 @@ def serve_directory(
         register_logger.setLevel("INFO")
     web_app = build_app(
         catalog_adapter,
-        {"allow_anonymous_access": public},
+        {
+            "allow_anonymous_access": public,
+            "single_user_api_key": api_key,
+        },
         server_settings,
     )
     if watch:
@@ -268,6 +279,14 @@ def serve_catalog(
             "Turns off requirement for API key authentication for reading. "
             "However, the API key is still required for writing, so data cannot be modified even with "
             "this option selected."
+        ),
+    ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Set the single-user API key. "
+            "By default, a random key is generated at startup and printed."
         ),
     ),
     host: str = typer.Option(
@@ -388,7 +407,13 @@ or use an existing one:
         init_if_not_exists=init,
     )
     web_app = build_app(
-        tree, {"allow_anonymous_access": public}, server_settings, scalable=scalable
+        tree,
+        {
+            "allow_anonymous_access": public,
+            "single_user_api_key": api_key,
+        },
+        server_settings,
+        scalable=scalable,
     )
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
@@ -412,6 +437,14 @@ def serve_pyobject(
             "Turns off requirement for API key authentication for reading. "
             "However, the API key is still required for writing, so data cannot be modified even with this "
             "option selected."
+        ),
+    ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Set the single-user API key. "
+            "By default, a random key is generated at startup and printed."
         ),
     ),
     host: str = typer.Option(
@@ -453,7 +486,13 @@ def serve_pyobject(
             "available_bytes"
         ] = object_cache_available_bytes
     web_app = build_app(
-        tree, {"allow_anonymous_access": public}, server_settings, scalable=scalable
+        tree,
+        {
+            "allow_anonymous_access": public,
+            "single_user_api_key": api_key,
+        },
+        server_settings,
+        scalable=scalable,
     )
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
@@ -507,6 +546,14 @@ def serve_config(
             "option selected."
         ),
     ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Set the single-user API key. "
+            "By default, a random key is generated at startup and printed."
+        ),
+    ),
     host: str = typer.Option(
         None,
         help=(
@@ -543,6 +590,11 @@ def serve_config(
         if "authentication" not in parsed_config:
             parsed_config["authentication"] = {}
         parsed_config["authentication"]["allow_anonymous_access"] = True
+    # Let --api-key flag override config.
+    if api_key:
+        if "authentication" not in parsed_config:
+            parsed_config["authentication"] = {}
+        parsed_config["authentication"]["single_user_api_key"] = api_key
 
     # Delay this import so that we can fail faster if config-parsing fails above.
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -409,8 +409,8 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         ]:
             if authentication.get(item) is not None:
                 setattr(settings, item, authentication[item])
-            if authentication.get("single_user_api_key") is not None:
-                settings.single_user_api_key_generated = False
+        if authentication.get("single_user_api_key") is not None:
+            settings.single_user_api_key_generated = False
         for item in [
             "allow_origins",
             "response_bytesize_limit",

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -409,6 +409,8 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         ]:
             if authentication.get(item) is not None:
                 setattr(settings, item, authentication[item])
+            if authentication.get("single_user_api_key") is not None:
+                settings.single_user_api_key_generated = False
         for item in [
             "allow_origins",
             "response_bytesize_limit",


### PR DESCRIPTION
Closes #583 

e.g.

```
tiled serve catalog --temp --api-key=secret
```

Since there is only ever one key, I think a flag plus the existing env var (`TILED_SINGLE_USER_API_KEY`) is good enough for now. We can add `--api-key-file` later if we like.