### PR TITLE
Data sources on new client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - `docker-compose.yml` now uses the healthcheck endpoint `/healthz`
 
+### Fixed
+
+- Bug in Python client resulted in error when accessing data sources on a
+  just-created object.
+
 ## 2024-12-09
 
 ### Added

--- a/tiled/_tests/test_asset_access.py
+++ b/tiled/_tests/test_asset_access.py
@@ -33,7 +33,12 @@ def client(context):
 
 def test_include_data_sources_method_on_self(client):
     "Calling include_data_sources() fetches data sources on self."
-    client.write_array([1, 2, 3], key="x")
+    x = client.write_array([1, 2, 3], key="x")
+    # Fetch data_sources on x object directly.
+    with pytest.warns(UserWarning):
+        # This fetches the sources with an additional implicit request.
+        x.data_sources()
+    # Fetch data_sources on x object, looked up in client.
     with pytest.warns(UserWarning):
         # This fetches the sources with an additional implicit request.
         client["x"].data_sources()

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -285,6 +285,7 @@ client or pass the optional parameter `include_data_sources=True` to
         return type(self)(
             self.context,
             item=self._item,
+            structure=self._structure,
             structure_clients=structure_clients,
             include_data_sources=include_data_sources,
             **kwargs,

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -273,6 +273,7 @@ client or pass the optional parameter `include_data_sources=True` to
         self,
         structure_clients=UNCHANGED,
         include_data_sources=UNCHANGED,
+        structure=UNCHANGED,
         **kwargs,
     ):
         """
@@ -282,10 +283,12 @@ client or pass the optional parameter `include_data_sources=True` to
             structure_clients = self.structure_clients
         if include_data_sources is UNCHANGED:
             include_data_sources = self._include_data_sources
+        if structure is UNCHANGED:
+            structure = self._structure
         return type(self)(
             self.context,
             item=self._item,
-            structure=self._structure,
+            structure=structure,
             structure_clients=structure_clients,
             include_data_sources=include_data_sources,
             **kwargs,


### PR DESCRIPTION
Bug, found by @genematx:

```py
In [9]: c = from_profile('local', api_key='secret')

In [10]: arr = c.write_array([1,2,3], key='arr')

In [11]: arr.data_sources()
...
TypeError: 'ArrayStructure' object is not subscriptable
```

We had unit-tested `c['arr'].data_sources()` but did not have a test covering calling `data_sources()` directly on the object return by `write_array(...)`, in the case where `include_data_sources=True` had not been set on the client and thus the data sources needed to be fetched.

This PR adds a unit test for that case, which reproduces the bug and fails. It then adds a fix.

### Checklist
- [x] Add a Changelog entry
- [ ] ~Add the ticket number which this PR closes to the comment section~
