### PR TITLE
💉 Add health check for hosting containerized tiled instances

### DIFF
--- a/tiled/_tests/test_routes.py
+++ b/tiled/_tests/test_routes.py
@@ -5,7 +5,7 @@ from starlette.status import HTTP_200_OK
 from ..server.app import build_app
 
 
-@pytest.mark.parametrize("path", ["/", "/docs"])
+@pytest.mark.parametrize("path", ["/", "/docs", "/healthz"])
 @pytest.mark.asyncio
 async def test_meta_routes(path):
     app = build_app({})

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -217,6 +217,12 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
 
     app = FastAPI(lifespan=lifespan)
 
+    # Healthcheck for deployment to containerized systems, needs to preempt other responses.
+    # Standardized for Kubernetes, but also used by other systems.
+    @app.get("/healthz", status_code=201)
+    async def healthz():
+        return {"status": "ready"}
+
     if SHARE_TILED_PATH:
         # If the distribution includes static assets, serve UI routes.
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -219,7 +219,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
 
     # Healthcheck for deployment to containerized systems, needs to preempt other responses.
     # Standardized for Kubernetes, but also used by other systems.
-    @app.get("/healthz", status_code=201)
+    @app.get("/healthz", status_code=200)
     async def healthz():
         return {"status": "ready"}
 


### PR DESCRIPTION
Kubernetes and other container orchestration platforms require pods that expose themselves as services to prove that they are alive and ready to handle HTTP responses, while this response can be baked into deployment yml, it's considered best practice to actually have the service return something indicating that it is healthy.

This implements the spec defined in the [Kubernetes Readyness](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) Probe section.

This resolves part of issue #648