### PR TITLE
Address deprecation warnings from pydantic 2.x

### DIFF
--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -109,7 +109,7 @@ class RootNode:
 
     def __init__(self, metadata, specs, access_policy):
         self.metadata_ = metadata or {}
-        self.specs = [Spec.parse_obj(spec) for spec in specs or []]
+        self.specs = [Spec.model_validate(spec) for spec in specs or []]
         self.ancestors = []
         self.key = None
         self.data_sources = None
@@ -279,7 +279,7 @@ class CatalogNodeAdapter:
         self.conditions = conditions or []
         self.queries = queries or []
         self.structure_family = node.structure_family
-        self.specs = [Spec.parse_obj(spec) for spec in node.specs]
+        self.specs = [Spec.model_validate(spec) for spec in node.specs]
         self.ancestors = node.ancestors
         self.key = node.key
         self.access_policy = access_policy

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -583,7 +583,7 @@ class CatalogNodeAdapter:
             ancestors=self.segments,
             metadata_=metadata,
             structure_family=structure_family,
-            specs=[s.dict() for s in specs or []],
+            specs=[s.model_dump() for s in specs or []],
         )
         async with self.context.session() as db:
             # TODO Consider using nested transitions to ensure that
@@ -879,7 +879,7 @@ class CatalogNodeAdapter:
             # SQLAlchemy reserved word 'metadata'.
             values["metadata_"] = metadata
         if specs is not None:
-            values["specs"] = [s.dict() for s in specs]
+            values["specs"] = [s.model_dump() for s in specs]
         async with self.context.session() as db:
             current = (
                 await db.execute(select(orm.Node).where(orm.Node.id == self.node.id))
@@ -1111,7 +1111,7 @@ def _prepare_structure(structure_family, structure):
     "Convert from pydantic model to dict."
     if structure is None:
         return None
-    return structure.dict()
+    return structure.model_dump()
 
 
 def binary_op(query, tree, operation):

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -792,7 +792,7 @@ async def generate_apikey(db, principal, apikey_params, request):
     # db.refresh(new_key)
     return json_or_msgpack(
         request,
-        schemas.APIKeyWithSecret.from_orm(new_key, secret=secret.hex()).dict(),
+        schemas.APIKeyWithSecret.from_orm(new_key, secret=secret.hex()).model_dump(),
     )
 
 
@@ -834,7 +834,9 @@ async def principal_list(
     principals = []
     for (principal_orm,) in principal_orms:
         latest_activity = await latest_principal_activity(db, principal_orm)
-        principal = schemas.Principal.from_orm(principal_orm, latest_activity).dict()
+        principal = schemas.Principal.from_orm(
+            principal_orm, latest_activity
+        ).model_dump()
         principals.append(principal)
     return json_or_msgpack(request, principals)
 
@@ -867,7 +869,7 @@ async def create_service_principal(
         )
     ).scalar()
 
-    principal = schemas.Principal.from_orm(fully_loaded_principal_orm).dict()
+    principal = schemas.Principal.from_orm(fully_loaded_principal_orm).model_dump()
     request.state.endpoint = "auth"
 
     return json_or_msgpack(request, principal)
@@ -904,7 +906,7 @@ async def principal(
     latest_activity = await latest_principal_activity(db, principal_orm)
     return json_or_msgpack(
         request,
-        schemas.Principal.from_orm(principal_orm, latest_activity).dict(),
+        schemas.Principal.from_orm(principal_orm, latest_activity).model_dump(),
     )
 
 
@@ -1104,7 +1106,7 @@ async def current_apikey_info(
     api_key_orm = await lookup_valid_api_key(db, secret)
     if api_key_orm is None:
         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-    return json_or_msgpack(request, schemas.APIKey.from_orm(api_key_orm).dict())
+    return json_or_msgpack(request, schemas.APIKey.from_orm(api_key_orm).model_dump())
 
 
 @base_authentication_router.delete("/apikey")
@@ -1169,7 +1171,7 @@ async def whoami(
     latest_activity = await latest_principal_activity(db, principal_orm)
     return json_or_msgpack(
         request,
-        schemas.Principal.from_orm(principal_orm, latest_activity).dict(),
+        schemas.Principal.from_orm(principal_orm, latest_activity).model_dump(),
     )
 
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -429,7 +429,7 @@ async def construct_resource(
             # Convert from dataclass to pydantic.
             # The dataclass implementation of Spec supports dict() method
             # for ease of going between dataclass and pydantic.
-            specs.append(schemas.Spec(**spec.dict()))
+            specs.append(schemas.Spec(**spec.model_dump()))
         attributes["specs"] = specs
     if (entry is not None) and entry.structure_family == StructureFamily.container:
         attributes["structure_family"] = StructureFamily.container

--- a/tiled/server/pydantic_array.py
+++ b/tiled/server/pydantic_array.py
@@ -153,7 +153,7 @@ class StructDtype(BaseModel):
         )
 
 
-Field.update_forward_refs()
+Field.model_rebuild()
 
 
 class ArrayStructure(BaseModel):

--- a/tiled/server/pydantic_array.py
+++ b/tiled/server/pydantic_array.py
@@ -18,7 +18,7 @@ import sys
 from typing import List, Optional, Tuple, Union
 
 import numpy
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ..structures.array import Endianness, Kind
 
@@ -163,8 +163,7 @@ class ArrayStructure(BaseModel):
     dims: Optional[Tuple[str, ...]] = None  # None or tuple of names like ("x", "y")
     resizable: Union[bool, Tuple[bool, ...]] = False
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     @classmethod
     def from_json(cls, structure):

--- a/tiled/server/pydantic_awkward.py
+++ b/tiled/server/pydantic_awkward.py
@@ -5,8 +5,7 @@ class AwkwardStructure(pydantic.BaseModel):
     length: int
     form: dict
 
-    class Config:
-        extra = "forbid"
+    model_config = pydantic.ConfigDict(extra="forbid")
 
     @classmethod
     def from_json(cls, structure):

--- a/tiled/server/pydantic_sparse.py
+++ b/tiled/server/pydantic_sparse.py
@@ -12,8 +12,7 @@ class COOStructure(pydantic.BaseModel):
     resizable: Union[bool, Tuple[bool, ...]] = False
     layout: SparseLayout = SparseLayout.COO
 
-    class Config:
-        extra = "forbid"
+    model_config = pydantic.ConfigDict(extra="forbid")
 
 
 # This may be extended to a Union of structures if more are added.

--- a/tiled/server/pydantic_table.py
+++ b/tiled/server/pydantic_table.py
@@ -2,7 +2,7 @@ import base64
 import io
 from typing import List, Tuple, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ..structures.table import B64_ENCODED_PREFIX
 
@@ -21,8 +21,7 @@ class TableStructure(BaseModel):
     columns: List[str]
     resizable: Union[bool, Tuple[bool, ...]] = False
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     @classmethod
     def from_dask_dataframe(cls, ddf):

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -234,7 +234,7 @@ async def distinct(
         )
 
         return json_or_msgpack(
-            request, schemas.GetDistinctResponse.parse_obj(distinct).model_dump()
+            request, schemas.GetDistinctResponse.model_validate(distinct).model_dump()
         )
     else:
         raise HTTPException(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -142,7 +142,7 @@ async def about(
                 "documentation": f"{base_url}/docs",
             },
             meta={"root_path": request.scope.get("root_path") or "" + "/api"},
-        ).dict(),
+        ).model_dump(),
         expires=datetime.utcnow() + timedelta(seconds=600),
     )
 
@@ -202,7 +202,7 @@ async def search(
             headers["Cache-Control"] = "must-revalidate"
         return json_or_msgpack(
             request,
-            resource.dict(),
+            resource.model_dump(),
             expires=expires,
             headers=headers,
         )
@@ -234,7 +234,7 @@ async def distinct(
         )
 
         return json_or_msgpack(
-            request, schemas.GetDistinctResponse.parse_obj(distinct).dict()
+            request, schemas.GetDistinctResponse.parse_obj(distinct).model_dump()
         )
     else:
         raise HTTPException(
@@ -347,7 +347,7 @@ async def metadata(
 
     return json_or_msgpack(
         request,
-        schemas.Response(data=resource, meta=meta).dict(),
+        schemas.Response(data=resource, meta=meta).model_dump(),
         expires=getattr(entry, "metadata_stale_at", None),
     )
 
@@ -1188,7 +1188,7 @@ async def _create_node(
     response_data = {
         "id": key,
         "links": links,
-        "data_sources": [ds.dict() for ds in node.data_sources],
+        "data_sources": [ds.model_dump() for ds in node.data_sources],
     }
     if metadata_modified:
         response_data["metadata"] = metadata
@@ -1475,7 +1475,7 @@ async def get_revisions(
         limit,
         resolve_media_type(request),
     )
-    return json_or_msgpack(request, resource.dict())
+    return json_or_msgpack(request, resource.model_dump())
 
 
 @router.delete("/revisions/{path:path}")

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -386,8 +386,12 @@ class APIKeyRequestParams(pydantic.BaseModel):
     # Provide an example for expires_in. Otherwise, OpenAPI suggests lifetime=0.
     # If the user is not reading carefully, they will be frustrated when they
     # try to use the instantly-expiring API key!
-    expires_in: Optional[int] = pydantic.Field(..., example=600)  # seconds
-    scopes: Optional[List[str]] = pydantic.Field(..., example=["inherit"])
+    expires_in: Optional[int] = pydantic.Field(
+        ..., json_schema_extra={"example": 600}
+    )  # seconds
+    scopes: Optional[List[str]] = pydantic.Field(
+        ..., json_schema_extra={"example": ["inherit"]}
+    )
     note: Optional[str] = None
 
 

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar, Union
 
 import pydantic.generics
 from pydantic import Field, StringConstraints
@@ -15,6 +15,10 @@ from .pydantic_array import ArrayStructure
 from .pydantic_awkward import AwkwardStructure
 from .pydantic_sparse import SparseStructure
 from .pydantic_table import TableStructure
+
+if TYPE_CHECKING:
+    import tiled.authn_database.orm
+    import tiled.catalog.orm
 
 DataT = TypeVar("DataT")
 LinksT = TypeVar("LinksT")
@@ -95,7 +99,7 @@ class Asset(pydantic.BaseModel):
     id: Optional[int] = None
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.catalog.orm.Asset) -> Asset:
         return cls(
             data_uri=orm.data_uri,
             is_directory=orm.is_directory,
@@ -120,7 +124,7 @@ class Revision(pydantic.BaseModel):
     time_updated: datetime
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.catalog.orm.Revision) -> Revision:
         # Trailing underscore in 'metadata_' avoids collision with
         # SQLAlchemy reserved word 'metadata'.
         return cls(
@@ -151,7 +155,7 @@ class DataSource(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="forbid")
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.catalog.orm.DataSource) -> DataSource:
         return cls(
             id=orm.id,
             structure_family=orm.structure_family,
@@ -314,7 +318,7 @@ class Identity(pydantic.BaseModel):
     latest_login: Optional[datetime] = None
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.authn_database.orm.Identity) -> Identity:
         return cls(id=orm.id, provider=orm.provider, latest_login=orm.latest_login)
 
 
@@ -325,7 +329,7 @@ class Role(pydantic.BaseModel):
     # principals
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.authn_database.orm.Role) -> Role:
         return cls(name=orm.name, scopes=orm.scopes)
 
 
@@ -338,7 +342,7 @@ class APIKey(pydantic.BaseModel):
     latest_activity: Optional[datetime] = None
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.authn_database.orm.APIKey) -> APIKey:
         return cls(
             first_eight=orm.first_eight,
             expiration_time=orm.expiration_time,
@@ -352,7 +356,9 @@ class APIKeyWithSecret(APIKey):
     secret: str  # hex-encoded bytes
 
     @classmethod
-    def from_orm(cls, orm, secret):
+    def from_orm(
+        cls, orm: tiled.authn_database.orm.APIKeyWithSecret, secret: str
+    ) -> APIKeyWithSecret:
         return cls(
             first_eight=orm.first_eight,
             expiration_time=orm.expiration_time,
@@ -380,7 +386,7 @@ class Session(pydantic.BaseModel):
     revoked: bool
 
     @classmethod
-    def from_orm(cls, orm):
+    def from_orm(cls, orm: tiled.authn_database.orm.Session) -> Session:
         return cls(
             uuid=orm.uuid, expiration_time=orm.expiration_time, revoked=orm.revoked
         )
@@ -400,7 +406,11 @@ class Principal(pydantic.BaseModel):
     latest_activity: Optional[datetime] = None
 
     @classmethod
-    def from_orm(cls, orm, latest_activity=None):
+    def from_orm(
+        cls,
+        orm: tiled.authn_database.orm.Principal,
+        latest_activity: Optional[datetime] = None,
+    ) -> Principal:
         return cls(
             uuid=orm.uuid,
             type=orm.type,

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -458,6 +458,3 @@ class PutMetadataRequest(pydantic.BaseModel):
             if value in v[i:]:
                 raise ValueError
         return v
-
-
-NodeStructure.update_forward_refs()

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -64,8 +64,7 @@ class NodeStructure(pydantic.BaseModel):
     contents: Optional[Dict[str, Any]]
     count: int
 
-    class Config:
-        extra = "forbid"
+    model_config = pydantic.ConfigDict(extra="forbid")
 
 
 class SortingDirection(int, enum.Enum):
@@ -149,8 +148,7 @@ class DataSource(pydantic.BaseModel):
     assets: List[Asset] = []
     management: Management = Management.writable
 
-    class Config:
-        extra = "forbid"
+    model_config = pydantic.ConfigDict(extra="forbid")
 
     @classmethod
     def from_orm(cls, orm):
@@ -183,8 +181,7 @@ class NodeAttributes(pydantic.BaseModel):
     sorting: Optional[List[SortingItem]] = None
     data_sources: Optional[List[DataSource]] = None
 
-    class Config:
-        extra = "forbid"
+    model_config = pydantic.ConfigDict(extra="forbid")
 
 
 AttributesT = TypeVar("AttributesT")

--- a/tiled/structures/core.py
+++ b/tiled/structures/core.py
@@ -36,7 +36,7 @@ class Spec:
             output = f"{type(self).__name__}({self.name!r}, version={self.version!r})"
         return output
 
-    def dict(self):
+    def dict(self) -> dict[str, str | None]:
         # For easy interoperability with pydantic 1.x models
         return asdict(self)
 

--- a/tiled/structures/core.py
+++ b/tiled/structures/core.py
@@ -36,7 +36,7 @@ class Spec:
             output = f"{type(self).__name__}({self.name!r}, version={self.version!r})"
         return output
 
-    def dict(self) -> dict[str, str | None]:
+    def dict(self) -> dict[str, Optional[str]]:
         # For easy interoperability with pydantic 1.x models
         return asdict(self)
 

--- a/tiled/structures/core.py
+++ b/tiled/structures/core.py
@@ -6,7 +6,7 @@ the server and the client.
 
 import enum
 from dataclasses import asdict, dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 
 class StructureFamily(str, enum.Enum):
@@ -36,7 +36,7 @@ class Spec:
             output = f"{type(self).__name__}({self.name!r}, version={self.version!r})"
         return output
 
-    def dict(self) -> dict[str, Optional[str]]:
+    def dict(self) -> Dict[str, Optional[str]]:
         # For easy interoperability with pydantic 1.x models
         return asdict(self)
 

--- a/tiled/structures/core.py
+++ b/tiled/structures/core.py
@@ -37,4 +37,7 @@ class Spec:
         return output
 
     def dict(self):
+        # For easy interoperability with pydantic 1.x models
         return asdict(self)
+
+    model_dump = dict  # For easy interoperability with pydantic 2.x models


### PR DESCRIPTION
As described in #702, `pytest` displays many warnings from pydantic after the upgrade from 1.x to 2.x in #695. On this branch, pytest finishes with no warnings.

Closes #702 