### PR TITLE
Xarray specs bug

### DIFF
--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -1,6 +1,7 @@
 import dask.array
 import numpy
 import orjson
+import pandas
 import pytest
 import xarray
 import xarray.testing
@@ -11,6 +12,7 @@ from ..client import Context, from_context, record_history
 from ..client import xarray as xarray_client
 from ..serialization.xarray import serialize_json
 from ..server.app import build_app
+from ..structures.core import Spec
 
 image = numpy.random.random((3, 5))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
@@ -77,6 +79,40 @@ def test_xarray_dataset(client, key):
     expected = EXPECTED[key]
     actual = client[key].read().load()
     xarray.testing.assert_equal(actual, expected)
+
+
+def test_specs(client):
+    assert client["image"].specs == [Spec("xarray_dataset")]
+    assert client["image"]["image"].specs == [Spec("xarray_data_var")]
+    assert client["image"]["x"].specs == [Spec("xarray_coord")]
+
+
+def test_specs_mutation_bug(client):
+    # https://github.com/bluesky/tiled/issues/651
+    ds = pandas.DataFrame({"x": numpy.array([1, 2, 3])}).to_xarray()
+    tree = MapAdapter({"data": DatasetAdapter.from_dataset(ds)})
+    for _ in range(2):
+        # This bug caused additional, redundant specs to be appended on each
+        # iteration.
+        app = build_app(tree)
+        with Context.from_app(app) as context:
+            client = from_context(context)
+            data = client["data"]
+            data.read()
+            assert data.specs == [Spec("xarray_dataset")]
+
+
+def test_specs_override(client):
+    tree = MapAdapter(
+        {
+            key: DatasetAdapter.from_dataset(ds, specs=[Spec("test")])
+            for key, ds in EXPECTED.items()
+        }
+    )
+    app = build_app(tree)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+    assert client["image"].specs == [Spec("test")]
 
 
 @pytest.mark.parametrize("key", ["image", "weather"])

--- a/tiled/adapters/xarray.py
+++ b/tiled/adapters/xarray.py
@@ -16,6 +16,9 @@ class DatasetAdapter(MapAdapter):
     @classmethod
     def from_dataset(cls, dataset, *, specs=None, access_policy=None):
         mapping = _DatasetMap(dataset)
+        specs = specs or []
+        if "xarray_dataset" not in [spec.name for spec in specs]:
+            specs.append(Spec("xarray_dataset"))
         return cls(
             mapping,
             metadata={"attrs": dataset.attrs},
@@ -28,8 +31,6 @@ class DatasetAdapter(MapAdapter):
             raise TypeError(
                 "Use DatasetAdapter.from_dataset(...), not DatasetAdapter(...)."
             )
-        if specs is None:
-            specs = [Spec("xarray_dataset")]
         super().__init__(
             mapping, *args, specs=specs, access_policy=access_policy, **kwargs
         )

--- a/tiled/adapters/xarray.py
+++ b/tiled/adapters/xarray.py
@@ -28,8 +28,8 @@ class DatasetAdapter(MapAdapter):
             raise TypeError(
                 "Use DatasetAdapter.from_dataset(...), not DatasetAdapter(...)."
             )
-        specs = specs or []
-        specs.append(Spec("xarray_dataset"))
+        if specs is None:
+            specs = [Spec("xarray_dataset")]
         super().__init__(
             mapping, *args, specs=specs, access_policy=access_policy, **kwargs
         )


### PR DESCRIPTION
Closes #651

First commit reproduces the issue in a unit test, which fails. Second commit fixes the bug, and the unit test passes.

The xarray Dataset adapter was employing a Python anti-pattern here: mutating user input, specifically the list of `specs`. In the reported issue, the server was instantiating a variant of the adapter in a loop, via `new_variation()`, and the `specs` list was accumulating more items on each round. Eventually, it reached a server-imposed limit on the number of Specs that a node can carry (20) and raised an error, which brought the issue to attention.

The fix is to alter the logic to say, "If the user provides `specs`, use them. If the user provides no `specs` (`specs=None`) default to `specs=[Spec("xarray_dataset")]`.