### PR TITLE
Ignore DeprecationWarning from Pandas via cachey

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -25,6 +25,10 @@ from ..structures.sparse import COOStructure
 from ..validation_registration import ValidationRegistry
 from .utils import fail_with_status_code
 
+WARNING_PANDAS_BLOCKS = (
+    "DataFrame._data is deprecated and will be removed in a future version. "
+    "Use public APIs instead."
+)
 validation_registry = ValidationRegistry()
 validation_registry.register("SomeSpec", lambda *args, **kwargs: None)
 
@@ -112,6 +116,7 @@ def test_write_array_chunked(tree):
         assert result.specs == specs
 
 
+# @pytest.mark.filterwarnings(f"ignore:{WARNING_PANDAS_BLOCKS}:DeprecationWarning")
 def test_write_dataframe_full(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)
@@ -137,6 +142,7 @@ def test_write_dataframe_full(tree):
         assert result.specs == specs
 
 
+# @pytest.mark.filterwarnings(f"ignore:{WARNING_PANDAS_BLOCKS}:DeprecationWarning")
 def test_write_dataframe_partitioned(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)
@@ -390,6 +396,7 @@ async def test_delete_non_empty_node(tree):
         client.delete("a")
 
 
+# @pytest.mark.filterwarnings(f"ignore:{WARNING_PANDAS_BLOCKS}:DeprecationWarning")
 @pytest.mark.asyncio
 async def test_write_in_container(tree):
     "Create a container and write a structure into it."

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -19,16 +19,14 @@ from ..catalog import in_memory
 from ..client import Context, from_context, record_history
 from ..queries import Key
 from ..server.app import build_app
+
+# from ..server.object_cache import WARNING_PANDAS_BLOCKS
 from ..structures.core import Spec
 from ..structures.data_source import DataSource
 from ..structures.sparse import COOStructure
 from ..validation_registration import ValidationRegistry
 from .utils import fail_with_status_code
 
-WARNING_PANDAS_BLOCKS = (
-    "DataFrame._data is deprecated and will be removed in a future version. "
-    "Use public APIs instead."
-)
 validation_registry = ValidationRegistry()
 validation_registry.register("SomeSpec", lambda *args, **kwargs: None)
 


### PR DESCRIPTION
Calls to `cachey.nbytes()` issue a `DeprecationWarning` because of direct access to the deprecated internals of Pandas.
* https://github.com/bluesky/tiled/issues/675#issuecomment-1983581882

This PR catches those warnings at the corresponding calls in Tiled's `object_cache` module. It also shows where this could be limited to just the tests instead.

I favor doing this in the code rather than the tests, but it does add some uncertainty for thread safety.