### PR TITLE
fixed bytesize_repr

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -633,7 +633,7 @@ def node_repr(tree, sample):
 
 def bytesize_repr(num):
     # adapted from dask.utils
-    for x in ["B", "MB", "GB", "TB"]:
+    for x in ["B", "KB", "MB", "GB", "TB"]:
         if num < 1024.0:
             if x == "B":
                 s = f"{num:.0f} {x}"


### PR DESCRIPTION
Background
-----------------
Tiled logs (via show_logs()) have a bug where they show amounts that should be in KB in MB, for example:

```
21:06:12.193 ->  GET 'https://tiled.nsls2.bnl.gov/api/v1/array/block/ucal/raw/99c433c0-723d-4f4f-99af-110dc2e70076/primary/data/ucal_i0up?block=0&expected_shape=285' 'host:tiled.nsls2.bnl.gov' 'connection:keep-alive' 'accept-encoding:gzip, deflate, br, zstd' 'user-agent:python-tiled/0.1.0a105' 'accept:application/octet-stream' 'cookie:tiled_csrf=pQBJaBgdzI-J61BHFpRsiGX0cD3QumwAXiLc3GfUJDs' 'authorization:Bearer [redacted]'
21:06:12.381 <- (1.9 MB) 200 date:Fri, 26 Jan 2024 02:06:11 GMT server:uvicorn etag:8bb402e83e463694d800a09b9a975c5a content-length:1986 content-type:application/octet-stream content-encoding:zstd vary:Accept-Encoding server-timing:acl;dur=29.2, read;dur=3.1, tok;dur=0.1, pack;dur=0.3, compress;dur=0.1;ratio=1.1, app;dur=51.1 strict-transport-security:max-age=63072000

In [30]: resp = history.responses[-1]

In [31]: resp.num_bytes_downloaded
Out[31]: 1986
```

Looking into the log messages, the unit is produced by bytesize_repr. It turns out that bytesize_repr was skipping KB entirely. KB are a useful unit, intermediate between B and MB, and they should be included in bytesize_repr. This pull request adds KB into the list between B and MB.