### PR TITLE
Handle `In(key, [])` and `NotIn(key, [])` correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Propagate setting `include_data_sources` into child nodes.
 - Populate attributes in member data variables and coordinates of xarray Datasets.
 - Update dependencies.
+- Fix behavior of queries `In` and `NotIn` when passed an empty list of values.
 
 ## v0.1.0a120 (25 April 2024)
 

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -261,7 +261,7 @@ def test_notin(client, query_values):
 
 
 def test_not_in_empty(client):
-    assert list(client.search(NotIn("letter", []))) == []
+    assert sorted(list(client.search(NotIn("letter", [])))) == sorted(list(client))
 
 
 @pytest.mark.parametrize(

--- a/tiled/_tests/test_queries.py
+++ b/tiled/_tests/test_queries.py
@@ -230,6 +230,10 @@ def test_in(client, query_values):
     ]
 
 
+def test_in_empty(client):
+    assert list(client.search(In("letter", []))) == []
+
+
 @pytest.mark.parametrize(
     "query_values",
     [
@@ -254,6 +258,10 @@ def test_notin(client, query_values):
             - set(["a", "k", "z"])
         )
     )
+
+
+def test_not_in_empty(client):
+    assert list(client.search(NotIn("letter", []))) == []
 
 
 @pytest.mark.parametrize(

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -766,6 +766,8 @@ def notin(query: Any, tree: MapAdapter) -> MapAdapter:
 
     """
     matches = {}
+    if len(query.value) == 0:
+        return tree
     for key, value, term in iter_child_metadata(query.key, tree):
         if term not in query.value:
             matches[key] = value


### PR DESCRIPTION
This fixes an important bug in queries on the SQL-backed catalog. This bug is important particularly given queries' role in implementing authorization. The issue is that that `In("color", ["red", "green"])` issues a query `WHERE color="red" OR color="green"` via the SQLAlchemy construction `or_(...)` where `...` is a list comprehension of the possible values. But if said list is _empty_ the effect is no restriction at all, this results in not additional filter on the results! When in fact the desired result is no rows returned: `In("color", [])` is a condition that no results satisfy.

This seems to be a recognized easy mistake to make; SQLAlchemy has deprecated the usage:

```
SADeprecationWarning: Invoking or_() without arguments is deprecated, and will be disallowed in a future release.   For an empty or_() construct, use 'or_(false(), *args)' or 'or_(False, *args)'.
```

This will be easier to review commit-by-commit:

1. Tested added that exercises the bug, and fails
2. Function refactored from conditional branching to dispatch, in a pattern that @padraic-shafer has taught me to reach for more often.
3. Bug fixed, passing test

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
