### PR TITLE
Skip duplicate data during copy from one catalog to another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
   dictionary with 'selected' as the key, to match default type/behavior.
 - The method `BaseClient.data_sources()` returns dataclass objects instead of
   raw dict objects.
+- `tiled.client.sync` has conflict handling, with initial options of 'error'
+  (default), 'warn', and 'skip'
 
 ### Fixed
 

--- a/tiled/client/sync.py
+++ b/tiled/client/sync.py
@@ -1,10 +1,12 @@
-import httpx
 import itertools
+
+import httpx
 
 from ..structures.core import StructureFamily
 from ..structures.data_source import DataSource, Management
 from .base import BaseClient
 from .utils import ClientError
+
 
 def copy(
     source: BaseClient,
@@ -119,7 +121,7 @@ def _copy_container(source, dest):
             )
         except ClientError as e:
             if e.response.status_code == httpx.codes.CONFLICT:
-                print('Skipped existing entry (or UUID hash collision)')
+                print("Skipped existing entry (or UUID hash collision)")
                 continue
             else:
                 raise e


### PR DESCRIPTION
Following up from comment on #735, this PR provides extremely rudimentary duplicate skipping during a `tiled.client.sync.copy`.  ~~I think it makes sense to put this behavior behind a flag `skip_duplicates` and leave it False by default.~~  Duplicate handling is a little tricky for performance; I think the scope of `.copy()` is pretty clear that it doesn't update nodes in the destination catalog if the source has changed (though this, of course, might eventually be desirable behavior).  

(edit per @danielballan's suggestion below: this flag is now a str called `on_conflict` with implemented options 'error' (default), 'warn', and 'skip')

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
