### PR TITLE
🔑->🗑️ Enable Tiled Admins to delete API Keys belonging to other user's principals

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -658,7 +658,7 @@ def test_api_key_bypass_scopes(enter_username_password, principals_context):
 
 
 def test_admin_delete_principal_apikey(
-    enter_password,
+    enter_username_password,
     principals_context,
 ):
     """
@@ -666,7 +666,7 @@ def test_admin_delete_principal_apikey(
     """
     with principals_context["context"] as context:
         # Log in as Bob (Ordinary user)
-        with enter_password("secret2"):
+        with enter_username_password("bob", "secret2"):
             context.authenticate(username="bob")
 
         # Create an ordinary user API Key
@@ -675,7 +675,7 @@ def test_admin_delete_principal_apikey(
         context.logout()
 
         # Log in as Alice (Admin)
-        with enter_password("secret1"):
+        with enter_username_password("alice", "secret1"):
             context.authenticate(username="alice")
 
         # Delete the created API Key via service principal

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -677,7 +677,7 @@ def test_admin_delete_principal_apikey(
         principal_uuid = principals_context["uuid"][username]
         api_key_info = context.admin.create_api_key(principal_uuid, scopes=scopes)
         # Delete the created API Key via service principal
-        context.admin.delete_service_principal_apikey(
+        context.admin.revoke_api_key(
             principal_uuid, api_key_info["first_eight"]
         )
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -402,7 +402,10 @@ class Context:
 
     def create_api_key(self, scopes=None, expires_in=None, note=None):
         """
-        Generate a new API for the currently-authenticated user.
+        Generate a new API key.
+
+        Users with administrative scopes may use ``Context.admin.revoke_api_key``
+        to create API keys on behalf of other users or services.
 
         Parameters
         ----------
@@ -426,12 +429,17 @@ class Context:
 
     def revoke_api_key(self, first_eight):
         """
-        Destroy a user's API key
+        Revoke an API key.
+
+        The API key must belong to the currently-authenticated user or service.
+        Users with administrative scopes may use ``Context.admin.revoke_api_key``
+        to revoke API keys belonging to other users.
 
         Parameters
         ----------
         first_eight : str
-            Limit the chances of accidental deletion with this confirmation.
+            Identify the API key to be deleted by passing its first 8 characters.
+            (Any additional characters passed will be truncated.)
         """
         handle_error(
             self.http_client.delete(
@@ -861,14 +869,17 @@ class Admin:
 
     def revoke_api_key(self, uuid, first_eight=None):
         """
-        Destroy ANY service principal's API key.
+        Revoke an API key belonging to any user or service.
 
         Parameters
         ----------
         uuid : str
-            Identify the principal who's API key will be deleted.
+            Identify the principal whose API key will be deleted. This is
+            required in order to reduce the chance of accidentally revoking
+            the wrong key.
         first_eight : str
-            Limit the chances of accidental deletion with this confirmation.
+            Identify the API key to be deleted by passing its first 8 characters.
+            (Any additional characters passed will be truncated.)
         """
         return handle_error(
             self.context.http_client.delete(

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -437,7 +437,7 @@ class Context:
             self.http_client.delete(
                 self.server_info["authentication"]["links"]["apikey"],
                 headers={"x-csrf": self.http_client.cookies["tiled_csrf"]},
-                params={"first_eight": first_eight},
+                params={"first_eight": first_eight[:8]},
             )
         )
 
@@ -874,7 +874,7 @@ class Admin:
             self.context.http_client.delete(
                 f"{self.base_url}/auth/principal/{uuid}/apikey",
                 headers={"Accept": MSGPACK_MIME_TYPE},
-                params={"first_eight": first_eight},
+                params={"first_eight": first_eight[:8]},
             )
         )
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -837,6 +837,25 @@ class Admin:
             )
         ).json()
 
+    def delete_service_principal_apikey(self, uuid, first_eight=None):
+        """
+        Destroy a service principal's API key.
+
+        Parameters
+        ----------
+        uuid : str
+            Identify the principal who's API key will be deleted.
+        first_eight : str
+            Limit the chances of accidental deletion with this confirmation.
+        """
+        return handle_error(
+            self.context.http_client.delete(
+                f"{self.base_url}/auth/principal/{uuid}/apikey",
+                headers={"Accept": MSGPACK_MIME_TYPE},
+                params={"first_eight": first_eight},
+            )
+        )
+
 
 class CannotPrompt(Exception):
     pass

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -412,6 +412,14 @@ class Context:
         ).json()
 
     def revoke_api_key(self, first_eight):
+        """
+        Destroy a user's API key
+
+        Parameters
+        ----------
+        first_eight : str
+            Limit the chances of accidental deletion with this confirmation.
+        """
         handle_error(
             self.http_client.delete(
                 self.server_info["authentication"]["links"]["apikey"],
@@ -837,9 +845,9 @@ class Admin:
             )
         ).json()
 
-    def delete_service_principal_apikey(self, uuid, first_eight=None):
+    def revoke_api_key(self, uuid, first_eight=None):
         """
-        Destroy a service principal's API key.
+        Destroy ANY service principal's API key.
 
         Parameters
         ----------

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -916,7 +916,7 @@ async def principal(
     "/principal/{uuid}/apikey",
     response_model=schemas.Principal,
 )
-async def delete_service_principal_apikey(
+async def revoke_apikey_for_principal(
     request: Request,
     uuid: uuid_module.UUID,
     first_eight: str,


### PR DESCRIPTION
### Checklist
- [ ] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

Resolves #766 enhancement request by providing a way for admins to delete keys belonging to other users via principal, through the `api/v1/auth/principal/{principal_uuid}/apikey?first_eight={first_eight}'` endpoint.