### PR TITLE
FIX: Remove deprecated sphinx API.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,8 +113,6 @@ todo_include_todos = False
 html_theme = "sphinx_rtd_theme"
 import sphinx_rtd_theme
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
```
sphinx.errors.SphinxWarning: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```