### PR TITLE
Fix critical regression in `tiled serve directory`

### DIFF
--- a/tiled/_tests/test_cli.py
+++ b/tiled/_tests/test_cli.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 import subprocess
 import sys
@@ -8,13 +9,16 @@ import httpx
 import pytest
 
 
+@contextlib.contextmanager
 def run_cli(command):
     "Run '/path/to/this/python -m ...'"
-    return subprocess.Popen(
+    process = subprocess.Popen(
         [sys.executable, "-m"] + command.split(),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+    yield process
+    process.terminate()
 
 
 def scrape_server_url_from_logs(process):
@@ -58,8 +62,8 @@ def check_server_readiness(process):
 )
 def test_serve_directory(args, tmpdir):
     "Test 'tiled serve directory ... with a variety of arguments."
-    process = run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args)
-    check_server_readiness(process)
+    with run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args) as process:
+        check_server_readiness(process)
 
 
 @pytest.mark.parametrize(
@@ -71,5 +75,5 @@ def test_serve_directory(args, tmpdir):
 )
 def test_serve_catalog_temp(args, tmpdir):
     "Test 'tiled serve catalog --temp ... with a variety of arguments."
-    process = run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args)
-    check_server_readiness(process)
+    with run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args) as process:
+        check_server_readiness(process)

--- a/tiled/_tests/test_cli.py
+++ b/tiled/_tests/test_cli.py
@@ -49,7 +49,6 @@ def check_server_readiness(process):
     "Given a server process, check that it responds successfully to HTTP."
     url = scrape_server_url_from_logs(process)
     httpx.get(url).raise_for_status()
-    process.terminate()
 
 
 @pytest.mark.parametrize(

--- a/tiled/_tests/test_cli.py
+++ b/tiled/_tests/test_cli.py
@@ -1,0 +1,75 @@
+import re
+import subprocess
+import sys
+import threading
+from queue import Queue
+
+import httpx
+import pytest
+
+
+def run_cli(command):
+    "Run '/path/to/this/python -m ...'"
+    return subprocess.Popen(
+        [sys.executable, "-m"] + command.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def scrape_server_url_from_logs(process):
+    "Scrape from server logs 'Uvicorn running on https://...'"
+
+    def target(queue):
+        pattern = re.compile(r"Uvicorn running on (\S*)")
+        while not process.poll():
+            line = process.stderr.readline()
+            if match := pattern.search(line.decode()):
+                break
+        url = match.group(1)
+        queue.put(url)
+
+    queue = Queue()
+    thread = threading.Thread(target=target, args=(queue,))
+    thread.start()
+    url = queue.get(timeout=10)
+    # If the server has an error starting up, the target() will
+    # never find a match, and a TimeoutError will be raised above.
+    # The thread will leak. This is the best reasonably simple,
+    # portable approach available.
+    thread.join()
+    return url
+
+
+def check_server_readiness(process):
+    "Given a server process, check that it responds successfully to HTTP."
+    url = scrape_server_url_from_logs(process)
+    httpx.get(url).raise_for_status()
+    process.terminate()
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "",
+        "--verbose",
+        "--api-key secret",
+    ],
+)
+def test_serve_directory(args, tmpdir):
+    "Test 'tiled serve directory ... with a variety of arguments."
+    process = run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args)
+    check_server_readiness(process)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "",
+        "--api-key secret",
+    ],
+)
+def test_serve_catalog_temp(args, tmpdir):
+    "Test 'tiled serve catalog --temp ... with a variety of arguments."
+    process = run_cli(f"tiled serve directory {tmpdir!s} --port 0 " + args)
+    check_server_readiness(process)

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -223,7 +223,9 @@ def serve_directory(
 
             import uvicorn
 
-            config = uvicorn.Config(web_app, host=host, port=port)
+            config = uvicorn.Config(
+                web_app, host=host, port=port, log_config=log_config
+            )
             server = uvicorn.Server(config)
             await server.serve()
 

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 from typing import List, Optional
@@ -140,7 +141,7 @@ def serve_directory(
     asyncio.run(initialize_database(engine))
     stamp_head(ALEMBIC_INI_TEMPLATE_PATH, ALEMBIC_DIR, database)
 
-    from ..catalog import from_uri
+    from ..catalog import from_uri as catalog_from_uri
     from ..server.app import build_app, print_admin_api_key_if_generated
 
     server_settings = {}
@@ -182,15 +183,25 @@ def serve_directory(
             )
         mimetype, obj_ref = match.groups()
         adapters_by_mimetype[mimetype] = obj_ref
-    catalog_adapter = from_uri(
+    catalog_adapter = catalog_from_uri(
         database,
         readable_storage=[directory],
         adapters_by_mimetype=adapters_by_mimetype,
     )
-    typer.echo(f"Indexing '{directory}' ...")
     if verbose:
         register_logger.addHandler(StreamHandler())
         register_logger.setLevel("INFO")
+    # Set the API key manually here, rather than letting the server do it,
+    # so that we can pass it to the client.
+    generated = False
+    if api_key is None:
+        api_key = os.getenv("TILED_SINGLE_USER_API_KEY")
+        if api_key is None:
+            import secrets
+
+            api_key = secrets.token_hex(32)
+            generated = True
+
     web_app = build_app(
         catalog_adapter,
         {
@@ -199,15 +210,39 @@ def serve_directory(
         },
         server_settings,
     )
+    import functools
+
+    import anyio
+    import httpcore
+    import uvicorn
+
+    from ..client import from_uri as client_from_uri
+
+    print_admin_api_key_if_generated(web_app, host=host, port=port, force=generated)
+    api_url = f"http://{host}:{port}/api/v1/"
+
+    async def run_server():
+        config = uvicorn.Config(web_app, host=host, port=port)
+        server = uvicorn.Server(config)
+        await server.serve()
+
     if watch:
 
-        async def walk_and_serve():
-            import anyio
+        async def serve_and_walk():
+            server_task = asyncio.create_task(run_server())
+            # Wait for server to start up, with a retry loop.
+            async with httpcore.AsyncConnectionPool(retries=5) as http:
+                await http.request("GET", api_url)
+            # When we add an AsyncClient for Tiled, use that here.
+            client = await anyio.to_thread.run_sync(
+                functools.partial(client_from_uri, api_url, api_key=api_key)
+            )
 
+            typer.echo(f"Server is up. Indexing files in {directory}...")
             event = anyio.Event()
             asyncio.create_task(
                 watch_(
-                    catalog_adapter,
+                    client,
                     directory,
                     initial_walk_complete_event=event,
                     mimetype_detection_hook=mimetype_detection_hook,
@@ -218,22 +253,24 @@ def serve_directory(
                 )
             )
             await event.wait()
-            typer.echo("Initial indexing complete. Starting server...")
-            print_admin_api_key_if_generated(web_app, host=host, port=port)
+            typer.echo("Initial indexing complete. Watching for changes...")
+            await server_task
 
-            import uvicorn
-
-            config = uvicorn.Config(
-                web_app, host=host, port=port, log_config=log_config
-            )
-            server = uvicorn.Server(config)
-            await server.serve()
-
-        asyncio.run(walk_and_serve())
     else:
-        asyncio.run(
-            register(
-                catalog_adapter,
+
+        async def serve_and_walk():
+            server_task = asyncio.create_task(run_server())
+            # Wait for server to start up, with a retry loop.
+            async with httpcore.AsyncConnectionPool(retries=5) as http:
+                await http.request("GET", api_url)
+            # When we add an AsyncClient for Tiled, use that here.
+            client = await anyio.to_thread.run_sync(
+                functools.partial(client_from_uri, api_url, api_key=api_key)
+            )
+
+            typer.echo(f"Server is up. Indexing files in {directory}...")
+            await register(
+                client,
                 directory,
                 mimetype_detection_hook=mimetype_detection_hook,
                 mimetypes_by_file_ext=mimetypes_by_file_ext,
@@ -241,14 +278,10 @@ def serve_directory(
                 walkers=walkers,
                 key_from_filename=key_from_filename,
             )
-        )
+            typer.echo("Indexing complete.")
+            await server_task
 
-        typer.echo("Indexing complete. Starting server...")
-        print_admin_api_key_if_generated(web_app, host=host, port=port)
-
-        import uvicorn
-
-        uvicorn.run(web_app, host=host, port=port, log_config=log_config)
+    asyncio.run(serve_and_walk())
 
 
 def serve_catalog(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -956,7 +956,10 @@ def __getattr__(name):
     raise AttributeError(name)
 
 
-def print_admin_api_key_if_generated(web_app, host, port):
+def print_admin_api_key_if_generated(
+    web_app: FastAPI, host: str, port: int, force: bool = False
+):
+    "Print message to stderr with API key if server-generated (or force=True)."
     host = host or "127.0.0.1"
     port = port or 8000
     settings = web_app.dependency_overrides.get(get_settings, get_settings)()
@@ -972,7 +975,7 @@ def print_admin_api_key_if_generated(web_app, host, port):
 """,
             file=sys.stderr,
         )
-    if (not authenticators) and settings.single_user_api_key_generated:
+    if (not authenticators) and (force or settings.single_user_api_key_generated):
         print(
             f"""
     Navigate a web browser or connect a Tiled client to:

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -26,7 +26,7 @@ class Error(pydantic.BaseModel):
     message: str
 
 
-class Response(pydantic.generics.GenericModel, Generic[DataT, LinksT, MetaT]):
+class Response(pydantic.BaseModel, Generic[DataT, LinksT, MetaT]):
     data: Optional[DataT]
     error: Optional[Error] = None
     links: Optional[LinksT] = None
@@ -243,9 +243,7 @@ class ContainerMeta(pydantic.BaseModel):
     count: int
 
 
-class Resource(
-    pydantic.generics.GenericModel, Generic[AttributesT, ResourceLinksT, ResourceMetaT]
-):
+class Resource(pydantic.BaseModel, Generic[AttributesT, ResourceLinksT, ResourceMetaT]):
     "A JSON API Resource"
     id: Union[str, uuid.UUID]
     attributes: AttributesT


### PR DESCRIPTION
The CLI had no unit tests (see #518) because there were some subtle issues to think through about how to do that. This enabled a critical regression to slip though in #661 that fully broke `tiled serve directory ...`. The regression was not immediately noticed because `tiled serve directory` is kind of a "toy" entrypoint: it doesn't scale, but it's really great for demos and for early users trying out tiled.

In #661, the process of registering external files with Tiled changed from being a server-side activity, with direct access to the SQL database, to a client-side activity, performed via HTTP requests. The `tiled serve directory ...` CLI entrypoint was not correctly updated to account for this change.

In this PR, the regression is fixed. Additionally, some basic unit tests are added to protect against future regressions. More unit tests should be added in follow-up PRs, but this provides a framework. The critical thing is enabling the tests to start a server on a high random free port, specified by the OS, extract which port is being used, and run a basic HTTP `GET` to confirm that the server is alive.

Additionally, interactive tests:

```
$ tiled serve directory files/
Creating catalog database at /tmp/tmp5mvp19yd/catalog.db

    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=649b0deb311915915fbc4d219edc97ea58568916af3e6b29ce41113bf6101a05


INFO:     Started server process [1906101]
INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev40+g7af28d15
OBJECT CACHE: Will use up to 4_996_978_483 bytes (15% of total physical RAM)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:38548 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
Server is up. Indexing files in files/...
INFO:     127.0.0.1:38564 - "DELETE /api/v1/nodes/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/metadata/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "GET /api/v1/metadata/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/metadata/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "GET /api/v1/metadata/more/even_more HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
INFO:     127.0.0.1:38564 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
Indexing complete.
```

```
$ tiled serve directory files/ --verbose
Creating catalog database at /tmp/tmp0wtk0cbc/catalog.db

    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=6fd7ad132eafc2c826c31046c9f9e72dd83123489129314c6f566396e684cba4


INFO:     Started server process [1906240]
INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev40+g7af28d15
OBJECT CACHE: Will use up to 4_996_978_483 bytes (15% of total physical RAM)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:55062 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
Server is up. Indexing files in files/...
  Overwriting '/'
INFO:     127.0.0.1:55074 - "DELETE /api/v1/nodes/ HTTP/1.1" 200 OK
  Walking 'files'
    Resolved mimetype 'image/tiff' with adapter for 'files/c.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/ HTTP/1.1" 200 OK
    Resolved mimetype 'image/tiff' with adapter for 'files/b.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/ HTTP/1.1" 200 OK
    Resolved mimetype 'image/tiff' with adapter for 'files/a.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/ HTTP/1.1" 200 OK
    Resolved mimetype 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' with adapter for 'files/tables.xlsx'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/ HTTP/1.1" 200 OK
    Resolved mimetype 'text/csv' with adapter for 'files/another_table.csv'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "POST /api/v1/metadata/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "GET /api/v1/metadata/more HTTP/1.1" 200 OK
  Walking 'files/more'
    Resolved mimetype 'image/tiff' with adapter for 'files/more/d.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "POST /api/v1/metadata/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:55074 - "GET /api/v1/metadata/more/even_more HTTP/1.1" 200 OK
  Walking 'files/more/even_more'
    Resolved mimetype 'image/tiff' with adapter for 'files/more/even_more/e.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
    Resolved mimetype 'image/tiff' with adapter for 'files/more/even_more/f.tif'
INFO:     127.0.0.1:55074 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
Indexing complete.
```

```
$ tiled serve directory files/ --api-key=secret
Creating catalog database at /tmp/tmp2al810dj/catalog.db
INFO:     Started server process [1906388]
INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev40+g7af28d15
OBJECT CACHE: Will use up to 4_996_978_483 bytes (15% of total physical RAM)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:51766 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
Server is up. Indexing files in files/...
INFO:     127.0.0.1:51778 - "DELETE /api/v1/nodes/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/metadata/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "GET /api/v1/metadata/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/metadata/more HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "GET /api/v1/metadata/more/even_more HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
INFO:     127.0.0.1:51778 - "POST /api/v1/register/more/even_more HTTP/1.1" 200 OK
Indexing complete.
```