### PR TITLE
Improve resource management in tests

### DIFF
--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -1,3 +1,4 @@
+import io
 import os
 import sys
 import tempfile
@@ -47,6 +48,13 @@ def set_tiled_cache_dir():
         os.environ["TILED_CACHE_DIR"] = str(tmpdir)
         yield
         del os.environ["TILED_CACHE_DIR"]
+
+
+@pytest.fixture(scope="function")
+def buffer():
+    "Generate a temporary buffer for testing file export + re-import."
+    with io.BytesIO() as buffer:
+        yield buffer
 
 
 @pytest.fixture

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -1,4 +1,3 @@
-import io
 import json
 
 import numpy
@@ -180,11 +179,10 @@ def test_access_control_with_api_key_auth(context, enter_password):
         context.api_key = None
 
 
-def test_node_export(enter_password, context):
+def test_node_export(enter_password, context, buffer):
     "Exporting a node should include only the children we can see."
     with enter_password("secret1"):
         alice_client = from_context(context, username="alice")
-    buffer = io.BytesIO()
     alice_client.export(buffer, format="application/json")
     alice_client.logout()
     buffer.seek(0)

--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -122,10 +122,8 @@ def test_nan_infinity_handler(tmpdir, context):
     def strict_parse_constant(c):
         raise ValueError(f"{c} is not valid JSON")
 
-    open_json = json.load(
-        open(Path(tmpdir, "testjson", "test.json"), "r"),
-        parse_constant=strict_parse_constant,
-    )
+    with open(Path(tmpdir, "testjson", "test.json"), "r") as json_file:
+        open_json = json.load(json_file, parse_constant=strict_parse_constant)
 
     expected_list = [0.0, 1.0, None, None, None]
     assert open_json == expected_list

--- a/tiled/_tests/test_awkward.py
+++ b/tiled/_tests/test_awkward.py
@@ -1,4 +1,3 @@
-import io
 import json
 
 import awkward
@@ -70,7 +69,7 @@ def test_slicing(client):
         assert sliced_response_size < full_response_size
 
 
-def test_export_json(client):
+def test_export_json(client, buffer):
     # Write data into catalog. It will be stored as directory of buffers
     # named like 'node0-offsets' and 'node2-data'.
     array = awkward.Array(
@@ -82,7 +81,7 @@ def test_export_json(client):
     )
     aac = client.write_awkward(array, key="test")
 
-    file = io.BytesIO()
+    file = buffer
     aac.export(file, format="application/json")
     actual = bytes(file.getbuffer()).decode()
     assert actual == awkward.to_json(array)

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -43,6 +43,7 @@ def test_directory_fields(client, fields):
 
     assert_single_request_to_url(history, url_path)
     assert_requested_fields_fetched(buffer, fields, client)
+    buffer.close()
 
 
 @pytest.fixture(scope="module")
@@ -70,6 +71,7 @@ def test_excel_fields(client, fields):
 
     assert_single_request_to_url(history, url_path)
     assert_requested_fields_fetched(buffer, fields, client)
+    buffer.close()
 
 
 def mark_xfail(value, unsupported="UNSPECIFIED ADAPTER"):
@@ -82,9 +84,9 @@ def mark_xfail(value, unsupported="UNSPECIFIED ADAPTER"):
 def zarr_data_dir(tmpdir_factory):
     "Generate a temporary Zarr group file with multiple datasets."
     tmpdir = tmpdir_factory.mktemp("zarr_files")
-    root = zarr.open(str(tmpdir / "zarr_group.zarr"), "w")
-    for i, name in enumerate("abcde"):
-        root.create_dataset(name, data=range(i, i + 3))
+    with zarr.open(str(tmpdir / "zarr_group.zarr"), "w") as root:
+        for i, name in enumerate("abcde"):
+            root.create_dataset(name, data=range(i, i + 3))
     return tmpdir
 
 
@@ -100,6 +102,7 @@ def test_zarr_group_fields(client, fields):
 
     assert_single_request_to_url(history, url_path)
     assert_requested_fields_fetched(buffer, fields, client)
+    buffer.close()
 
 
 @pytest.fixture(scope="module")
@@ -127,6 +130,7 @@ def test_hdf5_fields(client, fields):
 
     assert_single_request_to_url(history, url_path)
     assert_requested_fields_fetched(buffer, fields, client)
+    buffer.close()
 
 
 def assert_single_request_to_url(history, url_path):
@@ -138,7 +142,7 @@ def assert_single_request_to_url(history, url_path):
 
 def assert_requested_fields_fetched(buffer, fields, client):
     "Only the requested fields were fetched."
-    file = h5py.File(buffer)
-    actual_fields = set(file.keys())
+    with h5py.File(buffer) as file:
+        actual_fields = set(file.keys())
     expected = set(fields or client.keys())  # By default all fields were fetched
     assert actual_fields == expected

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -1,5 +1,3 @@
-import io
-
 import anyio
 import h5py
 import pandas
@@ -30,13 +28,6 @@ def example_data_dir(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp("example_files")
     generate_files(tmpdir)
     return tmpdir
-
-
-@pytest.fixture(scope="function")
-def buffer():
-    "Generate a temporary buffer for testing file export + re-import."
-    with io.BytesIO() as buffer:
-        yield buffer
 
 
 @pytest.mark.parametrize("fields", (None, (), ("a", "b")))

--- a/tiled/_tests/test_container_files.py
+++ b/tiled/_tests/test_container_files.py
@@ -23,16 +23,15 @@ async def test_excel(tmpdir):
 
 @pytest.mark.asyncio
 async def test_zarr_array(tmpdir):
-    with zarr.open(
-        str(tmpdir / "za.zarr"), "w", shape=(3,), chunks=(3,), dtype="i4"
-    ) as z:
-        z[:] = [1, 2, 3]
+    z = zarr.open(str(tmpdir / "za.zarr"), "w", shape=(3,), chunks=(3,), dtype="i4")
+    z[:] = [1, 2, 3]
     catalog = in_memory(readable_storage=[tmpdir])
     with Context.from_app(build_app(catalog)) as context:
         client = from_context(context)
         await register(client, tmpdir)
         tree(client)
         client["za"].read()
+    z.store.close()
 
 
 @pytest.mark.asyncio

--- a/tiled/_tests/test_container_files.py
+++ b/tiled/_tests/test_container_files.py
@@ -1,5 +1,3 @@
-import io
-
 import h5py
 import pandas
 import pytest
@@ -53,7 +51,7 @@ async def test_zarr_group(tmpdir):
 
 
 @pytest.mark.asyncio
-async def test_hdf5(tmpdir):
+async def test_hdf5(tmpdir, buffer):
     with h5py.File(str(tmpdir / "h.h5"), "w") as file:
         file["x"] = [1, 2, 3]
         group = file.create_group("g")
@@ -66,5 +64,4 @@ async def test_hdf5(tmpdir):
         client["h"]["x"].read()
         client["h"]["g"]["y"].read()
 
-        buffer = io.BytesIO()
         client.export(buffer, format="application/json")

--- a/tiled/_tests/test_container_files.py
+++ b/tiled/_tests/test_container_files.py
@@ -25,8 +25,10 @@ async def test_excel(tmpdir):
 
 @pytest.mark.asyncio
 async def test_zarr_array(tmpdir):
-    z = zarr.open(str(tmpdir / "za.zarr"), "w", shape=(3,), chunks=(3,), dtype="i4")
-    z[:] = [1, 2, 3]
+    with zarr.open(
+        str(tmpdir / "za.zarr"), "w", shape=(3,), chunks=(3,), dtype="i4"
+    ) as z:
+        z[:] = [1, 2, 3]
     catalog = in_memory(readable_storage=[tmpdir])
     with Context.from_app(build_app(catalog)) as context:
         client = from_context(context)
@@ -37,9 +39,9 @@ async def test_zarr_array(tmpdir):
 
 @pytest.mark.asyncio
 async def test_zarr_group(tmpdir):
-    root = zarr.open(str(tmpdir / "zg.zarr"), "w")
-    root.create_dataset("x", data=[1, 2, 3])
-    root.create_dataset("y", data=[4, 5, 6])
+    with zarr.open(str(tmpdir / "zg.zarr"), "w") as root:
+        root.create_dataset("x", data=[1, 2, 3])
+        root.create_dataset("y", data=[4, 5, 6])
     catalog = in_memory(readable_storage=[tmpdir])
     with Context.from_app(build_app(catalog)) as context:
         client = from_context(context)

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -4,7 +4,6 @@ This tests tiled's writing routes with an in-memory store.
 Persistent stores are being developed externally to the tiled package.
 """
 import base64
-import io
 from datetime import datetime
 
 import awkward
@@ -443,11 +442,10 @@ async def test_bytes_in_metadata(tree):
 
 
 @pytest.mark.asyncio
-async def test_container_export(tree):
+async def test_container_export(tree, buffer):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
 
         a = client.create_container("a")
         a.write_array([1, 2, 3], key="b")
-        buffer = io.BytesIO()
         client.export(buffer, format="application/json")


### PR DESCRIPTION
Several tests were not closing files and buffers. This PR addresses that by using context managers where possible, and explicitly closing the resource handles otherwise.

These updates do not affect the outcome of the tests but should reduce the resources open at any given time. It also acts as a good example, as the tests are often references for how to use the tiled APIs.  Fewer `ResourceWarning`s are emitted during testing as well.