### PR TITLE
Log catalog init

### DIFF
--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1290,14 +1290,11 @@ def from_uri(
             stderr=subprocess.PIPE,
             check=True,
         )
-
         # Capture stdout and stderr from the subprocess and write to logging
         stdout = process.stdout.decode()
         stderr = process.stderr.decode()
-
         logging.info(f"Subprocess stdout: {stdout}")
         logging.error(f"Subprocess stderr: {stderr}")
-
     if not SCHEME_PATTERN.match(uri):
         # Interpret URI as filepath.
         uri = f"sqlite+aiosqlite:///{uri}"


### PR DESCRIPTION
Tiled can start up in a mode where it initializes the catalog database. This is done in a subprocess call. I have had several cases where that failed, but I didn't know. So, I'd like to add logging from the subprocess to tiled's main log. Happy to take advice on a more graceful way to do it, but this seems to work.