### PR TITLE
Make sqlalchemy use connection pooling for catalog db

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,9 +1,10 @@
 # Write the benchmarking functions here.
 # See "Writing benchmarks" in the asv docs for more information.
 
+import tempfile
+
 import numpy
 import pandas
-import tempfile
 
 from tiled.adapters.array import ArrayAdapter
 from tiled.adapters.mapping import MapAdapter

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1290,7 +1290,9 @@ def from_uri(
         # Interpret URI as filepath.
         uri = f"sqlite+aiosqlite:///{uri}"
 
-    engine = create_async_engine(uri, echo=echo, json_serializer=json_serializer)
+    engine = create_async_engine(
+        uri, echo=echo, json_serializer=json_serializer, poolclass=AsyncAdaptedQueuePool
+    )
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)
     return CatalogContainerAdapter(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import JSONB, REGCONFIG
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import selectinload
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 from sqlalchemy.sql.expression import cast
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_415_UNSUPPORTED_MEDIA_TYPE
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -15,6 +15,7 @@ import anyio
 from fastapi import HTTPException
 from sqlalchemy import delete, event, func, not_, or_, select, text, type_coerce, update
 from sqlalchemy.dialects.postgresql import JSONB, REGCONFIG
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import selectinload
@@ -1291,8 +1292,18 @@ def from_uri(
         # Interpret URI as filepath.
         uri = f"sqlite+aiosqlite:///{uri}"
 
+    parsed_url = make_url(uri)
+    if (parsed_url.get_dialect().name == "sqlite") and (
+        parsed_url.database != ":memory:"
+    ):
+        # For file-backed SQLite databases, connection pooling offers a
+        # significant performance boost. For SQLite databases that exist
+        # only in process memory, pooling is not applicable.
+        poolclass = AsyncAdaptedQueuePool
+    else:
+        poolclass = None  # defer to sqlalchemy default
     engine = create_async_engine(
-        uri, echo=echo, json_serializer=json_serializer, poolclass=AsyncAdaptedQueuePool
+        uri, echo=echo, json_serializer=json_serializer, poolclass=poolclass
     )
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)


### PR DESCRIPTION
This PR results from the investigation done in #663, as well as a group coding session to implement a new benchmark for the catalog db (especially with input from @genematx, @Kezzsim, @danielballan).

I spent some extra time experimenting with asv to understand better what it does before putting up this PR.  The new benchmark can be singled out by running: `asv run --environment existing:same --bench "time_repeated_write"`.

While some initial benchmarks seemed to show a modest performance improvement from connection pooling, I found (after running additional benchmarks) that this improvement was really just variance in the benchmark results. Instead, benchmarks seem to show that performance is ~identical regardless of connection pooling. This at least means that there is no apparent regression, which was our primary concern.

asv has several parameters that can adjust how benchmarks are taken, with the ability to customize things like warmup time, rounds per benchmark, samples per round, benchmark timeouts, etc. I played with these settings to see if they had any impact on our results, and it seemed the answer is "no". 

It is worth pointing out that asv [defaults](https://asv.readthedocs.io/en/v0.6.3/writing_benchmarks.html#timing) to  `timeit.default_timer` - and so it _should_ measure the time spent in subprocesses. I was worried about this, since aiosqlite drops into a thread (per db connection).
