### PR TITLE
Fix username logging on 500 responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+- Fix regression introduced in the previous release (v0.1.0b1) where exceptions
+  raised in the server sent _no_ response instead of properly sending a 500
+  response. (This presents in the client as, "Server disconnected without
+  sending a response.") A test now protects against this class of regression.
+
 ## v0.1.0b2 (2024-05-28)
 
 ## Changed

--- a/tiled/_tests/test_server.py
+++ b/tiled/_tests/test_server.py
@@ -1,0 +1,72 @@
+import asyncio
+import functools
+
+import anyio
+import uvicorn
+from fastapi import APIRouter
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
+
+from ..catalog import in_memory
+from ..client import from_uri
+from ..server.app import build_app
+from ..server.logging_config import LOGGING_CONFIG
+
+router = APIRouter()
+
+
+@router.get("/error")
+def error():
+    1 / 0  # error!
+
+
+def test_500_response():
+    """
+    Test that unexpected server error returns 500 response.
+
+    This test is meant to catch regressions in which server exceptions can
+    result in the server sending no response at all, leading clients to raise
+    like:
+
+    httpx.RemoteProtocolError: Server disconnected without sending a response.
+
+    This can happen when bugs are introduced in the middleware layer.
+    """
+    API_KEY = "secret"
+    catalog = in_memory()
+    app = build_app(catalog, {"single_user_api_key": API_KEY})
+    app.include_router(router)
+    config = uvicorn.Config(app, port=0, log_config=LOGGING_CONFIG)
+    server = uvicorn.Server(config)
+
+    async def run_server():
+        print("run_server")
+        await server.serve()
+
+    async def wait_for_server():
+        "Wait for server to start up, or raise TimeoutError."
+        for _ in range(100):
+            await asyncio.sleep(0.1)
+            if server.started:
+                break
+        else:
+            raise TimeoutError("Server did not start in 10 seconds.")
+        host, port = server.servers[0].sockets[0].getsockname()
+        return f"http://{host}:{port}"
+
+    async def test():
+        server_task = asyncio.create_task(run_server())
+        url = await wait_for_server()
+
+        # When we add an AsyncClient for Tiled, use that here.
+        client = await anyio.to_thread.run_sync(
+            functools.partial(from_uri, url, api_key=API_KEY)
+        )
+        response = await anyio.to_thread.run_sync(
+            client.context.http_client.get, f"{url}/error"
+        )
+        assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+        print("asserted")
+        await server_task.shutdown()
+        await server_task()
+
+    asyncio.run(test())

--- a/tiled/_tests/test_server.py
+++ b/tiled/_tests/test_server.py
@@ -39,7 +39,6 @@ def test_500_response():
     server = uvicorn.Server(config)
 
     async def run_server():
-        print("run_server")
         await server.serve()
 
     async def wait_for_server():
@@ -65,7 +64,6 @@ def test_500_response():
             client.context.http_client.get, f"{url}/error"
         )
         assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
-        print("asserted")
         await server_task.shutdown()
         await server_task()
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -877,6 +877,10 @@ Back up the database, and then run:
         request.state.principal = SpecialUsers.public
         response = await call_next(request)
         response.__class__ = PatchedStreamingResponse  # tolerate memoryview
+        import random
+
+        if random.random() > 0.5:
+            raise Exception
         current_principal.set(request.state.principal)
         return response
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -330,6 +330,8 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
     async def unhandled_exception_handler(
         request: Request, exc: Exception
     ) -> JSONResponse:
+        principal = getattr(request.state, "principal", None)
+        current_principal.set(principal)
         return await http_exception_handler(
             request,
             HTTPException(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -330,6 +330,8 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
     async def unhandled_exception_handler(
         request: Request, exc: Exception
     ) -> JSONResponse:
+        # The current_principal_logging_filter middleware will not have
+        # had a chance to finish running, so set the principal here.
         principal = getattr(request.state, "principal", None)
         current_principal.set(principal)
         return await http_exception_handler(
@@ -877,10 +879,6 @@ Back up the database, and then run:
         request.state.principal = SpecialUsers.public
         response = await call_next(request)
         response.__class__ = PatchedStreamingResponse  # tolerate memoryview
-        import random
-
-        if random.random() > 0.5:
-            raise Exception
         current_principal.set(request.state.principal)
         return response
 

--- a/tiled/server/principal_log_filter.py
+++ b/tiled/server/principal_log_filter.py
@@ -8,8 +8,10 @@ class PrincipalFilter(Filter):
     """Logging filter to attach username or Service Principal UUID to LogRecord"""
 
     def filter(self, record: LogRecord) -> bool:
-        principal = current_principal.get()
-        if isinstance(principal, SpecialUsers):
+        principal = current_principal.get(None)
+        if principal is None:
+            short_name = "unset"
+        elif isinstance(principal, SpecialUsers):
             short_name = f"{principal.value}"
         elif principal.type == "service":
             short_name = f"service:{principal.uuid}"

--- a/tiled/server/principal_log_filter.py
+++ b/tiled/server/principal_log_filter.py
@@ -10,6 +10,9 @@ class PrincipalFilter(Filter):
     def filter(self, record: LogRecord) -> bool:
         principal = current_principal.get(None)
         if principal is None:
+            # This should not be possible, but it is here for
+            # defense in depth. Any errors raised in the filter
+            # cause the server to send no response at all.
             short_name = "unset"
         elif isinstance(principal, SpecialUsers):
             short_name = f"{principal.value}"

--- a/tiled/server/principal_log_filter.py
+++ b/tiled/server/principal_log_filter.py
@@ -10,9 +10,9 @@ class PrincipalFilter(Filter):
     def filter(self, record: LogRecord) -> bool:
         principal = current_principal.get(None)
         if principal is None:
-            # This should not be possible, but it is here for
-            # defense in depth. Any errors raised in the filter
-            # cause the server to send no response at all.
+            # This will only occur if an uncaught exception was raised in the
+            # server before the authentication code ran. This will always be
+            # associated with a 500 Internal Server Error response.
             short_name = "unset"
         elif isinstance(principal, SpecialUsers):
             short_name = f"{principal.value}"


### PR DESCRIPTION
A bug causes the server to send no response, such that the client raised:

```
RemoteProtocolError: Server disconnected without sending a response.
```

instead of returning 500 response. This was a regression introduced in #750.

Needs test.

Closes #750

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
