### PR TITLE
Fix regression against older servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   classmethods for instantiation from files and registered Tiled nodes, respectively.
 - Refactor CSVAdapter to allow pd.read_csv kwargs
 - Removed `tiled.adapters.zarr.read_zarr` utility function.
+- Server declares authentication provider modes are `external` or `internal`. The
+  latter was renamed from `password`. Client accepts either `internal` or `password`
+  for backward-compatibility with older servers.
 
 ### Added
 

--- a/tiled/schemas.py
+++ b/tiled/schemas.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class AboutAuthenticationProvider(BaseModel):
@@ -8,6 +8,13 @@ class AboutAuthenticationProvider(BaseModel):
     mode: Literal["internal", "external"]
     links: Dict[str, str]
     confirmation_message: Optional[str] = None
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def accept_mode_password_as_backcompat_alias_for_internal(cls, value: Any) -> Any:
+        if isinstance(value, str) and value == "password":
+            value = "internal"
+        return value
 
 
 class AboutAuthenticationLinks(BaseModel):


### PR DESCRIPTION
I caught a regression when using the Python client `main` branch to connect to NSLS2 prod:

```
ValidationError: 1 validation error for About
authentication.providers.0.mode
  Input should be 'internal' or 'external' [type=literal_error, input_value='password', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/literal_error
```

This is from #862.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
