### PR TITLE
Fix regression in serialization of `memoryview`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Follow-up fix to compatibility with Starlette v0.38.0
 - Adapt to change in dask public API in dask 2024.9.0.
 
 ## v0.1.0b8 (2024-09-06)

--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -12,6 +12,7 @@ from starlette.status import HTTP_400_BAD_REQUEST, HTTP_406_NOT_ACCEPTABLE
 from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter
 from ..client import Context, from_context
+from ..serialization.array import as_buffer
 from ..server.app import build_app
 from .utils import fail_with_status_code
 
@@ -163,3 +164,9 @@ def test_array_interface(context):
         # smoke test
         v.chunks
         v.dims
+
+
+@pytest.mark.parametrize("kind", list(array_cases))
+def test_as_buffer(kind):
+    output = as_buffer(array_cases[kind], {})
+    assert len(output) == len(bytes(output))

--- a/tiled/_tests/test_server.py
+++ b/tiled/_tests/test_server.py
@@ -74,3 +74,9 @@ def test_500_response(server):
     client = from_uri(server, api_key=API_KEY)
     response = client.context.http_client.get(f"{server}/error")
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+
+
+def test_writing_integration(server):
+    client = from_uri(server, api_key=API_KEY)
+    x = client.write_array([1, 2, 3], key="array")
+    x[:]

--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -17,7 +17,7 @@ def as_buffer(array, metadata):
     # The memoryview path fails for datetime type (and possibly some others?)
     # but it generally works for standard types like int, float, bool, str.
     try:
-        return memoryview(numpy.ascontiguousarray(array))
+        return memoryview(numpy.ascontiguousarray(array)).cast("B")
     except ValueError:
         return numpy.asarray(array).tobytes()
 


### PR DESCRIPTION
This is a follow up to #781, adjusting to an upstream change in Starlette.

The crux of the issue is that `len(memoryview(array)) != len(bytes(memoryview(array)))` unless the memoryview is cast to bytes `"B"`.

From inside `tiled.serialization.array.as_buffer`:

```py
(Pdb) l
 17  	    # The memoryview path fails for datetime type (and possibly some others?)
 18  	    # but it generally works for standard types like int, float, bool, str.
 19  	    try:
 20  	        result = memoryview(numpy.ascontiguousarray(array))
 21  	        breakpoint()
 22  ->	        return result
 23  	    except ValueError:
 24  	        result = numpy.asarray(array).tobytes()
 25  	        breakpoint()
 26  	        return result
 27  	
(Pdb) p array
array([1, 2, 3])
(Pdb) numpy.ascontiguousarray(array) is array
True
(Pdb) p memoryview(numpy.ascontiguousarray(array))
<memory at 0x730b20567f40>
(Pdb) p bytes(memoryview(numpy.ascontiguousarray(array)))
b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00'
(Pdb) p array.tobytes()
b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00'
(Pdb) p len(memoryview(numpy.ascontiguousarray(array)))
3
(Pdb) p len(bytes(memoryview(numpy.ascontiguousarray(array))))
24
```

This PR adds a unit test on `as_buffer` and an integration test of writing arrays. Interestingly, this bug does not present when we test with ASGI. It only presents when we push the array through an actual socket, such that the the metadata on the `memoryview` does not pass from server to client. This is why it was not caught by our existing CI tests, which use ASGI. The added integration test runs a TCP server.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
