### PR TITLE
Support FullText search on SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
-## Unreleased
+## v0.1.0b1
+
+### Added
+
+- Support for `FullText` search on SQLite-backed catalogs
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ dataframe = [
 dev = [
     "coverage",
     "flake8",
+    "importlib_resources;python_version < \"3.9\"",
     "ldap3",
     "pre-commit",
     "pytest <8",  # TMP pin while plugins catch up

--- a/tiled/_tests/sql/before_creating_fts5_virtual_table.sql
+++ b/tiled/_tests/sql/before_creating_fts5_virtual_table.sql
@@ -1,0 +1,111 @@
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE nodes (
+	id INTEGER NOT NULL,
+	"key" VARCHAR(1023) NOT NULL,
+	ancestors JSON,
+	structure_family VARCHAR(9) NOT NULL,
+	metadata JSON NOT NULL,
+	specs JSON NOT NULL,
+	time_created DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	time_updated DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (id),
+	CONSTRAINT key_ancestors_unique_constraint UNIQUE ("key", ancestors)
+);
+INSERT INTO nodes VALUES(1,'x','[]','array','{"color":"blue"}','[]','2024-05-25 10:18:38','2024-05-25 10:18:38');
+CREATE TABLE structures (
+	id VARCHAR(32) NOT NULL,
+	structure JSON NOT NULL,
+	PRIMARY KEY (id),
+	UNIQUE (id)
+);
+INSERT INTO structures VALUES('8e5b0a1237f27c3d04d2cb94bc695ff8','{"data_type":{"endianness":"little","kind":"i","itemsize":8},"chunks":[[3]],"shape":[3],"dims":null,"resizable":false}');
+CREATE TABLE assets (
+	id INTEGER NOT NULL,
+	data_uri VARCHAR(1023),
+	is_directory BOOLEAN NOT NULL,
+	hash_type VARCHAR(63),
+	hash_content VARCHAR(1023),
+	size INTEGER,
+	time_created DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	time_updated DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (id)
+);
+INSERT INTO assets VALUES(1,'file://localhost/home/dallan/Repos/bnl/tiled/data/x',1,NULL,NULL,NULL,'2024-05-25 10:18:38','2024-05-25 10:18:38');
+CREATE TABLE data_sources (
+	id INTEGER NOT NULL,
+	node_id INTEGER NOT NULL,
+	structure_id VARCHAR(32),
+	mimetype VARCHAR(255) NOT NULL,
+	parameters JSON,
+	management VARCHAR(9) NOT NULL,
+	structure_family VARCHAR(9) NOT NULL,
+	time_created DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	time_updated DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (id),
+	FOREIGN KEY(node_id) REFERENCES nodes (id) ON DELETE CASCADE,
+	FOREIGN KEY(structure_id) REFERENCES structures (id) ON DELETE CASCADE
+);
+INSERT INTO data_sources VALUES(1,1,'8e5b0a1237f27c3d04d2cb94bc695ff8','application/x-zarr','{}','writable','array','2024-05-25 10:18:38','2024-05-25 10:18:38');
+CREATE TABLE revisions (
+	id INTEGER NOT NULL,
+	node_id INTEGER NOT NULL,
+	revision_number INTEGER NOT NULL,
+	metadata JSON NOT NULL,
+	specs JSON NOT NULL,
+	time_created DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	time_updated DATETIME DEFAULT (CURRENT_TIMESTAMP),
+	PRIMARY KEY (id),
+	CONSTRAINT node_id_revision_number_unique_constraint UNIQUE (node_id, revision_number),
+	FOREIGN KEY(node_id) REFERENCES nodes (id) ON DELETE CASCADE
+);
+CREATE TABLE data_source_asset_association (
+	data_source_id INTEGER NOT NULL,
+	asset_id INTEGER NOT NULL,
+	parameter VARCHAR(255),
+	num INTEGER,
+	PRIMARY KEY (data_source_id, asset_id),
+	CONSTRAINT parameter_num_unique_constraint UNIQUE (data_source_id, parameter, num),
+	FOREIGN KEY(data_source_id) REFERENCES data_sources (id) ON DELETE CASCADE,
+	FOREIGN KEY(asset_id) REFERENCES assets (id) ON DELETE CASCADE
+);
+INSERT INTO data_source_asset_association VALUES(1,1,'data_uri',NULL);
+CREATE TABLE alembic_version (
+	version_num VARCHAR(32) NOT NULL,
+	CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+INSERT INTO alembic_version VALUES('e756b9381c14');
+CREATE INDEX ix_nodes_id ON nodes (id);
+CREATE INDEX top_level_metadata ON nodes (ancestors, time_created, id, metadata);
+CREATE UNIQUE INDEX ix_assets_data_uri ON assets (data_uri);
+CREATE INDEX ix_assets_id ON assets (id);
+CREATE INDEX ix_data_sources_id ON data_sources (id);
+CREATE INDEX ix_revisions_id ON revisions (id);
+CREATE TRIGGER cannot_insert_num_null_if_num_exists
+BEFORE INSERT ON data_source_asset_association
+WHEN NEW.num IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'Can only insert num=NULL if no other row exists for the same parameter')
+    WHERE EXISTS
+    (
+        SELECT 1
+        FROM data_source_asset_association
+        WHERE parameter = NEW.parameter
+        AND data_source_id = NEW.data_source_id
+    );
+END;
+CREATE TRIGGER cannot_insert_num_int_if_num_null_exists
+BEFORE INSERT ON data_source_asset_association
+WHEN NEW.num IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'Can only insert INTEGER num if no NULL row exists for the same parameter')
+    WHERE EXISTS
+    (
+        SELECT 1
+        FROM data_source_asset_association
+        WHERE parameter = NEW.parameter
+        AND num IS NULL
+        AND data_source_id = NEW.data_source_id
+    );
+END;
+COMMIT;

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -163,18 +163,10 @@ def test_contains(client):
 
 
 def test_full_text(client):
-    if client.metadata["backend"] in {"sqlite"}:
-
-        def cm():
-            return fail_with_status_code(HTTP_400_BAD_REQUEST)
-
-    else:
-        cm = nullcontext
-    with cm():
-        assert list(client.search(FullText("z"))) == ["z", "does_contain_z"]
-        # plainto_tsquery fails to find certain words, weirdly, so it is a useful
-        # test that we are using tsquery
-        assert list(client.search(FullText("purple"))) == ["full_text_test_case"]
+    assert list(client.search(FullText("z"))) == ["z", "does_contain_z"]
+    # plainto_tsquery fails to find certain words, weirdly, so it is a useful
+    # test that we are using tsquery
+    assert list(client.search(FullText("purple"))) == ["full_text_test_case"]
 
 
 def test_regex(client):

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -29,7 +29,7 @@ from ..queries import (
 )
 from ..server.app import build_app
 from .conftest import TILED_TEST_POSTGRESQL_URI
-from .utils import fail_with_status_code, temp_postgres
+from .utils import fail_with_status_code, sqlite_from_dump, temp_postgres
 
 keys = list(string.ascii_lowercase)
 mapping = {
@@ -167,11 +167,28 @@ def test_contains(client):
 
 
 def test_full_text(client):
+    "Basic test of FullText query"
     assert list(client.search(FullText("z"))) == ["z", "does_contain_z"]
     # plainto_tsquery fails to find certain words, weirdly, so it is a useful
     # test that we are using tsquery
     assert list(client.search(FullText("purple"))) == ["full_text_test_case"]
     assert list(client.search(FullText("urple"))) == ["full_text_test_case_urple"]
+
+
+def test_full_text_after_migration():
+    # Load a SQL database created by an older version of Tiled, predating FullText
+    # support, and verify that the migration indexes the pre-existing metadata.
+    with sqlite_from_dump("before_creating_fts5_virtual_table.sql") as database_path:
+        subprocess.check_call(
+            [sys.executable]
+            + f"-m tiled catalog upgrade-database sqlite+aiosqlite:///{database_path}".split()
+        )
+        catalog = from_uri(database_path)
+        app = build_app(catalog)
+        with Context.from_app(app) as context:
+            client = from_context(context)
+            assert list(client.search(FullText("blue"))) == ["x"]
+            assert list(client.search(FullText("red"))) == []  # does not exist
 
 
 def test_full_text_update(client):

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -178,7 +178,7 @@ def test_full_text_update(client):
     if client.metadata["backend"] == "map":
         pytest.skip("Updating not supported")
     # Update the fulltext index and check that it is current with the main data.
-    try:     
+    try:
         client["full_text_test_case"].update_metadata({"color": "red"})
         assert list(client.search(FullText("purple"))) == []
         assert list(client.search(FullText("red"))) == ["full_text_test_case"]

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -87,4 +87,5 @@ def sqlite_from_dump(filename):
         ref = resources.files("tiled._tests.sql") / filename
         with resources.as_file(ref) as path:
             conn.executescript(path.read_text())
+        conn.close()
         yield database_path

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -1,7 +1,11 @@
 import contextlib
 import getpass
+import sqlite3
+import sys
+import tempfile
 import uuid
 from enum import IntEnum
+from pathlib import Path
 
 import httpx
 import pytest
@@ -10,6 +14,11 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from ..client import context
 from ..client.base import BaseClient
+
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
+else:
+    from importlib import resources  # Python >= 3.9 only
 
 
 @contextlib.contextmanager
@@ -64,3 +73,18 @@ class URL_LIMITS(IntEnum):
     HUGE = 80_000
     DEFAULT = BaseClient.URL_CHARACTER_LIMIT
     TINY = 10
+
+
+@contextlib.contextmanager
+def sqlite_from_dump(filename):
+    """Create a SQLite db in a temporary directory, loading a SQL script.
+
+    SQL script should be given as a filename, assumed to be in tiled/_tests/sql/
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        database_path = Path(directory, "catalog.db")
+        conn = sqlite3.connect(database_path)
+        ref = resources.files("tiled._tests.sql") / filename
+        with resources.as_file(ref) as path:
+            conn.executescript(path.read_text())
+        yield database_path

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -16,10 +16,6 @@ from urllib.parse import quote_plus, urlparse
 import anyio
 from fastapi import HTTPException
 from sqlalchemy import (
-    JSON,
-    Column,
-    Integer,
-    Table,
     delete,
     event,
     false,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1,5 +1,4 @@
 import collections
-import functools
 import importlib
 import itertools as it
 import logging
@@ -383,9 +382,8 @@ class CatalogNodeAdapter:
         if (self.context.engine.dialect.name == "sqlite") and any(
             isinstance(condition.type, MatchType) for condition in self.conditions
         ):
-            metadata_fts5 = _sqlite_fts5_virtual_table(orm.Node.metadata)
             statement = statement.join(
-                metadata_fts5, metadata_fts5.c.rowid == orm.Node.id
+                orm.metadata_fts5, orm.metadata_fts5.c.rowid == orm.Node.id
             )
         for condition in self.conditions:
             statement = statement.filter(condition)
@@ -1200,8 +1198,7 @@ def contains(query, tree):
 def full_text(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
     if dialect_name == "sqlite":
-        metadata_fts5 = _sqlite_fts5_virtual_table(orm.Node.metadata)
-        condition = metadata_fts5.c.metadata.match(query.text)
+        condition = orm.metadata_fts5.c.metadata.match(query.text)
     elif dialect_name == "postgresql":
         tsvector = func.jsonb_to_tsvector(
             cast("simple", REGCONFIG), orm.Node.metadata_, cast(["string"], JSONB)
@@ -1477,13 +1474,3 @@ STRUCTURES = {
     StructureFamily.sparse: CatalogSparseAdapter,
     StructureFamily.table: CatalogTableAdapter,
 }
-
-
-@functools.lru_cache(1)
-def _sqlite_fts5_virtual_table(sqlalchemy_metadata):
-    return Table(
-        "metadata_fts5",
-        sqlalchemy_metadata,
-        Column("rowid", Integer, primary_key=True),
-        Column("metadata", JSON),
-    )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1187,9 +1187,9 @@ def contains(query, tree):
 def full_text(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
     if dialect_name == "sqlite":
-        # condition = orm.Node.metadata_.op("LIKE")(query.text)
-        # condition = orm.Node.id == text("metadata_fts5.rowid")
-        # condition = condition & text("metadata_fts5.metadata MATCH :text").bindparams(text=query.text)
+        #condition = orm.Node.metadata_.op("LIKE")(query.text)
+        #condition = orm.Node.id == text("metadata_fts5.rowid")
+        #condition = condition & text("metadata_fts5.metadata MATCH :text").bindparams(text=query.text)
         raise UnsupportedQueryType("full_text")
     elif dialect_name == "postgresql":
         tsvector = func.jsonb_to_tsvector(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1187,6 +1187,9 @@ def contains(query, tree):
 def full_text(query, tree):
     dialect_name = tree.engine.url.get_dialect().name
     if dialect_name == "sqlite":
+        # condition = orm.Node.metadata_.op("LIKE")(query.text)
+        # condition = orm.Node.id == text("metadata_fts5.rowid")
+        # condition = condition & text("metadata_fts5.metadata MATCH :text").bindparams(text=query.text)
         raise UnsupportedQueryType("full_text")
     elif dialect_name == "postgresql":
         tsvector = func.jsonb_to_tsvector(

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,6 +5,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "ed3a4223a600",
     "e756b9381c14",
     "2ca16566d692",
     "1cd99c02d0c7",

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -39,9 +39,9 @@ def upgrade():
             """,
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_au AFTER UPDATE ON nodes BEGIN
-              INSERT INTO metadata_ft5_index(metadata_ft5_index, rowid, metadata)
+              INSERT INTO metadata_fts5_index(metadata_fts5_index, rowid, metadata)
               VALUES('delete', old.id, old.metadata);
-              INSERT INTO metadata_ft5_index(rowid, metadata)
+              INSERT INTO metadata_fts5_index(rowid, metadata)
               VALUES (new.id, new.metadata);
             END;
             """,

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -1,0 +1,55 @@
+"""Create sqlite table for fulltext search
+
+Revision ID: ed3a4223a600
+Revises: e756b9381c14
+Create Date: 2024-04-11 16:41:01.369520
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ed3a4223a600'
+down_revision = 'e756b9381c14'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "sqlite":
+        statements = [
+            # Create an external content fts5 table.
+            # See https://www.sqlite.org/fts5.html Section 4.4.3.
+            """
+            CREATE VIRTUAL TABLE metadata_fts5 USING fts5(metadata, content='nodes', content_rowid='id');
+            """,
+            # Triggers keep the index synchronized with the nodes table.
+            """
+            CREATE TRIGGER nodes_metadata_fts5_sync_ai AFTER INSERT ON nodes BEGIN
+              INSERT INTO metadata_fts5(rowid, metadata)
+              VALUES (new.id, new.metadata);
+            END;
+            """,
+            """
+            CREATE TRIGGER nodes_metadata_fts5_sync_ad AFTER DELETE ON nodes BEGIN
+              INSERT INTO metadata_fts5(metadata_fts5, rowid, metadata)
+              VALUES('delete', old.id, old.metadata);
+            END;
+            """,
+            """
+            CREATE TRIGGER nodes_metadata_fts5_sync_au AFTER UPDATE ON nodes BEGIN
+              INSERT INTO metadata_ft5_index(metadata_ft5_index, rowid, metadata)
+              VALUES('delete', old.id, old.metadata);
+              INSERT INTO metadata_ft5_index(rowid, metadata)
+              VALUES (new.id, new.metadata);
+            END;
+            """,
+        ]
+        for statement in statements:
+            op.execute(sa.text(statement))
+
+
+def downgrade():
+    pass

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -28,7 +28,7 @@ def upgrade():
             """
             INSERT INTO metadata_fts5(rowid, metadata)
             SELECT id, metadata FROM nodes;
-            """
+            """,
             # Triggers keep the index synchronized with the nodes table.
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_ai AFTER INSERT ON nodes BEGIN

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -24,6 +24,11 @@ def upgrade():
             """
             CREATE VIRTUAL TABLE metadata_fts5 USING fts5(metadata, content='nodes', content_rowid='id');
             """,
+            # Insert all existing node content into the fts5 table.
+            """
+            INSERT INTO metadata_fts5(rowid, metadata)
+            SELECT id, metadata FROM nodes;
+            """
             # Triggers keep the index synchronized with the nodes table.
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_ai AFTER INSERT ON nodes BEGIN

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -39,9 +39,9 @@ def upgrade():
             """,
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_au AFTER UPDATE ON nodes BEGIN
-              INSERT INTO metadata_fts5_index(metadata_fts5_index, rowid, metadata)
+              INSERT INTO metadata_fts5(metadata_fts5, rowid, metadata)
               VALUES('delete', old.id, old.metadata);
-              INSERT INTO metadata_fts5_index(rowid, metadata)
+              INSERT INTO metadata_fts5(rowid, metadata)
               VALUES (new.id, new.metadata);
             END;
             """,

--- a/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
+++ b/tiled/catalog/migrations/versions/ed3a4223a600_create_sqlite_table_for_fulltext_search.py
@@ -5,13 +5,12 @@ Revises: e756b9381c14
 Create Date: 2024-04-11 16:41:01.369520
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'ed3a4223a600'
-down_revision = 'e756b9381c14'
+revision = "ed3a4223a600"
+down_revision = "e756b9381c14"
 branch_labels = None
 depends_on = None
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -279,7 +279,7 @@ class FTS5Table(Table):
 
 
 @compiles(schema.CreateTable, "sqlite")
-def _compile(element: schema.CreateTable, compiler, **kw):
+def _compile_fts5_virtual_table_sqlite(element: schema.CreateTable, compiler, **kw):
     if not isinstance(element.target, FTS5Table):
         return compiler.visit_create_table(element, **kw)
     name = compiler.preparer.format_table(element.target)
@@ -291,10 +291,10 @@ def _compile(element: schema.CreateTable, compiler, **kw):
     return f"CREATE VIRTUAL TABLE {name} USING fts5({cols}, content='nodes', content_rowid='id')"
 
 
-# Preclude the creation of the FTS5 virtual table in posgres instances,
-# Where fulltext search is handled by a different indexing mechanism.
 @compiles(schema.CreateTable, "postgresql")
-def _compile(element: schema.CreateTable, compiler, **kw):
+def _compile_no_op_fts5_postgresql(element: schema.CreateTable, compiler, **kw):
+    # Preclude the creation of the FTS5 virtual table in posgres instances,
+    # Where fulltext search is handled by a different indexing mechanism.
     if not isinstance(element.target, FTS5Table):
         return compiler.visit_create_table(element, **kw)
     return "SELECT 1"

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -295,9 +295,9 @@ def create_virtual_table_fits5(target, connection, **kw):
             """,
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_au AFTER UPDATE ON nodes BEGIN
-              INSERT INTO metadata_ft5_index(metadata_ft5_index, rowid, metadata)
+              INSERT INTO metadata_fts5_index(metadata_fts5_index, rowid, metadata)
               VALUES('delete', old.id, old.metadata);
-              INSERT INTO metadata_ft5_index(rowid, metadata)
+              INSERT INTO metadata_fts5_index(rowid, metadata)
               VALUES (new.id, new.metadata);
             END;
             """,

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -255,7 +255,7 @@ EXECUTE FUNCTION raise_if_null_parameter_exists();"""
         )
 
 
-@event.listens_for(DataSourceAssetAssociation.__table__, "after_create")
+@event.listens_for(Node.__table__, "after_create")
 def create_index_metadata_tsvector_search(target, connection, **kw):
     # This creates a ts_vector based metadata search index for fulltext.
     # Postgres only feature
@@ -271,7 +271,7 @@ def create_index_metadata_tsvector_search(target, connection, **kw):
         )
 
 
-@event.listens_for(DataSourceAssetAssociation.__table__, "after_create")
+@event.listens_for(Node.__table__, "after_create")
 def create_virtual_table_fits5(target, connection, **kw):
     if connection.engine.dialect.name == "sqlite":
         statements = [

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -295,9 +295,9 @@ def create_virtual_table_fits5(target, connection, **kw):
             """,
             """
             CREATE TRIGGER nodes_metadata_fts5_sync_au AFTER UPDATE ON nodes BEGIN
-              INSERT INTO metadata_fts5_index(metadata_fts5_index, rowid, metadata)
+              INSERT INTO metadata_fts5(metadata_fts5, rowid, metadata)
               VALUES('delete', old.id, old.metadata);
-              INSERT INTO metadata_fts5_index(rowid, metadata)
+              INSERT INTO metadata_fts5(rowid, metadata)
               VALUES (new.id, new.metadata);
             END;
             """,


### PR DESCRIPTION
This PR has commits from @Kezzsim and me. It adds support for full text search backed by SQLite.

SQLite full text search support via [FTS5](https://www.sqlite.org/fts5.html) is solid and feature-ful, but the implementation is somewhat different. It employs a `VIRTUAL TABLE` instead of an `INDEX`. Database triggers are used to keep the content of this table in sync with the `nodes` table. We must perform a `JOIN` on that virtual table in order to filter our results with a `MATCH` query against the indexed node `metadata`.

We get queries that look like:

```
SELECT nodes."key" 
FROM nodes JOIN metadata_fts5 ON metadata_fts5.rowid = nodes.id 
WHERE nodes.ancestors = ? AND metadata_fts5.metadata MATCH ? ORDER BY nodes.time_created, nodes.id
 LIMIT ? OFFSET ?
```

(as shown by setting `TILED_ECHO_SQL=1` when starting the server).

I think the implementation is about as clean as it can be, until we go and refactor all the SQLAlchemy code into a separate module. But I'd like to kick the tires a bit more before we merge.

We also need to test the migration interactively, and particularly ensure that _existing rows_ in the `nodes` table are added to the `VIRTUAL TABLE`.

Closes #546 