### PR TITLE
Fix access control docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Maintenance
 
 - Addressed DeprecationWarnings from Python and dependencies
+- Update AccessPolicy Docs to match new filter arguments
 
 ## v0.1.0-b13 (2024-01-09)
 

--- a/docs/source/explanations/access-control.md
+++ b/docs/source/explanations/access-control.md
@@ -101,10 +101,10 @@ class PASSAccessPolicy:
                 f"Its identities are: {principal.identities}"
             )
 
-    def allowed_scopes(self, node, principal):
+    def allowed_scopes(self, node, principal, path_parts):
         return {"read:metadata", "read:data"}
 
-    def filters(self, node, principal, scopes):
+    def filters(self, node, principal, scopes, path_parts):
         queries = []
         id = self._get_id(principal)
         if not scopes.issubset({"read:metadata", "read:data"}):


### PR DESCRIPTION
Add `path_parts` argument to the example `PASSAccessPolicy` in docs

Updates `filter()` and `allowed_scopes()`

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section (None)
