### PR TITLE
Address warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Maintenance
+
+- Addressed DeprecationWarnings from Python and dependencies
+
 ## v0.1.0-b13 (2024-01-09)
 
 ### Added

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -312,8 +312,8 @@ def test_write_dataframe_internal_via_client(client):
 
 def test_write_xarray_dataset(client):
     ds = xarray.Dataset(
-        {"temp": (["time"], [101, 102, 103])},
-        coords={"time": (["time"], [1, 2, 3])},
+        {"temp": (["time"], numpy.array([101, 102, 103]))},
+        coords={"time": (["time"], numpy.array([1, 2, 3]))},
     )
     dsc = write_xarray_dataset(client, ds, key="test_xarray_dataset")
     assert set(dsc) == {"temp", "time"}

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -53,7 +53,9 @@ tree = MapAdapter(
                         coords={
                             "lon": (["x", "y"], lon),
                             "lat": (["x", "y"], lat),
-                            "time": [1, 2, 3],  # using ints here so HDF5 can export
+                            "time": numpy.array(
+                                [1, 2, 3]
+                            ),  # using ints here so HDF5 can export
                         },
                     )
                 ),

--- a/tiled/_tests/test_inlined_contents.py
+++ b/tiled/_tests/test_inlined_contents.py
@@ -20,8 +20,8 @@ tree = MapAdapter(
     {
         "dataset": DatasetAdapter.from_dataset(
             xarray.Dataset(
-                data_vars={"temperature": ("time", [100, 99, 98])},
-                coords={"time": [1, 2, 3]},
+                data_vars={"temperature": ("time", numpy.array([100, 99, 98]))},
+                coords={"time": numpy.array([1, 2, 3])},
             )
         ),
     },

--- a/tiled/_tests/test_sync.py
+++ b/tiled/_tests/test_sync.py
@@ -65,7 +65,9 @@ def populate_internal(client):
         awkward.Array([1, [2, 3]]), key="d", metadata={"color": "red"}, specs=["alpha"]
     )
     # sparse
-    coo = sparse.COO(coords=[[2, 5]], data=[1.3, 7.5], shape=(10,))
+    coo = sparse.COO(
+        coords=numpy.array([[2, 5]]), data=numpy.array([1.3, 7.5]), shape=(10,)
+    )
     client.write_sparse(key="e", coords=coo.coords, data=coo.data, shape=coo.shape)
 
     # nested

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -253,8 +253,14 @@ def test_write_dataframe_dict(tree):
 @pytest.mark.parametrize(
     "coo",
     [
-        sparse.COO(coords=[[2, 5]], data=[1.3, 7.5], shape=(10,)),
-        sparse.COO(coords=[[0, 1], [2, 3]], data=[3.8, 4.0], shape=(4, 4)),
+        sparse.COO(
+            coords=numpy.array([[2, 5]]), data=numpy.array([1.3, 7.5]), shape=(10,)
+        ),
+        sparse.COO(
+            coords=numpy.array([[0, 1], [2, 3]]),
+            data=numpy.array([3.8, 4.0]),
+            shape=(4, 4),
+        ),
     ],
 )
 def test_write_sparse_full(tree, coo):
@@ -317,7 +323,9 @@ def test_write_sparse_chunked(tree):
         assert numpy.array_equal(
             result_array.todense(),
             sparse.COO(
-                coords=[[2, 4, N + 0, N + 1]], data=[3.1, 2.8, 6.7, 1.2], shape=(10,)
+                coords=numpy.array([[2, 4, N + 0, N + 1]]),
+                data=numpy.array([3.1, 2.8, 6.7, 1.2]),
+                shape=(10,),
             ).todense(),
         )
 
@@ -543,7 +551,9 @@ async def test_write_in_container(tree):
         client.delete("a")
 
         a = client.create_container("a")
-        coo = sparse.COO(coords=[[2, 5]], data=[1.3, 7.5], shape=(10,))
+        coo = sparse.COO(
+            coords=numpy.array([[2, 5]]), data=numpy.array([1.3, 7.5]), shape=(10,)
+        )
         b = a.write_sparse(coords=coo.coords, data=coo.data, shape=coo.shape, key="b")
         b.read()
         a.delete("b")

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -4,7 +4,7 @@ import itertools
 import operator
 import sys
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -286,7 +286,7 @@ class MapAdapter(MappingType[str, AnyAdapter], IndexersMixin):
         """
         if self.metadata_stale_after is None:
             return None
-        return self.metadata_stale_after + datetime.utcnow()
+        return self.metadata_stale_after + datetime.now(UTC)
 
     @property
     def entries_stale_at(self) -> Optional[datetime]:
@@ -298,7 +298,7 @@ class MapAdapter(MappingType[str, AnyAdapter], IndexersMixin):
         """
         if self.entries_stale_after is None:
             return None
-        return self.entries_stale_after + datetime.utcnow()
+        return self.entries_stale_after + datetime.now(UTC)
 
     def new_variation(
         self,

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -4,7 +4,7 @@ import itertools
 import operator
 import sys
 from collections import Counter
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -286,7 +286,7 @@ class MapAdapter(MappingType[str, AnyAdapter], IndexersMixin):
         """
         if self.metadata_stale_after is None:
             return None
-        return self.metadata_stale_after + datetime.now(UTC)
+        return self.metadata_stale_after + datetime.now(timezone.utc)
 
     @property
     def entries_stale_at(self) -> Optional[datetime]:
@@ -298,7 +298,7 @@ class MapAdapter(MappingType[str, AnyAdapter], IndexersMixin):
         """
         if self.entries_stale_after is None:
             return None
-        return self.entries_stale_after + datetime.now(UTC)
+        return self.entries_stale_after + datetime.now(timezone.utc)
 
     def new_variation(
         self,

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -1,6 +1,6 @@
 import hashlib
 import uuid as uuid_module
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -77,12 +77,12 @@ async def purge_expired(db, cls):
     """
     Remove expired entries.
     """
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     num_expired = 0
     statement = (
         select(cls)
         .filter(cls.expiration_time.is_not(None))
-        .filter(cls.expiration_time < now)
+        .filter(cls.expiration_time.replace(tzinfo=UTC) < now)
     )
     result = await db.execute(statement)
     for obj in result.scalars():
@@ -144,10 +144,9 @@ async def lookup_valid_session(db, session_id):
     ).scalar()
     if session is None:
         return None
-    if (
-        session.expiration_time is not None
-        and session.expiration_time < datetime.utcnow()
-    ):
+    if session.expiration_time is not None and session.expiration_time.replace(
+        tzinfo=UTC
+    ) < datetime.now(UTC):
         await db.delete(session)
         await db.commit()
         return None
@@ -171,7 +170,7 @@ async def lookup_valid_pending_session_by_device_code(db, device_code):
         return None
     if (
         pending_session.expiration_time is not None
-        and pending_session.expiration_time < datetime.utcnow()
+        and pending_session.expiration_time.replace(tzinfo=UTC) < datetime.now(UTC)
     ):
         await db.delete(pending_session)
         await db.commit()
@@ -189,7 +188,7 @@ async def lookup_valid_pending_session_by_user_code(db, user_code):
         return None
     if (
         pending_session.expiration_time is not None
-        and pending_session.expiration_time < datetime.utcnow()
+        and pending_session.expiration_time.replace(tzinfo=UTC) < datetime.now(UTC)
     ):
         await db.delete(pending_session)
         await db.commit()
@@ -228,7 +227,7 @@ async def lookup_valid_api_key(db, secret):
     Look up an API key. Ensure that it is valid.
     """
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     hashed_secret = hashlib.sha256(secret).digest()
     api_key = (
         await db.execute(
@@ -244,7 +243,9 @@ async def lookup_valid_api_key(db, secret):
     if api_key is None:
         # No match
         validated_api_key = None
-    elif (api_key.expiration_time is not None) and (api_key.expiration_time < now):
+    elif (api_key.expiration_time is not None) and (
+        api_key.expiration_time.replace(tzinfo=UTC) < now
+    ):
         # Match is expired. Delete it.
         await db.delete(api_key)
         await db.commit()

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -1,6 +1,6 @@
 import hashlib
 import uuid as uuid_module
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -77,12 +77,12 @@ async def purge_expired(db, cls):
     """
     Remove expired entries.
     """
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     num_expired = 0
     statement = (
         select(cls)
         .filter(cls.expiration_time.is_not(None))
-        .filter(cls.expiration_time.replace(tzinfo=UTC) < now)
+        .filter(cls.expiration_time.replace(tzinfo=timezone.utc) < now)
     )
     result = await db.execute(statement)
     for obj in result.scalars():
@@ -145,8 +145,8 @@ async def lookup_valid_session(db, session_id):
     if session is None:
         return None
     if session.expiration_time is not None and session.expiration_time.replace(
-        tzinfo=UTC
-    ) < datetime.now(UTC):
+        tzinfo=timezone.utc
+    ) < datetime.now(timezone.utc):
         await db.delete(session)
         await db.commit()
         return None
@@ -170,7 +170,8 @@ async def lookup_valid_pending_session_by_device_code(db, device_code):
         return None
     if (
         pending_session.expiration_time is not None
-        and pending_session.expiration_time.replace(tzinfo=UTC) < datetime.now(UTC)
+        and pending_session.expiration_time.replace(tzinfo=timezone.utc)
+        < datetime.now(timezone.utc)
     ):
         await db.delete(pending_session)
         await db.commit()
@@ -188,7 +189,8 @@ async def lookup_valid_pending_session_by_user_code(db, user_code):
         return None
     if (
         pending_session.expiration_time is not None
-        and pending_session.expiration_time.replace(tzinfo=UTC) < datetime.now(UTC)
+        and pending_session.expiration_time.replace(tzinfo=timezone.utc)
+        < datetime.now(timezone.utc)
     ):
         await db.delete(pending_session)
         await db.commit()
@@ -227,7 +229,7 @@ async def lookup_valid_api_key(db, secret):
     Look up an API key. Ensure that it is valid.
     """
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     hashed_secret = hashlib.sha256(secret).digest()
     api_key = (
         await db.execute(
@@ -244,7 +246,7 @@ async def lookup_valid_api_key(db, secret):
         # No match
         validated_api_key = None
     elif (api_key.expiration_time is not None) and (
-        api_key.expiration_time.replace(tzinfo=UTC) < now
+        api_key.expiration_time.replace(tzinfo=timezone.utc) < now
     ):
         # Match is expired. Delete it.
         await db.delete(api_key)

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -879,7 +879,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         Write a sparse.COO array.
 
         >>> import sparse
-        >>> coo = sparse.COO(coords=[[2, 5]], data=[1.3, 7.5], shape=(10,))
+        >>> from numpy import array
+        >>> coo = sparse.COO(coords=array([[2, 5]]), data=array([1.3, 7.5]), shape=(10,))
         >>> c.write_sparse(coords=coo.coords, data=coo.data, shape=coo.shape)
 
         This only supports a single chunk. For chunked upload, use lower-level methods.
@@ -891,8 +892,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         >>> x = c.new("sparse", [data_source])
         # Upload the data in each chunk.
         # Coords are given with in the reference frame of each chunk.
-        >>> x.write_block(coords=[[2, 4]], data=[3.1, 2.8], block=(0,))
-        >>> x.write_block(coords=[[0, 1]], data=[6.7, 1.2], block=(1,))
+        >>> x.write_block(coords=array([[2, 4]]), data=array([3.1, 2.8]), block=(0,))
+        >>> x.write_block(coords=array([[0, 1]]), data=array([6.7, 1.2]), block=(1,))
         """
         from ..structures.sparse import COOStructure
 

--- a/tiled/examples/xdi.py
+++ b/tiled/examples/xdi.py
@@ -80,7 +80,7 @@ def read_xdi(data_uri, structure=None, metadata=None, specs=None, access_policy=
 
         # TODO validate
 
-        df = pd.read_table(file, delim_whitespace=True, names=col_labels)
+        df = pd.read_table(file, sep=r"\s+", names=col_labels)
 
     return DataFrameAdapter.from_pandas(
         df,

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -251,7 +251,6 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             return FileResponse(
                 full_path,
                 stat_result=stat_result,
-                method="GET",
                 status_code=HTTP_200_OK,
             )
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -270,9 +270,9 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             principal=Security(get_current_principal, scopes=[]),
         ):
             return templates.TemplateResponse(
+                request,
                 "index.html",
                 {
-                    "request": request,
                     # This is used to construct the link to the React UI.
                     "root_url": get_root_url(request),
                     # If defined, this adds a Binder link to the page.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -3,7 +3,7 @@ import hashlib
 import secrets
 import uuid as uuid_module
 import warnings
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -83,7 +83,7 @@ DEVICE_CODE_POLLING_INTERVAL = 5  # seconds
 
 def utcnow():
     "UTC now with second resolution"
-    return datetime.utcnow().replace(microsecond=0)
+    return datetime.now(UTC).replace(microsecond=0)
 
 
 class Mode(enum.Enum):
@@ -1038,7 +1038,11 @@ async def slide_session(refresh_token, settings, db):
     now = utcnow()
     # This token is *signed* so we know that the information came from us.
     # If the Session is forgotten or revoked or expired, do not allow refresh.
-    if (session is None) or session.revoked or (session.expiration_time < now):
+    if (
+        (session is None)
+        or session.revoked
+        or (session.expiration_time.replace(tzinfo=UTC) < now)
+    ):
         # Do not leak (to a potential attacker) whether this has been *revoked*
         # specifically. Give the same error as if it had expired.
         raise HTTPException(

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -587,9 +587,9 @@ def build_device_code_user_code_form_route(authentication, provider):
             f"{get_base_url(request)}/auth/provider/{provider}/device_code?code={code}"
         )
         return templates.TemplateResponse(
+            request,
             "device_code_form.html",
             {
-                "request": request,
                 "code": code,
                 "action": action,
             },
@@ -627,9 +627,9 @@ def build_device_code_user_code_submit_route(authenticator, provider):
         if pending_session is None:
             message = "Invalid user code. It may have been mistyped, or the pending request may have expired."
             return templates.TemplateResponse(
+                request,
                 "device_code_form.html",
                 {
-                    "request": request,
                     "code": code,
                     "action": action,
                     "message": message,
@@ -639,9 +639,9 @@ def build_device_code_user_code_submit_route(authenticator, provider):
         user_session_state = await authenticator.authenticate(request)
         if not user_session_state:
             return templates.TemplateResponse(
+                request,
                 "device_code_failure.html",
                 {
-                    "request": request,
                     "message": (
                         "User code was correct but authentication with third party failed. "
                         "Ask administrator to see logs for details."
@@ -660,9 +660,9 @@ def build_device_code_user_code_submit_route(authenticator, provider):
         db.add(pending_session)
         await db.commit()
         return templates.TemplateResponse(
+            request,
             "device_code_success.html",
             {
-                "request": request,
                 "interval": DEVICE_CODE_POLLING_INTERVAL,
             },
         )

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -3,7 +3,7 @@ import hashlib
 import secrets
 import uuid as uuid_module
 import warnings
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -83,7 +83,7 @@ DEVICE_CODE_POLLING_INTERVAL = 5  # seconds
 
 def utcnow():
     "UTC now with second resolution"
-    return datetime.now(UTC).replace(microsecond=0)
+    return datetime.now(timezone.utc).replace(microsecond=0)
 
 
 class Mode(enum.Enum):
@@ -1041,7 +1041,7 @@ async def slide_session(refresh_token, settings, db):
     if (
         (session is None)
         or session.revoked
-        or (session.expiration_time.replace(tzinfo=UTC) < now)
+        or (session.expiration_time.replace(tzinfo=timezone.utc) < now)
     ):
         # Do not leak (to a potential attacker) whether this has been *revoked*
         # specifically. Give the same error as if it had expired.

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -8,7 +8,7 @@ import sys
 import types
 import uuid
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import md5
 from typing import Any
 
@@ -225,7 +225,7 @@ async def construct_entries_response(
             keys = tree.keys()[offset : offset + limit]  # noqa: E203
         items = [(key, None) for key in keys]
     # This value will not leak out. It just used to seed comparisons.
-    metadata_stale_at = datetime.now(UTC) + timedelta(days=1_000_000)
+    metadata_stale_at = datetime.now(timezone.utc) + timedelta(days=1_000_000)
     must_revalidate = getattr(tree, "must_revalidate", True)
     for key, entry in items:
         resource = await construct_resource(

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -8,7 +8,7 @@ import sys
 import types
 import uuid
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from hashlib import md5
 from typing import Any
 
@@ -225,7 +225,7 @@ async def construct_entries_response(
             keys = tree.keys()[offset : offset + limit]  # noqa: E203
         items = [(key, None) for key in keys]
     # This value will not leak out. It just used to seed comparisons.
-    metadata_stale_at = datetime.utcnow() + timedelta(days=1_000_000)
+    metadata_stale_at = datetime.now(UTC) + timedelta(days=1_000_000)
     must_revalidate = getattr(tree, "must_revalidate", True)
     for key, entry in items:
         resource = await construct_resource(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -3,7 +3,7 @@ import inspect
 import os
 import re
 import warnings
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from pathlib import Path
 from typing import Any, List, Optional
@@ -151,7 +151,7 @@ async def about(
             },
             meta={"root_path": request.scope.get("root_path") or "" + "/api"},
         ).model_dump(),
-        expires=datetime.utcnow() + timedelta(seconds=600),
+        expires=datetime.now(UTC) + timedelta(seconds=600),
     )
 
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -3,7 +3,7 @@ import inspect
 import os
 import re
 import warnings
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
 from typing import Any, List, Optional
@@ -151,7 +151,7 @@ async def about(
             },
             meta={"root_path": request.scope.get("root_path") or "" + "/api"},
         ).model_dump(),
-        expires=datetime.now(UTC) + timedelta(seconds=600),
+        expires=datetime.now(timezone.utc) + timedelta(seconds=600),
     )
 
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1646,7 +1646,6 @@ async def get_asset(
     return FileResponseWithRange(
         full_path,
         stat_result=stat_result,
-        method="GET",
         status_code=status_code,
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         range=range,


### PR DESCRIPTION
Various DeprecationWarnings and others have crept up.

- `datetime.utcnow()` (naive) -> `datetime.now(UTC)` (localized), and any comparisons with the result of this also need to be localized
- `sparse.COO` wants true numpy arrays, not Python lists.
- `pandas` removed `delim_whitespace`.
- `TemplateResponse` changed around its signature.
- `FileResponse` no longer accepts `method` parameter (it's implicitly always `GET`).

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
