### PR TITLE
HOTFIX: Remove unintended FastAPI dep introduced by type checking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
-- A depending on `fastapi` was introduced in `tiled.adapters`. This has been
+- A dependency on `fastapi` was introduced in `tiled.adapters`. This has been
   removed.
 
 ## v0.1.0a121 (21 May 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- A depending on `fastapi` was introduced in `tiled.adapters`. This has been
+  removed.
+
 ## v0.1.0a121 (21 May 2024)
 
 ### Added

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -5,9 +5,20 @@ import operator
 import sys
 from collections import Counter
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
-from fastapi import APIRouter
+if TYPE_CHECKING:
+    from fastapi import APIRouter
 
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..queries import (


### PR DESCRIPTION
This failed our config validation CI on NSLS2/tiled-site-config because the `fastapi` dep leaked into `tiled.config`.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
