### PR TITLE
Do not look for tokens if there are no providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Added `.get` methods on TableAdapter and ParquetDatasetAdapter
 - Ability to read string-valued columns of data frames as arrays
 
+### Fixed
+
+- Do not attempt to use auth tokens if the server declares no authentication
+  providers.
+
 ### Maintenance
 
 - Make depedencies shared by client and server into core dependencies.

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -136,9 +136,10 @@ def from_context(
     >>> c = from_uri("...", api_key="...")
     """
             )
-        found_valid_tokens = remember_me and context.use_cached_tokens()
-        if (not found_valid_tokens) and auth_is_required:
-            context.authenticate(remember_me=remember_me)
+        if has_providers:
+            found_valid_tokens = remember_me and context.use_cached_tokens()
+            if (not found_valid_tokens) and auth_is_required:
+                context.authenticate(remember_me=remember_me)
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"
     content = handle_error(


### PR DESCRIPTION
Fix for

```
File ~/Repos/bnl/tiled/tiled/client/constructors.py:139, in from_context(context, structure_clients, node_path_parts, include_data_sources, remember_me)
    131     if auth_is_required and not has_providers:
    132         raise RuntimeError(
    133             """This server requires API key authentication.
    134 Set an api_key as in:
   (...)
    137 """
    138         )
--> 139     found_valid_tokens = remember_me and context.use_cached_tokens()
    140     if (not found_valid_tokens) and auth_is_required:
    141         context.authenticate(remember_me=remember_me)

File ~/Repos/bnl/tiled/tiled/client/context.py:674, in Context.use_cached_tokens(self)
    665 def use_cached_tokens(self):
    666     """
    667     Attempt to reconnect using cached tokens.
    668
   (...)
    672         Indicating whether valid cached tokens were found
    673     """
--> 674     refresh_url = self.server_info["authentication"]["links"]["refresh_session"]
    675     csrf_token = self.http_client.cookies["tiled_csrf"]
    677     # Try automatically authenticating using cached tokens, if any.

TypeError: 'NoneType' object is not subscriptable
```


### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
