### PR TITLE
Switch to blosc2; add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
       fail-fast: false
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
       fail-fast: false
     steps:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Physics",
 ]
 
@@ -51,7 +52,7 @@ all = [
     "asyncpg",
     "appdirs",
     "awkward >=2.4.3",
-    "blosc",
+    "blosc2",
     "cachetools",
     "cachey",
     "click !=8.1.0",
@@ -108,7 +109,7 @@ array = [
 client = [
     "appdirs",
     "awkward >=2.4.3",
-    "blosc",
+    "blosc2",
     "click !=8.1.0",
     "dask[array]",
     "dask[dataframe]",
@@ -132,7 +133,7 @@ client = [
 # These are used by the client/server to more efficiently compress.
 # They fall back to gzip (which is slower) if these are not installed.
 compression = [
-    "blosc",
+    "blosc2",
     "lz4",
     "zstandard",
 ]
@@ -233,7 +234,7 @@ server = [
     "asgi-correlation-id",
     "asyncpg",
     "awkward >=2.4.3",
-    "blosc",
+    "blosc2",
     "cachetools",
     "cachey",
     "click !=8.1.0",

--- a/tiled/client/decoders.py
+++ b/tiled/client/decoders.py
@@ -3,7 +3,7 @@ from httpx._decoders import SUPPORTED_DECODERS
 
 from ..utils import modules_available
 
-if modules_available("blosc"):
+if modules_available("blosc2"):
 
     class BloscDecoder:
         def __init__(self):
@@ -18,13 +18,13 @@ if modules_available("blosc"):
 
         def flush(self) -> bytes:
             # Hide this here to defer the numpy import that it triggers.
-            import blosc
+            import blosc2
 
             if len(self._data) == 1:
                 (data,) = self._data
             else:
                 data = b"".join(self._data)
-            return blosc.decompress(data)
+            return blosc2.decompress(data)
 
     SUPPORTED_DECODERS["blosc"] = BloscDecoder
 

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -328,14 +328,8 @@ if modules_available("lz4"):
     ]:
         compression_registry.register(media_type, "lz4", LZ4Buffer)
 
-if modules_available("blosc"):
-    import blosc
-
-    # The choice of settings here is cribbed from distributed.protocol.compression.
-    n = blosc.set_nthreads(2)
-    if hasattr("blosc", "releasegil"):
-        blosc.set_releasegil(True)
-    blosc_settings = {"cname": "lz4", "clevel": 5}
+if modules_available("blosc2"):
+    import blosc2
 
     class BloscBuffer:
         """
@@ -352,9 +346,9 @@ if modules_available("blosc"):
             if hasattr(b, "itemsize"):
                 # This could be memoryview or numpy.ndarray, for example.
                 # Blosc uses item-aware shuffling for improved results.
-                compressed = blosc.compress(b, typesize=b.itemsize, **blosc_settings)
+                compressed = blosc2.compress(b, typesize=b.itemsize)
             else:
-                compressed = blosc.compress(b, **blosc_settings)
+                compressed = blosc2.compress(b)
             self._file.write(compressed)
 
         def close(self):


### PR DESCRIPTION
The library [blosc2](https://pypi.org/project/blosc2/) is evidently superseding [blosc](https://pypi.org/project/blosc), which has not published a release since 2022 and has yet to publish Python 3.12-compatible wheels. This is blocking Tiled support for Python 3.12.

Blosc2 claims to be fully backward-compatible with Blosc1-serialized bytes. I'd like to verify that old tiled clients can talk to new tiled servers before we merge.

As an aside, while looking into this I noticed that [`distributed` dropped support for blosc](https://github.com/dask/distributed/pull/6027). Someday it would be good to evaluate how much value we are deriving from this dependency, but I'm inclined to keep it for now.