### PR TITLE
Accept Python dict from client "write_dataframe" and TableAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Added
+- Add method to `TableAdapter` which accepts a Python dictionary.
+
+### Changed
+- Make `tiled.client` accept a Python dictionary when fed to `write_dataframe()`.
+- The `generated_minimal` example no longer requires pandas and instead uses a Python dict.
+
 ### Fixed
 - A bug in `Context.__getstate__` caused picking to fail if applied twice.
 

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -174,6 +174,32 @@ def test_write_dataframe_partitioned(tree):
         assert result.specs == specs
 
 
+# @pytest.mark.filterwarnings(f"ignore:{WARNING_PANDAS_BLOCKS}:DeprecationWarning")
+def test_write_dataframe_dict(tree):
+    with Context.from_app(
+        build_app(tree, validation_registry=validation_registry)
+    ) as context:
+        client = from_context(context)
+
+        data = {f"Column{i}": (1 + i) * numpy.ones(5) for i in range(5)}
+        df = pandas.DataFrame(data)
+        metadata = {"scan_id": 1, "method": "A"}
+        specs = [Spec("SomeSpec")]
+
+        with record_history() as history:
+            client.write_dataframe(data, metadata=metadata, specs=specs)
+        # one request for metadata, one for data
+        assert len(history.requests) == 1 + 1
+
+        results = client.search(Key("scan_id") == 1)
+        result = results.values().first()
+        result_dataframe = result.read()
+
+        pandas.testing.assert_frame_equal(result_dataframe, df)
+        assert result.metadata == metadata
+        assert result.specs == specs
+
+
 @pytest.mark.parametrize(
     "coo",
     [

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -174,7 +174,6 @@ def test_write_dataframe_partitioned(tree):
         assert result.specs == specs
 
 
-# @pytest.mark.filterwarnings(f"ignore:{WARNING_PANDAS_BLOCKS}:DeprecationWarning")
 def test_write_dataframe_dict(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -58,6 +58,38 @@ class TableAdapter:
         )
 
     @classmethod
+    def from_pydict(
+        cls,
+        *args: Any,
+        metadata: Optional[JSON] = None,
+        specs: Optional[List[Spec]] = None,
+        access_policy: Optional[AccessPolicy] = None,
+        npartitions: int = 1,
+        **kwargs: Any,
+    ) -> "TableAdapter":
+        """
+
+        Parameters
+        ----------
+        args :
+        metadata :
+        specs :
+        access_policy :
+        npartitions :
+        kwargs :
+
+        Returns
+        -------
+
+        """
+        ddf = dask.dataframe.from_dict(*args, npartitions=npartitions, **kwargs)
+        if specs is None:
+            specs = [Spec("dataframe")]
+        return cls.from_dask_dataframe(
+            ddf, metadata=metadata, specs=specs, access_policy=access_policy
+        )
+
+    @classmethod
     def from_dask_dataframe(
         cls,
         ddf: dask.dataframe.DataFrame,

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -58,7 +58,7 @@ class TableAdapter:
         )
 
     @classmethod
-    def from_pydict(
+    def from_dict(
         cls,
         *args: Any,
         metadata: Optional[JSON] = None,

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -942,6 +942,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         if isinstance(dataframe, dask.dataframe.DataFrame):
             structure = TableStructure.from_dask_dataframe(dataframe)
+        elif isinstance(dataframe, dict):
+            structure = TableStructure.from_pydict(dataframe)
         else:
             structure = TableStructure.from_pandas(dataframe)
         client = self.new(

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -943,7 +943,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         if isinstance(dataframe, dask.dataframe.DataFrame):
             structure = TableStructure.from_dask_dataframe(dataframe)
         elif isinstance(dataframe, dict):
-            structure = TableStructure.from_pydict(dataframe)
+            structure = TableStructure.from_dict(dataframe)
         else:
             structure = TableStructure.from_pandas(dataframe)
         client = self.new(

--- a/tiled/examples/generated_minimal.py
+++ b/tiled/examples/generated_minimal.py
@@ -1,5 +1,4 @@
 import numpy
-import pandas
 import xarray
 
 from tiled.adapters.array import ArrayAdapter
@@ -11,14 +10,12 @@ tree = MapAdapter(
     {
         "A": ArrayAdapter.from_array(numpy.ones((100, 100))),
         "B": ArrayAdapter.from_array(numpy.ones((100, 100, 100))),
-        "C": DataFrameAdapter.from_pandas(
-            pandas.DataFrame(
-                {
-                    "x": 1 * numpy.ones(100),
-                    "y": 2 * numpy.ones(100),
-                    "z": 3 * numpy.ones(100),
-                }
-            ),
+        "C": DataFrameAdapter.from_pydict(
+            {
+                "x": 1 * numpy.ones(100),
+                "y": 2 * numpy.ones(100),
+                "z": 3 * numpy.ones(100),
+            },
             npartitions=3,
         ),
         "D": DatasetAdapter.from_dataset(

--- a/tiled/examples/generated_minimal.py
+++ b/tiled/examples/generated_minimal.py
@@ -2,7 +2,7 @@ import numpy
 import xarray
 
 from tiled.adapters.array import ArrayAdapter
-from tiled.adapters.dataframe import DataFrameAdapter
+from tiled.adapters.dataframe import TableAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.adapters.xarray import DatasetAdapter
 
@@ -10,7 +10,7 @@ tree = MapAdapter(
     {
         "A": ArrayAdapter.from_array(numpy.ones((100, 100))),
         "B": ArrayAdapter.from_array(numpy.ones((100, 100, 100))),
-        "C": DataFrameAdapter.from_pydict(
+        "C": TableAdapter.from_pydict(
             {
                 "x": 1 * numpy.ones(100),
                 "y": 2 * numpy.ones(100),

--- a/tiled/examples/generated_minimal.py
+++ b/tiled/examples/generated_minimal.py
@@ -10,7 +10,7 @@ tree = MapAdapter(
     {
         "A": ArrayAdapter.from_array(numpy.ones((100, 100))),
         "B": ArrayAdapter.from_array(numpy.ones((100, 100, 100))),
-        "C": TableAdapter.from_pydict(
+        "C": TableAdapter.from_dict(
             {
                 "x": 1 * numpy.ones(100),
                 "y": 2 * numpy.ones(100),

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -10,7 +10,10 @@ from ..utils import APACHE_ARROW_FILE_MIME_TYPE, XLSX_MIME_TYPE, modules_availab
 def serialize_arrow(df, metadata, preserve_index=True):
     import pyarrow
 
-    table = pyarrow.Table.from_pandas(df, preserve_index=preserve_index)
+    if isinstance(df, dict):
+        table = pyarrow.Table.from_pydict(df)
+    else:
+        table = pyarrow.Table.from_pandas(df, preserve_index=preserve_index)
     sink = pyarrow.BufferOutputStream()
     with pyarrow.ipc.new_file(sink, table.schema) as writer:
         writer.write_table(table)

--- a/tiled/structures/table.py
+++ b/tiled/structures/table.py
@@ -48,7 +48,7 @@ class TableStructure:
         return cls(arrow_schema=data_uri, npartitions=1, columns=list(df.columns))
 
     @classmethod
-    def from_pydict(cls, d):
+    def from_dict(cls, d):
         import pyarrow
 
         schema_bytes = pyarrow.Table.from_pydict(d).schema.serialize()

--- a/tiled/structures/table.py
+++ b/tiled/structures/table.py
@@ -47,6 +47,15 @@ class TableStructure:
         data_uri = B64_ENCODED_PREFIX + schema_b64
         return cls(arrow_schema=data_uri, npartitions=1, columns=list(df.columns))
 
+    @classmethod
+    def from_pydict(cls, pd):
+        import pyarrow
+
+        schema_bytes = pyarrow.Table.from_pydict(pd).schema.serialize()
+        schema_b64 = base64.b64encode(schema_bytes).decode("utf-8")
+        data_uri = B64_ENCODED_PREFIX + schema_b64
+        return cls(arrow_schema=data_uri, npartitions=1, columns=list(pd.keys()))
+
     @property
     def arrow_schema_decoded(self):
         import pyarrow

--- a/tiled/structures/table.py
+++ b/tiled/structures/table.py
@@ -48,13 +48,13 @@ class TableStructure:
         return cls(arrow_schema=data_uri, npartitions=1, columns=list(df.columns))
 
     @classmethod
-    def from_pydict(cls, pd):
+    def from_pydict(cls, d):
         import pyarrow
 
-        schema_bytes = pyarrow.Table.from_pydict(pd).schema.serialize()
+        schema_bytes = pyarrow.Table.from_pydict(d).schema.serialize()
         schema_b64 = base64.b64encode(schema_bytes).decode("utf-8")
         data_uri = B64_ENCODED_PREFIX + schema_b64
-        return cls(arrow_schema=data_uri, npartitions=1, columns=list(pd.keys()))
+        return cls(arrow_schema=data_uri, npartitions=1, columns=list(d.keys()))
 
     @property
     def arrow_schema_decoded(self):


### PR DESCRIPTION
In ref of #733. 

Both cases insist upon a dataframe-compatible shape. For `write_dataframe`:
```
d = {'a': [1,2,3], 'b': [4,5,6,7]}
c.write_dataframe(d, key='n')
[...]
ArrowInvalid: Column 1 named b expected length 3 but got length 4
```
`pyarrow.lib.Table.validate()` is in the stack trace, and docs say that a pyarrow Table is:

> A collection of top-level named, **equal length** Arrow arrays.


For TableAdapter:
```
d = {'a': [1,2,3,4,5], 'b': [4,5,6,7,8,9]}
tdf = DataFrameAdapter.from_pydict(d, npartitions=1)
[...]
ValueError: An error occurred while calling the from_dict method registered to the pandas backend.
Original Message: All arrays must be of the same length
```
This comes from `dask.dataframe.from_dict`.


Lastly, Dan pointed out that this dict support let us slightly simplify `generated_minimal.py`, and I've confirmed that a simple dict replicates [the example ](https://blueskyproject.io/tiled/how-to/direct-client.html#from-a-service-side-tree-instance)identically.

```
client['C'].read()
Out[4]:
      x    y    z
0   1.0  2.0  3.0
1   1.0  2.0  3.0
2   1.0  2.0  3.0
3   1.0  2.0  3.0
4   1.0  2.0  3.0
..  ...  ...  ...
95  1.0  2.0  3.0
96  1.0  2.0  3.0
97  1.0  2.0  3.0
98  1.0  2.0  3.0
99  1.0  2.0  3.0

[100 rows x 3 columns]
```

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
