### PR TITLE
Coerce metadata to dict if `select_metadata` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - SQLite-backed catalogs now employ connection pooling. This results in a
   significant speed-up and avoids frequently re-opening the SQLite file.
+- Metadata returned from the use of the `select_metadata` is now a one-item
+  dictionary with 'selected' as the key, to match default type/behavior.
 
 ## v0.1.0a120 (25 April 2024)
 

--- a/tiled/_tests/test_select_metadata.py
+++ b/tiled/_tests/test_select_metadata.py
@@ -1,0 +1,38 @@
+# This tests an experimental feature likely to be deprecated.
+# https://github.com/bluesky/tiled/issues/217
+import pathlib
+
+import pytest
+
+from tiled.catalog import in_memory
+from tiled.client import Context, from_context
+from tiled.server.app import build_app
+
+
+@pytest.fixture(scope="module")
+def module_tmp_path(tmp_path_factory: pytest.TempdirFactory) -> pathlib.Path:
+    return tmp_path_factory.mktemp("temp")
+
+
+@pytest.fixture(scope="module")
+def client(module_tmp_path):
+    catalog = in_memory(writable_storage=module_tmp_path)
+    app = build_app(catalog)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+        client.write_array([1], key="x", metadata={"sample": {"color": "red"}})
+        client.write_array([2], key="y", metadata={"sample": {"color": "blue"}})
+        yield client
+
+
+def test_select_metadata(client):
+    http_client = client.context.http_client
+    # /metadata
+    response = http_client.get("/api/v1/metadata/x?select_metadata=[sample.color]")
+    result = response.json()
+    assert result["data"]["attributes"]["metadata"] == {"selected": ["red"]}
+    # /search
+    response = http_client.get("/api/v1/search/?select_metadata=[sample.color]")
+    result = response.json()
+    for item, color in zip(result["data"], ["red", "blue"]):
+        assert item["attributes"]["metadata"] == {"selected": [color]}

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -415,9 +415,9 @@ async def construct_resource(
         attributes["data_sources"] = entry.data_sources
     if schemas.EntryFields.metadata in fields:
         if select_metadata is not None:
-            attributes["metadata"] = jmespath.compile(select_metadata).search(
+            attributes["metadata"] = {'selected': jmespath.compile(select_metadata).search(
                 entry.metadata()
-            )
+            )}
         else:
             attributes["metadata"] = entry.metadata()
     if schemas.EntryFields.specs in fields:

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -415,9 +415,9 @@ async def construct_resource(
         attributes["data_sources"] = entry.data_sources
     if schemas.EntryFields.metadata in fields:
         if select_metadata is not None:
-            attributes["metadata"] = {'selected': jmespath.compile(select_metadata).search(
-                entry.metadata()
-            )}
+            attributes["metadata"] = {
+                "selected": jmespath.compile(select_metadata).search(entry.metadata())
+            }
         else:
             attributes["metadata"] = entry.metadata()
     if schemas.EntryFields.specs in fields:


### PR DESCRIPTION
See description in #731.  This PR implements a minimal fix for this problem by forcing `metadata` into a one-member dictionary if `select_metadata` is used.

I'm not sure if a test should be added to cover this behavior, given that we intend to soon deprecate this feature in favor of a newer solution.  I would appreciate input here.  One complication is that the default example datasets do not have associated metadata...

 ### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
