### PR TITLE
📂🆙 Switch from appdirs to platformdirs

### DIFF
--- a/docs/source/how-to/profiles.md
+++ b/docs/source/how-to/profiles.md
@@ -67,7 +67,7 @@ including:
 
 Tiled will also look for profiles in locations specific to the
 operating system and the software environment,
-[in accordance](https://pypi.org/project/appdirs/) with
+[in accordance](https://pypi.org/project/platformdirs/) with
 [standards](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 To see the full list on your system:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ all = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "platformdirs",
     "asgi-correlation-id",
     "asyncpg",
     "awkward >=2.4.3",
@@ -75,6 +74,7 @@ all = [
     "packaging",
     "pandas",
     "pillow",
+    "platformdirs",
     "prometheus_client",
     "pyarrow",
     "pydantic >=2, <3",
@@ -102,7 +102,6 @@ array = [
 ]
 # This is the "kichen sink" fully-featured client dependency set.
 client = [
-    "platformdirs",
     "awkward >=2.4.3",
     "blosc2; python_version >= '3.10'",
     "dask[array]",
@@ -118,6 +117,7 @@ client = [
     "numpy",
     "orjson",
     "pandas",
+    "platformdirs",
     "pyarrow",
     "pyyaml",
     "rich",
@@ -173,7 +173,6 @@ formats = [
 ]
 # These are the requirements needed for basic client functionality.
 minimal-client = [
-    "platformdirs",
     "entrypoints",
     "httpx >=0.20.0,!=0.23.1",
     "json-merge-patch",
@@ -181,6 +180,7 @@ minimal-client = [
     "jsonschema",
     "msgpack >=1.0.0",
     "orjson",
+    "platformdirs",
     "pyyaml",
     "rich",
     "typer",
@@ -192,7 +192,6 @@ minimal-server = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "platformdirs",
     "asgi-correlation-id",
     "cachetools",
     "canonicaljson",
@@ -207,6 +206,7 @@ minimal-server = [
     "msgpack >=1.0.0",
     "orjson",
     "packaging",
+    "platformdirs",
     "prometheus_client",
     "pydantic >=2, <3",
     "pydantic-settings >=2, <3",
@@ -227,7 +227,6 @@ server = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "platformdirs",
     "asgi-correlation-id",
     "asyncpg",
     "awkward >=2.4.3",
@@ -255,6 +254,7 @@ server = [
     "packaging",
     "pandas",
     "pillow",
+    "platformdirs",
     "prometheus_client",
     "pyarrow",
     "pydantic >=2, <3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ all = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "appdirs",
+    "platformdirs",
     "asgi-correlation-id",
     "asyncpg",
     "awkward >=2.4.3",
@@ -102,7 +102,7 @@ array = [
 ]
 # This is the "kichen sink" fully-featured client dependency set.
 client = [
-    "appdirs",
+    "platformdirs",
     "awkward >=2.4.3",
     "blosc2; python_version >= '3.10'",
     "dask[array]",
@@ -173,7 +173,7 @@ formats = [
 ]
 # These are the requirements needed for basic client functionality.
 minimal-client = [
-    "appdirs",
+    "platformdirs",
     "entrypoints",
     "httpx >=0.20.0,!=0.23.1",
     "json-merge-patch",
@@ -192,7 +192,7 @@ minimal-server = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "appdirs",
+    "platformdirs",
     "asgi-correlation-id",
     "cachetools",
     "canonicaljson",
@@ -227,7 +227,7 @@ server = [
     "aiosqlite",
     "alembic",
     "anyio",
-    "appdirs",
+    "platformdirs",
     "asgi-correlation-id",
     "asyncpg",
     "awkward >=2.4.3",

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -9,8 +9,8 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
-import platformdirs
 import httpx
+import platformdirs
 
 from .utils import SerializableLock, TiledResponse
 

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
-import appdirs
+import platformdirs
 import httpx
 
 from .utils import SerializableLock, TiledResponse
@@ -187,7 +187,7 @@ class Cache:
             # Resolve this here, not at module scope, because the test suite
             # injects TILED_CACHE_DIR env var to use a temporary directory.
             TILED_CACHE_DIR = Path(
-                os.getenv("TILED_CACHE_DIR", appdirs.user_cache_dir("tiled"))
+                os.getenv("TILED_CACHE_DIR", platformdirs.user_cache_dir("tiled"))
             )
             # TODO Detect filesystem of TILED_CACHE_DIR. If it is a networked filesystem
             # use a temporary database instead.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -8,7 +8,7 @@ import urllib.parse
 import warnings
 from pathlib import Path
 
-import appdirs
+import platformdirs
 import httpx
 
 from .._version import __version__ as tiled_version
@@ -65,7 +65,7 @@ class Context:
         # Resolve this here, not at module scope, because the test suite
         # injects TILED_CACHE_DIR env var to use a temporary directory.
         TILED_CACHE_DIR = Path(
-            os.getenv("TILED_CACHE_DIR", appdirs.user_cache_dir("tiled"))
+            os.getenv("TILED_CACHE_DIR", platformdirs.user_cache_dir("tiled"))
         )
         headers.setdefault("accept-encoding", ACCEPT_ENCODING)
         # Set the User Agent to help the server fail informatively if the client
@@ -915,7 +915,7 @@ def _default_identity_filepath(api_uri):
     # Resolve this here, not at module scope, because the test suite
     # injects TILED_CACHE_DIR env var to use a temporary directory.
     TILED_CACHE_DIR = Path(
-        os.getenv("TILED_CACHE_DIR", appdirs.user_cache_dir("tiled"))
+        os.getenv("TILED_CACHE_DIR", platformdirs.user_cache_dir("tiled"))
     )
     return Path(
         TILED_CACHE_DIR, "default_identities", urllib.parse.quote_plus(str(api_uri))

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -8,8 +8,8 @@ import urllib.parse
 import warnings
 from pathlib import Path
 
-import platformdirs
 import httpx
+import platformdirs
 
 from .._version import __version__ as tiled_version
 from ..utils import UNSET, DictView

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -14,7 +14,7 @@ import warnings
 from functools import lru_cache
 from pathlib import Path
 
-import appdirs
+import platformdirs
 import jsonschema
 
 from .utils import parse
@@ -49,7 +49,7 @@ _all_paths = [
     ),  # hard-coded system path
     Path(
         os.getenv(
-            "TILED_SITE_PROFILES", Path(appdirs.site_config_dir("tiled"), "profiles")
+            "TILED_SITE_PROFILES", Path(platformdirs.site_config_dir("tiled"), "profiles")
         )
     ),  # XDG-compliant system path
     Path(sys.prefix, "etc", "tiled", "profiles"),  # environment
@@ -57,7 +57,7 @@ _all_paths = [
         os.getenv("TILED_PROFILES", Path.home() / ".config/tiled/profiles")
     ),  # hard-coded user path
     Path(
-        os.getenv("TILED_PROFILES", Path(appdirs.user_config_dir("tiled"), "profiles"))
+        os.getenv("TILED_PROFILES", Path(platformdirs.user_config_dir("tiled"), "profiles"))
     ),  # system-dependent user path
 ]
 # Remove duplicates (i.e. if XDG and hard-coded are the same on this system).

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -15,8 +15,8 @@ import warnings
 from functools import lru_cache
 from pathlib import Path
 
-import platformdirs
 import jsonschema
+import platformdirs
 
 from .utils import parse
 

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -6,6 +6,7 @@ See config.py for server configuration.
 It contains several functions that are factored to facilitate testing,
 but the user-facing functionality is striaghtforward.
 """
+
 import collections
 import collections.abc
 import os
@@ -49,7 +50,8 @@ _all_paths = [
     ),  # hard-coded system path
     Path(
         os.getenv(
-            "TILED_SITE_PROFILES", Path(platformdirs.site_config_dir("tiled"), "profiles")
+            "TILED_SITE_PROFILES",
+            Path(platformdirs.site_config_dir("tiled"), "profiles"),
         )
     ),  # XDG-compliant system path
     Path(sys.prefix, "etc", "tiled", "profiles"),  # environment
@@ -57,7 +59,9 @@ _all_paths = [
         os.getenv("TILED_PROFILES", Path.home() / ".config/tiled/profiles")
     ),  # hard-coded user path
     Path(
-        os.getenv("TILED_PROFILES", Path(platformdirs.user_config_dir("tiled"), "profiles"))
+        os.getenv(
+            "TILED_PROFILES", Path(platformdirs.user_config_dir("tiled"), "profiles")
+        )
     ),  # system-dependent user path
 ]
 # Remove duplicates (i.e. if XDG and hard-coded are the same on this system).


### PR DESCRIPTION
Resolves #743 which is of the same name. A self explanatory upgrade to get around the depreciation of `appdirs`