### PR TITLE
Refactor the initialization of dask.DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - Addressed DeprecationWarnings from Python and dependencies
 - Update AccessPolicy Docs to match new filter arguments
+- Refactored intialization of dask DataFrame
 
 ## v0.1.0-b13 (2024-01-09)
 

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -164,18 +164,18 @@ class _DaskDataFrameClient(BaseClient):
         # server-side dask array.
         label = f"remote-dask-dataframe-{self.item['links']['self']}"
         meta = structure.meta
-
         if columns is not None:
             meta = meta[columns]
+
         ddf = dask.dataframe.from_map(
             self._get_partition,
             range(structure.npartitions),
             meta=meta,
             label=label,
             divisions=(None,) * (1 + structure.npartitions),
+            columns=columns,
         )
-        if columns is not None:
-            ddf = ddf[columns]
+
         return ddf
 
     # We implement *some* of the Mapping interface here but intentionally not


### PR DESCRIPTION
There have a been a few changes in the dask DataFrame API in v. 2025.1.0:
1. The import has changed from `dask.dataframe.core.DataFrame` to `dask.dataframe.DataFrame`.
2. The direct instantiation of `DataFrame` objects is currently [discouraged](https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.html#:~:text=The%20class%20is%20not%20meant%20to%20be%20instantiated%20directly.). Therefore, the instantiation was changed to `dask.dataframe.from_map` ([link](https://docs.dask.org/en/stable/generated/dask.dataframe.from_map.html#dask.dataframe.from_map)) taking as its argument a callable that creates certain partitions. The `name` kwarg has been replaced with `label`.

### Checklist
- [x] Add a Changelog entry
- [x] ~~Add the ticket number which this PR closes to the comment section~~
