### PR TITLE
Support service principal in `SimpleAccessPolicy`

### DIFF
--- a/tiled/access_policies.py
+++ b/tiled/access_policies.py
@@ -65,6 +65,8 @@ class SimpleAccessPolicy:
         # If this is being called, filter_access has let us get this far.
         if principal is SpecialUsers.public:
             allowed = PUBLIC_SCOPES
+        elif principal.type == "service":
+            allowed = self.scopes
         elif self._get_id(principal) in self.admins:
             allowed = ALL_SCOPES
         # The simple policy does not provide for different Principals to
@@ -79,7 +81,11 @@ class SimpleAccessPolicy:
         if principal is SpecialUsers.public:
             queries.append(KeysFilter(self.public))
         else:
-            id = self._get_id(principal)
+            # Services have no identities; just use the uuid.
+            if principal.type == "service":
+                id = str(principal.uuid)
+            else:
+                id = self._get_id(principal)
             if id in self.admins:
                 return queries
             if not scopes.issubset(self.scopes):

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -306,7 +306,7 @@ properties:
           Tiled officially supports PostgreSQL and SQLite, but any database engine
           supported by SQLAlchemy *may* work.
       init_if_not_exists:
-        type: bool
+        type: boolean
         description: |
           Initialize authentication database tables if database is empty.
       pool_pre_ping:

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -305,6 +305,10 @@ properties:
 
           Tiled officially supports PostgreSQL and SQLite, but any database engine
           supported by SQLAlchemy *may* work.
+      init_if_not_exists:
+        type: bool
+        description: |
+          Initialize authentication database tables if database is empty.
       pool_pre_ping:
         type: boolean
         description: |

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
     )  # 300 MB
     reject_undeclared_specs = bool(int(os.getenv("TILED_REJECT_UNDECLARED_SPECS", 0)))
     database_uri: Optional[str] = os.getenv("TILED_DATABASE_URI")
+    database_init_if_not_exists: bool = int(
+        os.getenv("TILED_DATABASE_INIT_IF_NOT_EXISTS", False)
+    )
     database_pool_size: Optional[int] = int(os.getenv("TILED_DATABASE_POOL_SIZE", 5))
     database_pool_pre_ping: Optional[bool] = bool(
         int(os.getenv("TILED_DATABASE_POOL_PRE_PING", 1))


### PR DESCRIPTION
This makes it possible to add a service principal's uuid (as it has no identity/username...) to a `SimpleAccessPolicy`. Test included.

In support of C2QA / @jmaruland.