### PR TITLE
Fix Context repr when authenticated as service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+- When authenticated as a Service Principal, display the SP's uuid in
+  the client Context repr.
+
 ## v0.1.0b4 (2024-06-18)
 
 ### Changed

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -591,6 +591,9 @@ def test_admin_create_service_principal(enter_password, principals_context):
         context.api_key = service_api_key_info["secret"]
         assert context.whoami()["type"] == "service"
 
+        # Test service repr
+        assert f"authenticated as service '{principal_uuid}'" in repr(context)
+
 
 def test_admin_api_key_any_principal_exceeds_scopes(enter_password, principals_context):
     """

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -168,9 +168,14 @@ class Context:
             if self.server_info["authentication"].get("links"):
                 whoami = self.whoami()
                 auth_info.append("as")
-                auth_info.append(
-                    ",".join(f"'{identity['id']}'" for identity in whoami["identities"])
-                )
+                if whoami["type"] == "service":
+                    auth_info.append(f"service '{whoami['uuid']}'")
+                else:
+                    auth_info.append(
+                        ",".join(
+                            f"'{identity['id']}'" for identity in whoami["identities"]
+                        )
+                    )
             if self.api_key is not None:
                 auth_info.append(
                     f"with API key '{self.api_key[:min(len(self.api_key)//2, 8)]}...'"


### PR DESCRIPTION
Before:

```py
In [3]: c.context
Out[3]: <Context authenticated as  with API key '28aed21f...'>
```

After:

```py
In [3]: c.context
Out[3]: <Context authenticated as service 'f14ef9b-8848-4d80-b576-539161a7aadb' with API key '28aed21f...'>
```

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
