### PR TITLE
feat: tty free login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - A new method `DataFrameClient.append_partition`.
 - Support for registering Groups and Datasets _within_ an HDF5 file
 - Tiled version is logged by server at startup.
+- Hook to authentication prompt to make password login available without TTY.
 
 ### Fixed
 

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -95,6 +95,7 @@ def test_password_auth(enter_username_password, config):
 
 
 def test_password_auth_hook(config):
+    """Verify behavior with user-defined 'prompt_for_reauthentication' hook."""
     with Context.from_app(build_app_from_config(config)) as context:
         # Log in as Alice.
         context.authenticate(username="alice", password="secret1")

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -104,7 +104,7 @@ def test_password_auth_hook(config):
         with pytest.raises(CannotPrompt):
             context.http_client.auth.sync_clear_token("refresh_token")
             context.http_client.auth.sync_clear_token("access_token")
-            context.authenticate(username="alice")
+            context.authenticate(username="alice", prompt_for_reauthentication=False)
 
         # Log in as Bob.
         context.authenticate(username="bob", password="secret2")

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -96,7 +96,7 @@ def test_password_auth(enter_username_password, config):
 
 def test_password_auth_hook(config):
     with Context.from_app(build_app_from_config(config)) as context:
-        # Passing prompt_for_reauthentication=False should riase an
+        # Passing prompt_for_reauthentication=False should raise
         with pytest.raises(CannotPrompt):
             context.authenticate(
                 username="alice", password="secret1", prompt_for_reauthentication=False

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -61,11 +61,12 @@ def enter_username_password(username, password):
     ...     # Run code that calls prompt_for_credentials and subsequently getpass.getpass().
     """
 
+    original_prompt = context.PROMPT_FOR_REAUTHENTICATION
+    original_credentials = context.prompt_for_credentials
+    context.PROMPT_FOR_REAUTHENTICATION = True
+    context.prompt_for_credentials = lambda u, p: (username, password)
     try:
-        original_prompt = context.PROMPT_FOR_REAUTHENTICATION
-        original_credentials = context.prompt_for_credentials
-        context.PROMPT_FOR_REAUTHENTICATION = True
-        context.prompt_for_credentials = lambda u, p: (username, password)
+        # Ensures that raise in calling routine does not prevent context from being exited.
         yield
     finally:
         context.PROMPT_FOR_REAUTHENTICATION = original_prompt

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -55,22 +55,23 @@ async def temp_postgres(uri):
 @contextlib.contextmanager
 def enter_username_password(username, password):
     """
-    Override getpass, used like:
+    Override getpass, or prompt_for_credentials with username only
+    used like:
 
     >>> with enter_password(...):
     ...     # Run code that calls getpass.getpass().
     """
 
     original_prompt = context.PROMPT_FOR_REAUTHENTICATION
-    original_getusername = context.prompt_for_username
+    original_credentials = context.prompt_for_credentials
     original_getpass = getpass.getpass
     context.PROMPT_FOR_REAUTHENTICATION = True
-    context.prompt_for_username = lambda u: username
+    context.prompt_for_credentials = lambda u: username, password
     setattr(getpass, "getpass", lambda: password)
     yield
     setattr(getpass, "getpass", original_getpass)
     context.PROMPT_FOR_REAUTHENTICATION = original_prompt
-    context.prompt_for_username = original_getusername
+    context.prompt_for_credentials = original_credentials
 
 
 class URL_LIMITS(IntEnum):

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -1,5 +1,4 @@
 import contextlib
-import getpass
 import sqlite3
 import sys
 import tempfile

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -55,21 +55,18 @@ async def temp_postgres(uri):
 @contextlib.contextmanager
 def enter_username_password(username, password):
     """
-    Override getpass, or prompt_for_credentials with username only
+    Override getpass, when prompt_for_credentials with username only
     used like:
 
-    >>> with enter_password(...):
-    ...     # Run code that calls getpass.getpass().
+    >>> with enter_username_password(...):
+    ...     # Run code that calls prompt_for_credentials and subsequently getpass.getpass().
     """
 
     original_prompt = context.PROMPT_FOR_REAUTHENTICATION
     original_credentials = context.prompt_for_credentials
-    original_getpass = getpass.getpass
     context.PROMPT_FOR_REAUTHENTICATION = True
-    context.prompt_for_credentials = lambda u: username, password
-    setattr(getpass, "getpass", lambda: password)
+    context.prompt_for_credentials = lambda u, p: (username, password)
     yield
-    setattr(getpass, "getpass", original_getpass)
     context.PROMPT_FOR_REAUTHENTICATION = original_prompt
     context.prompt_for_credentials = original_credentials
 

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -61,13 +61,15 @@ def enter_username_password(username, password):
     ...     # Run code that calls prompt_for_credentials and subsequently getpass.getpass().
     """
 
-    original_prompt = context.PROMPT_FOR_REAUTHENTICATION
-    original_credentials = context.prompt_for_credentials
-    context.PROMPT_FOR_REAUTHENTICATION = True
-    context.prompt_for_credentials = lambda u, p: (username, password)
-    yield
-    context.PROMPT_FOR_REAUTHENTICATION = original_prompt
-    context.prompt_for_credentials = original_credentials
+    try:
+        original_prompt = context.PROMPT_FOR_REAUTHENTICATION
+        original_credentials = context.prompt_for_credentials
+        context.PROMPT_FOR_REAUTHENTICATION = True
+        context.prompt_for_credentials = lambda u, p: (username, password)
+        yield
+    finally:
+        context.PROMPT_FOR_REAUTHENTICATION = original_prompt
+        context.prompt_for_credentials = original_credentials
 
 
 class URL_LIMITS(IntEnum):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -30,6 +30,7 @@ def prompt_for_credentials(username, password):
     """
     if username is not None and password is not None:
         # If both are provided, return them as-is, without prompting.
+        # This is particularly useful for GUI clients without a TTY Console.
         return username, password
     elif username:
         username_reprompt = input(f"Username [{username}]: ")

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -27,7 +27,7 @@ def prompt_for_credentials(username, password):
     """
     Utility function that displays a username prompt.
     """
-    if username and password:
+    if username is not None and password is not None:
         # If both are provided, return them as-is, without prompting.
         return username, password
     elif username:
@@ -539,7 +539,7 @@ class Context:
             except CannotRefreshAuthentication:
                 # Continue below, where we will prompt for log in.
                 self.http_client.auth = None
-                if not prompt_for_reauthentication:
+                if not prompt_for_reauthentication and not password:
                     raise
             else:
                 # We have a live session for the specified provider and username already.
@@ -556,7 +556,7 @@ credentials in the stdin. Options:
   to force it to prompt.
 - Provide an API key in the environment variable TILED_API_KEY for Tiled to use.
 - Catch the CannotPrompt exception and handle it in your application if providing both
-  username and password programmatically.
+  username and password programmatically with prompt_for_reauthentication=True.
 """
             )
         self.http_client.auth = None


### PR DESCRIPTION
Closes #815 

## Adds
Hook to send password directly to authenticate. Not added to `login` since `context.authenticate` is meant for programatic use, and we probably shouldn't encourage general users to type their password without `getpass` protections. Tests are added to mirror auth tests. 
`prompt_for_reauthentication` is expected as True for the hook to function, and the `CannotPrompt` error is updated to reflect that. Alternatively, this could be updated to use `if not prompt_for_reauthentication and password is not UNSET`. 

## Fixes
Idempotency in context manager used by tests to avoid TTY input for context manager. (It was used in all tests previously, so idempotentcy was not relevant).

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
