### PR TITLE
Allow reading string-valued arrays from DataFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Added
+
+- Added `.get` methods on TableAdapter and ParquetDatasetAdapter
+- Ability to read string-valued columns of data frames as arrays
+
 ### Maintenance
 
 - Make depedencies shared by client and server into core dependencies.

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -13,6 +13,7 @@ from ..type_aliases import JSON
 from ..utils import path_from_uri
 from .dataframe import DataFrameAdapter
 from .utils import init_adapter_from_catalog
+from .array import ArrayAdapter
 
 
 class ParquetDatasetAdapter:
@@ -163,3 +164,7 @@ class ParquetDatasetAdapter:
 
         """
         return self._structure
+
+
+    def get(self, key: str) -> Union[ArrayAdapter, None]:
+        return self.dataframe_adapter.get(key)

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -11,9 +11,9 @@ from ..structures.data_source import DataSource
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
 from ..utils import path_from_uri
+from .array import ArrayAdapter
 from .dataframe import DataFrameAdapter
 from .utils import init_adapter_from_catalog
-from .array import ArrayAdapter
 
 
 class ParquetDatasetAdapter:
@@ -164,7 +164,6 @@ class ParquetDatasetAdapter:
 
         """
         return self._structure
-
 
     def get(self, key: str) -> Union[ArrayAdapter, None]:
         return self.dataframe_adapter.get(key)

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -135,30 +135,25 @@ class TableAdapter:
         return f"{type(self).__name__}({self._structure.columns!r})"
 
     def __getitem__(self, key: str) -> ArrayAdapter:
-        """
+        # Must compute to determine shape
+        array = self.read([key])[key].values
 
-        Parameters
-        ----------
-        key :
+        # Convert (experimental) pandas.StringDtype to numpy's unicode string dtype
+        if isinstance(array.dtype, pandas.StringDtype):
+            import numpy
 
-        Returns
-        -------
+            max_size = max((len(i) for i in array.ravel()))
+            array = array.astype(dtype=numpy.dtype(f"<U{max_size}"))
 
-        """
-        # Must compute to determine shape.
-        return ArrayAdapter.from_array(self.read([key])[key].values)
+        return ArrayAdapter.from_array(array)
+
+    def get(self, key: str) -> Union[ArrayAdapter, None]:
+        if key not in self.structure().columns:
+            return None
+        return self[key]
 
     def items(self) -> Iterator[Tuple[str, ArrayAdapter]]:
-        """Iterator over table columns
-
-        Returns
-        -------
-        Tuples of column names and corresponding ArrayAdapters
-        """
-        yield from (
-            (key, ArrayAdapter.from_array(self.read([key])[key].values))
-            for key in self._structure.columns
-        )
+        yield from ((key, self[key]) for key in self._structure.columns)
 
     def metadata(self) -> JSON:
         return self._metadata


### PR DESCRIPTION
1. Added `.get` method to `TableAdapter` and `ParquetDatasetAdapter`
2. Allow representation of string-valued arrays derived from columns of data frames. The resulting arrays are cast as `<U{max_size}` type, where `max_size` is the maximum length among all strings in the array.

### Checklist
- [x] Add a Changelog entry
- [x] ~~Add the ticket number which this PR closes to the comment section~~
