### PR TITLE
Make structure family a property on the client side

### DIFF
--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -138,6 +138,7 @@ Tiled currently includes two clients for each structure family:
    tiled.client.base.BaseClient.formats
    tiled.client.base.BaseClient.metadata
    tiled.client.base.BaseClient.uri
+   tiled.client.base.BaseClient.structure_family
    tiled.client.base.BaseClient.item
    tiled.client.base.BaseClient.login
    tiled.client.base.BaseClient.logout

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -172,6 +172,11 @@ class BaseClient:
         "Direct link to this entry"
         return self.item["links"]["self"]
 
+    @property
+    def structure_family(self):
+        "Quick access to this entry"
+        return self.item["attributes"]["structure_family"]
+
     def new_variation(self, structure_clients=UNCHANGED, **kwargs):
         """
         This is intended primarily for internal use and use by subclasses.

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -175,7 +175,7 @@ class BaseClient:
     @property
     def structure_family(self):
         "Quick access to this entry"
-        return self.item["attributes"]["structure_family"]
+        return StructureFamily[self.item["attributes"]["structure_family"]]
 
     def new_variation(self, structure_clients=UNCHANGED, **kwargs):
         """


### PR DESCRIPTION
Adding this feature on the client side to have a quick and easy access to structure family.