### PR TITLE
Thread-safety for the client Cache()

### DIFF
--- a/tiled/_tests/test_client_cache.py
+++ b/tiled/_tests/test_client_cache.py
@@ -1,9 +1,9 @@
-import time
-import sqlite3
-from contextlib import closing
-import concurrent.futures
 import asyncio
+import concurrent.futures
+import sqlite3
 import threading
+import time
+from contextlib import closing
 
 import numpy
 import pytest

--- a/tiled/_tests/test_client_cache.py
+++ b/tiled/_tests/test_client_cache.py
@@ -1,5 +1,9 @@
+import time
 import sqlite3
 from contextlib import closing
+import concurrent.futures
+import asyncio
+import threading
 
 import numpy
 import pytest
@@ -7,7 +11,7 @@ import pytest
 from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter
 from ..client import Context, from_context, record_history
-from ..client.cache import Cache, CachedResponse
+from ..client.cache import Cache, CachedResponse, with_thread_lock
 from ..server.app import build_app
 
 tree = MapAdapter(
@@ -169,3 +173,52 @@ def test_clear_cache(client):
     assert cache.count() > 0
     cache.clear()
     assert cache.size() == cache.count() == 0
+
+
+def test_not_thread_safe(client, monkeypatch):
+    # Check that writes fail if thread safety is disabled
+    monkeypatch.setattr(sqlite3, "threadsafety", 0)
+    cache = client.context.cache
+    # Clear the cache in another thread
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        future = executor.submit(cache.clear)
+        with pytest.raises(RuntimeError):
+            future.result(timeout=1)
+
+
+@pytest.mark.skipif(
+    sqlite3.threadsafety < 2, reason="sqlite not built with thread safe support"
+)
+def test_thread_safety(client):
+    cache = client.context.cache
+    # Clear the cache in another thread
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        future = executor.submit(cache.clear)
+        future.result(timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_thread_lock():
+    """Check that we can prevent concurrent thread writes."""
+
+    class Timer:
+        _lock = threading.Lock()
+        sleep_time = 0.01
+
+        @with_thread_lock
+        def sleep(self):
+            time.sleep(self.sleep_time)
+
+    timer = Timer()
+    # Run the timer twice concurrently
+    loop = asyncio.get_running_loop()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        coros = [
+            loop.run_in_executor(executor, timer.sleep),
+            loop.run_in_executor(executor, timer.sleep),
+        ]
+        t0 = time.perf_counter()
+        await asyncio.gather(*coros)
+        run_time = time.perf_counter() - t0
+    # Check that the threads didn't run in parallel
+    assert run_time >= (2.0 * timer.sleep_time), "Threads did not lock"

--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -8,6 +8,7 @@ import pytest
 from packaging.version import parse
 
 from ..client import from_context
+from ..client.cache import Cache
 from ..client.context import Context
 
 MIN_VERSION = "0.1.0a104"
@@ -24,7 +25,7 @@ def test_pickle_context():
 
 
 @pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
-def test_pickle_clients(structure_clients):
+def test_pickle_clients(structure_clients, tmpdir):
     try:
         httpx.get(API_URL).raise_for_status()
     except Exception:
@@ -34,7 +35,8 @@ def test_pickle_clients(structure_clients):
             raise pytest.skip(
                 f"Server at {API_URL} is running too old a version to test against."
             )
-        client = from_context(context, structure_clients)
+        cache = Cache(tmpdir / "http_response_cache.db")
+        client = from_context(context, structure_clients, cache)
         pickle.loads(pickle.dumps(client))
         for segements in [
             ["generated"],
@@ -46,3 +48,10 @@ def test_pickle_clients(structure_clients):
                 original = original[segment]
             roundtripped = pickle.loads(pickle.dumps(original))
             assert roundtripped.uri == original.uri
+
+
+def test_lock_round_trip(tmpdir):
+    cache = Cache(tmpdir / "http_response_cache.db")
+    cache_round_tripped = pickle.loads(pickle.dumps(cache))
+    # implementation detail!
+    assert cache._lock.lock is cache_round_tripped._lock.lock

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -1,3 +1,4 @@
+import enum
 import json
 import os
 import sqlite3
@@ -162,6 +163,18 @@ def with_thread_lock(fn):
     return wrapper
 
 
+class ThreadingMode(enum.IntEnum):
+    """Threading mode used in the sqlite3 package.
+
+    https://docs.python.org/3/library/sqlite3.html#sqlite3.threadsafety
+
+    """
+
+    SINGLE_THREAD = 0
+    MULTI_THREAD = 1
+    SERIALIZED = 3
+
+
 class Cache:
     def __init__(
         self,
@@ -201,9 +214,8 @@ class Cache:
         lock (``@with_thread_lock``) to prevent parallel writes.
 
         """
-        SERIALIZED = 3  # Could be defined in an enum elsewhere
         is_main_thread = threading.current_thread().ident == self._owner_thread
-        sqlite_is_safe = sqlite3.threadsafety == SERIALIZED
+        sqlite_is_safe = sqlite3.threadsafety == ThreadingMode.SERIALIZED
         return is_main_thread or sqlite_is_safe
 
     def __getstate__(self):

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -6,6 +6,7 @@ import typing as tp
 from contextlib import closing
 from datetime import datetime
 from pathlib import Path
+from functools import wraps
 
 import appdirs
 import httpx
@@ -146,6 +147,21 @@ def _prepare_database(filepath, readonly):
     return conn
 
 
+def with_thread_lock(fn):
+    """Makes sure the wrapper isn't accessed concurrently."""
+
+    @wraps(fn)
+    def wrapper(obj, *args, **kwargs):
+        obj._lock.acquire()
+        try:
+            result = fn(obj, *args, **kwargs)
+        finally:
+            obj._lock.release()
+        return result
+
+    return wrapper
+
+
 class Cache:
     def __init__(
         self,
@@ -171,17 +187,23 @@ class Cache:
         self._filepath = filepath
         self._owner_thread = threading.current_thread().ident
         self._conn = _prepare_database(filepath, readonly)
+        self._lock = threading.Lock()
 
     def __repr__(self):
         return f"<{type(self).__name__} {str(self._filepath)!r}>"
 
     def write_safe(self):
-        """
-        Check that it is safe to write.
+        """Check that it is safe to write.
 
-        SQLite is not threadsafe for concurrent _writes_.
+        SQLite is not threadsafe for concurrent _writes_ unless the
+        underlying sqlite library was built with thread safety
+        enabled. Even still, it may be a good idea to use a thread
+        lock (``@with_thread_lock``) to prevent parallel writes.
+
         """
-        return threading.current_thread().ident == self._owner_thread
+        is_main_thread = threading.current_thread().ident == self._owner_thread
+        sqlite_is_safe = sqlite3.threadsafety > 2
+        return is_main_thread or sqlite_is_safe
 
     def __getstate__(self):
         return (self.filepath, self.capacity, self.max_item_size, self._readonly)
@@ -223,6 +245,7 @@ class Cache:
     def max_item_size(self, max_item_size):
         self._max_item_size = max_item_size
 
+    @with_thread_lock
     def clear(self):
         """
         Drop all entries from HTTP response cache.
@@ -237,6 +260,7 @@ class Cache:
             cur.execute("DELETE FROM responses")
             self._conn.commit()
 
+    @with_thread_lock
     def get(self, request: httpx.Request) -> tp.Optional[httpx.Response]:
         """Get cached response from Cache.
 
@@ -271,6 +295,7 @@ WHERE cache_key = ?""",
 
         return load(row, request)
 
+    @with_thread_lock
     def set(
         self,
         *,
@@ -321,6 +346,7 @@ VALUES
             self._conn.commit()
         return True
 
+    @with_thread_lock
     def delete(self, request: httpx.Request) -> None:
         """Delete an entry from cache.
 

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -5,8 +5,8 @@ import threading
 import typing as tp
 from contextlib import closing
 from datetime import datetime
-from pathlib import Path
 from functools import wraps
+from pathlib import Path
 
 import appdirs
 import httpx

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -201,8 +201,9 @@ class Cache:
         lock (``@with_thread_lock``) to prevent parallel writes.
 
         """
+        SERIALIZED = 3  # Could be defined in an enum elsewhere
         is_main_thread = threading.current_thread().ident == self._owner_thread
-        sqlite_is_safe = sqlite3.threadsafety > 2
+        sqlite_is_safe = sqlite3.threadsafety == SERIALIZED
         return is_main_thread or sqlite_is_safe
 
     def __getstate__(self):


### PR DESCRIPTION
Based on a mattermost conversation. I wanted to use the Cache() from multiple threads so I could make an awaitable wrapper around the Tiled client. 

sqlite3 does support thread-safety if it's built into the underlying sqlite library. So this PR has the cache check if the sqlite3 library supports thread-safety, and if it does then allows writes from other threads.

https://docs.python.org/3/library/sqlite3.html#sqlite3.threadsafety

Even still, I'm not sure how parallel writes get handled, so I also included a thread lock forcing parallel writes to wait until previous writes are done. Might be overkill but I don't have a way to check this easily so figured I'd err on the side of caution.