### PR TITLE
Use HTTPS if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Server declares authentication provider modes are `external` or `internal`. The
   latter was renamed from `password`. Client accepts either `internal` or `password`
   for backward-compatibility with older servers.
+- Make context switch to HTTPS URI, if available, upon creation
 
 ### Added
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -385,6 +385,14 @@ class Context:
         """
         uri = httpx.URL(uri)
         node_path_parts = []
+        # Ensure that HTTPS is used if available
+        # Rely on location header from HTTP->HTTPS redirect to determine if exists
+        if uri.scheme == "http":
+            redirect_header = httpx.get(uri).headers.get("location", None)
+            if redirect_header is not None:
+                redirect_uri = httpx.URL(redirect_header)
+                if redirect_uri.scheme == "https":
+                    uri = redirect_uri
         if "/metadata" in uri.path:
             api_path, _, node_path = uri.path.partition("/metadata")
             api_uri = uri.copy_with(path=api_path)


### PR DESCRIPTION
This change makes a newly created Tiled client switch to HTTPS, if available, if constructed using an HTTP argument as parameter.

This serves two purposes:
* Prevents that client from hitting an HTTP->HTTPS redirect on every request
* Prevents certain requests from breaking for clients created using an HTTP URL (such as a POST when redirects are setup to give 301 responses)

For example, here is a POST request to logout resulting in only one POST request, instead of a POST followed by redirected GET as would happen if HTTP were used:
```
In [4]: c = from_uri("http://tiled.nsls2.bnl.gov")

[...]

In [5]: c.logout()
14:57:39.140 -> (204 B) POST 'https://tiled.nsls2.bnl.gov/api/v1/auth/session/revoke' 'host:tiled.nsls2.bnl.gov' 'accept:*/*' [...]
```

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
