### PR TITLE
Scientific Metadata Search Engine client service using TypeSense

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ all = [
     "xarray",
     "zarr",
     "zstandard",
+    "typesense",
 ]
 # These are needed by the client and server to transmit/receive arrays.
 array = [

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1247,7 +1247,7 @@ def in_memory(
     readable_storage=None,
     echo=DEFAULT_ECHO,
     adapters_by_mimetype=None,
-    typesenseClient=None,
+    typesense_client=None,
 ):
     uri = "sqlite+aiosqlite:///:memory:"
     return from_uri(
@@ -1259,7 +1259,7 @@ def in_memory(
         readable_storage=readable_storage,
         echo=echo,
         adapters_by_mimetype=adapters_by_mimetype,
-        typesenseClient=typesenseClient,
+        typesense_client=typesense_client,
     )
 
 
@@ -1274,7 +1274,7 @@ def from_uri(
     init_if_not_exists=False,
     echo=DEFAULT_ECHO,
     adapters_by_mimetype=None,
-    typesenseClient=None,
+    typesense_client=None,
 ):
     uri = str(uri)
     if init_if_not_exists:
@@ -1296,12 +1296,12 @@ def from_uri(
     engine = create_async_engine(uri, echo=echo, json_serializer=json_serializer)
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)
-    if typesenseClient:
-        typesenseClient = typesense.client(
-            typesenseClient["host"],
-            typesenseClient["port"],
-            typesenseClient["protocol"],
-            typesenseClient["api_key"],
+    if typesense_client:
+        typesense_client = typesense.Client(
+            {
+                "api_key": typesense_client["api_key"],
+                "nodes": typesense_client["nodes"],
+            }
         )
     return CatalogContainerAdapter(
         Context(engine, writable_storage, readable_storage, adapters_by_mimetype),


### PR DESCRIPTION
We can successfully instantiate and connect to a new Typesense instance with this `.yml` file and the command `tiled serve config config.yml`

```yaml
authentication:
  # The default is false. Set to true to enable any HTTP client that can
  # connect to _read_. An API key is still required to write.
  allow_anonymous_access: false
  single_user_api_key: "secret"  # for dev
trees:
  - path: /
    tree: catalog
    args:
      uri: "sqlite+aiosqlite:///:memory:"
      # or, uri: "sqlite+aiosqlite:////catalog.db"
      # or, "postgresql+asyncpg://..."
      writable_storage: "tmp/"
      init_if_not_exists: true
      typesense_client:
        api_key: "secret"
        schemas:
        nodes:
          - host: "http://localhost"
            port: 8108
            protocol: "http"
``` 

However there is still a lot of specific work to be done, namely items mentioned in #605 :

- [X] Set up Typesense client dependencies
- [X] Instantiate a client and have it connect with a typesense server
- [ ] Create a bluesky event model reader that generates a standard base schema
- [ ] Save schemas to files that are extensible and include-able by name so the entire schema does not have to be explicitly set each time. 
  - (e.g. you could have a schema file for each beamline at NSLS-II with some of their metadata shape imparted)
- [ ] Hook into `Context.__init__`
  - [ ] Initialize Typesense instance by iterating over all data in the tiled instance
  - [ ] Upsert search engine data on database insertion by registering `[after_insert]` sqlalchemy hook