### PR TITLE
Fix bug: xarray Dataset data variables/coordinates don't have attributes populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Propagate setting `include_data_sources` into child nodes.
+- Populate attributes in member data variables and coordinates of xarray Datasets.
 
 ## v0.1.0a120 (25 April 2024)
 

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -78,7 +78,7 @@ def client():
 def test_xarray_dataset(client, key):
     expected = EXPECTED[key]
     actual = client[key].read().load()
-    xarray.testing.assert_equal(actual, expected)
+    xarray.testing.assert_identical(actual, expected)
 
 
 def test_specs(client):

--- a/tiled/client/sync.py
+++ b/tiled/client/sync.py
@@ -59,7 +59,8 @@ def _copy_table(source, dest):
 def _copy_container(source, dest):
     for key, child_node in source.items():
         original_data_sources = child_node.include_data_sources().data_sources()
-        if not original_data_sources:
+        num_data_sources = len(original_data_sources)
+        if num_data_sources == 0:
             # A container with no data sources is just an organizational
             # entity in the database.
             if child_node.structure_family == StructureFamily.container:
@@ -69,7 +70,7 @@ def _copy_container(source, dest):
                     f"Unable to copy {child_node} which is a "
                     f"{child_node.structure_family} but has no data sources."
                 )
-        else:
+        elif num_data_sources == 1:
             (original_data_source,) = original_data_sources
             if original_data_source.management == Management.external:
                 data_sources = [original_data_source]
@@ -85,6 +86,12 @@ def _copy_container(source, dest):
                             structure=original_data_source.structure,
                         )
                     ]
+        else:
+            # As of this writing this is impossible, but we anticipate that
+            # it may be added someday.
+            raise NotImplementedError(
+                "Multiple Data Sources in one Node is not supported."
+            )
         node = dest.new(
             key=key,
             structure_family=child_node.structure_family,

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -90,9 +90,17 @@ class DaskDatasetClient(Container):
                     )
             else:
                 if "xarray_coord" in spec_names:
-                    coords[name] = (array_client.dims, array_client.read(),array_client.metadata["attrs"])
+                    coords[name] = (
+                        array_client.dims,
+                        array_client.read(),
+                        array_client.metadata["attrs"],
+                    )
                 elif "xarray_data_var" in spec_names:
-                    data_vars[name] = (array_client.dims, array_client.read(),array_client.metadata["attrs"])
+                    data_vars[name] = (
+                        array_client.dims,
+                        array_client.read(),
+                        array_client.metadata["attrs"],
+                    )
                 else:
                     raise ValueError(
                         "Child nodes of xarray_dataset should include spec "

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -75,11 +75,13 @@ class DaskDatasetClient(Container):
                     coords[name] = (
                         array_client.dims,
                         coords_fetcher.register(name, array_client, array_structure),
+                        array_client.metadata["attrs"],
                     )
                 elif "xarray_data_var" in spec_names:
                     data_vars[name] = (
                         array_client.dims,
                         data_vars_fetcher.register(name, array_client, array_structure),
+                        array_client.metadata["attrs"],
                     )
                 else:
                     raise ValueError(
@@ -88,9 +90,9 @@ class DaskDatasetClient(Container):
                     )
             else:
                 if "xarray_coord" in spec_names:
-                    coords[name] = (array_client.dims, array_client.read())
+                    coords[name] = (array_client.dims, array_client.read(),array_client.metadata["attrs"])
                 elif "xarray_data_var" in spec_names:
-                    data_vars[name] = (array_client.dims, array_client.read())
+                    data_vars[name] = (array_client.dims, array_client.read(),array_client.metadata["attrs"])
                 else:
                     raise ValueError(
                         "Child nodes of xarray_dataset should include spec "


### PR DESCRIPTION
Found a bug that dodged unit testing in the xarray client: while an overall Dataset's attributes were being correctly populated from the metadata of the tiled node, the member/child data variables and coordinates' attributes were not being populated.  This is important for several of xarray's hinting features to work properly (e.g., a coordinate can have a 'unit' attribute that populates a plot axis).  The testing miss was that the test used `xarray.testing.assert_equal()` rather than `xarray.testing.assert_identical` which explicitly tests names and attributes.  The test miss and the underlying issue are both fixed here.  Thanks to @martintb for help in tracking this one down.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
