### PR TITLE
Do not assume 'content-encoding' header is set.

### DIFF
--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -125,13 +125,14 @@ def capture_request_metrics(request, response):
             metrics["read"]["pack"]
         )
     if "compress" in metrics:
-        encoding = response.headers["content-encoding"]
-        COMPRESSION_DURATION.labels(
-            method=method, code=code, endpoint=endpoint, encoding=encoding
-        ).observe(metrics["compress"]["dur"])
-        COMPRESSION_RATIO.labels(
-            method=method, code=code, endpoint=endpoint, encoding=encoding
-        ).observe(metrics["compress"]["ratio"])
+        encoding = response.headers.get("content-encoding")
+        if encoding:
+            COMPRESSION_DURATION.labels(
+                method=method, code=code, endpoint=endpoint, encoding=encoding
+            ).observe(metrics["compress"]["dur"])
+            COMPRESSION_RATIO.labels(
+                method=method, code=code, endpoint=endpoint, encoding=encoding
+            ).observe(metrics["compress"]["ratio"])
 
 
 @lru_cache()


### PR DESCRIPTION
We are seeing a whole lot of

```
File "/opt/venv/lib/python3.11/site-packages/tiled/server/app.py", line 879, in capture_metrics_prometheus
    metrics.capture_request_metrics(request, response)
  File "/opt/venv/lib/python3.11/site-packages/tiled/server/metrics.py", line 128, in capture_request_metrics
    encoding = response.headers["content-encoding"]
               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
File "/opt/venv/lib/python3.11/site-packages/starlette/datastructures.py", line 565, in __getitem__
    raise KeyError(key)
KeyError: 'content-encoding'
```

in the production logs.