### PR TITLE
Fix `create_container`

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import dask.dataframe
 import numpy
+import pandas
 import pandas.testing
 import pytest
 import sparse
@@ -377,6 +378,27 @@ async def test_delete_non_empty_node(tree):
         # Delete from the bottom up.
         c.delete("d")
         b.delete("c")
+        a.delete("b")
+        client.delete("a")
+
+
+@pytest.mark.asyncio
+async def test_write_in_container(tree):
+    "Create a container and write a structure into it."
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+        a = client.create_container("a")
+        df = pandas.DataFrame({"a": [1, 2, 3]})
+        b = a.write_dataframe(df, key="b")
+        b.read()
+        a.delete("b")
+        client.delete("a")
+
+        a = client.create_container("a")
+        arr = numpy.array([1, 2, 3])
+        b = a.write_array(arr, key="b")
+        b.read()
         a.delete("b")
         client.delete("a")
 


### PR DESCRIPTION
Hotfix for AIMM, jumping on a bug report from @jmaruland / @dylanmcreynolds:

## Demonstration of bug

Server:
```
$ tiled serve catalog --temp --api-key=secret
Creating catalog database at /tmp/tmpfuzb6cgw/catalog.db
Creating writable catalog data directory at /tmp/tmpfuzb6cgw/data
```

Client:

```py
In [1]: from tiled.client import from_uri

In [2]: c = from_uri('http://localhost:8000/', api_key='secret')

In [3]: c
Out[3]: <Container {}>

In [4]: x = c.create_container('x')

In [5]: import pandas

In [6]: df = pandas.DataFrame({"a": [1, 2, 3]})

In [7]: x.write_dataframe(df, key="b")
...
HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:8000/api/v1/metadata/x'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
```

If look the data directory, copy/pasted from the server startup output above, a directory for x was never created:

```
$ tree /tmp/tmpfuzb6cgw/data
/tmp/tmpfuzb6cgw/data

0 directories, 0 files
```

## Fix

* Unit test reproduces issue.
* Fix in separate commit fixes it.
* Interactive example above now works as expected, and data is confirmed readable.

```py
from tiled.client import from_uri
c = from_uri('http://localhost:8000', api_key='secret')
c
x = c.create_container('x')
import pandas
df = pandas.DataFrame({"a": [1, 2, 3]})
x.write_dataframe(df, key="b")
c['x']['b'].read()
```

It's remarkable that this bug has gone uncaught (or unreported). I think `create_container` is not on the main path for any of our early users, so we may be the first users.