### PR TITLE
Include correlation ID in exception message.

### DIFF
--- a/tiled/_tests/test_metrics.py
+++ b/tiled/_tests/test_metrics.py
@@ -1,9 +1,12 @@
 import re
 
+import httpx
+import pytest
 from fastapi import APIRouter
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
 from ..client import Context, from_context
+from ..client.utils import handle_error
 from ..server.app import build_app_from_config
 
 config = {
@@ -49,3 +52,15 @@ def test_error_code():
         response_404 = client.context.http_client.get("/does_not_exist")
         assert response_404.status_code == HTTP_404_NOT_FOUND
         assert total_request_time(client, 404) - baseline_time[404] > 0
+
+
+def test_correlation_id():
+    "Test that exceptions include correlation ID."
+    app = build_app_from_config(config)
+    app.include_router(router)
+    with Context.from_app(app, raise_server_exceptions=False) as context:
+        client = from_context(context)
+        response_500 = client.context.http_client.get("/error")
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            handle_error(response_500)
+        assert "correlation ID" in exc_info.value.args[0]

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -29,7 +29,7 @@ def raise_for_status(response) -> None:
         )
 
     if response.is_success:
-        return
+        return response
 
     if response.has_redirect_location:
         message = (

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -18,7 +18,7 @@ def raise_for_status(response) -> None:
     """
     Raise the `httpx.HTTPStatusError` if one occurred. Include correlation ID.
     """
-    # This adapted from the method httpx.Response.raise_for_status, modified to
+    # This is adapted from the method httpx.Response.raise_for_status, modified to
     # remove the generic link to HTTP status documentation and include the
     # correlation ID.
     request = response._request


### PR DESCRIPTION
For 5XX errors, client will include correlation ID in error message:

```
httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'http://testserver/error'
For more information, server admin can search server logs for correlation ID a13bf544cf8c2539.
```