### PR TITLE
Use POST for otherwise long GET urls

### DIFF
--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -209,3 +209,11 @@ def example_data_adapter(request):
     either manually (as in the fixture 'a') or via the app (as in the fixture 'client').
     """
     yield request.getfixturevalue(request.param)
+
+
+@pytest.fixture(scope="module")
+def set_and_deplete(request: pytest.FixtureRequest):
+    "Initial values must all be removed or else calling tests fail"
+    values = set(request.param)
+    yield values
+    assert not values

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -12,7 +12,6 @@ from .. import profiles
 from ..catalog import from_uri, in_memory
 from ..client.base import BaseClient
 from ..server.settings import get_settings
-from .utils import URL_LIMITS
 from .utils import enter_password as utils_enter_password
 from .utils import temp_postgres
 
@@ -229,8 +228,9 @@ def url_limit(request: pytest.FixtureRequest):
     and by equivalent POST requests when the URL_CHARACTER_LIMIT is short.
     """
     URL_CHARACTER_LIMIT = int(request.param)
+    PREVIOUS_LIMIT = BaseClient.URL_CHARACTER_LIMIT
     # Temporarily adjust the URL length limit to change client behavior.
     BaseClient.URL_CHARACTER_LIMIT = URL_CHARACTER_LIMIT
     yield
     # Then restore the original value.
-    BaseClient.URL_CHARACTER_LIMIT = int(URL_LIMITS.ORIGINAL)
+    BaseClient.URL_CHARACTER_LIMIT = PREVIOUS_LIMIT

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -10,7 +10,9 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from .. import profiles
 from ..catalog import from_uri, in_memory
+from ..client.base import BaseClient
 from ..server.settings import get_settings
+from .utils import URL_LIMITS
 from .utils import enter_password as utils_enter_password
 from .utils import temp_postgres
 
@@ -217,3 +219,18 @@ def set_and_deplete(request: pytest.FixtureRequest):
     values = set(request.param)
     yield values
     assert not values
+
+
+@pytest.fixture
+def url_limit(request: pytest.FixtureRequest):
+    """Adjust the URL length limit for the client's GET requests.
+
+    Data will be fetched by GET requests when the URL_CHARACTER_LIMIT is long,
+    and by equivalent POST requests when the URL_CHARACTER_LIMIT is short.
+    """
+    URL_CHARACTER_LIMIT = int(request.param)
+    # Temporarily adjust the URL length limit to change client behavior.
+    BaseClient.URL_CHARACTER_LIMIT = URL_CHARACTER_LIMIT
+    yield
+    # Then restore the original value.
+    BaseClient.URL_CHARACTER_LIMIT = int(URL_LIMITS.ORIGINAL)

--- a/tiled/_tests/test_awkward.py
+++ b/tiled/_tests/test_awkward.py
@@ -11,6 +11,7 @@ from ..catalog import in_memory
 from ..client import Context, from_context, record_history
 from ..server.app import build_app
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE
+from .utils import URL_LIMITS
 
 
 @pytest.fixture
@@ -130,10 +131,9 @@ def test_large_number_of_form_keys(client):
     # https://github.com/bluesky/tiled/pull/577
 
     # The HTTP spec itself has no limit, but tools impose a pragmatic one.
-    # Nginx defaults to 8k bytes. Chrome is around 2000.
     # This is a representative value.
-    URL_LENGTH_LIMIT = 2000
-    NUM_KEYS = 7000  # meant to achieve a large body of form_keys
+    URL_LENGTH_LIMIT = URL_LIMITS.DEFAULT
+    NUM_KEYS = 7_000  # meant to achieve a large body of form_keys
     array = awkward.Array([{f"key{i:05}": i for i in range(NUM_KEYS)}])
     aac = client.write_awkward(array, key="test")
     with record_history() as h:

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -159,7 +159,7 @@ def test_url_limit_bypass(context, dataframe_client, expected_method):
 
 @pytest.mark.parametrize("http_method", ("GET", "POST"))
 @pytest.mark.parametrize("link", ("full", "partition"))
-def test_http_url_limit_bypass(context, http_method, link):
+def test_http_fetch_columns(context, http_method, link):
     "GET requests beyond the URL length limit should become POST requests."
     if http_method not in ("GET", "POST"):
         pytest.fail(reason="HTTP method {http_method} is not expected.")

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -6,8 +6,9 @@ import pytest
 
 from ..adapters.dataframe import DataFrameAdapter
 from ..adapters.mapping import MapAdapter
-from ..client import Context, from_context, record_history
+from ..client import Context
 from ..client import dataframe as _dataframe_client
+from ..client import from_context, record_history
 from ..server.app import build_app
 
 tree = MapAdapter(
@@ -36,9 +37,7 @@ tree = MapAdapter(
         ),
         # a dataframe with many columns
         "wide": DataFrameAdapter.from_pandas(
-            pandas.DataFrame(
-                {f"column_{i:03d}": i * numpy.ones(5) for i in range(10)}
-            ),
+            pandas.DataFrame({f"column_{i:03d}": i * numpy.ones(5) for i in range(10)}),
             npartitions=1,
         ),
     }
@@ -147,7 +146,6 @@ def test_url_limit_bypass(context, dataframe_client, expected_method):
         assert list(actual.columns) == columns
 
         requests = list(request for request in history.requests)
-        print(f'{requests = }')
         assert len(requests) == df_client.structure().npartitions
 
         request_methods = list(request.method for request in requests)

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -163,6 +163,7 @@ def test_http_url_limit_bypass(context, http_method, link):
     "GET requests beyond the URL length limit should become POST requests."
     if http_method not in ("GET", "POST"):
         pytest.fail(reason="HTTP method {http_method} is not expected.")
+
     client = from_context(context)
     url_path = client["wide"].item["links"][link]
     original_df = tree["wide"].read()
@@ -187,12 +188,6 @@ def test_http_url_limit_bypass(context, http_method, link):
 
         requests = list(request for request in history.requests)
         assert len(requests) == 1
-
-        request_methods = list(request.method for request in requests)
-        if http_method == "POST":
-            assert "POST" in request_methods  # At least one POST request
-        elif http_method == "GET":
-            assert "POST" not in request_methods  # No POST request
 
 
 def test_deprecated_query_parameter(context):

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -6,9 +6,8 @@ import pytest
 
 from ..adapters.dataframe import DataFrameAdapter
 from ..adapters.mapping import MapAdapter
-from ..client import Context
-from ..client import dataframe as _dataframe_client
-from ..client import from_context, record_history
+from ..client import Context, from_context, record_history
+from ..client.base import BaseClient
 from ..serialization.table import deserialize_arrow
 from ..server.app import build_app
 from .utils import fail_with_status_code
@@ -110,30 +109,35 @@ def test_dask(context):
 
 class URL_LIMITS(IntEnum):
     HUGE = 80_000
-    ORIGINAL = _dataframe_client.URL_CHARACTER_LIMIT
+    ORIGINAL = BaseClient.URL_CHARACTER_LIMIT
     TINY = 10
 
 
 @pytest.fixture
-def dataframe_client(request: pytest.FixtureRequest):
-    URL_MAX_LENGTH = int(request.param)
-    # Temporarily adjust the URL length limit to change client behavior
-    _dataframe_client.URL_CHARACTER_LIMIT = URL_MAX_LENGTH
-    yield _dataframe_client
-    # Then restore the original value
-    _dataframe_client.URL_CHARACTER_LIMIT = URL_LIMITS.ORIGINAL
+def url_limit(request: pytest.FixtureRequest):
+    """Adjust the URL length limit for the client's GET requests.
+
+    Data will be fetched by GET requests when the URL_CHARACTER_LIMIT is long,
+    and by equivalent POST requests when the URL_CHARACTER_LIMIT is short.
+    """
+    URL_CHARACTER_LIMIT = int(request.param)
+    # Temporarily adjust the URL length limit to change client behavior.
+    BaseClient.URL_CHARACTER_LIMIT = URL_CHARACTER_LIMIT
+    yield
+    # Then restore the original value.
+    BaseClient.URL_CHARACTER_LIMIT = int(URL_LIMITS.ORIGINAL)
 
 
 @pytest.mark.parametrize(
-    "dataframe_client, expected_method",
+    "url_limit, expected_method",
     (
         (URL_LIMITS.HUGE, "GET"),  # URL query should fit in a GET request
         (URL_LIMITS.ORIGINAL, None),  # Expected method not specified
         (URL_LIMITS.TINY, "POST"),  # URL query is too long for a GET request
     ),
-    indirect=["dataframe_client"],
+    indirect=["url_limit"],
 )
-def test_url_limit_bypass(context, dataframe_client, expected_method):
+def test_url_limit_bypass(context, url_limit, expected_method):
     "GET requests beyond the URL length limit should become POST requests."
     client = from_context(context)
     df_client = client["wide"]

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -108,7 +108,7 @@ def test_dask(context):
     "url_limit, expected_method",
     (
         (URL_LIMITS.HUGE, "GET"),  # URL query should fit in a GET request
-        (URL_LIMITS.ORIGINAL, None),  # Expected method not specified
+        (URL_LIMITS.DEFAULT, None),  # Expected method is not specified
         (URL_LIMITS.TINY, "POST"),  # URL query is too long for a GET request
     ),
     indirect=["url_limit"],

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 import numpy
 import pandas.testing
 import pytest
@@ -7,10 +5,9 @@ import pytest
 from ..adapters.dataframe import DataFrameAdapter
 from ..adapters.mapping import MapAdapter
 from ..client import Context, from_context, record_history
-from ..client.base import BaseClient
 from ..serialization.table import deserialize_arrow
 from ..server.app import build_app
-from .utils import fail_with_status_code
+from .utils import URL_LIMITS, fail_with_status_code
 
 tree = MapAdapter(
     {
@@ -105,27 +102,6 @@ def test_dask(context):
     expected = tree["basic"].read()
     pandas.testing.assert_frame_equal(client.read().compute(), expected)
     pandas.testing.assert_frame_equal(client.compute(), expected)
-
-
-class URL_LIMITS(IntEnum):
-    HUGE = 80_000
-    ORIGINAL = BaseClient.URL_CHARACTER_LIMIT
-    TINY = 10
-
-
-@pytest.fixture
-def url_limit(request: pytest.FixtureRequest):
-    """Adjust the URL length limit for the client's GET requests.
-
-    Data will be fetched by GET requests when the URL_CHARACTER_LIMIT is long,
-    and by equivalent POST requests when the URL_CHARACTER_LIMIT is short.
-    """
-    URL_CHARACTER_LIMIT = int(request.param)
-    # Temporarily adjust the URL length limit to change client behavior.
-    BaseClient.URL_CHARACTER_LIMIT = URL_CHARACTER_LIMIT
-    yield
-    # Then restore the original value.
-    BaseClient.URL_CHARACTER_LIMIT = int(URL_LIMITS.ORIGINAL)
 
 
 @pytest.mark.parametrize(

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -1,10 +1,13 @@
+from enum import IntEnum
+
 import numpy
 import pandas.testing
 import pytest
 
 from ..adapters.dataframe import DataFrameAdapter
 from ..adapters.mapping import MapAdapter
-from ..client import Context, from_context
+from ..client import Context, from_context, record_history
+from ..client import dataframe as _dataframe_client
 from ..server.app import build_app
 
 tree = MapAdapter(
@@ -28,6 +31,13 @@ tree = MapAdapter(
                     "y": 2 * numpy.ones(5),
                     "z": 3 * numpy.ones(5),
                 }
+            ),
+            npartitions=1,
+        ),
+        # a dataframe with many columns
+        "wide": DataFrameAdapter.from_pandas(
+            pandas.DataFrame(
+                {f"column_{i:03d}": i * numpy.ones(5) for i in range(10)}
             ),
             npartitions=1,
         ),
@@ -60,6 +70,28 @@ def test_dataframe_column_access(context):
         numpy.testing.assert_equal(actual, expected)
 
 
+@pytest.mark.xfail(reason="HTTP API accepts only one column")
+def test_dataframe_multicolumn_access(context):
+    client = from_context(context)
+    original_df = tree["basic"].read()
+    columns = list(original_df.columns)
+    assert len(columns) > 1
+    client["basic"][columns]
+
+
+def test_dataframe_multicolumn_read(context):
+    client = from_context(context)
+    original_df = tree["basic"].read()
+    columns = list(original_df.columns)[::2]  # Select a subset of columns
+    assert len(columns) > 1
+    actual_df = client["basic"].read(columns)
+
+    for col in columns:
+        expected = original_df[col].values
+        actual = actual_df[col]
+        numpy.testing.assert_equal(actual, expected)
+
+
 def test_dataframe_single_partition(context):
     client = from_context(context)
     expected = tree["single_partition"].read()
@@ -73,3 +105,42 @@ def test_dask(context):
     expected = tree["basic"].read()
     pandas.testing.assert_frame_equal(client.read().compute(), expected)
     pandas.testing.assert_frame_equal(client.compute(), expected)
+
+
+class URL_LIMITS(IntEnum):
+    HUGE = 80_000
+    ORIGINAL = 2_000
+    TINY = 10
+
+
+@pytest.mark.parametrize(
+    "URL_MAX_LENGTH, expected_method",
+    (
+        (URL_LIMITS.HUGE, "GET"),  # URL query should fit in a GET request
+        (URL_LIMITS.ORIGINAL, None),  # Expected method not specified
+        (URL_LIMITS.TINY, "POST"),  # URL query is too long for a GET request
+    )
+)
+def test_url_limit_bypass(context, URL_MAX_LENGTH, expected_method):
+    "GET requests beyond the URL length limit should become POST requests."
+    client = from_context(context)
+    df_client = client["wide"]
+    original_df = tree["wide"].read()
+    columns = list(original_df.columns)[::2]  # Pick a subset of columns
+    expected = tree["wide"].read(columns)
+    assert list(expected.columns) == columns
+
+    with record_history() as history:
+        actual = df_client.read(columns)
+        pandas.testing.assert_frame_equal(actual, expected)
+        assert list(actual.columns) == columns
+
+        requests = list(request for request in history.requests)
+        print(f'{requests = }')
+        assert len(requests) == df_client.structure().npartitions
+
+        request_methods = list(request.method for request in requests)
+        if expected_method == "POST":
+            assert "POST" in request_methods  # At least one POST request
+        elif expected_method == "GET":
+            assert "POST" not in request_methods  # No POST request

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 import dask.array
 import numpy
 import orjson
@@ -11,10 +9,10 @@ import xarray.testing
 from ..adapters.mapping import MapAdapter
 from ..adapters.xarray import DatasetAdapter
 from ..client import Context, from_context, record_history
-from ..client.base import BaseClient
 from ..serialization.xarray import serialize_json
 from ..server.app import build_app
 from ..structures.core import Spec
+from .utils import URL_LIMITS
 
 image = numpy.random.random((3, 5))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
@@ -151,27 +149,6 @@ def test_wide_table_optimization_off(client):
     with record_history() as history:
         wide.read(optimize_wide_table=False)
     assert len(history.requests) >= 10
-
-
-class URL_LIMITS(IntEnum):
-    HUGE = 80_000
-    ORIGINAL = BaseClient.URL_CHARACTER_LIMIT
-    TINY = 10
-
-
-@pytest.fixture
-def url_limit(request: pytest.FixtureRequest):
-    """Adjust the URL length limit for the client's GET requests.
-
-    Data will be fetched by GET requests when the URL_CHARACTER_LIMIT is long,
-    and by equivalent POST requests when the URL_CHARACTER_LIMIT is short.
-    """
-    URL_CHARACTER_LIMIT = int(request.param)
-    # Temporarily adjust the URL length limit to change client behavior.
-    BaseClient.URL_CHARACTER_LIMIT = URL_CHARACTER_LIMIT
-    yield
-    # Then restore the original value.
-    BaseClient.URL_CHARACTER_LIMIT = int(URL_LIMITS.ORIGINAL)
 
 
 @pytest.mark.parametrize(

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -151,8 +151,8 @@ def test_wide_table_optimization_off(client):
     assert len(history.requests) >= 10
 
 
-def test_url_limit_handling(client):
-    "Check that requests and split up to stay below the URL length limit."
+def test_url_limit_batching(client):
+    "Check that requests are split up to stay below the URL length limit."
     expected = EXPECTED["wide"]
     dsc = client["wide"]
     dsc.read()  # Dry run to run any one-off state-initializing requests.
@@ -191,6 +191,33 @@ def test_url_limit_handling(client):
     # number of requests may evolve as the library changes, but the trend should
     # hold.
     assert highest_request_count > higher_request_count > normal_request_count
+
+
+def test_url_limit_bypass(client):
+    "GET requests beyond the URL length limit should become POST requests."
+    expected = EXPECTED["wide"]
+    dsc = client["wide"]
+    dsc.read()  # Dry run to run any one-off state-initializing requests.
+    # Accumulate Requests here for later inspection.
+    requests = []
+
+    def accumulate(request):
+        requests.append(request)
+
+    client.context.http_client.event_hooks["request"].append(accumulate)
+    original = xarray_client.URL_CHARACTER_LIMIT
+    for URL_MAX_LENGTH in numpy.logspace(numpy.log10(original), 2., num=3):
+        try:
+            # It should never be necessary to tune this for real-world use,
+            # but we use this knob as a way to test its operation.
+            xarray_client.URL_CHARACTER_LIMIT = int(URL_MAX_LENGTH)
+            requests.clear()  # Empty the Request cache.
+            actual = dsc.read()
+            xarray.testing.assert_equal(actual, expected)
+            assert len(requests) == 1
+        finally:
+            # Restore default.
+            xarray_client.URL_CHARACTER_LIMIT = original
 
 
 @pytest.mark.parametrize("ds_node", tree.values(), ids=tree.keys())

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -227,7 +227,7 @@ def test_url_limit_bypass(client):
                 xarray_client.URL_CHARACTER_LIMIT = original
 
     request_methods = list(request.method for request in history.requests)
-    assert "GET" in request_methods   # URL_LIMITS.HUGE
+    assert "GET" in request_methods  # URL_LIMITS.HUGE
     assert "POST" in request_methods  # URL_LIMITS.TINY
 
 

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -151,48 +151,6 @@ def test_wide_table_optimization_off(client):
     assert len(history.requests) >= 10
 
 
-def test_url_limit_batching(client):
-    "Check that requests are split up to stay below the URL length limit."
-    expected = EXPECTED["wide"]
-    dsc = client["wide"]
-    dsc.read()  # Dry run to run any one-off state-initializing requests.
-    # Accumulate Requests here for later inspection.
-    requests = []
-
-    def accumulate(request):
-        # httpx.AsyncClient requires event hooks to be async functions.
-        requests.append(request)
-
-    client.context.http_client.event_hooks["request"].append(accumulate)
-    actual = dsc.read()
-    xarray.testing.assert_equal(actual, expected)
-    normal_request_count = len(requests)
-    original = xarray_client.URL_CHARACTER_LIMIT
-    try:
-        # It should never be necessary to tune this for real-world use, but we
-        # use this knob as a way to test its operation.
-        xarray_client.URL_CHARACTER_LIMIT = 200
-        # The client will need to split this across more requests in order to
-        # stay within the tighter limit.
-        requests.clear()  # Empty the Request cache before the next batch of requests.
-        actual = dsc.read()
-        xarray.testing.assert_equal(actual, expected)
-        higher_request_count = len(requests)
-        # Tighten even more.
-        xarray_client.URL_CHARACTER_LIMIT = 100
-        requests.clear()  # Empty the Request cache before the next batch of requests.
-        actual = dsc.read()
-        xarray.testing.assert_equal(actual, expected)
-        highest_request_count = len(requests)
-    finally:
-        # Restore default.
-        xarray_client.URL_CHARACTER_LIMIT = original
-    # The goal here is to test the *trend* not the specific values because the
-    # number of requests may evolve as the library changes, but the trend should
-    # hold.
-    assert highest_request_count > higher_request_count > normal_request_count
-
-
 def test_url_limit_bypass(client):
     "GET requests beyond the URL length limit should become POST requests."
     expected = EXPECTED["wide"]

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -207,13 +207,16 @@ def test_url_limit_bypass(client):
 
     client.context.http_client.event_hooks["request"].append(accumulate)
     original = xarray_client.URL_CHARACTER_LIMIT
-    ORIGINAL_LIMIT = numpy.log10(original)
-    TINY_LIMIT = numpy.log10(10)
-    for URL_MAX_LENGTH in numpy.logspace(ORIGINAL_LIMIT, TINY_LIMIT, num=3):
+    URL_LIMITS = {
+        "HUGE": 80_000,
+        "ORIGINAL": original,
+        "TINY": 10,
+    }
+    for URL_MAX_LENGTH in URL_LIMITS.values():
         try:
             # It should never be necessary to tune this for real-world use,
             # but we use this knob as a way to test its operation.
-            xarray_client.URL_CHARACTER_LIMIT = int(URL_MAX_LENGTH)
+            xarray_client.URL_CHARACTER_LIMIT = URL_MAX_LENGTH
             requests.clear()  # Empty the Request cache.
             actual = dsc.read()
             xarray.testing.assert_equal(actual, expected)

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -155,7 +155,7 @@ def test_wide_table_optimization_off(client):
     "url_limit, expected_method",
     (
         (URL_LIMITS.HUGE, "GET"),  # URL query should fit in a GET request
-        (URL_LIMITS.ORIGINAL, None),  # Expected method not specified
+        (URL_LIMITS.DEFAULT, None),  # Expected method is not specified
         (URL_LIMITS.TINY, "POST"),  # URL query is too long for a GET request
     ),
     indirect=["url_limit"],

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import getpass
 import uuid
+from enum import IntEnum
 
 import httpx
 import pytest
@@ -8,6 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from ..client import context
+from ..client.base import BaseClient
 
 
 @contextlib.contextmanager
@@ -56,3 +58,9 @@ def enter_password(password):
     yield
     setattr(getpass, "getpass", original_getpass)
     context.PROMPT_FOR_REAUTHENTICATION = original_prompt
+
+
+class URL_LIMITS(IntEnum):
+    HUGE = 80_000
+    ORIGINAL = BaseClient.URL_CHARACTER_LIMIT
+    TINY = 10

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -62,5 +62,5 @@ def enter_password(password):
 
 class URL_LIMITS(IntEnum):
     HUGE = 80_000
-    ORIGINAL = BaseClient.URL_CHARACTER_LIMIT
+    DEFAULT = BaseClient.URL_CHARACTER_LIMIT
     TINY = 10

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -87,6 +87,12 @@ class MetadataRevisions:
 
 
 class BaseClient:
+    # The HTTP spec does not define a size limit for URIs,
+    # but a common setting is 4K or 8K (for all the headers together).
+    # As another reference point, Internet Explorer imposes a
+    # 2048-character limit on URLs.
+    URL_CHARACTER_LIMIT = 2000  # number of characters
+
     def __init__(
         self,
         context,

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -91,7 +91,7 @@ class BaseClient:
     # but a common setting is 4K or 8K (for all the headers together).
     # As another reference point, Internet Explorer imposes a
     # 2048-character limit on URLs.
-    URL_CHARACTER_LIMIT = 2000  # number of characters
+    URL_CHARACTER_LIMIT = 2_000  # number of characters
 
     def __init__(
         self,

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -6,17 +6,13 @@ from ..utils import APACHE_ARROW_FILE_MIME_TYPE, UNCHANGED
 from .base import BaseClient
 from .utils import (
     MSGPACK_MIME_TYPE,
+    URL_CHARACTER_LIMIT,
     ClientError,
     client_for_item,
     export_util,
     handle_error,
 )
 
-# The HTTP spec does not define a size limit for URIs,
-# but a common setting is 4K or 8K (for all the headers together).
-# As another reference point, Internet Explorer imposes a
-# 2048-character limit on URLs.
-URL_CHARACTER_LIMIT = 2000  # number of characters
 _EXTRA_CHARS_PER_ITEM = len("&column=")
 
 

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -6,7 +6,6 @@ from ..utils import APACHE_ARROW_FILE_MIME_TYPE, UNCHANGED
 from .base import BaseClient
 from .utils import (
     MSGPACK_MIME_TYPE,
-    URL_CHARACTER_LIMIT,
     ClientError,
     client_for_item,
     export_util,
@@ -103,7 +102,7 @@ class _DaskDataFrameClient(BaseClient):
         url_length_for_get_request = len(URL_PATH) + sum(
             _EXTRA_CHARS_PER_ITEM + len(column) for column in (columns or ())
         )
-        if url_length_for_get_request > URL_CHARACTER_LIMIT:
+        if url_length_for_get_request > self.URL_CHARACTER_LIMIT:
             content = handle_error(
                 self.context.http_client.post(
                     URL_PATH,

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -13,6 +13,14 @@ from .utils import (
 )
 
 
+# The HTTP spec does not define a size limit for URIs,
+# but a common setting is 4K or 8K (for all the headers together).
+# As another reference point, Internet Explorer imposes a
+# 2048-character limit on URLs.
+URL_CHARACTER_LIMIT = 2000  # number of characters
+_EXTRA_CHARS_PER_ITEM = len("&column=")
+
+
 class _DaskDataFrameClient(BaseClient):
     "Client-side wrapper around an dataframe-like that returns dask dataframes"
 

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -11,6 +11,11 @@ import msgpack
 from ..utils import path_from_uri
 
 MSGPACK_MIME_TYPE = "application/x-msgpack"
+# The HTTP spec does not define a size limit for URIs,
+# but a common setting is 4K or 8K (for all the headers together).
+# As another reference point, Internet Explorer imposes a
+# 2048-character limit on URLs.
+URL_CHARACTER_LIMIT = 2000  # number of characters
 
 
 def handle_error(response):

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -11,11 +11,6 @@ import msgpack
 from ..utils import path_from_uri
 
 MSGPACK_MIME_TYPE = "application/x-msgpack"
-# The HTTP spec does not define a size limit for URIs,
-# but a common setting is 4K or 8K (for all the headers together).
-# As another reference point, Internet Explorer imposes a
-# 2048-character limit on URLs.
-URL_CHARACTER_LIMIT = 2000  # number of characters
 
 
 def handle_error(response):

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -8,7 +8,7 @@ from ..serialization.table import deserialize_arrow
 from ..structures.core import Spec
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE
 from .container import Container
-from .utils import handle_error
+from .utils import URL_CHARACTER_LIMIT, handle_error
 
 LENGTH_LIMIT_FOR_WIDE_TABLE_OPTIMIZATION = 1_000_000
 
@@ -115,11 +115,6 @@ class DatasetClient(DaskDatasetClient):
         )
 
 
-# The HTTP spec does not define a size limit for URIs,
-# but a common setting is 4K or 8K (for all the headers together).
-# As another reference point, Internet Explorer imposes a
-# 2048-character limit on URLs.
-URL_CHARACTER_LIMIT = 2000  # number of characters
 _EXTRA_CHARS_PER_ITEM = len("&field=")
 
 

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -156,13 +156,20 @@ class _WideTableFetcher:
                     _EXTRA_CHARS_PER_ITEM + len(variable) for variable in self.variables
                 )
                 if url_length_for_get_request > URL_CHARACTER_LIMIT:
-                    dataframe = self._post_variables(self.variables)
+                    dataframe = self._fetch_variables(self.variables, "POST")
                 else:
-                    dataframe = self._get_variables(self.variables)
+                    dataframe = self._fetch_variables(self.variables, "GET")
                 self._dataframe = dataframe.reset_index()
         return self._dataframe
 
-    def _get_variables(self, variables):
+    def _fetch_variables(self, variables, method="GET"):
+        if method == "GET":
+            return self._fetch_variables__get(variables)
+        if method == "POST":
+            return self._fetch_variables__post(variables)
+        raise NotImplementedError(f"Method {method} is not supported")
+
+    def _fetch_variables__get(self, variables):
         content = handle_error(
             self.get(
                 self.link,
@@ -171,7 +178,7 @@ class _WideTableFetcher:
         ).read()
         return deserialize_arrow(content)
 
-    def _post_variables(self, variables):
+    def _fetch_variables__post(self, variables):
         content = handle_error(
             self.post(
                 self.link,

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -7,8 +7,9 @@ import xarray
 from ..serialization.table import deserialize_arrow
 from ..structures.core import Spec
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE
+from .base import BaseClient
 from .container import Container
-from .utils import URL_CHARACTER_LIMIT, handle_error
+from .utils import handle_error
 
 LENGTH_LIMIT_FOR_WIDE_TABLE_OPTIMIZATION = 1_000_000
 
@@ -150,7 +151,7 @@ class _WideTableFetcher:
                 url_length_for_get_request = len(self.link) + sum(
                     _EXTRA_CHARS_PER_ITEM + len(variable) for variable in self.variables
                 )
-                if url_length_for_get_request > URL_CHARACTER_LIMIT:
+                if url_length_for_get_request > BaseClient.URL_CHARACTER_LIMIT:
                     dataframe = self._fetch_variables(self.variables, "POST")
                 else:
                     dataframe = self._fetch_variables(self.variables, "GET")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -623,7 +623,7 @@ async def table_partition(
     response_model=schemas.Response,
     name="full 'table' data",
 )
-async def table_full(
+async def get_table_full(
     request: Request,
     entry=SecureEntry(scopes=["read:data"]),
     column: Optional[List[str]] = Query(None, min_length=1),
@@ -631,6 +631,57 @@ async def table_full(
     filename: Optional[str] = None,
     serialization_registry=Depends(get_serialization_registry),
     settings: BaseSettings = Depends(get_settings),
+):
+    """
+    Fetch the data for the given table [GET route].
+    """
+    return await table_full(
+        request=request,
+        entry=entry,
+        column=column,
+        format=format,
+        filename=filename,
+        serialization_registry=serialization_registry,
+        settings=settings,
+    )
+
+
+@router.post(
+    "/table/full/{path:path}",
+    response_model=schemas.Response,
+    name="full 'table' data",
+)
+async def post_table_full(
+    request: Request,
+    entry=SecureEntry(scopes=["read:data"]),
+    column: Optional[List[str]] = Body(None, min_length=1),
+    format: Optional[str] = None,
+    filename: Optional[str] = None,
+    serialization_registry=Depends(get_serialization_registry),
+    settings: BaseSettings = Depends(get_settings),
+):
+    """
+    Fetch the data for the given table [POST route].
+    """
+    return await table_full(
+        request=request,
+        entry=entry,
+        column=column,
+        format=format,
+        filename=filename,
+        serialization_registry=serialization_registry,
+        settings=settings,
+    )
+
+
+async def table_full(
+    request: Request,
+    entry,
+    column: Optional[List[str]],
+    format: Optional[str],
+    filename: Optional[str],
+    serialization_registry,
+    settings: BaseSettings,
 ):
     """
     Fetch the data for the given table.

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1,6 +1,7 @@
 import dataclasses
 import inspect
 import os
+import warnings
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
@@ -504,6 +505,23 @@ async def get_table_partition(
     """
     Fetch a partition (continuous block of rows) from a DataFrame [GET route].
     """
+    if (field is not None) and (column is not None):
+        redundant_field_and_column = " ".join(
+            (
+                "Cannot accept both 'column' and 'field' query parameters",
+                "in the same /table/partition request.",
+                "Include these query values using only the 'column' parameter.",
+            )
+        )
+        raise HTTPException(status_code=400, detail=redundant_field_and_column)
+    elif field is not None:
+        field_is_deprecated = " ".join(
+            (
+                "Query parameter 'field' is deprecated for the /table/partition route.",
+                "Instead use the query parameter 'column'.",
+            )
+        )
+        warnings.warn(field_is_deprecated, DeprecationWarning)
     return await table_partition(
         request=request,
         partition=partition,

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 import anyio
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Security
 from jmespath.exceptions import JMESPathError
 from pydantic import BaseSettings
 from starlette.responses import FileResponse
@@ -604,7 +604,7 @@ async def table_full(
     response_model=schemas.Response,
     name="full 'container' metadata and data",
 )
-async def container_full(
+async def get_container_full(
     request: Request,
     entry=SecureEntry(scopes=["read:data"]),
     principal: str = Depends(get_current_principal),
@@ -612,6 +612,57 @@ async def container_full(
     format: Optional[str] = None,
     filename: Optional[str] = None,
     serialization_registry=Depends(get_serialization_registry),
+):
+    """
+    Fetch the data for the given container via a GET request.
+    """
+    return await container_full(
+        request=request,
+        entry=entry,
+        principal=principal,
+        field=field,
+        format=format,
+        filename=filename,
+        serialization_registry=serialization_registry,
+    )
+
+
+@router.post(
+    "/container/full/{path:path}",
+    response_model=schemas.Response,
+    name="full 'container' metadata and data",
+)
+async def post_container_full(
+    request: Request,
+    entry=SecureEntry(scopes=["read:data"]),
+    principal: str = Depends(get_current_principal),
+    field: Optional[List[str]] = Body(None, min_length=1),
+    format: Optional[str] = None,
+    filename: Optional[str] = None,
+    serialization_registry=Depends(get_serialization_registry),
+):
+    """
+    Fetch the data for the given container via a POST request.
+    """
+    return await container_full(
+        request=request,
+        entry=entry,
+        principal=principal,
+        field=field,
+        format=format,
+        filename=filename,
+        serialization_registry=serialization_registry,
+    )
+
+
+async def container_full(
+    request: Request,
+    entry,
+    principal: str,
+    field: Optional[List[str]],
+    format: Optional[str],
+    filename: Optional[str],
+    serialization_registry,
 ):
     """
     Fetch the data for the given container.


### PR DESCRIPTION
Closes #579.

This will eventually create POST alternatives to the existing `/container/full`, `/table/full`, and `/table/partition` GET endpoints.

Tests and updates will be rolled out one-by-one where feasible for Containers (xarray.Dataset, file directory, Excel file, Zarr file, HDF5 file) and Tables (pandas.DataFrame).

Will also update `/table/partition/{path}` to accept a `column` query parameter rather than `field`, as was recently done for `/table/full/{path}`. `field` will be deprecated but kept for backward compatibility for some duration.