### PR TITLE
Support ''Specs', Contains', 'In', and 'NotIn' queries on PostgreSQL backend

### DIFF
--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -146,15 +146,7 @@ def test_comparison(client):
 
 
 def test_contains(client):
-    if client.metadata["backend"] == "postgresql":
-
-        def cm():
-            return fail_with_status_code(400)
-
-    else:
-        cm = nullcontext
-    with cm():
-        assert list(client.search(Contains("letters", "z"))) == ["does_contain_z"]
+    assert list(client.search(Contains("letters", "z"))) == ["does_contain_z"]
 
 
 def test_full_text(client):
@@ -215,19 +207,11 @@ def test_not_and_and_or(client):
     ],
 )
 def test_in(client, query_values):
-    if client.metadata["backend"] == "postgresql":
-
-        def cm():
-            return fail_with_status_code(400)
-
-    else:
-        cm = nullcontext
-    with cm():
-        assert sorted(list(client.search(In("letter", query_values)))) == [
-            "a",
-            "k",
-            "z",
-        ]
+    assert sorted(list(client.search(In("letter", query_values)))) == [
+        "a",
+        "k",
+        "z",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -240,17 +224,9 @@ def test_in(client, query_values):
     ],
 )
 def test_notin(client, query_values):
-    if client.metadata["backend"] == "postgresql":
-
-        def cm():
-            return fail_with_status_code(400)
-
-    else:
-        cm = nullcontext
-    with cm():
-        assert sorted(list(client.search(NotIn("letter", query_values)))) == sorted(
-            list(set(keys) - set(["a", "k", "z"]))
-        )
+    assert sorted(list(client.search(NotIn("letter", query_values)))) == sorted(
+        list(set(keys) - set(["a", "k", "z"]))
+    )
 
 
 @pytest.mark.parametrize(

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -250,25 +250,9 @@ def test_notin(client, query_values):
     ],
 )
 def test_specs(client, include_values, exclude_values):
-    if client.metadata["backend"] in {"postgresql", "sqlite"}:
-
-        def cm():
-            return fail_with_status_code(400)
-
-    else:
-        cm = nullcontext
-    with pytest.raises(TypeError):
-        SpecsQuery("foo")
-
-    with cm():
-        assert sorted(
-            list(client.search(SpecsQuery(include=include_values)))
-        ) == sorted(["specs_foo_bar", "specs_foo_bar_baz"])
-
-    with cm():
-        assert list(
-            client.search(SpecsQuery(include=include_values, exclude=exclude_values))
-        ) == ["specs_foo_bar"]
+    assert list(
+        client.search(SpecsQuery(include=include_values, exclude=exclude_values))
+    ) == ["specs_foo_bar"]
 
 
 def test_structure_families(client):

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -224,8 +224,19 @@ def test_in(client, query_values):
     ],
 )
 def test_notin(client, query_values):
+    # TODO: Postgres and SQlite ACTUALLY treat this query differently in external testing.
+    # SQLite WILL NOT include fields that do not have the key, which is correct.
+    # Postgres WILL include fields that do not have the key,
+    # because by extension they do not have the value. Also correct. Why?
     assert sorted(list(client.search(NotIn("letter", query_values)))) == sorted(
-        list(set(list(mapping.keys())) - set(["a", "k", "z"]))
+        list(
+            set(
+                list(mapping.keys())
+                if client.metadata["backend"] == "postgresql"
+                else keys
+            )
+            - set(["a", "k", "z"])
+        )
     )
 
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -225,7 +225,7 @@ def test_in(client, query_values):
 )
 def test_notin(client, query_values):
     assert sorted(list(client.search(NotIn("letter", query_values)))) == sorted(
-        list(set(keys) - set(["a", "k", "z"]))
+        list(set(list(mapping.keys())) - set(["a", "k", "z"]))
     )
 
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -33,7 +33,9 @@ from .utils import fail_with_status_code, temp_postgres
 keys = list(string.ascii_lowercase)
 mapping = {
     letter: ArrayAdapter.from_array(
-        number * numpy.ones(10), metadata={"letter": letter, "number": number}
+        number * numpy.ones(10),
+        metadata={"letter": letter, "number": number},
+        specs=[letter],
     )
     for letter, number in zip(keys, range(26))
 }
@@ -75,7 +77,9 @@ async def client(request, tmpdir_module):
         with Context.from_app(app) as context:
             client = from_context(context)
             for k, v in mapping.items():
-                client.write_array(v.read(), key=k, metadata=dict(v.metadata()))
+                client.write_array(
+                    v.read(), key=k, metadata=dict(v.metadata()), specs=v.specs
+                )
             yield client
     elif request.param == "postgresql":
         if not TILED_TEST_POSTGRESQL_URI:
@@ -104,7 +108,12 @@ async def client(request, tmpdir_module):
                 client = from_context(context)
                 # Write data into catalog.
                 for k, v in mapping.items():
-                    client.write_array(v.read(), key=k, metadata=dict(v.metadata()))
+                    client.write_array(
+                        v.read(),
+                        key=k,
+                        metadata=dict(v.metadata()),
+                        specs=v.specs,
+                    )
                 yield client
     else:
         assert False

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -32,12 +32,12 @@ async def temp_postgres(uri):
         await connection.commit()
     yield f"{uri}/{database_name}"
     # Drop the database.
-    async with engine.connect() as connection:
-        await connection.execute(
-            text("COMMIT")
-        )  # close the automatically-started transaction
-        await connection.execute(text(f"DROP DATABASE {database_name};"))
-        await connection.commit()
+    # async with engine.connect() as connection:
+    #     await connection.execute(
+    #         text("COMMIT")
+    #     )  # close the automatically-started transaction
+    #     await connection.execute(text(f"DROP DATABASE {database_name};"))
+    #     await connection.commit()
 
 
 @contextlib.contextmanager

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -32,12 +32,12 @@ async def temp_postgres(uri):
         await connection.commit()
     yield f"{uri}/{database_name}"
     # Drop the database.
-    # async with engine.connect() as connection:
-    #     await connection.execute(
-    #         text("COMMIT")
-    #     )  # close the automatically-started transaction
-    #     await connection.execute(text(f"DROP DATABASE {database_name};"))
-    #     await connection.commit()
+    async with engine.connect() as connection:
+        await connection.execute(
+            text("COMMIT")
+        )  # close the automatically-started transaction
+        await connection.execute(text(f"DROP DATABASE {database_name};"))
+        await connection.commit()
 
 
 @contextlib.contextmanager

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -994,7 +994,6 @@ def specs(query, tree):
 
 
 def in_or_not_in(query, tree, method):
-    print(method, "METHOD")
     dialect_name = tree.engine.url.get_dialect().name
     keys = query.key.split(".")
     attr = orm.Node.metadata_[keys]

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1004,8 +1004,6 @@ def in_or_not_in(query, tree, method):
                 )
             )
         elif method == "not_in":
-            print("NOT IN")
-            print(keys, query.value)
             condition = not_(
                 or_(
                     *(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -979,10 +979,10 @@ def specs(query, tree):
     if dialect_name == "sqlite":
         # Construct the conditions for includes
         for i, name in enumerate(query.include):
-            conditions.append(attr.like('%{"name": "' + name + '", %'))
+            conditions.append(attr.like(f'%{{"name":"{name}",%'))
         # Construct the conditions for excludes
         for i, name in enumerate(query.exclude):
-            conditions.append(not_(attr.like('%{"name": "' + name + '", %')))
+            conditions.append(not_(attr.like(f'%{{"name":"{name}",%')))
     elif dialect_name == "postgresql":
         if query.include:
             conditions.append(attr.op("@>")(specs_array_to_json(query.include)))

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -975,23 +975,19 @@ def contains(query, tree):
 def specs(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
     conditions = []
-    # attr = orm.Node.specs
-    # if dialect_name == "sqlite":
-    #     for spec in query.include:
-    #         conditions.append(_get_value(attr, type(query.value)).contains(query.value))
-    #     for spec in query.exclude:
-    #         conditions.append(
-    #             not_(_get_value(attr, type(query.value)).contains(query.value))
-    #         )
-    if dialect_name == "postgresql":
+    attr = orm.Node.specs
+    if dialect_name == "sqlite":
+        # Construct the conditions for includes
+        for i, name in enumerate(query.include):
+            conditions.append(attr.like('%{"name": "' + name + '", %'))
+        # Construct the conditions for excludes
+        for i, name in enumerate(query.exclude):
+            conditions.append(not_(attr.like('%{"name": "' + name + '", %')))
+    elif dialect_name == "postgresql":
         if query.include:
-            conditions.append(
-                orm.Node.specs.op("@>")(specs_array_to_json(query.include))
-            )
+            conditions.append(attr.op("@>")(specs_array_to_json(query.include)))
         if query.exclude:
-            conditions.append(
-                not_(orm.Node.specs.op("@>")(specs_array_to_json(query.exclude)))
-            )
+            conditions.append(not_(attr.op("@>")(specs_array_to_json(query.exclude))))
     else:
         raise UnsupportedQueryType("specs")
     return tree.new_variation(conditions=tree.conditions + conditions)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -970,6 +970,8 @@ def contains(query, tree):
     attr = orm.Node.metadata_[query.key.split(".")]
     if dialect_name == "sqlite":
         condition = _get_value(attr, type(query.value)).contains(query.value)
+    elif dialect_name == "postgresql":
+        condition = _get_value(attr, type(query.value)).contains(query.value)
     else:
         raise UnsupportedQueryType("Contains")
     return tree.new_variation(conditions=tree.conditions + [condition])

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -26,6 +26,7 @@ from tiled.queries import (
     NotEq,
     NotIn,
     Operator,
+    SpecsQuery,
     StructureFamilyQuery,
 )
 
@@ -978,13 +979,12 @@ def contains(query, tree):
 
 
 def specs(query, tree):
-    raise UnsupportedQueryType("Specs")
-    # conditions = []
-    # for spec in query.include:
-    #     conditions.append(func.json_contains(orm.Node.specs, spec))
-    # for spec in query.exclude:
-    #     conditions.append(not_(func.json_contains(orm.Node.specs.contains, spec)))
-    # return tree.new_variation(conditions=tree.conditions + conditions)
+    conditions = []
+    for spec in query.include:
+        conditions.append(func.json_contains(orm.Node.specs, spec))
+    for spec in query.exclude:
+        conditions.append(not_(func.json_contains(orm.Node.specs.contains, spec)))
+    return tree.new_variation(conditions=tree.conditions + conditions)
 
 
 def in_or_not_in(query, tree, method):
@@ -1037,8 +1037,8 @@ CatalogNodeAdapter.register_query(In, partial(in_or_not_in, method="in_"))
 CatalogNodeAdapter.register_query(NotIn, partial(in_or_not_in, method="not_in"))
 CatalogNodeAdapter.register_query(KeysFilter, keys_filter)
 CatalogNodeAdapter.register_query(StructureFamilyQuery, structure_family)
-# CatalogNodeAdapter.register_query(Specs, specs)
-# TODO: FullText, Regex, Specs
+CatalogNodeAdapter.register_query(SpecsQuery, specs)
+# TODO: FullText, Regex
 
 
 def in_memory(


### PR DESCRIPTION
Full coverage and support of all operators when using the Tiled postreSQL backend.

Progress as of PR submission:

- [x]  Contains
- [x]  In 
- [x]  NotIn
- [x]  Specs 

Right now contains is using the default ORM provided `contains` operator to be idempotent with sqlite, however this may be inefficient and subject to change. All other operators are using the more performant `@>` operator and `key_array_to_json` which we wrote to support the `eq` operator previously.

resolves #455

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206267194813267