### PR TITLE
Implement `--log-config` for all server CLI commands.

### DIFF
--- a/example_log_config.yml
+++ b/example_log_config.yml
@@ -1,0 +1,41 @@
+version: 1
+disable_existing_loggers: false
+filters:
+  correlation_id:
+    "()": asgi_correlation_id.CorrelationIdFilter
+    uuid_length: 16
+    default_value: '-'
+formatters:
+  default:
+    "()": uvicorn.logging.DefaultFormatter
+    datefmt: "%Y-%m-%dT%H:%M:%S"
+    format:  '[%(asctime)s.%(msecs)03dZ] [%(correlation_id)s] %(levelprefix)s %(message)s'
+    use_colors: true
+  access:
+    "()": uvicorn.logging.AccessFormatter
+    datefmt: "%Y-%m-%dT%H:%M:%S"
+    format: '[%(asctime)s.%(msecs)03dZ] [%(correlation_id)s] %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    filters:
+      - correlation_id
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    filters:
+      - correlation_id
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: INFO
+    handlers:
+      - access
+    propagate: no

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -199,10 +199,12 @@ def serve_directory(
 
     import anyio
     import uvicorn
+    from uvicorn.config import LOGGING_CONFIG
 
     from ..client import from_uri as client_from_uri
 
     print_admin_api_key_if_generated(web_app, host=host, port=port, force=generated)
+    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
     config = uvicorn.Config(web_app, host=host, port=port, log_config=log_config)
     server = uvicorn.Server(config)
 
@@ -435,7 +437,9 @@ or use an existing one:
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
     import uvicorn
+    from uvicorn.config import LOGGING_CONFIG
 
+    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
@@ -502,7 +506,9 @@ def serve_pyobject(
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
     import uvicorn
+    from uvicorn.config import LOGGING_CONFIG
 
+    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -203,7 +203,7 @@ def serve_directory(
     from ..client import from_uri as client_from_uri
 
     print_admin_api_key_if_generated(web_app, host=host, port=port, force=generated)
-    config = uvicorn.Config(web_app, host=host, port=port)
+    config = uvicorn.Config(web_app, host=host, port=port, log_config=log_config)
     server = uvicorn.Server(config)
 
     async def run_server():
@@ -334,6 +334,9 @@ def serve_catalog(
             "This verifies that the configuration is compatible with scaled (multi-process) deployments."
         ),
     ),
+    log_config: Optional[str] = typer.Option(
+        None, help="Custom uvicorn logging configuration file"
+    ),
 ):
     "Serve a catalog."
     import urllib.parse
@@ -433,7 +436,7 @@ or use an existing one:
 
     import uvicorn
 
-    uvicorn.run(web_app, host=host, port=port)
+    uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
 serve_app.command("catalog")(serve_catalog)
@@ -477,6 +480,9 @@ def serve_pyobject(
             "This verifies that the configuration is compatible with scaled (multi-process) deployments."
         ),
     ),
+    log_config: Optional[str] = typer.Option(
+        None, help="Custom uvicorn logging configuration file"
+    ),
 ):
     "Serve a Tree instance from a Python module."
     from ..server.app import build_app, print_admin_api_key_if_generated
@@ -497,7 +503,7 @@ def serve_pyobject(
 
     import uvicorn
 
-    uvicorn.run(web_app, host=host, port=port)
+    uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
 @serve_app.command("demo")
@@ -571,6 +577,9 @@ def serve_config(
             "This verifies that the configuration is compatible with scaled (multi-process) deployments."
         ),
     ),
+    log_config: Optional[str] = typer.Option(
+        None, help="Custom uvicorn logging configuration file"
+    ),
 ):
     "Serve a Tree as specified in configuration file(s)."
     import os
@@ -605,9 +614,10 @@ def serve_config(
 
     # Extract config for uvicorn.
     uvicorn_kwargs = parsed_config.pop("uvicorn", {})
-    # If --host is given, it overrides host in config. Same for --port.
+    # If --host is given, it overrides host in config. Same for --port and --log-config.
     uvicorn_kwargs["host"] = host or uvicorn_kwargs.get("host", "127.0.0.1")
     uvicorn_kwargs["port"] = port or uvicorn_kwargs.get("port", 8000)
+    uvicorn_kwargs["log_config"] = log_config or uvicorn_kwargs.get("log_config")
 
     # This config was already validated when it was parsed. Do not re-validate.
     logger.info(f"Using configuration from {Path(config_path).absolute()}")


### PR DESCRIPTION
This PR implements `--log-config` on:

- `tiled serve directory`
- `tiled serve catalog`
- `tiled serve config` (where it would override the config)

(It skips `tiled serve demo`, which is intentionally bare bones and does not accept many of the other options common to the others.)

Previously `--log-config` was _accepted_ by `tiled serve directory` only, and it was then ignored. :facepalm:  Expand for interactive tests demonstrating that we got it right this time, for each of the above.

<details>

```
$ tiled serve catalog --temp --log-config example_log_config.yml 
Creating catalog database at /tmp/tmpbb9mpn3_/catalog.db
Creating writable catalog data directory at /tmp/tmpbb9mpn3_/data

    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=0596b6db450d8d128197cf8f5e8b00d8e50f0c32788dd40b5245c8ab828e6af0


[2024-04-25T15:13:26.117Z] [-] INFO:     Started server process [137107]
[2024-04-25T15:13:26.118Z] [-] INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev57+g0cd0407b
[2024-04-25T15:13:26.120Z] [-] INFO:     Application startup complete.
[2024-04-25T15:13:26.121Z] [-] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```

```
$ tiled serve directory /tmp/data --log-config example_log_config.yml 
Creating catalog database at /tmp/tmpfbf9dqpk/catalog.db

    Navigate a web browser or connect a Tiled client to:

    http://127.0.0.1:8000?api_key=f760c7b4b8dff957b22aa69559fe77b301f20334a42bd7079041bf5103526e26


[2024-04-25T15:15:03.062Z] [-] INFO:     Started server process [137221]
[2024-04-25T15:15:03.062Z] [-] INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev57+g0cd0407b
[2024-04-25T15:15:03.066Z] [-] INFO:     Application startup complete.
[2024-04-25T15:15:03.066Z] [-] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
[2024-04-25T15:15:03.177Z] [9f868d706a9c17a7] INFO:     127.0.0.1:49660 - "GET /api/v1/ HTTP/1.1" 200 OK
[2024-04-25T15:15:03.269Z] [3a0e3028f590fb47] INFO:     127.0.0.1:49660 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
Server is up. Indexing files in /tmp/data...
[2024-04-25T15:15:03.280Z] [283a08dd56c8a025] INFO:     127.0.0.1:49660 - "DELETE /api/v1/nodes/ HTTP/1.1" 200 OK
[2024-04-25T15:15:03.604Z] [b74009411c58cdb1] INFO:     127.0.0.1:49660 - "POST /api/v1/register/ HTTP/1.1" 200 OK
Indexing complete.
```

```
 TILED_SINGLE_USER_API_KEY=secret tiled serve config example_configs/small_single_user_demo.yml --log-config example_log_config.yml 
Using configuration from /home/dallan/Repos/bnl/tiled/example_configs/small_single_user_demo.yml
[2024-04-25T15:16:59.403Z] [-] INFO:     Started server process [137639]
[2024-04-25T15:16:59.403Z] [-] INFO:     Waiting for application startup.
Tiled version 0.1.0a117.dev57+g0cd0407b
[2024-04-25T15:16:59.404Z] [-] INFO:     Application startup complete.
[2024-04-25T15:16:59.404Z] [-] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```

</details>

This PR also adds `example_log_config.yml` to the repo root