### PR TITLE
ENH: add alembic migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Added
 - Add method to `TableAdapter` which accepts a Python dictionary.
 - Added an `Arrow` adapter which supports reading/writing arrow tables via `RecordBatchFileReader`/`RecordBatchFileWriter`.
+- Add an alembic catalog migration script to rename `path` parameters of HDF5 nodes to `dataset`.
 
 ### Changed
 - Make `tiled.client` accept a Python dictionary when fed to `write_dataframe()`.

--- a/tiled/catalog/migrations/versions/562203c724c7_change_path_to_dataset_in_hdf5_assets.py
+++ b/tiled/catalog/migrations/versions/562203c724c7_change_path_to_dataset_in_hdf5_assets.py
@@ -1,0 +1,39 @@
+"""Change 'path' to 'dataset' in HDF5 assets
+
+Revision ID: 562203c724c7
+Revises: ed3a4223a600
+Create Date: 2024-08-09 10:13:36.384838
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from tiled.catalog.orm import JSONVariant
+
+# revision identifiers, used by Alembic.
+revision = '562203c724c7'
+down_revision = 'ed3a4223a600'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    connection = op.get_bind()
+    nodes = sa.Table(
+        "nodes",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer),
+        sa.Column("metadata", JSONVariant),
+    )
+
+    # Loop over all nodes that have 'parameters' field, choose and update those related to hdf5 files
+    condition = sa.text("CAST(nodes.metadata->>'parameters' AS TEXT) != ''")
+    cursor = connection.execute(sa.select(nodes.c.id, nodes.c.metadata).filter(condition).select_from(nodes))
+    for _id, _md in cursor:
+        if 'hdf5' in (_md.get('mimetype', '') + _md.get('spec', '')).lower():
+                if isinstance(_md['parameters'], dict) and ('path' in _md['parameters'].keys()):
+                    _md['parameters']['dataset'] = _md['parameters'].pop('path')
+                    connection.execute(nodes.update().where(nodes.c.id == _id).values(metadata=_md))
+
+def downgrade():
+    # This _could_ be implemented but we will wait for a need since we are
+    # still in alpha releases.
+    raise NotImplementedError

--- a/tiled/catalog/migrations/versions/83889e049ddc_add_table_to_structurefamily_enum.py
+++ b/tiled/catalog/migrations/versions/83889e049ddc_add_table_to_structurefamily_enum.py
@@ -31,7 +31,7 @@ def upgrade():
     connection = op.get_bind()
 
     if connection.engine.dialect.name == "postgresql":
-        # This change must be committed befor ethe new 'table' enum value can be used.
+        # This change must be committed before the new 'table' enum value can be used.
         with op.get_context().autocommit_block():
             op.execute(
                 sa.text(


### PR DESCRIPTION
This PR adds an alembic catalog migration script that searches for `path` parameter in Tiled nodes corresponding to hdf5 arrays and changes the key to `dataset`.

This is related to PR #775 and recent changes in the [ophyd-async schema](https://github.com/bluesky/ophyd-async/blob/5ac94e283b170b603df42a7d5fe33fd7f2786524/src/ophyd_async/core/_hdf_dataset.py#L64).

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
