### PR TITLE
Show auth state in Context repr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   that the data in it can be read.
 - Added `tiled.client.sync` with a utility for copying nodes between two
   Tiled instances.
+- Show authentication state in `Context` repr.
 
 ### Changed
 

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -77,11 +77,14 @@ def test_password_auth(enter_password, config):
             from_context(context, username="alice")
         # Reuse token from cache.
         client = from_context(context, username="alice")
+        assert "authenticated as 'alice'" in repr(client.context)
         client.logout()
+        assert "unauthenticated" in repr(client.context)
 
         # Log in as Bob.
         with enter_password("secret2"):
             client = from_context(context, username="bob")
+            assert "authenticated as 'bob'" in repr(client.context)
         client.logout()
 
         # Bob's password should not work for Alice.
@@ -333,6 +336,10 @@ def test_api_key_activity(enter_password, config):
         context.logout()
         assert key_info["latest_activity"] is None  # never used
         context.api_key = key_info["secret"]
+        assert "authenticated as 'alice'" in repr(context)
+        assert "with API key" in repr(context)
+        assert key_info["secret"][:8] in repr(context)
+        assert key_info["secret"][8:] not in repr(context)
 
         # Use the key for a couple requests and see that latest_activity becomes set and then increases.
         client = from_context(context)

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -172,7 +172,9 @@ class Context:
                     ",".join(f"'{identity['id']}'" for identity in whoami["identities"])
                 )
             if self.api_key is not None:
-                auth_info.append(f"with API key '{self.api_key[:min(len(self.api_key)//2, 8)]}...'")
+                auth_info.append(
+                    f"with API key '{self.api_key[:min(len(self.api_key)//2, 8)]}...'"
+                )
         auth_repr = " ".join(auth_info)
         return f"<{type(self).__name__} {auth_repr}>"
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -172,7 +172,7 @@ class Context:
                     ",".join(f"'{identity['id']}'" for identity in identities)
                 )
             if self.api_key is not None:
-                auth_info.append(f"with API key '{self.api_key[:8]}...'")
+                auth_info.append(f"with API key '{self.api_key[:min(len(self.api_key)//2, 8)]}...'")
         auth_repr = " ".join(auth_info)
         return f"<{type(self).__name__} {auth_repr}>"
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -159,6 +159,23 @@ class Context:
         self.api_key = api_key  # property setter sets Authorization header
         self.admin = Admin(self)  # accessor for admin-related requests
 
+    def __repr__(self):
+        auth_info = []
+        if (self.api_key is None) and (self.http_client.auth is None):
+            auth_info.append("(unauthenticated)")
+        else:
+            auth_info.append("authenticated")
+            identities = self.whoami()["identities"]
+            if identities:
+                auth_info.append("as")
+                auth_info.append(
+                    ",".join(f"'{identity['id']}'" for identity in identities)
+                )
+            if self.api_key is not None:
+                auth_info.append(f"with API key '{self.api_key[:8]}...'")
+        auth_repr = " ".join(auth_info)
+        return f"<{type(self).__name__} {auth_repr}>"
+
     def __enter__(self):
         return self
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -165,11 +165,11 @@ class Context:
             auth_info.append("(unauthenticated)")
         else:
             auth_info.append("authenticated")
-            identities = self.whoami()["identities"]
-            if identities:
+            if self.server_info["authentication"].get("links"):
+                whoami = self.whoami()
                 auth_info.append("as")
                 auth_info.append(
-                    ",".join(f"'{identity['id']}'" for identity in identities)
+                    ",".join(f"'{identity['id']}'" for identity in whoami["identities"])
                 )
             if self.api_key is not None:
                 auth_info.append(f"with API key '{self.api_key[:min(len(self.api_key)//2, 8)]}...'")


### PR DESCRIPTION
Against a mutli-user server:

```py
In [1]: from tiled.client import from_profile

In [2]: c = from_profile('nsls2')

In [3]: c.context
Out[3]: <Context authenticated as 'dallan'>

In [4]: c.context.api_key = '<redacted>'

In [5]: c.context
Out[5]: <Context authenticated as 'dallan' with API key '86d32845...'>

In [6]: c.logout()

In [7]: c.context
Out[7]: <Context (unauthenticated)>
```

Against a single-user server:
```py
In [1]: from tiled.client import from_profile

In [2]: c = from_profile('local', api_key='secret')

In [3]: c.context
Out[3]: <Context authenticated with API key 'secret...'>

In [4]: c.context.api_key = None

In [5]: c.context
Out[5]: <Context (unauthenticated)>
```

Needs unit tests

Closes #739 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
