### PR TITLE
on startup only add admin role if not already present

### DIFF
--- a/continuous_integration/scripts/start_LDAP.sh
+++ b/continuous_integration/scripts/start_LDAP.sh
@@ -3,5 +3,6 @@ set -e
 
 # Start LDAP server in docker container
 docker pull bitnami/openldap:latest
+pip install docker-compose
 docker-compose -f continuous_integration/docker-configs/ldap-docker-compose.yml up -d
 docker ps

--- a/continuous_integration/scripts/start_LDAP.sh
+++ b/continuous_integration/scripts/start_LDAP.sh
@@ -3,6 +3,5 @@ set -e
 
 # Start LDAP server in docker container
 docker pull bitnami/openldap:latest
-pip install docker-compose
-docker-compose -f continuous_integration/docker-configs/ldap-docker-compose.yml up -d
+docker compose -f continuous_integration/docker-configs/ldap-docker-compose.yml up -d
 docker ps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ Documentation = "https://blueskyproject.io/tiled"
 
 [tool.hatch]
 version.source = "vcs"
+version.fallback-version = "0.0.0"
 build.hooks.vcs.version-file = "tiled/_version.py"
 
 # Defining this (empty) section invokes hatch_build.py

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -312,6 +312,13 @@ def test_admin(enter_password, config):
         with fail_with_status_code(HTTP_401_UNAUTHORIZED):
             context.admin.show_principal(some_principal_uuid)
 
+    # Start the server a second time. Now alice is already an admin.
+    with Context.from_app(build_app_from_config(config)) as context:
+        with enter_password("secret1"):
+            context.authenticate(username="alice")
+        admin_roles = context.whoami()["roles"]
+        assert "admin" in [role["name"] for role in admin_roles]
+
 
 def test_api_key_activity(enter_password, config):
     """

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -210,6 +210,12 @@ async def make_admin_by_identity(db, identity_provider, id):
         principal = await create_user(db, identity_provider, id)
     else:
         principal = identity.principal
+
+    # check if principal already has admin role
+    for role in principal.roles:
+        if role.name == "admin":
+            return principal
+
     admin_role = (await db.execute(select(Role).filter(Role.name == "admin"))).scalar()
     assert admin_role is not None, "Admin role is missing from Roles table"
     principal.roles.append(admin_role)


### PR DESCRIPTION
Previously `make_admin_by_identity` unconditionally appended the admin role to the given principal.
This caused restarting the server to fail:
```
#config.yaml
database:
  uri: "sqlite+aiosqlite:///./authn.db"

authentication:
  providers:
  - provider: toy
    authenticator: tiled.authenticators:DictionaryAuthenticator
    args:
      users_to_passwords:
        alice: abc
  tiled_admins:
    - provider: toy
      id: alice
trees:
  - path: /
    tree: tiled.examples.toy_authentication:tree
```

```
> tiled admin initialize-database sqlite+aiosqlite:///./authn.db
> tiled serve config config.yaml
> tiled serve config config.yaml # fails when run the second time

...
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: principal_role_association.principal_id, 
principal_role_association.role_id
[SQL: INSERT INTO principal_role_association (principal_id, role_id) VALUES (?, ?)]
[parameters: (1, 2)]
```

To fix, check if the principal already has the admin role before appending it again.

Also includes two flyby fixes:
* provide fallback-version so install can succeed without full repo which can happen when building a docker container in a worktree
* handle missing correlation id in `raise_for_status`. This can happen if the request didn't make it to the tiled server, for example because the k8s ingress gave 413.