### PR TITLE
Use last policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - `docker-compose.yml` now uses the healthcheck endpoint `/healthz`
 - In client, support specifying API key expiration time as string with
   units, like ``"7d"` or `"10m"`.
+- Fix bug where access policies were not applied to child nodes during request
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - In client, support specifying API key expiration time as string with
   units, like ``"7d"` or `"10m"`.
 - Fix bug where access policies were not applied to child nodes during request
+- Add metadata-based access control to SimpleAccessPolicy
+- Add example test of metadata-based allowed_scopes which requires the path to the target node
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - Bug in Python client resulted in error when accessing data sources on a
   just-created object.
+- Fix bug where access policies were not applied to child nodes during request
+
+### Changed
+
+- Change access policy API to be async for filters and allowed_scopes
 
 ## 2024-12-09
 

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -25,6 +25,13 @@ arr_ad = ArrayAdapter.from_array(arr)
 
 
 class EntryBasedAccessPolicy(SimpleAccessPolicy):
+    """
+    This example access policy demonstrates how the metadata on some nested child node
+    can be efficiently consulted and incorporated in logic that determines access scopes.
+    In this test example, the metadata on the node quite literally lists some scopes that
+    it should not allow. In realistic examples it could be incorporated in site-specific logic.
+    """
+
     async def allowed_scopes(self, node, principal, path_parts):
         # If this is being called, filter_access has let us get this far.
         if principal is SpecialUsers.public:

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -1,4 +1,3 @@
-import copy
 import json
 
 import numpy
@@ -58,7 +57,7 @@ class EntryBasedAccessPolicy(SimpleAccessPolicy):
                 )
             remove_scope = node.metadata().get("remove_scope", None)
             if remove_scope in allowed:
-                allowed = copy.copy(allowed)
+                allowed = allowed.copy()
                 allowed.remove(remove_scope)
         return allowed
 

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -7,10 +7,10 @@ from fastapi import HTTPException
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
 from ..access_policies import (
+    ALL_SCOPES,
+    PUBLIC_SCOPES,
     SimpleAccessPolicy,
     SpecialUsers,
-    PUBLIC_SCOPES,
-    ALL_SCOPES,
 )
 from ..adapters.array import ArrayAdapter
 from ..adapters.mapping import MapAdapter

--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -400,7 +400,7 @@ def accesspolicy_protocol_functions(
     node: BaseAdapter,
     principal: Principal,
     scopes: Scopes,
-    path_parts: list,
+    path_parts: List[Any],
 ) -> None:
     policy.allowed_scopes(node, principal, path_parts)
     policy.filters(node, principal, scopes, path_parts)

--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -377,14 +377,18 @@ class CustomAccessPolicy:
         return None
 
     def allowed_scopes(
-        self, node: BaseAdapter, principal: Principal, path_parts: list
+        self, node: BaseAdapter, principal: Principal, path_parts: List[Any]
     ) -> Scopes:
         allowed = self.scopes
         somemetadata = node.metadata()  # noqa: 841
         return allowed
 
     def filters(
-        self, node: BaseAdapter, principal: Principal, scopes: Scopes, path_parts: list
+        self,
+        node: BaseAdapter,
+        principal: Principal,
+        scopes: Scopes,
+        path_parts: List[Any],
     ) -> Filters:
         queries: Filters = []
         somespecs = node.specs()  # noqa: 841

--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -376,13 +376,15 @@ class CustomAccessPolicy:
     def _get_id(self, principal: Principal) -> None:
         return None
 
-    def allowed_scopes(self, node: BaseAdapter, principal: Principal) -> Scopes:
+    def allowed_scopes(
+        self, node: BaseAdapter, principal: Principal, path_parts: list
+    ) -> Scopes:
         allowed = self.scopes
         somemetadata = node.metadata()  # noqa: 841
         return allowed
 
     def filters(
-        self, node: BaseAdapter, principal: Principal, scopes: Scopes
+        self, node: BaseAdapter, principal: Principal, scopes: Scopes, path_parts: list
     ) -> Filters:
         queries: Filters = []
         somespecs = node.specs()  # noqa: 841
@@ -390,10 +392,14 @@ class CustomAccessPolicy:
 
 
 def accesspolicy_protocol_functions(
-    policy: AccessPolicy, node: BaseAdapter, principal: Principal, scopes: Scopes
+    policy: AccessPolicy,
+    node: BaseAdapter,
+    principal: Principal,
+    scopes: Scopes,
+    path_parts: list,
 ) -> None:
-    policy.allowed_scopes(node, principal)
-    policy.filters(node, principal, scopes)
+    policy.allowed_scopes(node, principal, path_parts)
+    policy.filters(node, principal, scopes, path_parts)
 
 
 def test_accesspolicy_protocol(mocker: MockFixture) -> None:
@@ -410,11 +416,12 @@ def test_accesspolicy_protocol(mocker: MockFixture) -> None:
         uuid="12345678124123412345678123456781", type=PrincipalType.user
     )
     scopes = {"abc"}
+    path_parts = ["wx", "yz"]
 
     anyawkwardadapter = CustomAwkwardAdapter(container, structure, metadata=metadata)
 
     accesspolicy_protocol_functions(
-        anyaccesspolicy, anyawkwardadapter, principal, scopes
+        anyaccesspolicy, anyawkwardadapter, principal, scopes, path_parts
     )
     mock_call.assert_called_once()
     mock_call2.assert_called_once()

--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -368,7 +368,7 @@ def test_tableadapter_protocol(mocker: MockFixture) -> None:
     mock_call6.assert_called_once_with("abc")
 
 
-class CustomAccessPolicy:
+class CustomAccessPolicy(AccessPolicy):
     ALL = ALL_ACCESS
 
     def __init__(self, scopes: Optional[Scopes] = None) -> None:
@@ -407,7 +407,7 @@ async def accesspolicy_protocol_functions(
     await policy.filters(node, principal, scopes, path_parts)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore
 async def test_accesspolicy_protocol(mocker: MockFixture) -> None:
     mock_call = mocker.patch.object(CustomAwkwardAdapter, "metadata")
     mock_call2 = mocker.patch.object(CustomAwkwardAdapter, "specs")

--- a/tiled/access_policies.py
+++ b/tiled/access_policies.py
@@ -11,10 +11,10 @@ NO_ACCESS = Sentinel("NO_ACCESS")
 class DummyAccessPolicy:
     "Impose no access restrictions."
 
-    def allowed_scopes(self, node, principal):
+    def allowed_scopes(self, node, principal, path_parts):
         return ALL_SCOPES
 
-    def filters(self, node, principal, scopes):
+    def filters(self, node, principal, scopes, path_parts):
         return []
 
 
@@ -61,7 +61,7 @@ class SimpleAccessPolicy:
             )
         return id
 
-    def allowed_scopes(self, node, principal):
+    def allowed_scopes(self, node, principal, path_parts):
         # If this is being called, filter_access has let us get this far.
         if principal is SpecialUsers.public:
             allowed = PUBLIC_SCOPES
@@ -76,7 +76,7 @@ class SimpleAccessPolicy:
             allowed = self.scopes
         return allowed
 
-    def filters(self, node, principal, scopes):
+    def filters(self, node, principal, scopes, path_parts):
         queries = []
         if principal is SpecialUsers.public:
             queries.append(KeysFilter(self.public))

--- a/tiled/access_policies.py
+++ b/tiled/access_policies.py
@@ -13,10 +13,10 @@ NO_ACCESS = Sentinel("NO_ACCESS")
 class DummyAccessPolicy:
     "Impose no access restrictions."
 
-    def allowed_scopes(self, node, principal, path_parts):
+    async def allowed_scopes(self, node, principal, path_parts):
         return ALL_SCOPES
 
-    def filters(self, node, principal, scopes, path_parts):
+    async def filters(self, node, principal, scopes, path_parts):
         return []
 
 
@@ -64,7 +64,7 @@ class SimpleAccessPolicy:
             )
         return id
 
-    def allowed_scopes(self, node, principal, path_parts):
+    async def allowed_scopes(self, node, principal, path_parts):
         # If this is being called, filter_access has let us get this far.
         if principal is SpecialUsers.public:
             allowed = PUBLIC_SCOPES
@@ -79,7 +79,7 @@ class SimpleAccessPolicy:
             allowed = self.scopes
         return allowed
 
-    def filters(self, node, principal, scopes, path_parts):
+    async def filters(self, node, principal, scopes, path_parts):
         queries = []
         query_filter = KeysFilter if not self.key else partial(In, self.key)
         if principal is SpecialUsers.public:

--- a/tiled/adapters/protocols.py
+++ b/tiled/adapters/protocols.py
@@ -134,11 +134,17 @@ AnyAdapter = Union[
 
 class AccessPolicy(Protocol):
     @abstractmethod
-    def allowed_scopes(self, node: BaseAdapter, principal: Principal) -> Scopes:
+    def allowed_scopes(
+        self, node: BaseAdapter, principal: Principal, path_parts: List[Any]
+    ) -> Scopes:
         pass
 
     @abstractmethod
     def filters(
-        self, node: BaseAdapter, principal: Principal, scopes: Scopes
+        self,
+        node: BaseAdapter,
+        principal: Principal,
+        scopes: Scopes,
+        path_parts: List[Any],
     ) -> Filters:
         pass

--- a/tiled/adapters/protocols.py
+++ b/tiled/adapters/protocols.py
@@ -134,13 +134,13 @@ AnyAdapter = Union[
 
 class AccessPolicy(Protocol):
     @abstractmethod
-    def allowed_scopes(
+    async def allowed_scopes(
         self, node: BaseAdapter, principal: Principal, path_parts: List[Any]
     ) -> Scopes:
         pass
 
     @abstractmethod
-    def filters(
+    async def filters(
         self,
         node: BaseAdapter,
         principal: Principal,

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -25,13 +25,13 @@ async def walk(node, filter_for_access, pre=None):
     pre = pre[:] if pre else []
     if node.structure_family != StructureFamily.array:
         if hasattr(node, "items_range"):
-            for key, value in await filter_for_access(node, path_parts=[]).items_range(
-                0, None
-            ):
+            for key, value in await (
+                await filter_for_access(node, path_parts=[])
+            ).items_range(0, None):
                 async for d in walk(value, filter_for_access, pre + [key]):
                     yield d
         else:
-            for key, value in filter_for_access(node, path_parts=[]).items():
+            for key, value in (await filter_for_access(node, path_parts=[])).items():
                 async for d in walk(value, filter_for_access, pre + [key]):
                     yield d
     else:

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -25,11 +25,13 @@ async def walk(node, filter_for_access, pre=None):
     pre = pre[:] if pre else []
     if node.structure_family != StructureFamily.array:
         if hasattr(node, "items_range"):
-            for key, value in await filter_for_access(node).items_range(0, None):
+            for key, value in await filter_for_access(node, path_parts=[]).items_range(
+                0, None
+            ):
                 async for d in walk(value, filter_for_access, pre + [key]):
                     yield d
         else:
-            for key, value in filter_for_access(node).items():
+            for key, value in filter_for_access(node, path_parts=[]).items():
                 async for d in walk(value, filter_for_access, pre + [key]):
                     yield d
     else:

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -115,7 +115,7 @@ def SecureEntry(scopes, structure_families=None):
                     except (KeyError, TypeError):
                         raise NoEntry(path_parts)
                     if getattr(entry, "access_policy", None) is not None:
-                        path_parts_relative = path_parts[i + 1 :]
+                        path_parts_relative = path_parts[i + 1 :]  # noqa: E203
                         entry_with_access_policy = entry
                         # filter and keep only what we are allowed to see from here
                         entry = await filter_for_access(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -176,9 +176,6 @@ async def search(
     request.state.endpoint = "search"
     if entry.structure_family != StructureFamily.container:
         raise WrongTypeForRoute("This is not a Node; it cannot be searched or listed.")
-    entry = filter_for_access(
-        entry, principal, ["read:metadata"], request.state.metrics
-    )
     try:
         resource, metadata_stale_at, must_revalidate = await construct_entries_response(
             query_registry,

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -69,11 +69,11 @@ def get_root_url_low_level(request_headers, scope):
     return f"{scheme}://{host}{root_path}"
 
 
-def filter_for_access(entry, principal, scopes, metrics, path_parts):
+async def filter_for_access(entry, principal, scopes, metrics, path_parts):
     access_policy = getattr(entry, "access_policy", None)
     if access_policy is not None:
         with record_timing(metrics, "acl"):
-            queries = entry.access_policy.filters(
+            queries = await entry.access_policy.filters(
                 entry, principal, set(scopes), path_parts
             )
             if queries is NO_ACCESS:

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -69,11 +69,13 @@ def get_root_url_low_level(request_headers, scope):
     return f"{scheme}://{host}{root_path}"
 
 
-def filter_for_access(entry, principal, scopes, metrics):
+def filter_for_access(entry, principal, scopes, metrics, path_parts):
     access_policy = getattr(entry, "access_policy", None)
     if access_policy is not None:
         with record_timing(metrics, "acl"):
-            queries = entry.access_policy.filters(entry, principal, set(scopes))
+            queries = entry.access_policy.filters(
+                entry, principal, set(scopes), path_parts
+            )
             if queries is NO_ACCESS:
                 entry = EMPTY_NODE
             else:


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

In ref of #814 - though implementation was adjusted to preserve existing behavior (i.e. subtrees can have differing access policies, still). This fixes an issue where the intended access policy as defined for a tree in a Tiled config is not properly applied to resources that are children in that tree, since the children _themselves_ did not explicitly have an access policy attribute.

The behavior is now:
* Starting at the root and descending, filter the entry according to the access policy of each node (if the node has one)
* When retrieving the requested resource, use the last access policy encountered while descending the tree
* If the target resource is inside a catalog adapter, the access policy used during the request is whatever access policy the catalog adapter node has (even if `None`)

`filters` and `alllowed_scopes` now also takes a `path_parts` parameter which should be the list of segments from the current node until the target resource - in case the access policy needs this information to perform an access check (such as pulling information from a database).
