### PR TITLE
Do softer version check.

### DIFF
--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -716,17 +716,14 @@ Back up the database, and then run:
             try:
                 parsed_version = packaging.version.parse(raw_version)
             except Exception:
-                return JSONResponse(
-                    status_code=HTTP_400_BAD_REQUEST,
-                    content={
-                        "detail": (
-                            f"Python Tiled client is version is reported as {raw_version}. "
-                            "This cannot be parsed as a valid version."
-                        ),
-                    },
+                logger.warning(
+                    f"Python Tiled client is version is reported as {raw_version}. "
+                    "This cannot be parsed as a valid version."
                 )
             else:
-                if parsed_version < MINIMUM_SUPPORTED_PYTHON_CLIENT_VERSION:
+                if (not parsed_version.is_deverlease) and (
+                    parsed_version < MINIMUM_SUPPORTED_PYTHON_CLIENT_VERSION
+                ):
                     return JSONResponse(
                         status_code=HTTP_400_BAD_REQUEST,
                         content={

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -5,6 +5,7 @@ import os
 import secrets
 import sys
 import urllib.parse
+import warnings
 from contextlib import asynccontextmanager
 from functools import lru_cache, partial
 from pathlib import Path
@@ -715,11 +716,14 @@ Back up the database, and then run:
             agent, _, raw_version = user_agent.partition("/")
             try:
                 parsed_version = packaging.version.parse(raw_version)
-            except Exception:
-                logger.warning(
+            except Exception as caught_exception:
+                invalid_version_message = (
                     f"Python Tiled client version is reported as {raw_version}. "
                     "This cannot be parsed as a valid version."
                 )
+                logger.warning(invalid_version_message)
+                if isinstance(caught_exception, packaging.version.InvalidVersion):
+                    warnings.warn(invalid_version_message)
             else:
                 if (not parsed_version.is_devrelease) and (
                     parsed_version < MINIMUM_SUPPORTED_PYTHON_CLIENT_VERSION

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -717,11 +717,11 @@ Back up the database, and then run:
                 parsed_version = packaging.version.parse(raw_version)
             except Exception:
                 logger.warning(
-                    f"Python Tiled client is version is reported as {raw_version}. "
+                    f"Python Tiled client version is reported as {raw_version}. "
                     "This cannot be parsed as a valid version."
                 )
             else:
-                if (not parsed_version.is_deverlease) and (
+                if (not parsed_version.is_devrelease) and (
                     parsed_version < MINIMUM_SUPPORTED_PYTHON_CLIENT_VERSION
                 ):
                     return JSONResponse(


### PR DESCRIPTION
The Tiled Python client reports the version of Tiled that it is using its `user-agent` header, e.g. `python-tiled/0.1.0a118`. If this client version is known to be too old to interoperate with the Tiled server version, the server returns a 400 status code with an explanatory error message.

This can go wrong in a development install.. If the user has not recently fetched the upstream tags, it may report a version like `0.1.dev2335+g58bc300.d20240409`. This has created confusion in two unrelated incidents within the last two weeks.

This PR makes the version check softer:

1. If the version cannot be parsed, log a warning in the server logs and ignore.
2. If the version is a dev release, ignore.

This is not perfect. But I think the change does more good than harm.