### PR TITLE
Refactor Authenticators to make use of inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - Make depedencies shared by client and server into core dependencies.
 - Use schemas for describing server configuration on the client side too.
+- Refactored Authentication providers to make use of inheritance, adjusted
+  mode in the `AboutAuthenticationProvider` schema to be `internal`|`external`.
 
 ## v0.1.0-b16 (2024-01-23)
 

--- a/docs/source/reference/authentication.md
+++ b/docs/source/reference/authentication.md
@@ -49,7 +49,7 @@ $ http :8000/api/v1/ | jq .authentication
   "providers": [
     {
       "provider": "toy",
-      "mode": "password",
+      "mode": "internal",
       "links": {
         "auth_endpoint": "http://localhost:8000/api/v1/auth/provider/toy/token"
       },

--- a/example_configs/external_service/custom.py
+++ b/example_configs/external_service/custom.py
@@ -1,13 +1,13 @@
 import numpy
 
 from tiled.adapters.array import ArrayAdapter
-from tiled.authenticators import Mode, UserSessionState
+from tiled.authenticators import UserSessionState
+from tiled.server.protocols import InternalAuthenticator
 from tiled.structures.core import StructureFamily
 
 
-class Authenticator:
+class Authenticator(InternalAuthenticator):
     "This accepts any password and stashes it in session state as 'token'."
-    mode = Mode.password
 
     async def authenticate(self, username: str, password: str) -> UserSessionState:
         return UserSessionState(username, {"token": password})

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -5,7 +5,7 @@ import logging
 import re
 import secrets
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any, Mapping, Optional, cast
 
 import httpx
 from fastapi import APIRouter, Request
@@ -13,15 +13,18 @@ from jose import JWTError, jwt
 from pydantic import Secret
 from starlette.responses import RedirectResponse
 
-from .server.authentication import Mode
-from .server.protocols import UserSessionState
+from .server.protocols import (
+    ExternalAuthenticator,
+    InternalAuthenticator,
+    UserSessionState,
+)
 from .server.utils import get_root_url
 from .utils import modules_available
 
 logger = logging.getLogger(__name__)
 
 
-class DummyAuthenticator:
+class DummyAuthenticator(InternalAuthenticator):
     """
     For test and demo purposes only!
 
@@ -29,23 +32,20 @@ class DummyAuthenticator:
 
     """
 
-    mode = Mode.password
-
-    def __init__(self, confirmation_message=""):
+    def __init__(self, confirmation_message: str = ""):
         self.confirmation_message = confirmation_message
 
     async def authenticate(self, username: str, password: str) -> UserSessionState:
         return UserSessionState(username, {})
 
 
-class DictionaryAuthenticator:
+class DictionaryAuthenticator(InternalAuthenticator):
     """
     For test and demo purposes only!
 
     Check passwords from a dictionary of usernames mapped to passwords.
     """
 
-    mode = Mode.password
     configuration_schema = """
 $schema": http://json-schema.org/draft-07/schema#
 type: object
@@ -61,11 +61,15 @@ properties:
     description: May be displayed by client after successful login.
 """
 
-    def __init__(self, users_to_passwords, confirmation_message=""):
+    def __init__(
+        self, users_to_passwords: Mapping[str, str], confirmation_message: str = ""
+    ):
         self._users_to_passwords = users_to_passwords
         self.confirmation_message = confirmation_message
 
-    async def authenticate(self, username: str, password: str) -> UserSessionState:
+    async def authenticate(
+        self, username: str, password: str
+    ) -> Optional[UserSessionState]:
         true_password = self._users_to_passwords.get(username)
         if not true_password:
             # Username is not valid.
@@ -74,8 +78,7 @@ properties:
             return UserSessionState(username, {})
 
 
-class PAMAuthenticator:
-    mode = Mode.password
+class PAMAuthenticator(InternalAuthenticator):
     configuration_schema = """
 $schema": http://json-schema.org/draft-07/schema#
 type: object
@@ -89,7 +92,7 @@ properties:
     description: May be displayed by client after successful login.
 """
 
-    def __init__(self, service="login", confirmation_message=""):
+    def __init__(self, service: str = "login", confirmation_message: str = ""):
         if not modules_available("pamela"):
             raise ModuleNotFoundError(
                 "This PAMAuthenticator requires the module 'pamela' to be installed."
@@ -98,20 +101,20 @@ properties:
         self.confirmation_message = confirmation_message
         # TODO Try to open a PAM session.
 
-    async def authenticate(self, username: str, password: str) -> UserSessionState:
+    async def authenticate(
+        self, username: str, password: str
+    ) -> Optional[UserSessionState]:
         import pamela
 
         try:
             pamela.authenticate(username, password, service=self.service)
+            return UserSessionState(username, {})
         except pamela.PAMError:
             # Authentication failed.
             return
-        else:
-            return UserSessionState(username, {})
 
 
-class OIDCAuthenticator:
-    mode = Mode.external
+class OIDCAuthenticator(ExternalAuthenticator):
     configuration_schema = """
 $schema": http://json-schema.org/draft-07/schema#
 type: object
@@ -178,7 +181,7 @@ properties:
             cast(str, self._config_from_oidc_url.get("authorization_endpoint"))
         )
 
-    async def authenticate(self, request: Request) -> UserSessionState:
+    async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         code = request.query_params["code"]
         # A proxy in the middle may make the request into something like
         # 'http://localhost:8000/...' so we fix the first part but keep
@@ -216,11 +219,13 @@ properties:
         return UserSessionState(verified_body["sub"], {})
 
 
-class KeyNotFoundError(Exception):
-    pass
-
-
-async def exchange_code(token_uri, auth_code, client_id, client_secret, redirect_uri):
+async def exchange_code(
+    token_uri: str,
+    auth_code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> httpx.Response:
     """Method that talks to an IdP to exchange a code for an access_token and/or id_token
     Args:
         token_url ([type]): [description]
@@ -241,14 +246,12 @@ async def exchange_code(token_uri, auth_code, client_id, client_secret, redirect
     return response
 
 
-class SAMLAuthenticator:
-    mode = Mode.external
-
+class SAMLAuthenticator(ExternalAuthenticator):
     def __init__(
         self,
         saml_settings,  # See EXAMPLE_SAML_SETTINGS below.
-        attribute_name,  # which SAML attribute to use as 'id' for Idenity
-        confirmation_message="",
+        attribute_name: str,  # which SAML attribute to use as 'id' for Idenity
+        confirmation_message: str = "",
     ):
         self.saml_settings = saml_settings
         self.attribute_name = attribute_name
@@ -268,7 +271,7 @@ class SAMLAuthenticator:
         from onelogin.saml2.auth import OneLogin_Saml2_Auth
 
         @router.get("/login")
-        async def saml_login(request: Request):
+        async def saml_login(request: Request) -> RedirectResponse:
             req = await prepare_saml_from_fastapi_request(request)
             auth = OneLogin_Saml2_Auth(req, self.saml_settings)
             # saml_settings = auth.get_settings()
@@ -279,12 +282,11 @@ class SAMLAuthenticator:
             # else:
             #   print("Error found on Metadata: %s" % (', '.join(errors)))
             callback_url = auth.login()
-            response = RedirectResponse(url=callback_url)
-            return response
+            return RedirectResponse(url=callback_url)
 
         self.include_routers = [router]
 
-    async def authenticate(self, request) -> UserSessionState:
+    async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         if not modules_available("onelogin"):
             raise ModuleNotFoundError(
                 "This SAMLAuthenticator requires the module 'oneline' to be installed."
@@ -310,7 +312,7 @@ class SAMLAuthenticator:
             return None
 
 
-async def prepare_saml_from_fastapi_request(request, debug=False):
+async def prepare_saml_from_fastapi_request(request: Request) -> Mapping[str, str]:
     form_data = await request.form()
     rv = {
         "http_host": request.client.host,
@@ -336,7 +338,7 @@ async def prepare_saml_from_fastapi_request(request, debug=False):
     return rv
 
 
-class LDAPAuthenticator:
+class LDAPAuthenticator(InternalAuthenticator):
     """
     The authenticator code is based on https://github.com/jupyterhub/ldapauthenticator
     The parameter ``use_tls`` was added for convenience of testing.
@@ -518,8 +520,6 @@ class LDAPAuthenticator:
                 - provider: ldap_local
                 id: user02
     """
-
-    mode = Mode.password
 
     def __init__(
         self,
@@ -733,7 +733,9 @@ class LDAPAuthenticator:
                 attrs = conn.entries[0].entry_attributes_as_dict
         return attrs
 
-    async def authenticate(self, username: str, password: str) -> UserSessionState:
+    async def authenticate(
+        self, username: str, password: str
+    ) -> Optional[UserSessionState]:
         import ldap3
 
         username_saved = username  # Save the user name passed as a parameter

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -99,7 +99,7 @@ def prompt_for_credentials(http_client, providers: List[AboutAuthenticationProvi
     auth_endpoint = spec.links["auth_endpoint"]
     provider = spec.provider
     mode = spec.mode
-    if mode == "password":
+    if mode == "internal":
         # Prompt for username, password at terminal.
         username = username_input()
         PASSWORD_ATTEMPTS = 3

--- a/tiled/schemas.py
+++ b/tiled/schemas.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 class AboutAuthenticationProvider(BaseModel):
     provider: str
-    mode: Literal["password", "external"]
+    mode: Literal["internal", "external"]
     links: Dict[str, str]
     confirmation_message: Optional[str] = None
 

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -1,4 +1,3 @@
-import enum
 import hashlib
 import secrets
 import uuid as uuid_module
@@ -62,7 +61,7 @@ from ..authn_database.core import (
 from ..utils import SHARE_TILED_PATH, SpecialUsers
 from . import schemas
 from .core import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, json_or_msgpack
-from .protocols import UsernamePasswordAuthenticator, UserSessionState
+from .protocols import InternalAuthenticator, UserSessionState
 from .settings import get_settings
 from .utils import API_KEY_COOKIE_NAME, get_authenticators, get_base_url
 
@@ -84,11 +83,6 @@ DEVICE_CODE_POLLING_INTERVAL = 5  # seconds
 def utcnow():
     "UTC now with second resolution"
     return datetime.now(timezone.utc).replace(microsecond=0)
-
-
-class Mode(enum.Enum):
-    password = "password"
-    external = "external"
 
 
 class Token(BaseModel):
@@ -710,9 +704,7 @@ def build_device_code_token_route(authenticator, provider):
     return route
 
 
-def build_handle_credentials_route(
-    authenticator: UsernamePasswordAuthenticator, provider
-):
+def build_handle_credentials_route(authenticator: InternalAuthenticator, provider):
     "Register a handle_credentials route function for this Authenticator."
 
     async def route(

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -1,22 +1,23 @@
+from abc import ABC
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Optional
 
 from fastapi import Request
 
 
 @dataclass
 class UserSessionState:
-    """Data transfer class to communicate custom session state infromation."""
+    """Data transfer class to communicate custom session state information."""
 
     user_name: str
     state: dict = None
 
 
-class UsernamePasswordAuthenticator(Protocol):
-    def authenticate(self, username: str, password: str) -> UserSessionState:
-        pass
+class InternalAuthenticator(ABC):
+    def authenticate(self, username: str, password: str) -> Optional[UserSessionState]:
+        raise NotImplementedError
 
 
-class Authenticator(Protocol):
-    def authenticate(self, request: Request) -> UserSessionState:
-        pass
+class ExternalAuthenticator(ABC):
+    def authenticate(self, request: Request) -> Optional[UserSessionState]:
+        raise NotImplementedError

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -27,13 +27,14 @@ from starlette.status import (
 )
 
 from tiled.schemas import About
+from tiled.server.protocols import ExternalAuthenticator, InternalAuthenticator
 
 from .. import __version__
 from ..structures.core import Spec, StructureFamily
 from ..utils import ensure_awaitable, patch_mimetypes, path_from_uri
 from ..validation_registration import ValidationError
 from . import schemas
-from .authentication import Mode, get_authenticators, get_current_principal
+from .authentication import get_authenticators, get_current_principal
 from .core import (
     DEFAULT_PAGE_SIZE,
     DEPTH_LIMIT,
@@ -92,10 +93,10 @@ async def about(
     }
     provider_specs = []
     for provider, authenticator in authenticators.items():
-        if authenticator.mode == Mode.password:
+        if isinstance(authenticator, InternalAuthenticator):
             spec = {
                 "provider": provider,
-                "mode": authenticator.mode.value,
+                "mode": "internal",
                 "links": {
                     "auth_endpoint": f"{base_url}/auth/provider/{provider}/token"
                 },
@@ -103,10 +104,10 @@ async def about(
                     authenticator, "confirmation_message", None
                 ),
             }
-        elif authenticator.mode == Mode.external:
+        elif isinstance(authenticator, ExternalAuthenticator):
             spec = {
                 "provider": provider,
-                "mode": authenticator.mode.value,
+                "mode": "external",
                 "links": {
                     "auth_endpoint": f"{base_url}/auth/provider/{provider}/authorize"
                 },

--- a/web-frontend/src/openapi_schemas.ts
+++ b/web-frontend/src/openapi_schemas.ts
@@ -94,7 +94,7 @@ export interface components {
      * @description An enumeration.
      * @enum {string}
      */
-    AuthenticationMode: "password" | "external";
+    AuthenticationMode: "internal" | "external";
     /**
      * EntryFields
      * @description An enumeration.


### PR DESCRIPTION
Replaces the use of the Mode enum with inheritance from two abstract base classes that provide different authentication mechanisms. Added some type hints.

Replaced "password" in AboutAuthenticationProvider with "internal", which is then a matching pair with "external". 

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
