### PR TITLE
Fix bug with pickling `Context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+- A bug in `Context.__getstate__` caused picking to fail if applied twice.
+
 ## v0.1.0b5 (2024-06-27)
 
 ### Added

--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -47,11 +47,17 @@ def test_pickle_clients(structure_clients, tmpdir):
             for segment in segements:
                 original = original[segment]
             roundtripped = pickle.loads(pickle.dumps(original))
-            assert roundtripped.uri == original.uri
+            roundtripped_twice = pickle.loads(pickle.dumps(roundtripped))
+            assert roundtripped.uri == roundtripped_twice.uri == original.uri
 
 
 def test_lock_round_trip(tmpdir):
     cache = Cache(tmpdir / "http_response_cache.db")
     cache_round_tripped = pickle.loads(pickle.dumps(cache))
+    cache_round_tripped_twice = pickle.loads(pickle.dumps(cache_round_tripped))
     # implementation detail!
-    assert cache._lock.lock is cache_round_tripped._lock.lock
+    assert (
+        cache._lock.lock
+        is cache_round_tripped._lock.lock
+        is cache_round_tripped_twice._lock.lock
+    )

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -238,6 +238,7 @@ class Context:
             )
         self.http_client = httpx.Client(
             verify=verify,
+            transport=Transport(cache=cache),
             cookies=cookies,
             timeout=timeout,
             headers=headers,
@@ -246,6 +247,7 @@ class Context:
         )
         self._token_cache = token_cache
         self._cache = cache
+        self._verify = verify
         self.server_info = server_info
 
     @classmethod


### PR DESCRIPTION
Unit test reproduces reported bug:

```
E       AttributeError: 'Context' object has no attribute '_verify'
```

Next commit fixes bug.


### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
