### PR TITLE
Log Tiled version at startup.

### DIFF
--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -467,6 +467,9 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
 
     @app.on_event("startup")
     async def startup_event():
+        from .. import __version__
+
+        logger.info(f"Tiled version {__version__}")
         # Validate the single-user API key.
         settings = app.dependency_overrides[get_settings]()
         single_user_api_key = settings.single_user_api_key


### PR DESCRIPTION
Just a little thing I've been meaning to add for awhile. Useful as a sanity check, especially in the context of an orchestration system (systemd, k8s) where it is hard to interactively check the version.

Example:

```
Tiled version 0.1.0a117.dev2+g63b583be.d20240308
````

In context:

```
$ tiled serve catalog --temp
Creating catalog database at /tmp/tmpisbwvoie/catalog.db
Creating writable catalog data directory at /tmp/tmpisbwvoie/data

    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=bf592abcb31c3582aee3745e678874688aac8f7be0d6f311188002b24cc7954f


INFO:     Started server process [641543]
INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev2+g63b583be.d20240308
OBJECT CACHE: Will use up to 2_467_724_697 bytes (15% of total physical RAM)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```