### PR TITLE
Customize default uvicorn logging config to include authenticated user/service, correlation ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+## Changed
+
+- Customized default logging configuration to include correlation ID
+
 ## v0.1.0b1 (2024-05-25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Changed
 
-- Customized default logging configuration to include correlation ID
+- Customized default logging configuration to include correlation ID and username
+  of authenticated user.
+- Added `--log-timestamps` CLI flag to `tiled serve ...` to opt in to including
+  timestamp prefix in log messages.
 
 ## v0.1.0b1 (2024-05-25)
 

--- a/tiled/_tests/test_cli.py
+++ b/tiled/_tests/test_cli.py
@@ -25,7 +25,7 @@ def scrape_server_url_from_logs(process):
     "Scrape from server logs 'Uvicorn running on https://...'"
 
     def target(queue):
-        pattern = re.compile(r"Uvicorn running on (\S*)")
+        pattern = re.compile(r"Uvicorn running on .*(http:\/\/\S+:\d+).*")
         while not process.poll():
             line = process.stderr.readline()
             if match := pattern.search(line.decode()):

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -619,13 +619,16 @@ def serve_config(
         logger,
         print_admin_api_key_if_generated,
     )
+    from ..server.logging_config import LOGGING_CONFIG
 
     # Extract config for uvicorn.
     uvicorn_kwargs = parsed_config.pop("uvicorn", {})
     # If --host is given, it overrides host in config. Same for --port and --log-config.
     uvicorn_kwargs["host"] = host or uvicorn_kwargs.get("host", "127.0.0.1")
     uvicorn_kwargs["port"] = port or uvicorn_kwargs.get("port", 8000)
-    uvicorn_kwargs["log_config"] = log_config or uvicorn_kwargs.get("log_config")
+    uvicorn_kwargs["log_config"] = (
+        log_config or uvicorn_kwargs.get("log_config") or LOGGING_CONFIG
+    )
 
     # This config was already validated when it was parsed. Do not re-validate.
     logger.info(f"Using configuration from {Path(config_path).absolute()}")

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -102,6 +102,9 @@ def serve_directory(
     log_config: Optional[str] = typer.Option(
         None, help="Custom uvicorn logging configuration file"
     ),
+    log_timestamps: bool = typer.Option(
+        False, help="Include timestamps in log output."
+    ),
 ):
     "Serve a Tree instance from a directory of files."
     import tempfile
@@ -201,10 +204,9 @@ def serve_directory(
     import uvicorn
 
     from ..client import from_uri as client_from_uri
-    from ..server.logging_config import LOGGING_CONFIG
 
     print_admin_api_key_if_generated(web_app, host=host, port=port, force=generated)
-    log_config = log_config or LOGGING_CONFIG
+    log_config = _setup_log_config(log_config, log_timestamps)
     config = uvicorn.Config(web_app, host=host, port=port, log_config=log_config)
     server = uvicorn.Server(config)
 
@@ -339,6 +341,9 @@ def serve_catalog(
     log_config: Optional[str] = typer.Option(
         None, help="Custom uvicorn logging configuration file"
     ),
+    log_timestamps: bool = typer.Option(
+        False, help="Include timestamps in log output."
+    ),
 ):
     "Serve a catalog."
     import urllib.parse
@@ -438,9 +443,7 @@ or use an existing one:
 
     import uvicorn
 
-    from ..server.logging_config import LOGGING_CONFIG
-
-    log_config = log_config or LOGGING_CONFIG
+    log_config = _setup_log_config(log_config, log_timestamps)
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
@@ -488,6 +491,9 @@ def serve_pyobject(
     log_config: Optional[str] = typer.Option(
         None, help="Custom uvicorn logging configuration file"
     ),
+    log_timestamps: bool = typer.Option(
+        False, help="Include timestamps in log output."
+    ),
 ):
     "Serve a Tree instance from a Python module."
     from ..server.app import build_app, print_admin_api_key_if_generated
@@ -508,9 +514,7 @@ def serve_pyobject(
 
     import uvicorn
 
-    from ..server.logging_config import LOGGING_CONFIG
-
-    log_config = log_config or LOGGING_CONFIG
+    log_config = _setup_log_config(log_config, log_timestamps)
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
@@ -588,6 +592,9 @@ def serve_config(
     log_config: Optional[str] = typer.Option(
         None, help="Custom uvicorn logging configuration file"
     ),
+    log_timestamps: bool = typer.Option(
+        False, help="Include timestamps in log output."
+    ),
 ):
     "Serve a Tree as specified in configuration file(s)."
     import os
@@ -619,15 +626,15 @@ def serve_config(
         logger,
         print_admin_api_key_if_generated,
     )
-    from ..server.logging_config import LOGGING_CONFIG
 
     # Extract config for uvicorn.
     uvicorn_kwargs = parsed_config.pop("uvicorn", {})
     # If --host is given, it overrides host in config. Same for --port and --log-config.
     uvicorn_kwargs["host"] = host or uvicorn_kwargs.get("host", "127.0.0.1")
     uvicorn_kwargs["port"] = port or uvicorn_kwargs.get("port", 8000)
-    uvicorn_kwargs["log_config"] = (
-        log_config or uvicorn_kwargs.get("log_config") or LOGGING_CONFIG
+    uvicorn_kwargs["log_config"] = _setup_log_config(
+        log_config or uvicorn_kwargs.get("log_config"),
+        log_timestamps,
     )
 
     # This config was already validated when it was parsed. Do not re-validate.
@@ -648,3 +655,32 @@ def serve_config(
     import uvicorn
 
     uvicorn.run(web_app, **uvicorn_kwargs)
+
+
+def _setup_log_config(log_config, log_timestamps):
+    if log_config is None:
+        from ..server.logging_config import LOGGING_CONFIG
+
+        log_config = LOGGING_CONFIG
+
+    if log_timestamps:
+        import copy
+
+        log_config = copy.deepcopy(log_config)
+        try:
+            log_config["formatters"]["access"]["format"] = (
+                "[%(asctime)s.%(msecs)03dZ] "
+                + log_config["formatters"]["access"]["format"]
+            )
+            log_config["formatters"]["default"]["format"] = (
+                "[%(asctime)s.%(msecs)03dZ] "
+                + log_config["formatters"]["default"]["format"]
+            )
+        except KeyError:
+            typer.echo(
+                "The --log-timestamps option is only applicable with a logging "
+                "configuration that, like the default logging configuration, has "
+                "formatters 'access' and 'default'."
+            )
+            raise typer.Abort()
+    return log_config

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -199,12 +199,12 @@ def serve_directory(
 
     import anyio
     import uvicorn
-    from uvicorn.config import LOGGING_CONFIG
 
     from ..client import from_uri as client_from_uri
+    from ..server.logging_config import LOGGING_CONFIG
 
     print_admin_api_key_if_generated(web_app, host=host, port=port, force=generated)
-    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
+    log_config = log_config or LOGGING_CONFIG
     config = uvicorn.Config(web_app, host=host, port=port, log_config=log_config)
     server = uvicorn.Server(config)
 
@@ -437,9 +437,10 @@ or use an existing one:
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
     import uvicorn
-    from uvicorn.config import LOGGING_CONFIG
 
-    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
+    from ..server.logging_config import LOGGING_CONFIG
+
+    log_config = log_config or LOGGING_CONFIG
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 
@@ -506,9 +507,10 @@ def serve_pyobject(
     print_admin_api_key_if_generated(web_app, host=host, port=port)
 
     import uvicorn
-    from uvicorn.config import LOGGING_CONFIG
 
-    log_config = log_config or LOGGING_CONFIG  # fall back to uvicorn default
+    from ..server.logging_config import LOGGING_CONFIG
+
+    log_config = log_config or LOGGING_CONFIG
     uvicorn.run(web_app, host=host, port=port, log_config=log_config)
 
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -870,12 +870,6 @@ Back up the database, and then run:
             # An exception above would have triggered an early exit.
             return response
 
-    app.add_middleware(
-        CorrelationIdMiddleware,
-        header_name="X-Tiled-Request-ID",
-        generator=lambda: secrets.token_hex(8),
-    )
-
     @app.middleware("http")
     async def current_principal_logging_filter(request: Request, call_next):
         request.state.principal = SpecialUsers.public
@@ -883,6 +877,12 @@ Back up the database, and then run:
         response.__class__ = PatchedStreamingResponse  # tolerate memoryview
         current_principal.set(request.state.principal)
         return response
+
+    app.add_middleware(
+        CorrelationIdMiddleware,
+        header_name="X-Tiled-Request-ID",
+        generator=lambda: secrets.token_hex(8),
+    )
 
     return app
 

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -373,6 +373,8 @@ async def get_current_principal(
             ),
             headers=headers_for_401(request, security_scopes),
         )
+    # This is used to pass the currently-authenticated principal into the logger.
+    request.state.principal = principal
     return principal
 
 

--- a/tiled/server/logging_config.py
+++ b/tiled/server/logging_config.py
@@ -14,17 +14,17 @@ LOGGING_CONFIG = {
         "access": {
             "()": "uvicorn.logging.AccessFormatter",
             "datefmt": "%Y-%m-%dT%H:%M:%S",
-            "format": "[%(asctime)s.%(msecs)03dZ] "
-            "[%(correlation_id)s] %(levelprefix)s "
-            '%(client_addr)s (%(principal)s) - "%(request_line)s" '
-            "%(status_code)s",
+            "format": (
+                "[%(correlation_id)s] "
+                '%(client_addr)s (%(principal)s) - "%(request_line)s" '
+                "%(status_code)s"
+            ),
+            "use_colors": True,
         },
         "default": {
             "()": "uvicorn.logging.DefaultFormatter",
             "datefmt": "%Y-%m-%dT%H:%M:%S",
-            "format": "[%(asctime)s.%(msecs)03dZ] "
-            "[%(correlation_id)s] %(levelprefix)s "
-            "%(message)s",
+            "format": "[%(correlation_id)s] %(levelprefix)s %(message)s",
             "use_colors": True,
         },
     },

--- a/tiled/server/logging_config.py
+++ b/tiled/server/logging_config.py
@@ -1,11 +1,14 @@
 LOGGING_CONFIG = {
     "disable_existing_loggers": False,
     "filters": {
+        "principal": {
+            "()": "tiled.server.principal_log_filter.PrincipalFilter",
+        },
         "correlation_id": {
             "()": "asgi_correlation_id.CorrelationIdFilter",
             "default_value": "-",
             "uuid_length": 16,
-        }
+        },
     },
     "formatters": {
         "access": {
@@ -13,7 +16,7 @@ LOGGING_CONFIG = {
             "datefmt": "%Y-%m-%dT%H:%M:%S",
             "format": "[%(asctime)s.%(msecs)03dZ] "
             "[%(correlation_id)s] %(levelprefix)s "
-            '%(client_addr)s - "%(request_line)s" '
+            '%(client_addr)s (%(principal)s) - "%(request_line)s" '
             "%(status_code)s",
         },
         "default": {
@@ -28,7 +31,7 @@ LOGGING_CONFIG = {
     "handlers": {
         "access": {
             "class": "logging.StreamHandler",
-            "filters": ["correlation_id"],
+            "filters": ["principal", "correlation_id"],
             "formatter": "access",
             "stream": "ext://sys.stdout",
         },

--- a/tiled/server/logging_config.py
+++ b/tiled/server/logging_config.py
@@ -1,0 +1,51 @@
+LOGGING_CONFIG = {
+    "disable_existing_loggers": False,
+    "filters": {
+        "correlation_id": {
+            "()": "asgi_correlation_id.CorrelationIdFilter",
+            "default_value": "-",
+            "uuid_length": 16,
+        }
+    },
+    "formatters": {
+        "access": {
+            "()": "uvicorn.logging.AccessFormatter",
+            "datefmt": "%Y-%m-%dT%H:%M:%S",
+            "format": "[%(asctime)s.%(msecs)03dZ] "
+            "[%(correlation_id)s] %(levelprefix)s "
+            '%(client_addr)s - "%(request_line)s" '
+            "%(status_code)s",
+        },
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "datefmt": "%Y-%m-%dT%H:%M:%S",
+            "format": "[%(asctime)s.%(msecs)03dZ] "
+            "[%(correlation_id)s] %(levelprefix)s "
+            "%(message)s",
+            "use_colors": True,
+        },
+    },
+    "handlers": {
+        "access": {
+            "class": "logging.StreamHandler",
+            "filters": ["correlation_id"],
+            "formatter": "access",
+            "stream": "ext://sys.stdout",
+        },
+        "default": {
+            "class": "logging.StreamHandler",
+            "filters": ["correlation_id"],
+            "formatter": "default",
+            "stream": "ext://sys.stderr",
+        },
+    },
+    "loggers": {
+        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+        "uvicorn.error": {
+            "handlers": ["default"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+    "version": 1,
+}

--- a/tiled/server/principal_log_filter.py
+++ b/tiled/server/principal_log_filter.py
@@ -1,0 +1,21 @@
+from logging import Filter, LogRecord
+
+from ..utils import SpecialUsers
+from .app import current_principal
+
+
+class PrincipalFilter(Filter):
+    """Logging filter to attach username or Service Principal UUID to LogRecord"""
+
+    def filter(self, record: LogRecord) -> bool:
+        principal = current_principal.get()
+        if isinstance(principal, SpecialUsers):
+            short_name = f"{principal.value}"
+        elif principal.type == "service":
+            short_name = f"service:{principal.uuid}"
+        else:  # principal.type == "user"
+            short_name = ",".join(
+                f"'{identity.id}'" for identity in principal.identities
+            )
+        record.principal = short_name
+        return True


### PR DESCRIPTION
Log configuration can be customized (`--log-config`) and there is an `example_log_config.yml` in the repo, but I think it's worth changing the _default_ log configuration from base uvicorn defaults to one that includes timestamp and correlation ID.

Before:
```
$ tiled serve catalog --temp --api-key=secret
Creating catalog database at /tmp/tmp2cpih0xo/catalog.db
Creating writable catalog data directory at /tmp/tmp2cpih0xo/data
INFO:     Started server process [430162]
INFO:     Waiting for application startup.
Tiled version 0.1.0a123.dev17+gbd1c7c83.d20240525
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:45080 - "GET /api/v1/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:45080 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
```

After:
```
$ tiled serve catalog --temp --api-key=secret
Creating catalog database at /tmp/tmpec7fadbh/catalog.db
Creating writable catalog data directory at /tmp/tmpec7fadbh/data
[2024-05-25T08:51:45.347Z] [-] INFO:     Started server process [429720]
[2024-05-25T08:51:45.347Z] [-] INFO:     Waiting for application startup.
Tiled version 0.1.0a123.dev17+gbd1c7c83.d20240525
[2024-05-25T08:51:45.352Z] [-] INFO:     Application startup complete.
[2024-05-25T08:51:45.353Z] [-] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
[2024-05-25T08:51:45.857Z] [82e09cc2c13a7330] INFO:     127.0.0.1:33004 - "GET /api/v1/ HTTP/1.1" 200 OK
[2024-05-25T08:51:45.937Z] [d8e2e8a70ea301c9] INFO:     127.0.0.1:33004 - "GET /api/v1/metadata/?include_data_sources=false HTTP/1.1" 200 OK
```

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
