### PR TITLE
Fix: Regression due to httpx updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ## Unreleased
 
 - Fix curl and httpie installation in docker image.
+- Fix the construction of urls by passing query parameters as kwargs.
 
 ### Added
 

--- a/tiled/_tests/test_dataframe.py
+++ b/tiled/_tests/test_dataframe.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs, urlparse
+
 import numpy
 import pandas.testing
 import pytest
@@ -150,6 +152,7 @@ def test_http_fetch_columns(context, http_method, link):
     original_df = tree["wide"].read()
     columns = list(original_df.columns)[::2]  # Pick a subset of columns
     params = {
+        **parse_qs(urlparse(url_path).query),
         "partition": 0,  # Used by /table/partition; ignored by /table/full
         "column": columns,
     }
@@ -176,6 +179,7 @@ def test_deprecated_query_parameter(context):
     client = from_context(context)
     url_path = client["basic"].item["links"]["partition"]
     params = {
+        **parse_qs(urlparse(url_path).query),
         "partition": 0,
         "field": "x",
     }
@@ -189,6 +193,7 @@ def test_redundant_query_parameters(context):
     client = from_context(context)
     url_path = client["basic"].item["links"]["partition"]
     original_params = {
+        **parse_qs(urlparse(url_path).query),
         "partition": 0,
         "field": "x",
         "column": "y",

--- a/tiled/_tests/test_routes.py
+++ b/tiled/_tests/test_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from starlette.status import HTTP_200_OK
 
 from ..server.app import build_app
@@ -8,7 +8,7 @@ from ..server.app import build_app
 @pytest.mark.parametrize("path", ["/", "/docs", "/healthz"])
 @pytest.mark.asyncio
 async def test_meta_routes(path):
-    app = build_app({})
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=build_app({}))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(path)
     assert response.status_code == HTTP_200_OK

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -176,7 +176,7 @@ class _DaskArrayClient(BaseClient):
 
     def write_block(self, array, block, slice=...):
         url_path = self.item["links"]["block"].format(*block)
-        query_params = {
+        params = {
             **parse_qs(urlparse(url_path).query),
             **params_from_slice(slice),
         }
@@ -185,7 +185,7 @@ class _DaskArrayClient(BaseClient):
                 url_path,
                 content=array.tobytes(),
                 headers={"Content-Type": "application/octet-stream"},
-                params=query_params,
+                params=params,
             )
         )
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -55,7 +55,11 @@ class MetadataRevisions:
                 self.context.http_client.get(
                     self._link,
                     headers={"Accept": MSGPACK_MIME_TYPE},
-                    params={**parse_qs(urlparse(self._link).query), "page[offset]": offset, "page[limit]": limit},
+                    params={
+                        **parse_qs(urlparse(self._link).query),
+                        "page[offset]": offset,
+                        "page[limit]": limit,
+                    },
                 )
             ).json()
             (result,) = content["data"]

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -37,7 +37,11 @@ class MetadataRevisions:
             self.context.http_client.get(
                 self._link,
                 headers={"Accept": MSGPACK_MIME_TYPE},
-                params={"page[offset]": 0, "page[limit]": 0},
+                params={
+                    **parse_qs(urlparse(self._link).query),
+                    "page[offset]": 0,
+                    "page[limit]": 0,
+                },
             )
         ).json()
         length = content["meta"]["count"]
@@ -92,7 +96,11 @@ class MetadataRevisions:
             return result["data"]
 
     def delete_revision(self, n):
-        handle_error(self.context.http_client.delete(self._link, params={"number": n}))
+        handle_error(
+            self.context.http_client.delete(
+                self._link, params={**parse_qs(urlparse(self._link).query), "number": n}
+            )
+        )
 
 
 class BaseClient:
@@ -184,7 +192,10 @@ class BaseClient:
             self.context.http_client.get(
                 self.uri,
                 headers={"Accept": MSGPACK_MIME_TYPE},
-                params={"include_data_sources": self._include_data_sources},
+                params={
+                    **parse_qs(urlparse(self.uri).query),
+                    "include_data_sources": self._include_data_sources,
+                },
             )
         ).json()
         self._item = content["data"]
@@ -303,7 +314,11 @@ client or pass the optional parameter `include_data_sources=True` to
                 if asset.is_directory:
                     manifest = handle_error(
                         self.context.http_client.get(
-                            manifest_link, params={"id": asset.id}
+                            manifest_link,
+                            params={
+                                **parse_qs(urlparse(manifest_link).query),
+                                "id": asset.id,
+                            },
                         )
                     ).json()["manifest"]
                 else:
@@ -364,6 +379,7 @@ client or pass the optional parameter `include_data_sources=True` to
                             URL(
                                 bytes_link,
                                 params={
+                                    **parse_qs(urlparse(bytes_link).query),
                                     "id": asset.id,
                                     "relative_path": relative_path,
                                 },
@@ -378,7 +394,15 @@ client or pass the optional parameter `include_data_sources=True` to
                         ]
                     )
                 else:
-                    urls.append(URL(bytes_link, params={"id": asset.id}))
+                    urls.append(
+                        URL(
+                            bytes_link,
+                            params={
+                                **parse_qs(urlparse(bytes_link).query),
+                                "id": asset.id,
+                            },
+                        )
+                    )
                     paths.append(Path(base_path, ATTACHMENT_FILENAME_PLACEHOLDER))
         return download(self.context.http_client, urls, paths, max_workers=max_workers)
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -55,7 +55,7 @@ class MetadataRevisions:
                 self.context.http_client.get(
                     self._link,
                     headers={"Accept": MSGPACK_MIME_TYPE},
-                    params={"page[offset]": offset, "page[limit]": limit},
+                    params={**parse_qs(urlparse(self._link).query), "page[offset]": offset, "page[limit]": limit},
                 )
             ).json()
             (result,) = content["data"]
@@ -78,7 +78,7 @@ class MetadataRevisions:
                     self.context.http_client.get(
                         next_page_url,
                         headers={"Accept": MSGPACK_MIME_TYPE},
-                        params=params,
+                        params={**parse_qs(urlparse(next_page_url).query), **params},
                     )
                 ).json()
                 if len(result) == 0:
@@ -86,10 +86,6 @@ class MetadataRevisions:
                 else:
                     result["data"].append(content["data"])
                 next_page_url = content["links"]["next"]
-                if next_page_url:
-                    parsed_url = urlparse(next_page_url)
-                    params = parse_qs(parsed_url.query)
-                    next_page_url = parsed_url._replace(query="").geturl()
 
             return result["data"]
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -70,19 +70,17 @@ class MetadataRevisions:
             if offset is None:
                 offset = 0
             if item_.stop is None:
-                params = {"page[offset]": offset}
+                params = f"?page[offset]={offset}"
             else:
                 limit = item_.stop - offset
-                params = {"page[offset]": offset, "page[limit]": limit}
+                params = f"?page[offset]={offset}&page[limit]={limit}"
 
-            next_page_url = self._link
+            next_page_url = self._link + params
             result = []
             while next_page_url is not None:
                 content = handle_error(
                     self.context.http_client.get(
-                        next_page_url,
-                        headers={"Accept": MSGPACK_MIME_TYPE},
-                        params={**parse_qs(urlparse(next_page_url).query), **params},
+                        next_page_url, headers={"Accept": MSGPACK_MIME_TYPE}
                     )
                 ).json()
                 if len(result) == 0:

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -1,5 +1,6 @@
 import collections
 import collections.abc
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -140,7 +141,10 @@ Set an api_key as in:
             context.http_client.get(
                 item_uri,
                 headers={"Accept": MSGPACK_MIME_TYPE},
-                params={"include_data_sources": include_data_sources},
+                params={
+                    **parse_qs(urlparse(item_uri).query),
+                    "include_data_sources": include_data_sources,
+                },
             )
         ).json()
     except ClientError as err:
@@ -150,7 +154,7 @@ Set an api_key as in:
             and (context.http_client.auth is None)
         ):
             context.authenticate()
-            params = {}
+            params = (parse_qs(urlparse(item_uri).query),)
             if include_data_sources:
                 params["include_data_sources"] = True
             content = handle_error(

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -267,7 +267,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 self.context.http_client.get(
                     link,
                     headers={"Accept": MSGPACK_MIME_TYPE},
-                    params={**parse_qs(urlparse(link).query),**params},
+                    params={**parse_qs(urlparse(link).query), **params},
                 )
             ).json()
             self._cached_len = (

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -434,7 +434,6 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             }
             if self._include_data_sources:
                 params["include_data_sources"] = True
-            print(f"{next_page_url=}, {MSGPACK_MIME_TYPE=}, {params=}")
             content = handle_error(
                 self.context.http_client.get(
                     next_page_url,

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs, urlparse
+
 import dask
 import dask.dataframe.core
 import httpx
@@ -42,7 +44,10 @@ class _DaskDataFrameClient(BaseClient):
                     self.context.http_client.get(
                         self.uri,
                         headers={"Accept": MSGPACK_MIME_TYPE},
-                        params={"fields": "structure"},
+                        params={
+                            **parse_qs(urlparse(self.uri).query),
+                            "fields": "structure",
+                        },
                         timeout=TIMEOUT,
                     )
                 ).json()
@@ -79,7 +84,10 @@ class _DaskDataFrameClient(BaseClient):
                 self.context.http_client.get(
                     self.uri,
                     headers={"Accept": MSGPACK_MIME_TYPE},
-                    params={"fields": "structure"},
+                    params={
+                        **parse_qs(urlparse(self.uri).query),
+                        "fields": "structure",
+                    },
                 )
             ).json()
             columns = content["data"]["attributes"]["structure"]["columns"]
@@ -98,8 +106,8 @@ class _DaskDataFrameClient(BaseClient):
 
         See read_partition for a public version of this.
         """
-        params = {"partition": partition}
         URL_PATH = self.item["links"]["partition"]
+        params = {**parse_qs(urlparse(URL_PATH).query), "partition": partition}
         url_length_for_get_request = len(URL_PATH) + sum(
             _EXTRA_CHARS_PER_ITEM + len(column) for column in (columns or ())
         )

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs, urlparse
+
 import numpy
 import sparse
 from ndindex import ndindex
@@ -47,11 +49,12 @@ class SparseClient(BaseClient):
         # Fetch the data as an Apache Arrow table
         # with columns named dim0, dim1, ..., dimN, data.
         structure = self.structure()
-        params = params_from_slice(slice)
+        url_path = self.item["links"]["block"]
+        params = {**parse_qs(urlparse(url_path).query), **params_from_slice(slice)}
         params["block"] = ",".join(map(str, block))
         content = handle_error(
             self.context.http_client.get(
-                self.item["links"]["block"],
+                url_path,
                 headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
                 params=params,
             )
@@ -74,10 +77,11 @@ class SparseClient(BaseClient):
         # Fetch the data as an Apache Arrow table
         # with columns named dim0, dim1, ..., dimN, data.
         structure = self.structure()
-        params = params_from_slice(slice)
+        url_path = self.item["links"]["full"]
+        params = {**parse_qs(urlparse(url_path).query), **params_from_slice(slice)}
         content = handle_error(
             self.context.http_client.get(
-                self.item["links"]["full"],
+                url_path,
                 headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
                 params=params,
             )

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -3,6 +3,7 @@ import uuid
 from collections.abc import Hashable
 from pathlib import Path
 from threading import Lock
+from urllib.parse import parse_qs, urlparse
 from weakref import WeakValueDictionary
 
 import httpx
@@ -139,7 +140,12 @@ def export_util(file, format, get, link, params):
             format = ".".join(
                 suffix[1:] for suffix in Path(file).suffixes
             )  # e.g. "csv"
-        content = handle_error(get(link, params={"format": format, **params})).read()
+        content = handle_error(
+            get(
+                link,
+                params={**parse_qs(urlparse(link).query), "format": format, **params},
+            )
+        ).read()
         with open(file, "wb") as buffer:
             buffer.write(content)
     else:
@@ -147,7 +153,12 @@ def export_util(file, format, get, link, params):
         if format is None:
             # We have no filepath to infer to format from.
             raise ValueError("format must be specified when file is writeable buffer")
-        content = handle_error(get(link, params={"format": format, **params})).read()
+        content = handle_error(
+            get(
+                link,
+                params={**parse_qs(urlparse(link).query), "format": format, **params},
+            )
+        ).read()
         file.write(content)
 
 

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -1,4 +1,5 @@
 import threading
+from urllib.parse import parse_qs, urlparse
 
 import dask
 import dask.array
@@ -176,7 +177,11 @@ class _WideTableFetcher:
         content = handle_error(
             self.http_client.get(
                 self.link,
-                params={"format": APACHE_ARROW_FILE_MIME_TYPE, "field": variables},
+                params={
+                    **parse_qs(urlparse(self.link).query),
+                    "format": APACHE_ARROW_FILE_MIME_TYPE,
+                    "field": variables,
+                },
             )
         ).read()
         return deserialize_arrow(content)
@@ -186,7 +191,10 @@ class _WideTableFetcher:
             self.http_client.post(
                 self.link,
                 json=variables,
-                params={"format": APACHE_ARROW_FILE_MIME_TYPE},
+                params={
+                    **parse_qs(urlparse(self.link).query),
+                    "format": APACHE_ARROW_FILE_MIME_TYPE,
+                },
             )
         ).read()
         return deserialize_arrow(content)


### PR DESCRIPTION
Updates of `httpx` to version 0.28.0 break the existing pagination handling code (and likely other functionality too) where a url is constructed using query parameters that are passed as both, explicitly as part of the url and as kwargs to the `httpx.client`. This patch fixes this by refactoring the query parameters only as kwargs.

Furthermore, `httpx.AsyncClient` no longer accepts `app` as a kwarg; instead, the application needs to be wrapped into an `ASGITransport` object explicitly before being passed it to `AsyncClient`.

This behavior has been observed when running a CI/CD pipeline in the main Bluesky [repo](https://github.com/bluesky/bluesky/pull/1830#issuecomment-2512061914). After the fix, the previously failing tests have passed (in a local environment).

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
