### PR TITLE
Unpin dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,9 @@ all = [
     "cachetools",
     "cachey",
     "click !=8.1.0",
-    "dask <2024.3.0",
-    "dask[array] <2024.3.0",
-    "dask[dataframe] <2024.3.0",
+    "dask",
+    "dask[array]",
+    "dask[dataframe]",
     "entrypoints",
     "fastapi",
     "h5netcdf",
@@ -101,7 +101,7 @@ all = [
 ]
 # These are needed by the client and server to transmit/receive arrays.
 array = [
-    "dask[array] <2024.3.0",
+    "dask[array]",
     "numpy",
 ]
 # This is the "kichen sink" fully-featured client dependency set.
@@ -110,8 +110,8 @@ client = [
     "awkward >=2.4.3",
     "blosc",
     "click !=8.1.0",
-    "dask[array] <2024.3.0",
-    "dask[dataframe] <2024.3.0",
+    "dask[array]",
+    "dask[dataframe]",
     "entrypoints",
     "httpx >=0.20.0,!=0.23.1",
     "jsonschema",
@@ -138,7 +138,7 @@ compression = [
 ]
 # These are needed by the client and server to transmit/receive dataframes.
 dataframe = [
-    "dask[dataframe] <2024.3.0",
+    "dask[dataframe]",
     "pandas",
     "pyarrow",
 ]
@@ -196,7 +196,7 @@ minimal-server = [
     "cachey",
     "cachetools",
     "click !=8.1.0",
-    "dask <2024.3.0",
+    "dask",
     "fastapi",
     "httpx >=0.20.0,!=0.23.1",
     "canonicaljson",
@@ -237,9 +237,9 @@ server = [
     "cachetools",
     "cachey",
     "click !=8.1.0",
-    "dask <2024.3.0",
-    "dask[array] <2024.3.0",
-    "dask[dataframe] <2024.3.0",
+    "dask",
+    "dask[array]",
+    "dask[dataframe]",
     "fastapi",
     "h5netcdf",
     "h5py",
@@ -287,7 +287,7 @@ sparse = [
 ]
 # These are needed by the client and server to transmit/receive xarrays.
 xarray = [
-    "dask[array] <2024.3.0",
+    "dask[array]",
     "pandas",
     "pyarrow",
     "xarray",

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -429,6 +429,9 @@ client or pass the optional parameter `include_data_sources=True` to
         endpoint = self.uri.replace("/metadata/", "/nodes/", 1)
         handle_error(self.context.http_client.delete(endpoint))
 
+    def __dask_tokenize__(self):
+        return (type(self), self.uri)
+
 
 STRUCTURE_TYPES = OneShotCachedMap(
     {


### PR DESCRIPTION
This is a minimal fix to let us unpin our dask dependency and resolve #715. It still leaves us using the now-deprecated `dask.dataframe.core.DataFrame`, the original DataFrame implementation. We will separately need to migrate to the new supported implementation that comes from `dask-expr`.

Closes #715 