### PR TITLE
More idiomatic approach to `kwargs` in `ensure_awaitable`

### DIFF
--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -3,6 +3,7 @@ import builtins
 import collections.abc
 import contextlib
 import enum
+import functools
 import importlib
 import importlib.util
 import inspect
@@ -661,10 +662,7 @@ async def ensure_awaitable(func, *args, **kwargs):
     else:
         # run_sync() does not apply **kwargs to func
         # https://github.com/agronholm/anyio/issues/414
-        def func_with_kwargs(*args):
-            return func(*args, **kwargs)
-
-        return await anyio.to_thread.run_sync(func_with_kwargs, *args)
+        return await anyio.to_thread.run_sync(functools.partial(func, **kwargs), *args)
 
 
 def path_from_uri(uri):


### PR DESCRIPTION
This PR is cleaning up [an earlier update](https://github.com/bluesky/tiled/pull/660/files#diff-d16c63ca14863951c4586cc770a83b8cc0d7b8a6d0c8a6a073bd6ff21e07515d) to `ensure_awaitable()` that passes keyword args to the inner function. Now using the idiomatic approach rather than an ad hoc implementation of `partial`.