### PR TITLE
Fix Comparison Query Documentation

### DIFF
--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -237,7 +237,7 @@ class Comparison(NoBool):
 
     Parameters
     ----------
-    operator : {"gt", "lt", "ge", "lt"}
+    operator : {"gt", "lt", "ge", "le"}
     key : str
         e.g. "temperature"
     value : JSONSerializable


### PR DESCRIPTION
This PR fixes a typo that it was noticed in the documentation for the Comparison class