### PR TITLE
Replace use of internal Starlette compatibility (with python <3.9) function with wrapped function

### DIFF
--- a/tiled/server/file_response_with_range.py
+++ b/tiled/server/file_response_with_range.py
@@ -7,19 +7,13 @@
 # starlette adds support upstream, we should consider refactoring to use that.
 
 # Ref: https://github.com/encode/starlette/pull/1999
+import hashlib
 import os
 import stat
 import typing
 
 import anyio
-from starlette.responses import (
-    FileResponse,
-    Receive,
-    Scope,
-    Send,
-    formatdate,
-    md5_hexdigest,
-)
+from starlette.responses import FileResponse, Receive, Scope, Send, formatdate
 from starlette.status import HTTP_200_OK, HTTP_206_PARTIAL_CONTENT
 
 
@@ -52,7 +46,7 @@ class FileResponseWithRange(FileResponse):
             self.headers.setdefault("content-range", f"bytes {start}-{end}/{size}")
         else:
             content_length = size
-        etag = md5_hexdigest(etag_base.encode(), usedforsecurity=False)
+        etag = hashlib.md5(etag_base.encode(), usedforsecurity=False).hexdigest()
 
         self.headers.setdefault("content-length", content_length)
         self.headers.setdefault("last-modified", last_modified)


### PR DESCRIPTION
Starlette 0.44.0 and before contained an internal function for compatibility with python <3.9. As Starlette 0.45.0 dropped support for python 3.8, this was silently removed. As Tiled also has dropped support for python 3.8, we can remove the function.

https://github.com/encode/starlette/blob/0.44.0/starlette/_compat.py

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
