### PR TITLE
Clean up Python client auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Changed
 
 - Change access policy API to be async for filters and allowed_scopes
+- Pinned zarr to `<3` because Zarr 3 is still working on adding support for
+  certain features that we rely on from Zarr 2.
 
 ## 2024-12-09
 

--- a/docs/source/how-to/authentication.md
+++ b/docs/source/how-to/authentication.md
@@ -1,0 +1,149 @@
+# Python Client Authentication
+
+This covers authentication from the user (client) perspective. To learn how to
+_deploy_ authenticated Tiled servers, see {doc}`../explanations/security`.
+
+## Interactive Login
+
+Some Tiled servers are configured to let users connect anonymously without
+authenticating.
+
+```py
+>>> from tiled.client import from_uri
+>>> client = from_uri("https://...")
+>>> <Container ...>
+```
+
+Logging in may enable you to see more datasets that may not be public.
+Log in works in one of two ways, depending on the server.
+
+1. Username and password ("OAuth2 password grant")
+
+   ```py
+   >>> client.login()
+   Username: ...
+   Password:
+   ```
+
+2. Via a web browser ("OAuth2 device code grant")
+
+   ```py
+   >>> client.login()
+   You have 15 minutes visit this URL
+
+   https://...
+
+   and enter the code: XXXX-XXXX
+   ```
+
+In the future, Tiled will log you into this server automatically, without
+re-prompting for credentials, until your session expires.
+
+   ```py
+   >>> from tiled.client import from_uri
+   >>> client = from_uri("https://...")
+   # Automatically logged in!
+
+   # This is a quick way to verify whether you are already logged in
+   >>> client.context
+   <Context authenticated as '...'>
+   ```
+
+To opt out of this, set `remember_me=False`:
+
+```py
+>>> from tiled.client import from_uri
+>>> client = from_uri("https://...", remember_me=False)
+```
+
+```{note}
+Tiled stores OAuth2 tokens (it _never_ stores your password) in files
+with properly restricted permissions under `$XDG_CACHE_DIR/tiled/tokens`,
+typically `~/.config/tiled/tokens` on Linux and MacOS.
+
+To customize the location of this storage, set the environment variable
+`TILED_CACHE_DIR`.
+```
+
+Some Tiled servers are configured to always require login, disallowing any
+anonymous access. For those, the client will prompt immediately, such as:
+
+   >>> from tiled.client import from_uri
+   >>> client = from_uri("https://...")
+   Username:
+   ```
+
+## Noninteractive Authentication (API keys)
+
+There are environments where logging in interactively is not possible,
+such as running a batch script. For these applications, we recommend
+using an API key. These can be created from the CLI:
+
+```sh
+$ tiled login
+$ tiled api_key create
+```
+
+or from an interactive Python session:
+
+```py
+>>> client = from_uri("https://...")
+>>> client.login()
+>>> client.create_api_key()  # {"secret": ...}
+```
+
+The best way to provide an API key is to set the environment variable
+`TILED_API_KEY`. A script like this:
+
+```py
+from tiled.client import from_uri
+
+client = from_uri("https://....")
+```
+
+will detect that `TILED_API_KEY` is set and use that API key for
+authentication with Tiled. This is equivalent to:
+
+```py
+import os
+from tiled.client import from_uri
+
+client = from_uri("https://....", api_key=os.environ["TILED_API_KEY"])
+```
+
+Avoid typing the API key in to the code:
+
+```py
+from_uri("https://...", api_key="secret!")  # DON'T
+```
+
+as it is easy to accidentally share or leak.
+
+## Custom Applications
+
+Custom applications, such as a graphical interfaces that wrap Tiled,
+may not be able to use Tiled commandline-based prompts. They may
+provide their own mechanism for collection credentials
+(for password grants) or launching a browser and waiting for the
+user to authorize a session (for device code grants).
+
+Custom applications should avoid using the convenience functions
+`tiled.client.construtors.from_uri` and
+`tiled.client.construtors.from_profile`. Instead, follow this pattern:
+
+```py
+from tiled.client import Context
+
+def my_prompt(http_client, providers):
+    ...
+    return tokens
+
+
+URI = "https://..."
+context, node_path_parts = Context.from_any_uri(URI)
+context.authenticate(prompt_for_reauthentication=my_prompt)
+client = from_context(context, node_path_parts=node_path_parts)
+```
+
+Note that `my_prompt` will be called immediately _and may also be called again
+later_ if the active sessions expires or is revoked.

--- a/docs/source/how-to/authentication.md
+++ b/docs/source/how-to/authentication.md
@@ -81,7 +81,7 @@ using an API key. These can be created from the CLI:
 
 ```sh
 $ tiled login
-$ tiled api_key create
+$ tiled api_key create --expires-in 7d --note "for this week's experiment"
 ```
 
 or from an interactive Python session:
@@ -89,7 +89,13 @@ or from an interactive Python session:
 ```py
 >>> client = from_uri("https://...")
 >>> client.login()
->>> client.create_api_key()  # {"secret": ...}
+>>> client.create_api_key(expires_in="7d", note="for this week's experiment")
+{"secret": ...}
+ ```
+
+The expiration and note are optional, but recommended. Expiration can be given
+in units of years `y`, days `d`, hours `h`, minutes `m`, or seconds `s`.
+
 ```
 
 The best way to provide an API key is to set the environment variable

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -18,6 +18,7 @@ tutorials/plotly-integration
 ```{toctree}
 :caption: How To Guides
 
+how-to/authentication
 how-to/profiles
 how-to/client-logger
 how-to/docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ all = [
     "uvicorn[standard]",
     "watchfiles",
     "xarray",
-    "zarr",
+    "zarr <3",
     "zstandard",
 ]
 # These are needed by the client and server to transmit/receive arrays.
@@ -219,7 +219,7 @@ minimal-server = [
     "starlette",
     "typer",
     "uvicorn[standard]",
-    "zarr",
+    "zarr <3",
 ]
 # This is the "kichen sink" fully-featured server dependency set.
 server = [
@@ -270,7 +270,7 @@ server = [
     "typer",
     "uvicorn[standard]",
     "xarray",
-    "zarr",
+    "zarr <3",
     "zstandard",
 ]
 # These are needed by the client and server to transmit/receive sparse arrays.

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -216,7 +216,7 @@ def context(tmpdir_module):
     app = build_app_from_config(config)
     with Context.from_app(app) as context:
         with enter_username_password("admin", "admin"):
-            admin_client = from_context(context, username="admin")
+            admin_client = from_context(context)
             for k in ["c", "d", "e"]:
                 admin_client[k].write_array(arr, key="A1")
                 admin_client[k].write_array(arr, key="A2")
@@ -238,7 +238,7 @@ def test_entry_based_scopes(context, enter_username_password):
 
 def test_top_level_access_control(context, enter_username_password):
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client = from_context(context)
     assert "a" in alice_client
     assert "A2" in alice_client["a"]
     assert "A1" not in alice_client["a"]
@@ -254,7 +254,7 @@ def test_top_level_access_control(context, enter_username_password):
         alice_client["g"]["A4"]
 
     with enter_username_password("bob", "secret2"):
-        bob_client = from_context(context, username="bob")
+        bob_client = from_context(context)
     assert not list(bob_client)
     with pytest.raises(KeyError):
         bob_client["a"]
@@ -271,7 +271,7 @@ def test_top_level_access_control(context, enter_username_password):
 def test_access_control_with_api_key_auth(context, enter_username_password):
     # Log in, create an API key, log out.
     with enter_username_password("alice", "secret1"):
-        context.authenticate(username="alice")
+        context.authenticate()
     key_info = context.create_api_key()
     context.logout()
 
@@ -289,7 +289,7 @@ def test_access_control_with_api_key_auth(context, enter_username_password):
 def test_node_export(enter_username_password, context, buffer):
     "Exporting a node should include only the children we can see."
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client = from_context(context)
     alice_client.export(buffer, format="application/json")
     alice_client.logout()
     buffer.seek(0)
@@ -307,7 +307,7 @@ def test_node_export(enter_username_password, context, buffer):
 
 def test_create_and_update_allowed(enter_username_password, context):
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client = from_context(context)
 
     # Update
     alice_client["c"]["x"].metadata
@@ -326,7 +326,7 @@ def test_create_and_update_allowed(enter_username_password, context):
 
 def test_writing_blocked_by_access_policy(enter_username_password, context):
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client = from_context(context)
     alice_client["d"]["x"].metadata
     with fail_with_status_code(HTTP_403_FORBIDDEN):
         alice_client["d"]["x"].update_metadata(metadata={"added_key": 3})
@@ -335,7 +335,7 @@ def test_writing_blocked_by_access_policy(enter_username_password, context):
 
 def test_create_blocked_by_access_policy(enter_username_password, context):
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client = from_context(context)
     with fail_with_status_code(HTTP_403_FORBIDDEN):
         alice_client["e"].write_array([1, 2, 3])
     alice_client.logout()
@@ -397,7 +397,7 @@ def test_service_principal_access(tmpdir):
     }
     with Context.from_app(build_app_from_config(config)) as context:
         with enter_username_password("admin", "admin"):
-            admin_client = from_context(context, username="admin")
+            admin_client = from_context(context)
         sp = admin_client.context.admin.create_service_principal("user")
         key_info = admin_client.context.admin.create_api_key(sp["uuid"])
         admin_client.write_array([1, 2, 3], key="x")

--- a/tiled/_tests/test_access_control.py
+++ b/tiled/_tests/test_access_control.py
@@ -230,8 +230,9 @@ def context(tmpdir_module):
 
 
 def test_entry_based_scopes(context, enter_username_password):
+    alice_client = from_context(context)
     with enter_username_password("alice", "secret1"):
-        alice_client = from_context(context, username="alice")
+        alice_client.login()
     with pytest.raises(ClientError, match="Not enough permissions"):
         alice_client["h"]["x"].write(arr_zeros)
     alice_client["h"]["y"].write(arr_zeros)

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -77,6 +77,20 @@ def test_password_auth(enter_username_password, config):
         client.logout()
         assert "unauthenticated" in repr(client.context)
 
+        # Log in as Alice.
+        with enter_username_password("alice", "secret1"):
+            from_context(context)
+        # Log in again, but set remember_me=False to opt out of cache.
+        client = from_context(context, remember_me=False)
+        # Cached tokens are cleaered, not used.
+        assert "unauthenticated" in repr(client.context)
+        with enter_username_password("alice", "secret1"):
+            client.login()
+        assert "authenticated as 'alice'" in repr(client.context)
+        # Tokens were not cached.
+        client = from_context(context)
+        assert "unauthenticated" in repr(client.context)
+
         # Log in as Bob.
         with enter_username_password("bob", "secret2"):
             client = from_context(context)

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -417,14 +417,16 @@ async def test_access_control(tmpdir):
 
     app = build_app_from_config(config)
     with Context.from_app(app) as context:
+        admin_client = from_context(context)
         with enter_username_password("admin", "admin"):
-            admin_client = from_context(context, username="admin")
+            admin_client.login()
             for key in ["outer_x", "outer_y", "outer_z"]:
                 container = admin_client.create_container(key)
                 container.write_array([1, 2, 3], key="inner")
             admin_client.logout()
+        alice_client = from_context(context)
         with enter_username_password("alice", "secret1"):
-            alice_client = from_context(context, username="alice")
+            alice_client.login()
             alice_client["outer_x"]["inner"].read()
             with pytest.raises(KeyError):
                 alice_client["outer_y"]

--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -30,13 +30,13 @@ def test_pickle_clients(structure_clients, tmpdir):
         httpx.get(API_URL).raise_for_status()
     except Exception:
         raise pytest.skip(f"Could not connect to {API_URL}")
-    with Context(API_URL) as context:
+    cache = Cache(tmpdir / "http_response_cache.db")
+    with Context(API_URL, cache=cache) as context:
         if parse(context.server_info["library_version"]) < parse(MIN_VERSION):
             raise pytest.skip(
                 f"Server at {API_URL} is running too old a version to test against."
             )
-        cache = Cache(tmpdir / "http_response_cache.db")
-        client = from_context(context, structure_clients, cache)
+        client = from_context(context, structure_clients)
         pickle.loads(pickle.dumps(client))
         for segements in [
             ["generated"],

--- a/tiled/_tests/utils.py
+++ b/tiled/_tests/utils.py
@@ -61,16 +61,16 @@ def enter_username_password(username, password):
     ...     # Run code that calls prompt_for_credentials and subsequently getpass.getpass().
     """
 
-    original_prompt = context.PROMPT_FOR_REAUTHENTICATION
-    original_credentials = context.prompt_for_credentials
-    context.PROMPT_FOR_REAUTHENTICATION = True
-    context.prompt_for_credentials = lambda u, p: (username, password)
+    original_username_input = context.username_input
+    context.username_input = lambda: username
+    original_password_input = context.password_input
+    context.password_input = lambda: password
     try:
         # Ensures that raise in calling routine does not prevent context from being exited.
         yield
     finally:
-        context.PROMPT_FOR_REAUTHENTICATION = original_prompt
-        context.prompt_for_credentials = original_credentials
+        context.username_input = original_username_input
+        context.password_input = original_password_input
 
 
 class URL_LIMITS(IntEnum):

--- a/tiled/client/auth.py
+++ b/tiled/client/auth.py
@@ -82,7 +82,6 @@ class TiledAuth(httpx.Auth):
     def sync_clear_token(self, key):
         with self._sync_lock:
             if self.token_directory is not None:
-                self.tokens.pop(key, None)
                 filepath = self.token_directory / key
                 filepath.unlink(missing_ok=False)
             self.tokens.pop(key, None)  # Clear cached value.

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -172,13 +172,13 @@ class BaseClient:
         """
         self.context.login(username=username, provider=provider)
 
-    def logout(self, clear_default=False):
+    def logout(self):
         """
         Log out.
 
         This method is idempotent: if you are already logged out, it will do nothing.
         """
-        self.context.logout(clear_default=clear_default)
+        self.context.logout()
 
     def __repr__(self):
         return f"<{type(self).__name__}>"

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -153,7 +153,7 @@ class BaseClient:
             )
         return self._structure
 
-    def login(self, username=None, provider=None):
+    def login(self):
         """
         Depending on the server's authentication method, this will prompt for username/password:
 
@@ -170,7 +170,7 @@ class BaseClient:
 
         and enter the code: XXXX-XXXX
         """
-        self.context.login(username=username, provider=provider)
+        self.context.login()
 
     def logout(self):
         """

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -136,7 +136,7 @@ def from_context(
     >>> c = from_uri("...", api_key="...")
     """
             )
-        found_valid_tokens = context.use_cached_tokens()
+        found_valid_tokens = remember_me and context.use_cached_tokens()
         if (not found_valid_tokens) and auth_is_required:
             context.authenticate(remember_me=remember_me)
     # Context ensures that context.api_uri has a trailing slash.

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -126,9 +126,9 @@ def from_context(
     # 2. If there are cached valid credentials for this server, use them.
     # 3. If not, and the server requires authentication, prompt for authentication.
     if context.api_key is None:
-        if context.server_info["authentication"]["required"] and (
-            not context.server_info["authentication"]["providers"]
-        ):
+        auth_is_required = context.server_info["authentication"]["required"]
+        has_providers = len(context.server_info["authentication"]["providers"]) > 0
+        if auth_is_required and not has_providers:
             raise RuntimeError(
                 """This server requires API key authentication.
     Set an api_key as in:
@@ -137,9 +137,7 @@ def from_context(
     """
             )
         found_valid_tokens = context.use_cached_tokens()
-        if (not found_valid_tokens) and context.server_info["authentication"][
-            "required"
-        ]:
+        if (not found_valid_tokens) and auth_is_required:
             context.authenticate(remember_me=remember_me)
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -434,14 +434,18 @@ class Context:
             app=app,
             raise_server_exceptions=raise_server_exceptions,
         )
-        if (api_key is UNSET) and (
-            not context.server_info["authentication"]["providers"]
-        ):
-            # Extract the API key from the app and set it.
-            from ..server.settings import get_settings
+        if api_key is UNSET:
+            if not context.server_info["authentication"]["providers"]:
+                # This is a single-user server.
+                # Extract the API key from the app and set it.
+                from ..server.settings import get_settings
 
-            settings = app.dependency_overrides[get_settings]()
-            api_key = settings.single_user_api_key or None
+                settings = app.dependency_overrides[get_settings]()
+                api_key = settings.single_user_api_key or None
+            else:
+                # This is a multi-user server but no API key was passed,
+                # so we will leave it as None on the Context.
+                api_key = None
         context.api_key = api_key
         return context
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -428,7 +428,7 @@ class Context:
         context = cls(
             uri="http://local-tiled-app/api/v1",
             headers=headers,
-            api_key=api_key,
+            api_key=None,
             cache=cache,
             timeout=timeout,
             app=app,
@@ -676,6 +676,7 @@ class Context:
             self.whoami()
             return True
         except CannotRefreshAuthentication:
+            self.http_client.auth = None
             return False
 
     def force_auth_refresh(self):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -630,7 +630,15 @@ class Context:
         # will manage refreshing the tokens as needed.
         refresh_url = self.server_info["authentication"]["links"]["refresh_session"]
         csrf_token = self.http_client.cookies["tiled_csrf"]
-        token_directory = self._token_directory() if remember_me else None
+        if remember_me:
+            token_directory = self._token_directory()
+        else:
+            # Clear any existing tokens.
+            temp_auth = TiledAuth(refresh_url, csrf_token, self._token_directory())
+            temp_auth.sync_clear_token("access_token")
+            temp_auth.sync_clear_token("refresh_token")
+            # Store tokens in memory only, with no syncing to disk.
+            token_directory = None
         auth = TiledAuth(refresh_url, csrf_token, token_directory)
         auth.sync_set_token("access_token", tokens["access_token"])
         auth.sync_set_token("refresh_token", tokens["refresh_token"])

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -442,7 +442,7 @@ class Context:
 
             settings = app.dependency_overrides[get_settings]()
             api_key = settings.single_user_api_key or None
-            context.api_key = api_key
+        context.api_key = api_key
         return context
 
     @property

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -69,7 +69,7 @@ def identity_provider_input(providers, provider=None):
 
 def username_input():
     raise_if_cannot_prompt()
-    return input("Username")
+    return input("Username: ")
 
 
 def password_input():

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -48,7 +48,7 @@ def identity_provider_input(providers, provider=None):
         for i, spec in enumerate(providers, start=1):
             print(f"{i} - {spec['provider']}")
         raw_choice = input(
-            "Choose an authentication provider (or press Enter to escape): "
+            "Choose an authentication provider (or press Enter to cancel): "
         )
         if not raw_choice:
             print("No authentication provider chosen. Failed.")
@@ -108,7 +108,7 @@ def prompt_for_credentials(http_client, providers):
             except httpx.HTTPStatusError as err:
                 if err.response.status_code == httpx.codes.UNAUTHORIZED:
                     print(
-                        "Username or password not recognized. Retry, or press Enter to escape."
+                        "Username or password not recognized. Retry, or press Enter to cancel."
                     )
                     continue
                 raise
@@ -593,7 +593,7 @@ class Context:
         or prompt you to open a link in a web browser to login with a third party:
 
         >>> c.login()
-        You have ... minutes visit this URL
+        You have ... minutes to visit this URL
 
         https://...
 
@@ -609,7 +609,7 @@ class Context:
         tokens = prompt_for_credentials(self.http_client, providers)
         self.configure_auth(tokens, remember_me=remember_me)
 
-    # This is a convenience alias.
+    # These two methods are aliased for convenience.
     login = authenticate
 
     def configure_auth(self, tokens, remember_me=True):
@@ -624,7 +624,7 @@ class Context:
         self.http_client.auth = None
         if self.api_key is not None:
             raise RuntimeError(
-                "An API key is set. Cannot use both API key OAuth2 authenticaiton."
+                "An API key is set. Cannot use both API key and OAuth2 authentication."
             )
         # Configure an httpx.Auth instance on the http_client, which
         # will manage refreshing the tokens as needed.
@@ -912,7 +912,7 @@ def device_code_grant(http_client, auth_endpoint):
     authorization_uri = verification["authorization_uri"]
     print(
         f"""
-You have {int(verification['expires_in']) // 60} minutes visit this URL
+You have {int(verification['expires_in']) // 60} minutes to visit this URL
 
 {authorization_uri}
 

--- a/tiled/commandline/_utils.py
+++ b/tiled/commandline/_utils.py
@@ -79,6 +79,4 @@ def get_context(profile):
     context, _ = Context.from_any_uri(
         profile_content["uri"], verify=profile_content.get("verify", True)
     )
-    if context.server_info["authentication"]["required"]:
-        context.authenticate()
     return context

--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -78,6 +78,28 @@ def login(
         typer.echo(json.dumps(dict(context.tokens), indent=4))
 
 
+@cli_app.command("whoami")
+def whoami(
+    profile: Optional[str] = typer.Option(
+        None, help="If you use more than one Tiled server, use this to specify which."
+    ),
+):
+    """
+    Show logged in identity.
+    """
+    from ..client.context import Context
+
+    profile_name, profile_content = get_profile(profile)
+    options = {"verify": profile_content.get("verify", True)}
+    context, _ = Context.from_any_uri(profile_content["uri"], **options)
+    context.use_cached_tokens()
+    whoami = context.whoami()
+    if whoami is None:
+        typer.echo("Not authenticated.")
+    else:
+        typer.echo(",".join(identity["id"] for identity in whoami["identities"]))
+
+
 @cli_app.command("logout")
 def logout(
     profile: Optional[str] = typer.Option(

--- a/tiled/commandline/main.py
+++ b/tiled/commandline/main.py
@@ -26,7 +26,6 @@ which installs *everything* you might want. For other options, see:
 """
     ) from err
 
-from ..utils import UNSET
 
 cli_app = typer.Typer()
 
@@ -60,9 +59,6 @@ def login(
     profile: Optional[str] = typer.Option(
         None, help="If you use more than one Tiled server, use this to specify which."
     ),
-    set_default: bool = typer.Option(
-        True, help="Use this identity as the default for this API."
-    ),
     show_secret_tokens: bool = typer.Option(
         False, "--show-secret-tokens", help="Show secret tokens after successful login."
     ),
@@ -75,9 +71,7 @@ def login(
     profile_name, profile_content = get_profile(profile)
     options = {"verify": profile_content.get("verify", True)}
     context, _ = Context.from_any_uri(profile_content["uri"], **options)
-    # Override sticky 'default_identity'.
-    # Always prompt user to specify who they want to log in as.
-    context.authenticate(username=None, provider=None, set_default=True)
+    context.authenticate()
     if show_secret_tokens:
         import json
 
@@ -89,8 +83,6 @@ def logout(
     profile: Optional[str] = typer.Option(
         None, help="If you use more than one Tiled server, use this to specify which."
     ),
-    username: Optional[str] = typer.Option(None),
-    provider: Optional[str] = typer.Option(None),
 ):
     """
     Log out.
@@ -101,12 +93,8 @@ def logout(
     context, _ = Context.from_any_uri(
         profile_content["uri"], verify=profile_content.get("verify", True)
     )
-    if username is None:
-        username = UNSET
-    if provider is None:
-        provider = UNSET
-    context.authenticate(username=username, provider=provider, set_default=False)
-    context.logout()
+    if context.use_cached_tokens():
+        context.logout()
 
 
 @cli_app.command("tree")

--- a/tiled/config_schemas/client_profiles.yml
+++ b/tiled/config_schemas/client_profiles.yml
@@ -35,12 +35,15 @@ properties:
   username:
     type: string
     description: |
-      For authenticated Trees. Optional unless the Tree requires authentication.
+      DEPRECATED. Any value given here is ignored. Instead, credentials should
+      be provided interactively when needed. Or, any API key may be used for
+      noninteractive applications.
   auth_provider:
     type: string
     description: |
-      Authentication provider. If unspecified and there are multiple providers
-      supported by the server, the client will prompt the user to choose one.
+      DEPRECATED. Any value given here is ignored. Instead, credentials should
+      be provided interactively when needed. Or, any API key may be used for
+      noninteractive applications.
   headers:
     type: object
     additionalProperties: true

--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -10,6 +10,7 @@ but the user-facing functionality is striaghtforward.
 import collections
 import collections.abc
 import os
+import shutil
 import sys
 import warnings
 from functools import lru_cache
@@ -20,6 +21,9 @@ import platformdirs
 
 from .utils import parse
 
+TILED_CACHE_DIR = Path(
+    os.getenv("TILED_CACHE_DIR", platformdirs.user_cache_dir("tiled"))
+)
 __all__ = [
     "list_profiles",
     "load_profiles",
@@ -320,6 +324,10 @@ def set_default_profile_name(name):
         raise ProfileNotFound(name)
     with open(filepath, "w") as file:
         file.write(name)
+    # Clean up cruft from older versions of Tiled.
+    UNUSED_DIR = TILED_CACHE_DIR / "default_identities"
+    if UNUSED_DIR.is_dir():
+        shutil.rmtree(UNUSED_DIR)
 
 
 class ProfileNotFound(KeyError):


### PR DESCRIPTION
The goal of this PR is to improve the user experience and simplify the implementation for authentication in the Python client. There are no changes to the server in this PR.The new docs page in this PR, `docs/source/how-to/authentication.md`, is a good place to start. I recommend reading that before reading the summary below.

## Regressions fixed

The PR addresses a critical regressions, both released in v0.1.0b12

A [trailing-comma-as-tuple bug](https://github.com/bluesky/tiled/pull/823/files#diff-d951a6f56304c48bd302a77ab64c9e290913abf861ad83af86f21c427a7cd751R157) in #823 which manifests as

```
>>> from_uri("https://tiled.nsls2.bnl.gov")
...
KeyError: 0
```

and a deeper bug in #816 that prevents login:

```py
>>> from_uri("https://tiled.nsls2.bnl.gov")
ClientError: 401: Incorrect username or password https://tiled.nsls2.bnl.gov/api/v1/auth/provider/pam/token
```

## Design changes 

- The high-level convenience wrappers no longer collect an optional username. The `username` kwarg in `from_uri(..., username="...")` and `from_profile(..., username="...")` is now completely ignored (with a warning to the user). It will later be removed.
    - The `username` kwarg never made sense for browser-based (device code grant) auth anyway. (In that case, the username goes to the browser, not Tiled.) It always was a bit of wart.
    - The `username` kwarg has been the source of a lot of confusion over the years... with unintuitive behavior related to `username=None` and lately `username=UNSET`. I take this as a sign that it should not have been merged into the `from_uri` and `from_profile` convenience functions.
    - A username prompt like `Username [dallan]:` can be a "password trap". Tiled is trying to collect your username, but you might reflexively type your password onto the screen in clear text. If we don't have a valid session ready to reuse, we should just ask the user to type their username with plain old `Username:`.
- This PR enables users to opt out of stashing tokens with a new keyword argument: `from_uri("https://...", remember_me=False)`. The tokens will be stored only in memory. This is equivalent of logging into GMail in an Incognito Browser.
- For a given token directory---typically `$XDG_CACHE_DIR/tiled/tokens/`---Tiled only stashes tokens for one user at a time (per Tiled server, as defined by its `netloc`).
    - It seems like a mistake to have ever supported stashing more than one. Storing two distinct principals' tokens with the same file permissions invites leakage.
    - The use case I originally had in mind was two processes running in a shared account (e.g. an NSLS2 Operator Account) authenticated as differnet users. But this rather niche use case can be addressed in many other, simpler ways:
        - `remember_me=False` "incognito mode"
        - setting custom token cache locations using `TILED_CACHE_DIR`
        - using an API key
    - This removes the notion of "default identity" and simplifies the state on disk. Instead of deeply nested directories like `~/.cache/tiled/{netloc}/{idP}/{username}` we now just have one directory per tiled server: `~/.cache/tiled/{netloc}`.
    - There is no need for `logout(clear_default=True)`. Now `logout()` is all you need.

Importantly, it is still straightforward to authenticate to multiple servers in one session because the tokens are still scoped by the server's netloc:

```py
aps_client  = from_uri("https://tiled.aps.anl.gov")  # an aspirational URL
nsls2_client = from_uri("https://tield.nsls2.bnl.gov")
```

Finally, as mentioned in the docs, this provides a path for applications without access to an interactive terminal. The approach outlined there (which could be fleshed out in the future with a fuller example) will work for both password grant and device code grant modes, as well as for Tiled servers that offer multiple authentication providers. Authentication code has been factored out in to public functions `password_grant` and `device_code_grant`, suitable for reuse.

Closes #820 
Closes #831 
Closes #833 

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
