### PR TITLE
Fix issue when data is written to container created from the client

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -6,6 +6,7 @@ Persistent stores are being developed externally to the tiled package.
 import base64
 from datetime import datetime
 
+import awkward
 import dask.dataframe
 import numpy
 import pandas
@@ -398,6 +399,26 @@ async def test_write_in_container(tree):
         a = client.create_container("a")
         arr = numpy.array([1, 2, 3])
         b = a.write_array(arr, key="b")
+        b.read()
+        a.delete("b")
+        client.delete("a")
+
+        a = client.create_container("a")
+        coo = sparse.COO(coords=[[2, 5]], data=[1.3, 7.5], shape=(10,))
+        b = a.write_sparse(coords=coo.coords, data=coo.data, shape=coo.shape, key="b")
+        b.read()
+        a.delete("b")
+        client.delete("a")
+
+        a = client.create_container("a")
+        array = awkward.Array(
+            [
+                [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}],
+                [],
+                [{"x": 3.3, "y": [1, 2, 3]}],
+            ]
+        )
+        b = a.write_awkward(array, key="b")
         b.read()
         a.delete("b")
         client.delete("a")

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import dask.dataframe
 import numpy
+import pandas
 import pandas.testing
 import pytest
 import sparse
@@ -377,6 +378,27 @@ async def test_delete_non_empty_node(tree):
         # Delete from the bottom up.
         c.delete("d")
         b.delete("c")
+        a.delete("b")
+        client.delete("a")
+
+
+@pytest.mark.asyncio
+async def test_write_in_container(tree):
+    "Create a container and write a structure into it."
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+        a = client.create_container("a")
+        df = pandas.DataFrame({"a": [1, 2, 3]})
+        b = a.write_dataframe(df, key="b")
+        b.read()
+        a.delete("b")
+        client.delete("a")
+
+        a = client.create_container("a")
+        arr = numpy.array([1, 2, 3])
+        b = a.write_array(arr, key="b")
+        b.read()
         a.delete("b")
         client.delete("a")
 

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -40,7 +40,7 @@ class AwkwardBuffersAdapter(AwkwardAdapter):
     def init_storage(cls, directory, structure):
         from ..server.schemas import Asset
 
-        directory.mkdir()
+        directory.mkdir(parents=True, exist_ok=True)
         data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
         return [Asset(data_uri=data_uri, is_directory=True)]
 

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -42,7 +42,7 @@ class ParquetDatasetAdapter:
     def init_storage(cls, directory, structure):
         from ..server.schemas import Asset
 
-        directory.mkdir()
+        directory.mkdir(parents=True, exist_ok=True)
         data_uri = parse.urlunparse(("file", "localhost", str(directory), "", "", None))
         assets = [
             Asset(

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -46,7 +46,7 @@ class SparseBlocksParquetAdapter:
     ):
         from ..server.schemas import Asset
 
-        directory.mkdir()
+        directory.mkdir(parents=True, exist_ok=True)
 
         num_blocks = (range(len(n)) for n in structure.chunks)
         block_uris = []

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -35,6 +35,7 @@ class ZarrArrayAdapter(ArrayAdapter):
         # Use the first chunk along each dimension.
         zarr_chunks = tuple(dim[0] for dim in structure.chunks)
         shape = tuple(dim[0] * len(dim) for dim in structure.chunks)
+        directory.mkdir(parents=True, exist_ok=True)
         storage = zarr.storage.DirectoryStore(str(directory))
         zarr.storage.init_array(
             storage,


### PR DESCRIPTION
This PR fixes issue #625. In general, the issue was detected when a new container was created using `create_container()` from the tiled client and some data was added to this container. The result of this was a `FileNotFoundError`.
This PR adds a check in all the adapters that have a writing feature to create all the parent subdirectories that are necessary before the data is saved in storage.

Closes #625 