### PR TITLE
Scientific Metadata Search Engine (Fulltext) implementation for PostgreSQL 🔎

### DIFF
--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -159,7 +159,7 @@ def test_contains(client):
 
 
 def test_full_text(client):
-    if client.metadata["backend"] in {"postgresql", "sqlite"}:
+    if client.metadata["backend"] in {"sqlite"}:
 
         def cm():
             return fail_with_status_code(400)

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -45,6 +45,9 @@ mapping["does_contain_z"] = ArrayAdapter.from_array(
 mapping["does_not_contain_z"] = ArrayAdapter.from_array(
     numpy.ones(10), metadata={"letters": list(string.ascii_lowercase[:-1])}
 )
+mapping["full_text_test_case"] = ArrayAdapter.from_array(
+    numpy.ones(10), metadata={"color": "purple"}
+)
 
 mapping["specs_foo_bar"] = ArrayAdapter.from_array(numpy.ones(10), specs=["foo", "bar"])
 mapping["specs_foo_bar_baz"] = ArrayAdapter.from_array(
@@ -168,6 +171,9 @@ def test_full_text(client):
         cm = nullcontext
     with cm():
         assert list(client.search(FullText("z"))) == ["z", "does_contain_z"]
+        # plainto_tsquery fails to find certain words, weirdly, so it is a useful
+        # test that we are using tsquery
+        assert list(client.search(FullText("purple"))) == ["full_text_test_case"]
 
 
 def test_regex(client):

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -75,10 +75,10 @@ class MapAdapter(collections.abc.Mapping, IndexersMixin):
         specs : List[str], optional
         access_policy : AccessPolicy, optional
         entries_stale_after: timedelta
-            This server uses this to communite to the client how long
+            This server uses this to communicate to the client how long
             it should rely on a local cache before checking back for changes.
         metadata_stale_after: timedelta
-            This server uses this to communite to the client how long
+            This server uses this to communicate to the client how long
             it should rely on a local cache before checking back for changes.
         must_revalidate : bool
             Whether the client should strictly refresh stale cache items.
@@ -336,14 +336,7 @@ def iter_child_metadata(query_key, tree):
 def full_text_search(query, tree):
     matches = {}
     text = query.text
-    if query.case_sensitive:
-
-        def maybe_lower(s):
-            # no-op
-            return s
-
-    else:
-        maybe_lower = str.lower
+    maybe_lower = str.lower
     query_words = set(text.split())
     for key, value in tree.items():
         words = set(

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -336,13 +336,12 @@ def iter_child_metadata(query_key, tree):
 def full_text_search(query, tree):
     matches = {}
     text = query.text
-    maybe_lower = str.lower
     query_words = set(text.split())
     for key, value in tree.items():
         words = set(
             word
             for s in walk_string_values(value.metadata())
-            for word in maybe_lower(s).split()
+            for word in s.lower().split()
         )
         # Note that `not set.isdisjoint` is faster than `set.intersection`. At
         # the C level, `isdisjoint` loops over the set until it finds one match,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1073,7 +1073,7 @@ CatalogNodeAdapter.register_query(KeysFilter, keys_filter)
 CatalogNodeAdapter.register_query(StructureFamilyQuery, structure_family)
 CatalogNodeAdapter.register_query(SpecsQuery, specs)
 CatalogNodeAdapter.register_query(FullText, full_text)
-# TODO: FullText [in progress], Regex
+# TODO: Regex
 
 
 def in_memory(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1008,7 +1008,7 @@ def full_text(query, tree):
         tsvector = func.jsonb_to_tsvector(
             cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
         )
-        condition = tsvector.op("@@")(func.to_tsquery(query.text))
+        condition = tsvector.op("@@")(func.to_tsquery("simple", query.text))
         # condition = tsvector.match(query.text)
     else:
         raise UnsupportedQueryType("full_text")

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -13,11 +13,10 @@ from urllib.parse import quote_plus, urlparse
 import anyio
 from fastapi import HTTPException
 from sqlalchemy import delete, event, func, not_, or_, select, text, type_coerce, update
+from sqlalchemy.dialects.postgresql import JSONB, REGCONFIG
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.dialects.postgresql import JSONB, REGCONFIG
 from sqlalchemy.sql.expression import cast
-
 
 from tiled.queries import (
     Comparison,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1007,7 +1007,9 @@ def full_text(query, tree):
     if dialect_name == "sqlite":
         raise UnsupportedQueryType("full_text")
     elif dialect_name == "postgresql":
-        tsvector = func.jsonb_to_tsvector(cast('simple',REGCONFIG), orm.Node.metadata_, cast(["string"],JSONB))
+        tsvector = func.jsonb_to_tsvector(
+            cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
+        )
         conditions.append(tsvector.match(query.text))
     else:
         raise UnsupportedQueryType("full_text")

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1003,17 +1003,16 @@ def contains(query, tree):
 
 def full_text(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
-    conditions = []
     if dialect_name == "sqlite":
         raise UnsupportedQueryType("full_text")
     elif dialect_name == "postgresql":
         tsvector = func.jsonb_to_tsvector(
             cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
         )
-        conditions.append(tsvector.match(query.text))
+        condition = tsvector.match(query.text)
     else:
         raise UnsupportedQueryType("full_text")
-    return tree.new_variation(conditions=tree.conditions + conditions)
+    return tree.new_variation(conditions=tree.conditions + [condition])
 
 
 def specs(query, tree):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -21,6 +21,7 @@ from tiled.queries import (
     Comparison,
     Contains,
     Eq,
+    FullText,
     In,
     KeysFilter,
     NotEq,
@@ -984,6 +985,11 @@ def contains(query, tree):
     return tree.new_variation(conditions=tree.conditions + [condition])
 
 
+def full_text(query, tree):
+    raise UnsupportedQueryType("full_text")
+    # return tree.new_variation(conditions=tree.conditions)
+
+
 def specs(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
     conditions = []
@@ -1055,7 +1061,8 @@ CatalogNodeAdapter.register_query(NotIn, partial(in_or_not_in, method="not_in"))
 CatalogNodeAdapter.register_query(KeysFilter, keys_filter)
 CatalogNodeAdapter.register_query(StructureFamilyQuery, structure_family)
 CatalogNodeAdapter.register_query(SpecsQuery, specs)
-# TODO: FullText, Regex
+CatalogNodeAdapter.register_query(FullText, full_text)
+# TODO: FullText [in progress], Regex
 
 
 def in_memory(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1009,7 +1009,6 @@ def full_text(query, tree):
             cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
         )
         condition = tsvector.op("@@")(func.to_tsquery("simple", query.text))
-        # condition = tsvector.match(query.text)
     else:
         raise UnsupportedQueryType("full_text")
     return tree.new_variation(conditions=tree.conditions + [condition])

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1008,7 +1008,8 @@ def full_text(query, tree):
         tsvector = func.jsonb_to_tsvector(
             cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
         )
-        condition = tsvector.match(query.text)
+        condition = tsvector.op("@@")(func.to_tsquery(query.text))
+        # condition = tsvector.match(query.text)
     else:
         raise UnsupportedQueryType("full_text")
     return tree.new_variation(conditions=tree.conditions + [condition])

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,6 +5,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "1cd99c02d0c7",
     "a66028395cab",
     "3db11ff95b6c",
     "0b033e7fbe30",

--- a/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
@@ -1,0 +1,37 @@
+"""Create index for fulltext search
+
+Revision ID: 1cd99c02d0c7
+Revises: 3db11ff95b6c
+Create Date: 2024-01-24 15:53:12.348880
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import func
+
+# revision identifiers, used by Alembic.
+revision = '1cd99c02d0c7'
+down_revision = '3db11ff95b6c'
+branch_labels = None
+depends_on = None
+
+# Make JSONB available in column
+JSONVariant = sa.JSON().with_variant(JSONB(), "postgresql")
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            # There is no sane way to perform this using op.create_index()
+            op.execute("""
+                CREATE INDEX metadata_search
+                ON nodes
+                USING gin (jsonb_to_tsvector('simple', metadata, '["string"]'))
+                """)
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
@@ -5,10 +5,9 @@ Revises: a66028395cab
 Create Date: 2024-01-24 15:53:12.348880
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy import func
 
 # revision identifiers, used by Alembic.
 revision = "1cd99c02d0c7"

--- a/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
@@ -11,24 +11,27 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy import func
 
 # revision identifiers, used by Alembic.
-revision = '1cd99c02d0c7'
-down_revision = 'a66028395cab'
+revision = "1cd99c02d0c7"
+down_revision = "a66028395cab"
 branch_labels = None
 depends_on = None
 
 # Make JSONB available in column
 JSONVariant = sa.JSON().with_variant(JSONB(), "postgresql")
 
+
 def upgrade():
     connection = op.get_bind()
     if connection.engine.dialect.name == "postgresql":
         with op.get_context().autocommit_block():
             # There is no sane way to perform this using op.create_index()
-            op.execute("""
+            op.execute(
+                """
                 CREATE INDEX metadata_search
                 ON nodes
                 USING gin (jsonb_to_tsvector('simple', metadata, '["string"]'))
-                """)
+                """
+            )
 
 
 def downgrade():

--- a/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
@@ -27,7 +27,7 @@ def upgrade():
             # There is no sane way to perform this using op.create_index()
             op.execute(
                 """
-                CREATE INDEX metadata_search
+                CREATE INDEX metadata_tsvector_search
                 ON nodes
                 USING gin (jsonb_to_tsvector('simple', metadata, '["string"]'))
                 """

--- a/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/1cd99c02d0c7_create_index_for_fulltext_search.py
@@ -1,7 +1,7 @@
 """Create index for fulltext search
 
 Revision ID: 1cd99c02d0c7
-Revises: 3db11ff95b6c
+Revises: a66028395cab
 Create Date: 2024-01-24 15:53:12.348880
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy import func
 
 # revision identifiers, used by Alembic.
 revision = '1cd99c02d0c7'
-down_revision = '3db11ff95b6c'
+down_revision = 'a66028395cab'
 branch_labels = None
 depends_on = None
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -253,8 +253,13 @@ WHEN (NEW.num IS NOT NULL)
 EXECUTE FUNCTION raise_if_null_parameter_exists();"""
             )
         )
-        # This creates a ts_vector based metadata search index for fulltext.
-        # Postgres only feature
+
+
+@event.listens_for(DataSourceAssetAssociation.__table__, "after_create")
+def create_index_metadata_tsvector_search(target, connection, **kw):
+    # This creates a ts_vector based metadata search index for fulltext.
+    # Postgres only feature
+    if connection.engine.dialect.name == "postgresql":
         connection.execute(
             text(
                 """

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -95,12 +95,6 @@ class Node(Timestamped, Base):
             "id",
             "metadata",
             postgresql_using="gin",
-        ),
-        # This index supports ts_vector based full-text search.
-        Index(
-            "metadata_tsvector_search",
-            func.jsonb_to_tsvector("simple", metadata_, '["string"]'),
-            postgresql_using="gin",
         )
         # This is used by ORDER BY with the default sorting.
         # Index("ancestors_time_created", "ancestors", "time_created"),
@@ -257,6 +251,14 @@ WHEN (NEW.num IS NOT NULL)
 EXECUTE FUNCTION raise_if_null_parameter_exists();"""
             )
         )
+        # This creates a ts_vector based metadata search index for fulltext.
+        # Postgres only feature
+        connection.execute(
+            text( """
+                CREATE INDEX metadata_tsvector_search
+                ON nodes
+                USING gin (jsonb_to_tsvector('simple', metadata, '["string"]'))
+                """))
 
 
 class DataSource(Timestamped, Base):

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -149,9 +149,12 @@ class DataSourceAssetAssociation(Base):
 
 @event.listens_for(DataSourceAssetAssociation.__table__, "after_create")
 def unique_parameter_num_null_check(target, connection, **kw):
-    # Ensure that we cannot mix NULL and INTEGER values of num for
-    # a given data_source_id and parameter, and that there cannot be multiple
-    # instances of NULL.
+    # This creates a pair of triggers on the data_source_asset_association
+    # table. (There are a total of four defined below, two for the SQLite
+    # branch and two for the PostgreSQL branch.) Each pair include one trigger
+    # that runs when NEW.num IS NULL and one trigger than runs when
+    # NEW.num IS NOT NULL. Thus, for a given insert, only one of these
+    # triggers is run.
     if connection.engine.dialect.name == "sqlite":
         connection.execute(
             text(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -12,9 +12,8 @@ from sqlalchemy import (
     Unicode,
     event,
     text,
-    types,
 )
-from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import func
@@ -254,11 +253,14 @@ EXECUTE FUNCTION raise_if_null_parameter_exists();"""
         # This creates a ts_vector based metadata search index for fulltext.
         # Postgres only feature
         connection.execute(
-            text( """
+            text(
+                """
                 CREATE INDEX metadata_tsvector_search
                 ON nodes
                 USING gin (jsonb_to_tsvector('simple', metadata, '["string"]'))
-                """))
+                """
+            )
+        )
 
 
 class DataSource(Timestamped, Base):

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Integer,
     Table,
     Unicode,
-    text,
     types,
 )
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
@@ -102,7 +101,7 @@ class Node(Timestamped, Base):
         # This index supports full-text search.
         Index(
             "metadata_search",
-            func.to_tsvector(text("'simple'"), func.lower("metadata")),
+            func.jsonb_to_tsvector("simple", metadata_, '["string"]'),
             postgresql_using="gin",
         )
         # This is used by ORDER BY with the default sorting.

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -10,8 +10,10 @@ from sqlalchemy import (
     Index,
     Integer,
     Unicode,
+    event,
+    text,
+    types,
 )
-
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import UniqueConstraint
@@ -23,11 +25,6 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
-
-
-# Use TSVECTOR with PostgreSQL via SQLAlchemy for fullText indexing.
-class TSVector(types.TypeDecorator):
-    impl = TSVECTOR
 
 
 class Timestamped:

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -96,9 +96,9 @@ class Node(Timestamped, Base):
             "metadata",
             postgresql_using="gin",
         ),
-        # This index supports full-text search.
+        # This index supports ts_vector based full-text search.
         Index(
-            "metadata_search",
+            "metadata_tsvector_search",
             func.jsonb_to_tsvector("simple", metadata_, '["string"]'),
             postgresql_using="gin",
         )

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Index,
     Integer,
     Unicode,
+)
 
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -51,8 +51,6 @@ class FullText(NoBool):
 
     @classmethod
     def decode(cls, *, text):
-        # Note: If there were an argument called case_sensitive
-        # FastAPI would decode it into a boolean for us.
         return cls(text=text)
 
 

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -42,23 +42,18 @@ class FullText(NoBool):
     Parameters
     ----------
     text : str
-    case_sensitive : bool, optional
-        Default False (case-insensitive).
     """
 
     text: str
-    case_sensitive: bool = False
 
     def encode(self):
-        return {"text": self.text, "case_sensitive": json.dumps(self.case_sensitive)}
+        return {"text": self.text}
 
     @classmethod
-    def decode(cls, *, text, case_sensitive=False):
-        # Note: FastAPI decodes case_sensitive into a boolean for us.
-        return cls(
-            text=text,
-            case_sensitive=case_sensitive,
-        )
+    def decode(cls, *, text):
+        # Note: If there were an argument called case_sensitive
+        # FastAPI would decode it into a boolean for us.
+        return cls(text=text)
 
 
 @register(name="lookup")

--- a/web-frontend/src/openapi_schemas.ts
+++ b/web-frontend/src/openapi_schemas.ts
@@ -409,7 +409,6 @@ export interface operations {
         sort?: string;
         omit_links?: boolean;
         "filter[fulltext][condition][text]"?: string[];
-        "filter[fulltext][condition][case_sensitive]"?: boolean[];
         "filter[lookup][condition][key]"?: string[];
       };
     };


### PR DESCRIPTION
This feature adds a rudimentary scientific metadata search engine, implemented purely through Postgresql's native `ts_vector` and `ts_query` operations. Documented as part of the [Tiled client's FullText query](https://blueskyproject.io/tiled/reference/generated/tiled.queries.FullText.html#tiled.queries.FullText).

Tasks:
- [x]  Add fulltext logic to `adapter.py` to enable functionality
- [x]  Create a new computed index `metadata_search` for storing `jsonb_to_tsvector` data
- [x]  Generate Alembic migration to move existing tiled collections to the new standard
- [ ]   Add new tests that ensure the index is being invoked 

Resolves #457