### PR TITLE
Add structure_family to data_sources table.

### DIFF
--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -211,6 +211,7 @@ async def test_write_array_external(a, tmpdir):
         metadata={},
         data_sources=[
             DataSource(
+                structure_family="array",
                 mimetype="image/tiff",
                 structure=structure,
                 parameters={},
@@ -244,6 +245,7 @@ async def test_write_dataframe_external_direct(a, tmpdir):
         metadata={},
         data_sources=[
             DataSource(
+                structure_family="table",
                 mimetype="text/csv",
                 structure=structure,
                 parameters={},
@@ -274,6 +276,7 @@ async def test_write_array_internal_direct(a, tmpdir):
         metadata={},
         data_sources=[
             DataSource(
+                structure_family="array",
                 structure=structure,
                 management="writable",
             )
@@ -517,6 +520,7 @@ async def test_constraints_on_parameter_and_num(a, assets):
             specs=arr_adapter.specs,
             data_sources=[
                 DataSource(
+                    structure_family=arr_adapter.structure_family,
                     mimetype="application/x-test",
                     structure=asdict(arr_adapter.structure()),
                     parameters={},

--- a/tiled/_tests/test_directory_walker.py
+++ b/tiled/_tests/test_directory_walker.py
@@ -224,6 +224,7 @@ async def test_image_file_with_sidecar_metadata_file(tmpdir):
             specs=adapter.specs,
             data_sources=[
                 DataSource(
+                    structure_family=adapter.structure_family,
                     mimetype=MIMETYPE,
                     structure=dataclasses.asdict(adapter.structure()),
                     parameters={},
@@ -304,6 +305,7 @@ async def test_hdf5_virtual_datasets(tmpdir):
             specs=adapter.specs,
             data_sources=[
                 DataSource(
+                    structure_family=adapter.structure_family,
                     mimetype="application/x-hdf5",
                     structure=None,
                     parameters={},

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -629,6 +629,7 @@ class CatalogNodeAdapter:
                     ).on_conflict_do_nothing(index_elements=["id"])
                     await db.execute(statement)
                 data_source_orm = orm.DataSource(
+                    structure_family=data_source.structure_family,
                     mimetype=data_source.mimetype,
                     management=data_source.management,
                     parameters=data_source.parameters,

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,6 +5,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "e756b9381c14",
     "2ca16566d692",
     "1cd99c02d0c7",
     "a66028395cab",

--- a/tiled/catalog/migrations/versions/e756b9381c14_add_structure_family_to_data_sources.py
+++ b/tiled/catalog/migrations/versions/e756b9381c14_add_structure_family_to_data_sources.py
@@ -1,0 +1,65 @@
+"""Add structure_family to data_sources.
+
+Revision ID: e756b9381c14
+Revises: 2ca16566d692
+Create Date: 2024-02-20 09:18:45.405078
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.structures.core import StructureFamily
+
+# revision identifiers, used by Alembic.
+revision = "e756b9381c14"
+down_revision = "2ca16566d692"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    # Initialize new structure_family column as a nullable at first because
+    # existing rows will be empty.
+    op.add_column(
+        "data_sources",
+        sa.Column("structure_family", sa.Enum(StructureFamily), nullable=True),
+    )
+    data_sources = sa.Table(
+        "data_sources",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer),
+        sa.Column(
+            "node_id",
+            sa.Integer,
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("structure_family", sa.Enum(StructureFamily), nullable=True),
+    )
+    # Fill in structure_family from associated node.
+    results = connection.execute(
+        sa.text(
+            "SELECT data_sources.id, nodes.structure_family "
+            "FROM data_sources JOIN nodes ON "
+            "data_sources.node_id = nodes.id"
+        )
+    ).fetchall()
+    for data_source_id, structure_family in results:
+        connection.execute(
+            data_sources.update()
+            .values(structure_family=structure_family)
+            .where(data_sources.c.id == data_source_id)
+        )
+    # Now make structure_family NOT NULL.
+    if connection.engine.dialect.name == "sqlite":
+        with op.batch_alter_table("data_sources") as batch_op:
+            batch_op.alter_column("structure_family", nullable=False)
+    else:
+        op.alter_column("data_sources", "structure_family", nullable=False)
+
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -291,6 +291,7 @@ class DataSource(Timestamped, Base):
     node_id = Column(
         Integer, ForeignKey("nodes.id", ondelete="CASCADE"), nullable=False
     )
+    structure_family = Column(Enum(StructureFamily), nullable=False)
     structure_id = Column(
         Unicode(32), ForeignKey("structures.id", ondelete="CASCADE"), nullable=True
     )

--- a/tiled/catalog/register.py
+++ b/tiled/catalog/register.py
@@ -304,6 +304,7 @@ async def register_single_item(
         specs=adapter.specs,
         data_sources=[
             DataSource(
+                structure_family=adapter.structure_family,
                 mimetype=mimetype,
                 structure=dict_or_none(adapter.structure()),
                 parameters={},
@@ -381,6 +382,7 @@ async def register_tiff_sequence(catalog, name, sequence, settings):
         specs=adapter.specs,
         data_sources=[
             DataSource(
+                structure_family=adapter.structure_family,
                 mimetype=TIFF_SEQ_MIMETYPE,
                 structure=dict_or_none(adapter.structure()),
                 parameters={},

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -598,7 +598,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         data_sources = []
         if structure_family != StructureFamily.container:
             # TODO Handle multiple data sources.
-            data_sources.append({"structure": asdict(structure)})
+            data_sources.append(
+                {"structure": asdict(structure), "structure_family": structure_family}
+            )
         item = {
             "attributes": {
                 "metadata": metadata,

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -138,6 +138,7 @@ class Revision(pydantic.BaseModel):
 
 class DataSource(pydantic.BaseModel):
     id: Optional[int] = None
+    structure_family: StructureFamily
     structure: Optional[
         Union[
             ArrayStructure,
@@ -156,6 +157,7 @@ class DataSource(pydantic.BaseModel):
     def from_orm(cls, orm):
         return cls(
             id=orm.id,
+            structure_family=orm.structure_family,
             structure=getattr(orm.structure, "structure", None),
             mimetype=orm.mimetype,
             parameters=orm.parameters,


### PR DESCRIPTION
This adds `structure_family` to the `data_sources` table, in support of #528.

Migrations tested on the SQLite and PostgreSQL [example data](https://github.com/bluesky/tiled-example-database).