### PR TITLE
Fix bug in slicing into container adapter

### DIFF
--- a/tiled/_tests/test_container_files.py
+++ b/tiled/_tests/test_container_files.py
@@ -1,3 +1,5 @@
+import io
+
 import h5py
 import pandas
 import pytest
@@ -61,3 +63,6 @@ async def test_hdf5(tmpdir):
         tree(client)
         client["h"]["x"].read()
         client["h"]["g"]["y"].read()
+
+        buffer = io.BytesIO()
+        client.export(buffer, format="application/json")

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -4,6 +4,7 @@ This tests tiled's writing routes with an in-memory store.
 Persistent stores are being developed externally to the tiled package.
 """
 import base64
+import io
 from datetime import datetime
 
 import awkward
@@ -433,3 +434,14 @@ async def test_bytes_in_metadata(tree):
         assert value.startswith("data:application/octet-stream;base64,")
         label, encoded = value.split(",", 1)
         assert base64.b64decode(encoded) == b"raw_bytes"
+
+
+@pytest.mark.asyncio
+async def test_container_export(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+        a = client.create_container("a")
+        a.write_array([1, 2, 3], key="b")
+        buffer = io.BytesIO()
+        client.export(buffer, format="application/json")

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -760,7 +760,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
     async def keys_range(self, offset, limit):
         if self.data_sources:
             return (await self.get_adapter()).keys()[
-                offset : offset + limit  # noqa: E203
+                offset : (offset + limit) if limit is not None else None  # noqa: E203
             ]
         statement = select(orm.Node.key).filter(orm.Node.ancestors == self.segments)
         for condition in self.conditions:
@@ -781,7 +781,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
     async def items_range(self, offset, limit):
         if self.data_sources:
             return (await self.get_adapter()).items()[
-                offset : offset + limit  # noqa: E203
+                offset : (offset + limit) if limit is not None else None  # noqa: E203
             ]
         statement = select(orm.Node).filter(orm.Node.ancestors == self.segments)
         for condition in self.conditions:


### PR DESCRIPTION
This bug was found at [SasView Contributor Camp](https://github.com/SasView/sasview/wiki/ContributorCampXII) while trying to integrate Tiled with the `sasdata` loader.

The first commit reproduces the error by extending an existing test:

```
E           TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

It also adds a new test, which does not exercise the bug, but nonetheless adds useful coverage to this general area of functionality.

The second commit fixes the bug.