### PR TITLE
Add Python 3.12 to CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
       fail-fast: false
     steps:
 


### PR DESCRIPTION
We intend to keep 3.8 (and maybe temporarily reinstate 3.7) up to v0.1.0 so that there is _a_ stable version installable in older environments.