### PR TITLE
Move curl and httpie to final layer in dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+- Fix curl and httpie installation in docker image.
+
 ### Added
 
 - Add HTTP endpoint `PATCH /array/full/{path}` to enable updating and

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ FROM python:3.12-slim as builder
 # We need gcc to compile thriftpy2, a secondary dependency.
 RUN apt-get -y update && apt-get install -y git gcc
 
-# We want cURL and httpie so healthchecks can be performed within the container
-RUN apt-get install -y curl httpie
-
 WORKDIR /code
 
 # Ensure logs and error messages do not get stuck in a buffer.
@@ -52,6 +49,8 @@ FROM python:3.12-slim as runner
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+# We want cURL and httpie so healthchecks can be performed within the container
+RUN apt-get update && apt-get install -y curl httpie
 
 WORKDIR /deploy
 RUN mkdir /deploy/config


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry

#794 attempted to add `curl` and `httpie` to the docker image as a tool to be used in health checks. However, it was added to the `builder` layer, not the `runner` layer and hence not available at run time. This PR moves this installation.

Before this change:

```
docker exec -it ta991 bash
root@16a473d8c0e1:/deploy# curl
bash: curl: command not found
root@16a473d8c0e1:/deploy# 
```

After:
```
docker exec -it a901 bash
root@a90185b67888:/deploy# curl
curl: try 'curl --help' or 'curl --manual' for more information
root@a90185b67888:/deploy# 
```