### PR TITLE
Rename path argument to "dataset" in hdf5_lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Make `tiled.client` accept a Python dictionary when fed to `write_dataframe()`.
 - The `generated_minimal` example no longer requires pandas and instead uses a Python dict.
 - Remove unused pytest-warning ignores from `test_writing.py`.
+- Rename argument in `hdf5_lookup` function from `path` to `dataset` to reflect change in `ophyd_async`
 
 ### Fixed
 - A bug in `Context.__getstate__` caused picking to fail if applied twice.

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -385,6 +385,7 @@ def hdf5_lookup(
     specs: Optional[List[Spec]] = None,
     access_policy: Optional[AccessPolicy] = None,
     dataset: Optional[Union[List[Path], List[str]]] = None,
+    path: Optional[Union[List[Path], List[str]]] = None,
 ) -> Union[HDF5Adapter, ArrayAdapter]:
     """
 
@@ -398,12 +399,17 @@ def hdf5_lookup(
     specs :
     access_policy :
     dataset :
+    path :
 
     Returns
     -------
 
     """
-    dataset = dataset or []
+
+    if dataset is not None and path is not None:
+        raise ValueError("dataset and path kwargs should not both be set!")
+
+    dataset = dataset or path or []
     adapter = HDF5Adapter.from_uri(
         data_uri,
         structure=structure,

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -384,7 +384,7 @@ def hdf5_lookup(
     libver: str = "latest",
     specs: Optional[List[Spec]] = None,
     access_policy: Optional[AccessPolicy] = None,
-    path: Optional[Union[List[Path], List[str]]] = None,
+    dataset: Optional[Union[List[Path], List[str]]] = None,
 ) -> Union[HDF5Adapter, ArrayAdapter]:
     """
 
@@ -397,13 +397,13 @@ def hdf5_lookup(
     libver :
     specs :
     access_policy :
-    path :
+    dataset :
 
     Returns
     -------
 
     """
-    path = path or []
+    dataset = dataset or []
     adapter = HDF5Adapter.from_uri(
         data_uri,
         structure=structure,
@@ -413,7 +413,7 @@ def hdf5_lookup(
         specs=specs,
         access_policy=access_policy,
     )
-    for segment in path:
+    for segment in dataset:
         adapter = adapter.get(segment)  # type: ignore
         if adapter is None:
             raise KeyError(segment)


### PR DESCRIPTION
### Checklist
- [X] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section

Recent ophyd_async change renamed the internal HDF path parameter passed to the stream resource to `dataset` from `path`.

Required to merge this in sync with https://github.com/bluesky/bluesky/pull/1790. 

See: https://github.com/bluesky/ophyd-async/blob/5ac94e283b170b603df42a7d5fe33fd7f2786524/src/ophyd_async/core/_hdf_dataset.py#L64