### PR TITLE
Add smoke test utilities for the client

### DIFF
--- a/tiled/_tests/test_client_smoke.py
+++ b/tiled/_tests/test_client_smoke.py
@@ -1,0 +1,28 @@
+import collections
+
+import pytest
+
+from ..adapters.array import ArrayAdapter
+from ..adapters.mapping import MapAdapter
+from ..client import Context, from_context
+from ..client.smoke import read
+from ..server.app import build_app
+
+
+def f():
+    raise Exception("test!")
+
+
+def test_smoke_read():
+    data = collections.defaultdict(f)
+    data["A"] = ArrayAdapter.from_array([1, 2, 3], metadata={"A": "a"})
+
+    tree = MapAdapter(data)
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+    faulty_list = read(client)
+    assert len(faulty_list) == 1
+
+    with pytest.raises(Exception):
+        data["B"]

--- a/tiled/_tests/test_client_smoke.py
+++ b/tiled/_tests/test_client_smoke.py
@@ -1,5 +1,4 @@
-import collections
-
+import numpy as np
 import pytest
 
 from ..adapters.array import ArrayAdapter
@@ -9,20 +8,39 @@ from ..client.smoke import read
 from ..server.app import build_app
 
 
-def f():
-    raise Exception("test!")
+class Broken(Exception):
+    pass
 
 
-def test_smoke_read():
-    data = collections.defaultdict(f)
-    data["A"] = ArrayAdapter.from_array([1, 2, 3], metadata={"A": "a"})
+class BrokenArrayAdapter(ArrayAdapter):
+    def read(self, *args, **kwargs):
+        raise Broken
 
-    tree = MapAdapter(data)
+    def read_block(self, *args, **kwargs):
+        raise Broken
+
+
+@pytest.fixture(scope="module")
+def context():
+    mapping = {
+        "A": ArrayAdapter.from_array(np.array([1, 2, 3]), metadata={"A": "a"}),
+        "B": BrokenArrayAdapter.from_array(np.array([4, 5, 6]), metadata={"B": "b"}),
+    }
+
+    tree = MapAdapter(mapping)
     with Context.from_app(build_app(tree)) as context:
-        client = from_context(context)
+        yield context
+
+
+def test_smoke_read_list(context):
+    client = from_context(context)
 
     faulty_list = read(client)
     assert len(faulty_list) == 1
 
-    with pytest.raises(Exception):
-        data["B"]
+
+def test_smoke_read_raise(context):
+    client = from_context(context)
+
+    with pytest.raises(Broken):
+        read(client, strict=True)

--- a/tiled/client/smoke.py
+++ b/tiled/client/smoke.py
@@ -26,17 +26,17 @@ def read(node, verbose=False, strict=False):
     faulty_entries = []
     if node.structure_family == StructureFamily.container:
         for key, child_node in node.items():
-            fault_result = read(child_node, verbose=verbose)
+            fault_result = read(child_node, verbose=verbose, strict=strict)
             faulty_entries.extend(fault_result)
     else:
         try:
             tmp = node.read()  # noqa: F841
         except Exception as err:
-            if strict:
-                raise
+            faulty_entries.append(node.uri)
             if verbose:
                 print(f"ERROR: {node.item['id']} - {err!r}", file=sys.stderr)
-            faulty_entries.append(node.uri)
+            if strict:
+                raise
         else:
             if verbose:
                 print(f"SUCCESS: {node.item['id']} ", file=sys.stderr)

--- a/tiled/client/smoke.py
+++ b/tiled/client/smoke.py
@@ -1,0 +1,20 @@
+def read(node, faulty_docs=[], verbose=False):
+    if node.structure_family == "container":
+        for key, child_node in node.items():
+            fault_result = read(child_node)
+            if len(fault_result) > 0:
+                faulty_docs.append(fault_result)
+    else:
+        try:
+            if verbose:
+                print(f"reading node with data: {node.item['id']}")
+            tmp = node.read()  # noqa: F841
+        except Exception:
+            if verbose:
+                print(
+                    f"Node {node.item['id']} does not have a read method or data is fault"
+                )
+            faulty_docs.append(node.uri)
+            return faulty_docs
+
+    return faulty_docs

--- a/tiled/client/smoke.py
+++ b/tiled/client/smoke.py
@@ -1,20 +1,20 @@
+import sys
+
 from ..structures.core import StructureFamily
 
 
-def read(node, faulty_docs=[], verbose=False):
+def read(node, verbose=False, strict=False):
     """
-
 
     Parameters
     ----------
     node : tiled node
         A Client node with access to the tiled server.
         It can take form of anything compatible with the values in StructureFamily.
-    faulty_docs : List, optional
-        A list that keeps track of the URI of the faulty nodes
-        while the method traverses through the tree recursively. The default is [].
     verbose : bool, optional
         Enables status messages while process runs. The default is False.
+    strict : bool, optional
+        Enables debugging mode if a faulty node is found.
 
     Returns
     -------
@@ -22,21 +22,23 @@ def read(node, faulty_docs=[], verbose=False):
         A list with URIs of all the faulty nodes that were found.
 
     """
+
+    faulty_entries = []
     if node.structure_family == StructureFamily.container:
         for key, child_node in node.items():
             fault_result = read(child_node, verbose=verbose)
-            if len(fault_result) > 0:
-                faulty_docs.append(fault_result)
+            faulty_entries.extend(fault_result)
     else:
         try:
-            if verbose:
-                print(f"reading node with data: {node.item['id']}")
             tmp = node.read()  # noqa: F841
-        except Exception:
+        except Exception as err:
+            if strict:
+                raise
             if verbose:
-                print(
-                    f"Node {node.item['id']} does not have a read method or data is fault"
-                )
-            faulty_docs.append(node.uri)
+                print(f"ERROR: {node.item['id']} - {err!r}", file=sys.stderr)
+            faulty_entries.append(node.uri)
+        else:
+            if verbose:
+                print(f"SUCCESS: {node.item['id']} ", file=sys.stderr)
 
-    return faulty_docs
+    return faulty_entries

--- a/tiled/client/smoke.py
+++ b/tiled/client/smoke.py
@@ -1,7 +1,30 @@
+from ..structures.core import StructureFamily
+
+
 def read(node, faulty_docs=[], verbose=False):
-    if node.structure_family == "container":
+    """
+
+
+    Parameters
+    ----------
+    node : tiled node
+        A Client node with access to the tiled server.
+        It can take form of anything compatible with the values in StructureFamily.
+    faulty_docs : List, optional
+        A list that keeps track of the URI of the faulty nodes
+        while the method traverses through the tree recursively. The default is [].
+    verbose : bool, optional
+        Enables status messages while process runs. The default is False.
+
+    Returns
+    -------
+    faulty_docs : List
+        A list with URIs of all the faulty nodes that were found.
+
+    """
+    if node.structure_family == StructureFamily.container:
         for key, child_node in node.items():
-            fault_result = read(child_node)
+            fault_result = read(child_node, verbose=verbose)
             if len(fault_result) > 0:
                 faulty_docs.append(fault_result)
     else:
@@ -15,6 +38,5 @@ def read(node, faulty_docs=[], verbose=False):
                     f"Node {node.item['id']} does not have a read method or data is fault"
                 )
             faulty_docs.append(node.uri)
-            return faulty_docs
 
     return faulty_docs


### PR DESCRIPTION
This PR adds a group of methods to help test the integration of the datasets with a tiled server by making calls from the client and walking down the existing nodes. The goal is to automate a recursive method that identifies the correct nodes and applies the respective test feature to these nodes.
For the moment, we are adding read and export methods to smoke test the server.

Closes #606 