### PR TITLE
Revoke session on logout.

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -119,7 +119,7 @@ def test_logout(enter_password, config, tmpdir):
         # not been that long.
         client = from_context(context, username="alice")
         # The refresh token refers to a revoked session, so refreshing the
-        # session to new a *new* access and refresh token will fail.
+        # session to generate a *new* access and refresh token will fail.
         with pytest.raises(CannotRefreshAuthentication):
             client.context.force_auth_refresh()
 

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -92,7 +92,7 @@ def test_password_auth(enter_password, config):
 
 def test_logout(enter_password, config, tmpdir):
     """
-    A password that is wrong, empty, or belonging to a different user fails.
+    Logging out revokes the session, such that it cannot be refreshed.
     """
     with Context.from_app(build_app_from_config(config)) as context:
         # Log in as Alice.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -669,7 +669,13 @@ and enter the code:
             return
 
         # Revoke the current session.
-        handle_error(self.http_client.post(f"{self.api_uri}auth/logout"))
+        refresh_token = self.http_client.auth.sync_get_token("refresh_token")
+        handle_error(
+            self.http_client.post(
+                f"{self.api_uri}auth/session/revoke",
+                json={"refresh_token": refresh_token},
+            )
+        )
 
         # Clear on-disk state.
         self.http_client.auth.sync_clear_token("access_token")

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -670,18 +670,16 @@ and enter the code:
 
         # Revoke the current session.
         refresh_token = self.http_client.auth.sync_get_token("refresh_token")
-        csrf_token = self.http_client.cookies["tiled_csrf"]
-        # Manually build a request, circumventing auth because this request is not authenticated.
-        # The refresh_token in the body is the relevant proof, not the Authentication header.
-        request = httpx.Request(
-            "POST",
-            f"{self.api_uri}auth/session/revoke",
-            json={"refresh_token": refresh_token},
-            # Submit CSRF token in both header and cookie.
-            # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
-            headers={"x-csrf": csrf_token},
+        handle_error(
+            self.http_client.post(
+                f"{self.api_uri}auth/session/revoke",
+                json={"refresh_token": refresh_token},
+                # Circumvent auth because this request is not authenticated.
+                # The refresh_token in the body is the relevant proof, not the
+                # 'Authentication' header.
+                auth=None,
+            )
         )
-        handle_error(self.http_client.send(request, auth=None))
 
         # Clear on-disk state.
         self.http_client.auth.sync_clear_token("access_token")

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -672,7 +672,7 @@ and enter the code:
         refresh_token = self.http_client.auth.sync_get_token("refresh_token")
         csrf_token = self.http_client.cookies["tiled_csrf"]
         # Manually build a request, circumventing auth because this request is not authenticated.
-        # The refresh_token is the body is the relevant proof, not the Authentication header.
+        # The refresh_token in the body is the relevant proof, not the Authentication header.
         request = httpx.Request(
             "POST",
             f"{self.api_uri}auth/session/revoke",

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -915,7 +915,7 @@ async def revoke_session(
     return Response(status_code=204)
 
 
-@base_authentication_router.post("/session/revoke/{session_id}")
+@base_authentication_router.delete("/session/revoke/{session_id}")
 async def revoke_session_by_id(
     session_id: str,  # from path parameter
     request: Request,

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -919,6 +919,7 @@ async def revoke_session(
 async def revoke_session_by_id(
     session_id: str,  # from path parameter
     request: Request,
+    principal=Security(get_current_principal, scopes=[]),
     db=Depends(get_database_session),
 ):
     "Mark a Session as revoked so it cannot be refreshed again."

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -908,7 +908,7 @@ async def revoke_session(
     # Find this session in the database.
     session = await lookup_valid_session(db, session_id)
     if session is None:
-        raise HTTPException(404, detail=f"No session {session_id}")
+        raise HTTPException(409, detail=f"No session {session_id}")
     session.revoked = True
     db.add(session)
     await db.commit()

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -894,11 +894,32 @@ async def refresh_session(
     return new_tokens
 
 
-@base_authentication_router.delete("/session/revoke/{session_id}")
+@base_authentication_router.post("/session/revoke")
 async def revoke_session(
+    request: Request,
+    refresh_token: schemas.RefreshToken,
+    principal: schemas.Principal = Security(get_current_principal, scopes=[]),
+    settings: BaseSettings = Depends(get_settings),
+    db=Depends(get_database_session),
+):
+    "Mark a Session as revoked so it cannot be refreshed again."
+    request.state.endpoint = "auth"
+    payload = decode_token(refresh_token.refresh_token, settings.secret_keys)
+    session_id = payload["sid"]
+    # Find this session in the database.
+    session = await lookup_valid_session(db, session_id)
+    if session is None:
+        raise HTTPException(404, detail=f"No session {session_id}")
+    session.revoked = True
+    db.add(session)
+    await db.commit()
+    return Response(status_code=204)
+
+
+@base_authentication_router.post("/session/revoke/{session_id}")
+async def revoke_session_by_id(
     session_id: str,  # from path parameter
     request: Request,
-    principal: schemas.Principal = Security(get_current_principal, scopes=[]),
     db=Depends(get_database_session),
 ):
     "Mark a Session as revoked so it cannot be refreshed again."
@@ -1095,12 +1116,13 @@ async def whoami(
     )
 
 
-@base_authentication_router.post("/logout")
+@base_authentication_router.post("/logout", include_in_schema=False)
 async def logout(
     request: Request,
     response: Response,
     principal=Security(get_current_principal, scopes=[]),
 ):
+    "Deprecated. See revoke_session: POST /session/revoke."
     request.state.endpoint = "auth"
     response.delete_cookie(API_KEY_COOKIE_NAME)
     return {}

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -898,7 +898,6 @@ async def refresh_session(
 async def revoke_session(
     request: Request,
     refresh_token: schemas.RefreshToken,
-    principal: schemas.Principal = Security(get_current_principal, scopes=[]),
     settings: BaseSettings = Depends(get_settings),
     db=Depends(get_database_session),
 ):

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -919,7 +919,7 @@ async def revoke_session(
 async def revoke_session_by_id(
     session_id: str,  # from path parameter
     request: Request,
-    principal=Security(get_current_principal, scopes=[]),
+    principal: schemas.Principal = Security(get_current_principal, scopes=[]),
     db=Depends(get_database_session),
 ):
     "Mark a Session as revoked so it cannot be refreshed again."


### PR DESCRIPTION
Closes #602 

In `main`, logging out with the Python client discards the relevant tokens, but it leaves the session open. Anyone holding a copy of the refresh token (somehow) can refresh the session and continue to use it, as long as they do so within the refresh token lifetime (days or weeks).

Now, logging out first _revokes_ the session, such that it can not be refreshed again, and then discards the tokens. A new unit test verifies that the old refresh token cannot be reused after logout.