### PR TITLE
Replace `numpy.product()` with `.prod()`

### DIFF
--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -33,9 +33,8 @@ class _DaskArrayClient(BaseClient):
     @property
     def nbytes(self):
         structure = self.structure()
-        return (
-            numpy.prod(structure.shape) * structure.data_type.to_numpy_dtype().itemsize
-        )
+        itemsize = structure.data_type.to_numpy_dtype().itemsize
+        return numpy.prod(structure.shape) * itemsize
 
     @property
     def chunks(self):

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -24,7 +24,7 @@ class _DaskArrayClient(BaseClient):
 
     @property
     def size(self):
-        return numpy.product(self.structure().shape)
+        return numpy.prod(self.structure().shape)
 
     @property
     def dtype(self):
@@ -34,8 +34,7 @@ class _DaskArrayClient(BaseClient):
     def nbytes(self):
         structure = self.structure()
         return (
-            numpy.product(structure.shape)
-            * structure.data_type.to_numpy_dtype().itemsize
+            numpy.prod(structure.shape) * structure.data_type.to_numpy_dtype().itemsize
         )
 
     @property


### PR DESCRIPTION
This PR replaces the deprecated `numpy.product()` calls with equivalent calls to `numpy.prod()`, which is compatible with numpy 2.0.