### PR TITLE
Edit api creation docs to reflect correct CLI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Add HTTP endpoint `PATCH /array/full/{path}` to enable updating and
   optionally _extending_ an existing array.
 - Add associated Python client method `ArrayClient.patch`.
+- Minor fix to api key docs to reflect correct CLI usage.
 
 ## v0.1.0b11 (2024-11-14)
 

--- a/docs/source/how-to/api-keys.md
+++ b/docs/source/how-to/api-keys.md
@@ -188,7 +188,7 @@ Finally, the `--note` option can be used to label an API key as a reminder of
 where or how it is being used.
 
 ```
-$ tiled api_key create --note="Data validation pipeline" --scopes read:metadata read:data
+$ tiled api_key create --note="Data validation pipeline" --scopes read:metadata --scopes read:data
 573928c62e53096321fb874847bcc6a90ea636eebd8acbd7c5e9d18d2859847b3bfb4f19
 $ tiled api_key list
 First 8   Expires at (UTC)     Latest activity      Note                      Scopes


### PR DESCRIPTION
### Checklist
- [X] Add a Changelog entry
- [X] Add the ticket number which this PR closes to the comment section (N/A)

Currently, if the docs are followed, we get a typer error:

```
(2024-2.3-py311-tiled) [jwlodek@xf31id1-ws3 ~]$ tiled api_key create --scopes read:metadata read:data --profile nsls2
Usage: tiled api_key create [OPTIONS]
Try 'tiled api_key create --help' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────╮
│ Got unexpected extra argument (read:data)                                                         │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
```

This is because list arguments with `typer` work by using the same flag multiple times. I.e:

```
tiled api_key create --scopes read:metadata --scopes read:data --profile nsls2
```

If you run the above, it works as expected. My guess is that it is possible that this may need to be fixed in the docs in other places as well for other `List` CLI args.