### PR TITLE
Feat: client driven timeout

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -7,6 +7,7 @@ import time
 
 import numpy
 import pytest
+from click import prompt
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
 
 from ..adapters.array import ArrayAdapter
@@ -130,6 +131,21 @@ def test_password_auth_hook(config):
             prompt_for_reauthentication=lambda u, p: ("alice", "secret1"),
         )
         assert "authenticated as 'alice'" in repr(context)
+
+
+def test_refresh_expiration(config):
+    """Ensure we can force an early expiration of refresh tokens"""
+
+    with Context.from_app(build_app_from_config(config)) as context:
+        # Log in as Alice with a 1 sec refresh token expiration
+        spec, username = context.authenticate(
+            username="alice", password="secret1", refresh_token_max_age=1
+        )
+        assert "authenticated as 'alice'" in repr(context)
+        time.sleep(1.5)
+        # Attempt to refresh the token should fail
+        with pytest.raises(CannotRefreshAuthentication):
+            context.force_auth_refresh()
 
 
 def test_logout(enter_username_password, config, tmpdir):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -491,6 +491,7 @@ class Context:
         set_default=True,
         *,
         password=UNSET,
+        refresh_token_max_age: Optional[int] = None,
     ):
         """
         See login. This is for programmatic use.
@@ -572,6 +573,8 @@ credentials in the stdin. Options:
                 "username": username,
                 "password": password,
             }
+            if refresh_token_max_age is not None:
+                form_data["refresh_token_max_age"] = refresh_token_max_age
             token_response = self.http_client.post(
                 auth_endpoint, data=form_data, auth=None
             )

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -78,6 +78,9 @@ class Settings(BaseSettings):
             max_overflow=self.database_max_overflow,
         )
 
+    def get_refresh_token_max_age(self, requested_max_age: timedelta) -> timedelta:
+        return min(requested_max_age, self.refresh_token_max_age)
+
 
 @lru_cache()
 def get_settings():


### PR DESCRIPTION
Give the client a chance to manually reduce their refresh token lifetime. Example being, I want to auth but know I will only be active for 2 hours before leaving the beamline; this provides a secondary safety mechanism should I forget to logout. 

Closes #819 

### Checklist
- [ ] Add a Changelog entry
- [ x ] Add the ticket number which this PR closes to the comment section
