### PR TITLE
Write block tutorial

### DIFF
--- a/docs/source/tutorials/writing.md
+++ b/docs/source/tutorials/writing.md
@@ -66,7 +66,7 @@ Write array and tabular data.
 <DataFrameClient ['x', 'y']>
 ```
 
-In some scenarios, you may want to save individual arrays in a stacked manner, i.e. as a single higher dimensional array. This can be achieved in two ways: 
+In some scenarios, you may want to send data a chunk at a time, rather than sending the entire chunk at once. This might be in cases where the full data is not available at once, or the data is too large for memory. This can be achieved in two ways: 
 
 The first one is to stack them before saving back to client using the above mentioned `write_array` method. This works when the size of data is small.
 


### PR DESCRIPTION
This small PR adds a demonstration of the `write_block` functionality to the writing tutorial, as suggested in #693.

Key components covered in the code block:

- Pre-define `ArrayStructure`
- Split Chunks
- Allocate `ArrayClient`
- Use `write_block` with specific index

To follow the flow of the original tutorial, the session has been added right after the demonstration of `write_array` under the head of "Write data", please feel free to make changes as needed.   