### PR TITLE
WIP: Array Views

### DIFF
--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -85,8 +85,8 @@ def test_arrayadapter_protocol(mocker: MockFixture) -> None:
 
     array = numpy.random.rand(2, 512, 512)
     metadata: JSON = {"foo": "bar"}
-    anyslice = (1, 1, 1)
-    anyblock = (1, 1, 1)
+    anyslice = NDSlice(1, 1, 1)
+    anyblock = NDSlice(1, 1, 1)
 
     anyarrayadapter = CustomArrayAdapter(array, structure, metadata=metadata)
     assert anyarrayadapter.structure_family == StructureFamily.array
@@ -158,7 +158,7 @@ def test_awkwardadapter_protocol(mocker: MockFixture) -> None:
     structure = AwkwardStructure(length=2, form={"a": "b"})
 
     metadata: JSON = {"foo": "bar"}
-    anyslice = (1, 1, 1)
+    anyslice = NDSlice(1, 1, 1)
     container = DirectoryContainer(directory=Path("somedirectory"), form={})
     form_keys = ["a", "b", "c"]
 
@@ -247,8 +247,8 @@ def test_sparseadapter_protocol(mocker: MockFixture) -> None:
     array = numpy.random.rand(2, 512, 512)
     blocks: Dict[Tuple[int, ...], Tuple[NDArray[Any], Any]] = {(1,): (array, (1,))}
     metadata: JSON = {"foo": "bar"}
-    anyslice = (1, 1, 1)
-    anyblock = (1, 1, 1)
+    anyslice = NDSlice(1, 1, 1)
+    anyblock = NDSlice(1, 1, 1)
 
     anysparseadapter = CustomSparseAdapter(blocks, structure, metadata=metadata)
     assert anysparseadapter.structure_family == StructureFamily.sparse

--- a/tiled/_tests/test_views.py
+++ b/tiled/_tests/test_views.py
@@ -224,3 +224,14 @@ def test_external_assets(context, tiff_sequence, csv_file):
     assert numpy.array_equal(ext_v["image_v"].read(), img_data)
     assert numpy.array_equal(ext_v["col1_v"].read(), df3["col1"])
     assert numpy.array_equal(ext_v["col2_v"].read(), df3["col2"])
+
+
+def test_table_view(context):
+    client = from_context(context)
+    tbl_view = client["x/y"].create_table_view(
+        key="tbl_view",
+        arr_links=["/x/y/arr1", "/x/y/df1/A"],
+        slices=[(slice(0, 8, 3), 1), None],
+    )
+
+    tbl_view.read()

--- a/tiled/_tests/test_views.py
+++ b/tiled/_tests/test_views.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+
+import awkward
+import numpy
+import pandas
+import pytest
+import sparse
+import tifffile as tf
+
+from ..catalog import in_memory
+from ..client import Context, from_context
+from ..server.app import build_app
+from ..structures.array import ArrayStructure, BuiltinDtype
+from ..structures.core import StructureFamily
+from ..structures.data_source import Asset, DataSource, Management
+from ..structures.table import TableStructure
+
+rng = numpy.random.default_rng(12345)
+
+df1 = pandas.DataFrame({"A": ["one", "two", "three"], "B": [1, 2, 3]})
+df2 = pandas.DataFrame(
+    {
+        "C": ["red", "green", "blue", "white"],
+        "D": [10.0, 20.0, 30.0, 40.0],
+        "E": [0, 0, 0, 0],
+    }
+)
+df3 = pandas.DataFrame(
+    {
+        "col1": ["one", "two", "three", "four", "five"],
+        "col2": [1.0, 2.0, 3.0, 4.0, 5.0],
+    }
+)
+arr1 = rng.random(size=(13, 15), dtype="float64")
+arr2 = rng.integers(0, 255, size=(5, 7, 3), dtype="uint8")
+img_data = rng.integers(0, 255, size=(5, 13, 17, 3), dtype="uint8")
+
+md = {"md_key1": "md_val1", "md_key2": 2}
+
+@pytest.fixture
+def tiff_sequence(tmpdir):
+    sequence_directory = Path(tmpdir, "sequence")
+    sequence_directory.mkdir()
+    filepaths = []
+    for i in range(img_data.shape[0]):
+        fpath = sequence_directory / f"temp{i:05}.tif"
+        tf.imwrite(fpath, img_data[i, ...])
+        filepaths.append(fpath)
+
+    yield filepaths
+
+
+@pytest.fixture
+def csv_file(tmpdir):
+    fpath = Path(tmpdir, "test.csv")
+    df3.to_csv(fpath, index=False)
+
+    yield fpath
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory):
+    return in_memory(writable_storage=tmp_path_factory.getbasetemp())
+
+
+@pytest.fixture(scope="module")
+def context(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+        # Write data in the root container
+        client.write_array(arr1, key="arr1", metadata={"md_key": "md_for_arr1"})
+        client.write_dataframe(df1, key="df1", metadata={"md_key": "md_for_df1"})
+
+        # Write data in subcontainers
+        x = client.create_container(key="x", metadata=md)
+        x.write_array(arr1, key="arr1", metadata={"md_key": "md_for_arr1"})
+        x.write_array(arr2, key="arr2", metadata={"md_key": "md_for_arr2"})
+        x.write_dataframe(df1, key="df1", metadata={"md_key": "md_for_df1"})
+        x.write_dataframe(df2, key="df2", metadata={"md_key": "md_for_df2"})
+        y = x.create_container(key="y", metadata=md)
+        y.write_array(arr1, key="arr1", metadata={"md_key": "md_for_arr1"})
+        y.write_dataframe(df1, key="df1", metadata={"md_key": "md_for_df1"})
+
+        yield context
+
+
+def test_original_locations(context):
+    client = from_context(context)
+    arr_v = client.create_container(key = 'arr_v')
+    arr_v.create_array_view(links=['/arr1'], key='arr1')
+    arr_v.create_array_view(links=['/x/arr1'], key='x_arr1')
+    arr_v.create_array_view(links=['/x/y/arr1'], key='x_y_arr1')
+
+    for key in ('arr1', 'x_arr1', 'x_y_arr1'):
+        assert numpy.array_equal(arr_v[key].read(), arr1)
+
+
+def test_table_columns(context):
+    client = from_context(context)
+    tbl_v = client.create_container(key = 'tbl_v')
+    tbl_v.create_array_view(links=['/x/y/df1/A'], key='A')
+    tbl_v.create_array_view(links=['/x/y/df1/B'], key='B')
+
+    for key in ('A', 'B'):
+        assert numpy.array_equal(tbl_v[key].read(), df1[key])
+
+def test_slices(context):
+    client = from_context(context)
+    slc_v = client.create_container(key = 'slc_v')
+    slc_v.create_array_view(links=['/x/df2/C'], key='C', slices=[(slice(0, 2),)])
+    assert numpy.array_equal(slc_v['C'].read(), df2['C'][0:2])
+
+    slc_v.create_array_view(links=['/x/arr2'], key='a2_v', slices=[(slice(0, 2), 1, ...)])
+    assert numpy.array_equal(slc_v['a2_v'].read(), arr2[slice(0, 2), 1, ...])
+
+
+def test_external_assets(context, tiff_sequence, csv_file):
+    client = from_context(context)
+
+    # Write some data with external assets
+    tiff_assets = [
+        Asset(
+            data_uri=f"file://localhost{fpath}",
+            is_directory=False,
+            parameter="data_uris",
+            num=i + 1,
+        )
+        for i, fpath in enumerate(tiff_sequence)
+    ]
+    tiff_structure_0 = ArrayStructure(
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+        shape=(5, 13, 17, 3),
+        chunks=((1, 1, 1, 1, 1), (13,), (17,), (3,)),
+    )
+    tiff_data_source = DataSource(
+        mimetype="multipart/related;type=image/tiff",
+        assets=tiff_assets,
+        structure_family=StructureFamily.array,
+        structure=tiff_structure_0,
+        management=Management.external,
+    )
+
+    csv_assets = [
+        Asset(
+            data_uri=f"file://localhost{csv_file}",
+            is_directory=False,
+            parameter="data_uris",
+        )
+    ]
+    csv_data_source = DataSource(
+        mimetype="text/csv",
+        assets=csv_assets,
+        structure_family=StructureFamily.table,
+        structure=TableStructure.from_pandas(df3),
+        management=Management.external,
+    )
+
+    z = client.create_container(key="z")
+    z.new(
+        structure_family=StructureFamily.array,
+        data_sources=[tiff_data_source],
+        key="image",
+    )
+    z.new(
+        structure_family=StructureFamily.table,
+        data_sources=[csv_data_source],
+        key="table",
+    )
+
+    ext_v = client.create_container(key = 'ext_v')
+    ext_v.create_array_view(links=['/z/image'], key='image_v')
+    ext_v.create_array_view(links=['/z/table/col1'], key='col1_v')
+    ext_v.create_array_view(links=['/z/table/col2'], key='col2_v')
+    assert numpy.array_equal(ext_v['image_v'].read(), img_data)
+    assert numpy.array_equal(ext_v['col1_v'].read(), df3['col1'])
+    assert numpy.array_equal(ext_v['col2_v'].read(), df3['col2'])

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -148,16 +148,6 @@ class ArrayAdapter:
         return array
 
 
-class ArrayViewAdapter(ArrayAdapter):
-
-    structure_family = StructureFamily.array
-
-    @classmethod
-    def from_catalog(cls, data_source, node, **kwargs):
-        breakpoint()
-        pass
-
-
 def slice_and_shape_from_block_and_chunks(
     block: Tuple[int, ...], chunks: Tuple[Tuple[int, ...], ...]
 ) -> Tuple[NDSlice, Tuple[int, ...]]:

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -103,7 +103,7 @@ class ArrayAdapter:
         slice = data_source.parameters.get("slice")
         slice = NDSlice.from_json(slice) if slice is not None else None
         if isinstance(adapter, ArrayAdapter):
-            arr = adapter._array[slice] if slice else adapter._array
+            arr = adapter._array[tuple(slice)] if slice else adapter._array
         else:
             arr = adapter.read(slice) if slice else adapter.read()
 
@@ -129,7 +129,7 @@ class ArrayAdapter:
 
     def read(
         self,
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> NDArray[Any]:
         """
 
@@ -141,7 +141,7 @@ class ArrayAdapter:
         -------
 
         """
-        array = self._array[slice]
+        array = self._array[tuple(slice)] if slice else self._array
         if isinstance(self._array, dask.array.Array):
             return array.compute()
         return array
@@ -149,7 +149,7 @@ class ArrayAdapter:
     def read_block(
         self,
         block: Tuple[int, ...],
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> NDArray[Any]:
         """
 
@@ -164,7 +164,7 @@ class ArrayAdapter:
         """
         # Slice the whole array to get this block.
         slice_, _ = slice_and_shape_from_block_and_chunks(block, self._structure.chunks)
-        array = self._array[slice_]
+        array = self._array[tuple(slice_)]
         # Slice within the block.
         if slice is not None:
             array = array[slice]

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -104,6 +104,7 @@ class ArrayAdapter:
         if isinstance(adapter, ArrayAdapter):
             arr = adapter._array[tuple(slice)] if slice else adapter._array
         else:
+            # For adapters that do not inherit from ArrayAdapter
             arr = adapter.read(slice) if slice else adapter.read()
 
         return cls(

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -1,4 +1,3 @@
-from types import EllipsisType
 from typing import Any, List, Optional, Tuple, Union
 
 import dask.array

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import Any, List, Optional, Tuple, Union
 
 import dask.array
@@ -128,7 +129,7 @@ class ArrayAdapter:
 
     def read(
         self,
-        slice: NDSlice = NDSlice(...),
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> NDArray[Any]:
         """
 
@@ -148,7 +149,7 @@ class ArrayAdapter:
     def read_block(
         self,
         block: Tuple[int, ...],
-        slice: NDSlice = NDSlice(...),
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> NDArray[Any]:
         """
 
@@ -174,7 +175,7 @@ class ArrayAdapter:
 
 def slice_and_shape_from_block_and_chunks(
     block: Tuple[int, ...], chunks: Tuple[Tuple[int, ...], ...]
-) -> Tuple[NDSlice, Tuple[int, ...]]:
+) -> tuple[NDSlice, NDSlice]:
     """
     Given dask-like chunks and block id, return slice and shape of the block.
     Parameters

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -148,6 +148,16 @@ class ArrayAdapter:
         return array
 
 
+class ArrayViewAdapter(ArrayAdapter):
+
+    structure_family = StructureFamily.array
+
+    @classmethod
+    def from_catalog(cls, data_source, node, **kwargs):
+        breakpoint()
+        pass
+
+
 def slice_and_shape_from_block_and_chunks(
     block: Tuple[int, ...], chunks: Tuple[Tuple[int, ...], ...]
 ) -> Tuple[NDSlice, Tuple[int, ...]]:

--- a/tiled/adapters/csv.py
+++ b/tiled/adapters/csv.py
@@ -269,7 +269,6 @@ class CSVAdapter:
 
         return ArrayAdapter.from_array(array)
 
-
     def items(self) -> Iterator[Tuple[str, ArrayAdapter]]:
         """Iterator over table columns
 

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -13,6 +13,7 @@ from ..type_aliases import JSON
 from ..utils import path_from_uri
 from .dataframe import DataFrameAdapter
 from .utils import init_adapter_from_catalog
+from .array import ArrayAdapter
 
 
 class ParquetDatasetAdapter:
@@ -43,6 +44,9 @@ class ParquetDatasetAdapter:
         self._metadata = metadata or {}
         self._structure = structure
         self.specs = list(specs or [])
+
+    def get(self, key: str) -> ArrayAdapter:
+        return self.dataframe_adapter[key]
 
     @classmethod
     def from_catalog(

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -14,7 +14,6 @@ from ..utils import path_from_uri
 from .array import ArrayAdapter
 from .dataframe import DataFrameAdapter
 from .utils import init_adapter_from_catalog
-from .array import ArrayAdapter
 
 
 class ParquetDatasetAdapter:
@@ -45,9 +44,6 @@ class ParquetDatasetAdapter:
         self._metadata = metadata or {}
         self._structure = structure
         self.specs = list(specs or [])
-
-    def get(self, key: str) -> ArrayAdapter:
-        return self.dataframe_adapter[key]
 
     @classmethod
     def from_catalog(

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -203,7 +203,7 @@ class FileSequenceAdapter:
         return force_reshape(arr, sliced_shape)
 
     def read_block(
-        self, block: Tuple[int, ...], slice: Union[NDSlice, EllipsisType] = ...
+        self, block: Tuple[int, ...], slice: Optional[NDSlice] = None
     ) -> NDArray[Any]:
         """
 
@@ -219,7 +219,7 @@ class FileSequenceAdapter:
         if any(block[1:]):
             raise IndexError(block)
         arr = self.read(builtins.slice(block[0], block[0] + 1))
-        return arr[slice]
+        return arr[slice] if slice else arr
 
     def structure(self) -> ArrayStructure:
         """

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -2,6 +2,7 @@ import builtins
 import math
 import warnings
 from abc import abstractmethod
+from types import EllipsisType
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -145,7 +146,9 @@ class FileSequenceAdapter:
         # TODO How to deal with the many headers?
         return self._provided_metadata
 
-    def read(self, slice: Optional[NDSlice] = ...) -> NDArray[Any]:
+    def read(
+        self, slice: Union[NDSlice, EllipsisType, builtins.slice] = ...
+    ) -> NDArray[Any]:
         """Return a numpy array
 
         Receives a sequence of values to select from a collection of data files
@@ -200,7 +203,7 @@ class FileSequenceAdapter:
         return force_reshape(arr, sliced_shape)
 
     def read_block(
-        self, block: Tuple[int, ...], slice: Optional[NDSlice] = ...
+        self, block: Tuple[int, ...], slice: Union[NDSlice, EllipsisType] = ...
     ) -> NDArray[Any]:
         """
 

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -1,5 +1,4 @@
 import itertools
-from types import EllipsisType
 from typing import Any, List, Optional, Tuple, Union
 
 import dask.base

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -123,9 +123,9 @@ class SparseBlocksParquetAdapter:
         self,
         data: Union[dask.dataframe.DataFrame, pandas.DataFrame],
         block: Tuple[int, ...],
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> None:
-        if slice != ...:
+        if slice is not None:
             raise NotImplementedError(
                 "Writing into a slice of a sparse block is not yet supported."
             )
@@ -181,7 +181,7 @@ class SparseBlocksParquetAdapter:
     def read_block(
         self,
         block: Tuple[int, ...],
-        slice: Optional[Union[NDSlice, EllipsisType]] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> sparse.COO:
         """
 
@@ -197,7 +197,7 @@ class SparseBlocksParquetAdapter:
         coords, data = load_block(self.blocks[block])
         _, shape = slice_and_shape_from_block_and_chunks(block, self._structure.chunks)
         arr = sparse.COO(data=data[:], coords=coords[:], shape=shape)
-        return arr[slice]
+        return arr[slice] if slice else arr
 
     def structure(self) -> COOStructure:
         """

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -1,4 +1,5 @@
 import itertools
+from types import EllipsisType
 from typing import Any, List, Optional, Tuple, Union
 
 import dask.base
@@ -122,7 +123,7 @@ class SparseBlocksParquetAdapter:
         self,
         data: Union[dask.dataframe.DataFrame, pandas.DataFrame],
         block: Tuple[int, ...],
-        slice: NDSlice = ...,
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> None:
         if slice != ...:
             raise NotImplementedError(
@@ -178,7 +179,9 @@ class SparseBlocksParquetAdapter:
         return arr[slice]
 
     def read_block(
-        self, block: Tuple[int, ...], slice: Optional[NDSlice]
+        self,
+        block: Tuple[int, ...],
+        slice: Optional[Union[NDSlice, EllipsisType]] = ...,
     ) -> sparse.COO:
         """
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -2,7 +2,6 @@ import builtins
 import collections.abc
 import os
 import sys
-from types import EllipsisType
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import zarr.core

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -85,7 +85,7 @@ class ZarrArrayAdapter(ArrayAdapter):
 
     def read(
         self,
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> NDArray[Any]:
         """
 
@@ -97,12 +97,12 @@ class ZarrArrayAdapter(ArrayAdapter):
         -------
 
         """
-        return self._array[self._stencil()][slice]
+        return self._array[self._stencil()][slice or ...]
 
     def read_block(
         self,
         block: Tuple[int, ...],
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> NDArray[Any]:
         """
 
@@ -120,12 +120,12 @@ class ZarrArrayAdapter(ArrayAdapter):
         )
         # Slice the block out of the whole array,
         # and optionally a sub-slice therein.
-        return self._array[self._stencil()][block_slice][slice]
+        return self._array[self._stencil()][block_slice][slice or ...]
 
     def write(
         self,
         data: NDArray[Any],
-        slice: Union[NDSlice, EllipsisType] = ...,
+        slice: Optional[NDSlice] = None,
     ) -> None:
         """
 
@@ -138,7 +138,7 @@ class ZarrArrayAdapter(ArrayAdapter):
         -------
 
         """
-        if slice is not ...:
+        if slice is not None:
             raise NotImplementedError
         self._array[self._stencil()] = data
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -2,6 +2,7 @@ import builtins
 import collections.abc
 import os
 import sys
+from types import EllipsisType
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import zarr.core
@@ -84,7 +85,7 @@ class ZarrArrayAdapter(ArrayAdapter):
 
     def read(
         self,
-        slice: NDSlice = ...,
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> NDArray[Any]:
         """
 
@@ -101,7 +102,7 @@ class ZarrArrayAdapter(ArrayAdapter):
     def read_block(
         self,
         block: Tuple[int, ...],
-        slice: NDSlice = ...,
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> NDArray[Any]:
         """
 
@@ -124,7 +125,7 @@ class ZarrArrayAdapter(ArrayAdapter):
     def write(
         self,
         data: NDArray[Any],
-        slice: NDSlice = ...,
+        slice: Union[NDSlice, EllipsisType] = ...,
     ) -> None:
         """
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -479,8 +479,10 @@ class CatalogNodeAdapter:
                     node = (await db.execute(statement)).scalar()
                 if node is None:
                     raise RuntimeError("Can not find the root node for %s", asset.data_uri)
-                catalog_adapter = await STRUCTURES[node.structure_family](self.context, node).lookup_adapter(rest)
-                adapter = await catalog_adapter.get_adapter()
+                adapter = await STRUCTURES[node.structure_family](self.context, node).lookup_adapter(rest)
+                if isinstance(adapter, CatalogNodeAdapter):
+                    adapter = await adapter.get_adapter()
+
                 ndslice = deserialize_ndslice(data_source.parameters['slices'][0])
 
                 adapter = ArrayAdapter.from_array(adapter.read(slice=ndslice))

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -469,6 +469,8 @@ class CatalogNodeAdapter:
                     for s in ser_ndslice:
                         if isinstance(s, dict):
                             result.append(slice(s.get("start"), s.get('stop'), s.get('step')))
+                        elif s == 'ellipsis':
+                            result.append(...)
                         else:
                             result.append(s)
                     return tuple(result)
@@ -1097,21 +1099,6 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
             db.add(data_source)
             await db.commit()
             return structure_dict
-
-
-class CatalogArrayViewAdapter(CatalogNodeAdapter):
-    async def read(self, *args, **kwargs):
-        if not self.data_sources:
-            fields = kwargs.get("fields")
-            if fields:
-                return self.search(KeysFilter(fields))
-            return self
-        return await ensure_awaitable((await self.get_adapter()).read, *args, **kwargs)
-
-    async def read_block(self, *args, **kwargs):
-        return await ensure_awaitable(
-            (await self.get_adapter()).read_block, *args, **kwargs
-        )
 
 
 class CatalogAwkwardAdapter(CatalogNodeAdapter):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -511,7 +511,7 @@ class CatalogNodeAdapter:
             if asset.parameter is None:
                 continue
             scheme = urlparse(asset.data_uri).scheme
-            if scheme not in ("file"):
+            if scheme != "file":
                 raise NotImplementedError(
                     f"Only 'file://...' scheme URLs and Tiled views are currently supported, not {asset.data_uri}"
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1123,12 +1123,18 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
             return structure_dict
 
     async def update_structure(self):
+        import dataclasses
+
+        from ..server.pydantic_array import ArrayStructure
+
         assert len(self.data_sources) == 1
         data_source = self.data_sources[0]
-        if data_source.management == Management.view:
+        if self.management() == Management.view and self.structure().resizable:
             tiled_uri = data_source.assets[0].data_uri
             node, adapter = await self.get_adapter_for_tiled_uri(tiled_uri)
-            structure = adapter.structure()  # structure of the original array
+            structure = ArrayStructure.from_json(
+                dataclasses.asdict(adapter.structure())
+            )  # structure of the original array
             slice = data_source.parameters.get("slice")
             if slice is not None:
                 slice = NDSlice.from_json(slice)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -484,10 +484,8 @@ class CatalogNodeAdapter:
                 ndslice = deserialize_ndslice(data_source.parameters['slices'][0])
 
                 adapter = ArrayAdapter.from_array(adapter.read(slice=ndslice))
-
-                breakpoint()
             return adapter
-        parameters = collections.defaultdict(list)
+
         for asset in data_source.assets:
             if asset.parameter is None:
                 continue
@@ -511,17 +509,6 @@ class CatalogNodeAdapter:
                         f"Refusing to serve {asset.data_uri} because it is outside "
                         "the readable storage area for this server."
                     )
-            if asset.num is None:
-                parameters[asset.parameter] = asset.data_uri
-            else:
-                parameters[asset.parameter].append(asset.data_uri)
-        # breakpoint()
-        adapter_kwargs = dict(parameters)
-        adapter_kwargs.update(data_source.parameters)
-        adapter_kwargs["specs"] = self.node.specs
-        adapter_kwargs["metadata"] = self.node.metadata_
-        adapter_kwargs["structure"] = data_source.structure
-        adapter_kwargs["access_policy"] = self.access_policy
         adapter = await anyio.to_thread.run_sync(
             partial(
                 adapter_class.from_catalog,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1131,7 +1131,7 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
             structure = adapter.structure()  # structure of the original array
             slice = data_source.parameters.get("slice")
             if slice is not None:
-                slice = NDSlice(*slice)
+                slice = NDSlice.from_json(slice)
                 view_shape = ndindex(slice).newshape(structure.shape)
                 view_chunks = tuple(
                     (i,) for i in view_shape

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -148,11 +148,12 @@ class BaseClient:
         """
         if getattr(self._structure, "resizable", None):
             # In the future, conditionally fetch updated information.
-            raise NotImplementedError(
-                "The server has indicated that this has a dynamic, resizable "
-                "structure and this version of the Tiled Python client cannot "
-                "cope with that."
-            )
+            # raise NotImplementedError(
+            #     "The server has indicated that this has a dynamic, resizable "
+            #     "structure and this version of the Tiled Python client cannot "
+            #     "cope with that."
+            # )
+            pass
         return self._structure
 
     def login(self):

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -712,7 +712,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             specs=specs,
         )
 
-    def write_array(self, array, *, key=None, metadata=None, dims=None, specs=None):
+    def write_array(
+        self, array, *, key=None, metadata=None, dims=None, specs=None, resizable=False
+    ):
         """
         EXPERIMENTAL: Write an array.
 
@@ -765,6 +767,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             chunks=chunks,
             dims=dims,
             data_type=BuiltinDtype.from_numpy_dtype(array.dtype),
+            resizable=resizable,
         )
         client = self.new(
             StructureFamily.array,
@@ -827,10 +830,10 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 view_structure["chunks"] = view_chunks
         else:
             # The structure might change
-            raise NotImplementedError("Views of resizable arrays are not supported yet")
-            # view_structure = copy.deepcopy(input_structure)
-            # view_structure['shape'] = None
-            # view_structure['chunks'] = None
+            # raise NotImplementedError("Views of resizable arrays are not supported yet")
+            view_structure = copy.deepcopy(input_structure)
+            view_structure["shape"] = []
+            view_structure["chunks"] = []
 
         assets = [
             Asset(

--- a/tiled/mimetypes.py
+++ b/tiled/mimetypes.py
@@ -13,6 +13,7 @@ ZARR_MIMETYPE = "application/x-zarr"
 AWKWARD_BUFFERS_MIMETYPE = "application/x-awkward-buffers"
 DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
     {
+        "application/x-array-view": lambda: importlib.import_module("..adapters.array", __name__).ArrayViewAdapter,
         "image/tiff": lambda: importlib.import_module(
             "..adapters.tiff", __name__
         ).TiffAdapter,

--- a/tiled/mimetypes.py
+++ b/tiled/mimetypes.py
@@ -13,7 +13,7 @@ ZARR_MIMETYPE = "application/x-zarr"
 AWKWARD_BUFFERS_MIMETYPE = "application/x-awkward-buffers"
 DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
     {
-        "application/x-array-view": lambda: importlib.import_module("..adapters.array", __name__).ArrayViewAdapter,
+        "application/x-array-view": lambda: importlib.import_module("..adapters.array", __name__).ArrayAdapter,
         "image/tiff": lambda: importlib.import_module(
             "..adapters.tiff", __name__
         ).TiffAdapter,

--- a/tiled/mimetypes.py
+++ b/tiled/mimetypes.py
@@ -16,6 +16,9 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         "application/x-array-view": lambda: importlib.import_module(
             "..adapters.array", __name__
         ).ArrayAdapter,
+        "application/x-table-view": lambda: importlib.import_module(
+            "..adapters.table", __name__
+        ).TableViewAdapter,
         "image/tiff": lambda: importlib.import_module(
             "..adapters.tiff", __name__
         ).TiffAdapter,

--- a/tiled/mimetypes.py
+++ b/tiled/mimetypes.py
@@ -13,7 +13,9 @@ ZARR_MIMETYPE = "application/x-zarr"
 AWKWARD_BUFFERS_MIMETYPE = "application/x-awkward-buffers"
 DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
     {
-        "application/x-array-view": lambda: importlib.import_module("..adapters.array", __name__).ArrayAdapter,
+        "application/x-array-view": lambda: importlib.import_module(
+            "..adapters.array", __name__
+        ).ArrayAdapter,
         "image/tiff": lambda: importlib.import_module(
             "..adapters.tiff", __name__
         ).TiffAdapter,

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -327,6 +327,7 @@ async def metadata(
     include_data_sources: bool = Query(False),
     entry: Any = SecureEntry(scopes=["read:metadata"]),
     root_path: bool = Query(False),
+    tiled_uri: bool = Query(False),
 ):
     """Fetch the metadata and structure information for one entry"""
 
@@ -351,6 +352,8 @@ async def metadata(
             detail=f"Malformed 'select_metadata' parameter raised JMESPathError: {err}",
         )
     meta = {"root_path": request.scope.get("root_path") or "/"} if root_path else {}
+    if tiled_uri:
+        meta["tiled_uri"] = entry.tiled_uri
 
     return json_or_msgpack(
         request,

--- a/tiled/structures/data_source.py
+++ b/tiled/structures/data_source.py
@@ -10,6 +10,7 @@ class Management(str, enum.Enum):
     immutable = "immutable"
     locked = "locked"
     writable = "writable"
+    view = "view"
 
 
 @dataclasses.dataclass

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -5,7 +5,7 @@ if sys.version_info < (3, 10):
 else:
     from types import EllipsisType
 
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Set, Union
 
 JSON = Dict[str, Union[str, int, float, bool, Dict[str, "JSON"], List["JSON"]]]
 # NDSlice = Union[
@@ -14,7 +14,6 @@ JSON = Dict[str, Union[str, int, float, bool, Dict[str, "JSON"], List["JSON"]]]
 
 
 class NDSlice(tuple):
-
     def __new__(cls, *args: Union[int, slice, EllipsisType]):
         return super().__new__(cls, tuple(args))
 
@@ -24,10 +23,10 @@ class NDSlice(tuple):
         result = []
         for s in ser:
             if isinstance(s, dict):
-                result.append(slice(s.get("start"), s.get('stop'), s.get('step')))
+                result.append(slice(s.get("start"), s.get("stop"), s.get("step")))
             elif isinstance(s, int):
                 result.append(s)
-            elif s == 'ellipsis':
+            elif s == "ellipsis":
                 result.append(...)
             else:
                 raise ValueError("Can not intialize NDSlice from %s", s)
@@ -42,10 +41,11 @@ class NDSlice(tuple):
             elif isinstance(s, int):
                 result.append(s)
             elif s is Ellipsis:
-                result.append('ellipsis')
+                result.append("ellipsis")
             else:
                 raise ValueError("Unprocessable entry in NDSlice, %s", s)
         return result
+
 
 Scopes = Set[str]
 Query = Any  # for now...

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -8,9 +8,44 @@ else:
 from typing import Any, Dict, List, Set, Tuple, Union
 
 JSON = Dict[str, Union[str, int, float, bool, Dict[str, "JSON"], List["JSON"]]]
-NDSlice = Union[
-    int, slice, Tuple[Union[int, slice, EllipsisType], ...], EllipsisType
-]  # TODO Replace this with our Union for a slice/tuple/.../etc.
+# NDSlice = Union[
+#     int, slice, Tuple[Union[int, slice, EllipsisType], ...], EllipsisType
+# ]  # TODO Replace this with our Union for a slice/tuple/.../etc.
+
+
+class NDSlice(tuple):
+
+    def __new__(cls, *args: Union[int, slice, EllipsisType]):
+        return super().__new__(cls, tuple(args))
+
+    @classmethod
+    def from_json(cls, ser: list[JSON]):
+        "Deserialize a json represenattion of an NDSlice"
+        result = []
+        for s in ser:
+            if isinstance(s, dict):
+                result.append(slice(s.get("start"), s.get('stop'), s.get('step')))
+            elif isinstance(s, int):
+                result.append(s)
+            elif s == 'ellipsis':
+                result.append(...)
+            else:
+                raise ValueError("Can not intialize NDSlice from %s", s)
+        return tuple(result)
+
+    def to_json(self) -> list[JSON]:
+        "Convert NDSlice into a JSON-serializable representation"
+        result = []
+        for s in self:
+            if isinstance(s, slice):
+                result.append({"start": s.start, "stop": s.stop, "step": s.step})
+            elif isinstance(s, int):
+                result.append(s)
+            elif s is Ellipsis:
+                result.append('ellipsis')
+            else:
+                raise ValueError("Unprocessable entry in NDSlice, %s", s)
+        return result
 
 Scopes = Set[str]
 Query = Any  # for now...


### PR DESCRIPTION
This adds a mechanism for creating views of arrays in Tiled. The source for a view could be either an array or a column of a table already registered in Tiled. the view is represented as its own DataSource with possibly several Assets pointing to a location of the source in the Tiled catalog tree, e.g. `tiled://X/Y/image` or `tiled://X/Y/table/column_1`. There is a possibility to use additional parameters to slice or reshape (TBD?) the original array and present only a subset of its values as a view. Likewise, multiple arrays (declared in separate assets) can be concatenated into a single view (TBD?).

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
