### PR TITLE
Pin back dask while we update for dask-expr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,9 @@ all = [
     "cachetools",
     "cachey",
     "click !=8.1.0",
-    "dask",
-    "dask[array]",
-    "dask[dataframe]",
+    "dask <2024.3.0",
+    "dask[array] <2024.3.0",
+    "dask[dataframe] <2024.3.0",
     "entrypoints",
     "fastapi",
     "h5netcdf",
@@ -100,7 +100,7 @@ all = [
 ]
 # These are needed by the client and server to transmit/receive arrays.
 array = [
-    "dask[array]",
+    "dask[array] <2024.3.0",
     "numpy",
 ]
 # This is the "kichen sink" fully-featured client dependency set.
@@ -109,8 +109,8 @@ client = [
     "awkward >=2.4.3",
     "blosc",
     "click !=8.1.0",
-    "dask[array]",
-    "dask[dataframe]",
+    "dask[array] <2024.3.0",
+    "dask[dataframe] <2024.3.0",
     "entrypoints",
     "httpx >=0.20.0,!=0.23.1",
     "jsonschema",
@@ -137,7 +137,7 @@ compression = [
 ]
 # These are needed by the client and server to transmit/receive dataframes.
 dataframe = [
-    "dask[dataframe]",
+    "dask[dataframe] <2024.3.0",
     "pandas",
     "pyarrow",
 ]
@@ -195,7 +195,7 @@ minimal-server = [
     "cachey",
     "cachetools",
     "click !=8.1.0",
-    "dask",
+    "dask <2024.3.0",
     "fastapi",
     "httpx >=0.20.0,!=0.23.1",
     "canonicaljson",
@@ -235,9 +235,9 @@ server = [
     "cachetools",
     "cachey",
     "click !=8.1.0",
-    "dask",
-    "dask[array]",
-    "dask[dataframe]",
+    "dask <2024.3.0",
+    "dask[array] <2024.3.0",
+    "dask[dataframe] <2024.3.0",
     "fastapi",
     "h5netcdf",
     "h5py",
@@ -284,7 +284,7 @@ sparse = [
 ]
 # These are needed by the client and server to transmit/receive xarrays.
 xarray = [
-    "dask[array]",
+    "dask[array] <2024.3.0",
     "pandas",
     "pyarrow",
     "xarray",


### PR DESCRIPTION
The release of dask 2024.3 swaps out `dask.dataframe.core.DataFrame` for a completely new implementation developed in [dask-expr](https://github.com/dask/dask-expr), one that implements query planning.

This breaks some APIs that we are directly using in Tiled. Some research will be needed to determine the best way forward. While we do that, we should pin back dask.

This pins all instances in `pyproject.toml`:

```
$ git grep dask -- pyproject.toml
pyproject.toml:    "dask <2024.3.0",
pyproject.toml:    "dask[array] <2024.3.0",
pyproject.toml:    "dask[dataframe] <2024.3.0",
pyproject.toml:    "dask[array] <2024.3.0",
pyproject.toml:    "dask[array] <2024.3.0",
pyproject.toml:    "dask[dataframe] <2024.3.0",
pyproject.toml:    "dask[dataframe] <2024.3.0",
pyproject.toml:    "dask <2024.3.0",
pyproject.toml:    "dask <2024.3.0",
pyproject.toml:    "dask[array] <2024.3.0",
pyproject.toml:    "dask[dataframe] <2024.3.0",
pyproject.toml:    "dask[array] <2024.3.0",
```