### PR TITLE
Remove branching imports for Python <3.9

### DIFF
--- a/tiled/__init__.py
+++ b/tiled/__init__.py
@@ -1,1 +1,6 @@
-from ._version import __version__, __version_tuple__  # noqa: F401
+from ._version import __version__, __version_tuple__
+
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+]

--- a/tiled/adapters/awkward_directory_container.py
+++ b/tiled/adapters/awkward_directory_container.py
@@ -1,18 +1,9 @@
-import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Iterator
 
-if sys.version_info < (3, 9):
-    from typing_extensions import MutableMapping
 
-    MappingType = MutableMapping
-else:
-    import collections
-
-    MappingType = collections.abc.MutableMapping
-
-
-class DirectoryContainer(MappingType[str, bytes]):
+class DirectoryContainer(Mapping[str, bytes]):
     """ """
 
     def __init__(self, directory: Path, form: Any):

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -1,7 +1,6 @@
-import collections.abc
 import os
-import sys
 import warnings
+from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import h5py
@@ -27,17 +26,7 @@ def from_dataset(dataset: NDArray[Any]) -> ArrayAdapter:
     return ArrayAdapter.from_array(dataset, metadata=getattr(dataset, "attrs", {}))
 
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Mapping
-
-    MappingType = Mapping
-else:
-    import collections
-
-    MappingType = collections.abc.Mapping
-
-
-class HDF5Adapter(MappingType[str, Union["HDF5Adapter", ArrayAdapter]], IndexersMixin):
+class HDF5Adapter(Mapping[str, Union["HDF5Adapter", ArrayAdapter]], IndexersMixin):
     """
     Read an HDF5 file or a group within one.
 

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -1,8 +1,6 @@
-import collections.abc
 import copy
 import itertools
 import operator
-import sys
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import (
@@ -19,6 +17,8 @@ from typing import (
 
 if TYPE_CHECKING:
     from fastapi import APIRouter
+
+from collections.abc import Iterable, Mapping
 
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..queries import (
@@ -43,17 +43,8 @@ from ..utils import UNCHANGED, Sentinel
 from .protocols import AccessPolicy, AnyAdapter
 from .utils import IndexersMixin
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Mapping
 
-    MappingType = Mapping
-else:
-    import collections
-
-    MappingType = collections.abc.Mapping
-
-
-class MapAdapter(MappingType[str, AnyAdapter], IndexersMixin):
+class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
     """
     Adapt any mapping (dictionary-like object) to Tiled.
     """
@@ -537,7 +528,7 @@ def walk_string_values(tree: MapAdapter, node: Optional[Any] = None) -> Iterator
         elif hasattr(value, "items"):
             for k, v in value.items():
                 yield from walk_string_values(value, k)
-        elif isinstance(value, collections.abc.Iterable):
+        elif isinstance(value, Iterable):
             for item in value:
                 if isinstance(item, str):
                     yield item
@@ -706,7 +697,7 @@ def contains(query: Any, tree: MapAdapter) -> MapAdapter:
     matches = {}
     for key, value, term in iter_child_metadata(query.key, tree):
         if (
-            isinstance(term, collections.abc.Iterable)
+            isinstance(term, Iterable)
             and (not isinstance(term, str))
             and (query.value in term)
         ):

--- a/tiled/adapters/protocols.py
+++ b/tiled/adapters/protocols.py
@@ -1,6 +1,5 @@
-import collections.abc
-import sys
 from abc import abstractmethod
+from collections.abc import Mapping
 from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple, Union
 
 import dask.dataframe
@@ -35,17 +34,7 @@ class BaseAdapter(Protocol):
         pass
 
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Mapping
-
-    MappingType = Mapping
-else:
-    import collections
-
-    MappingType = collections.abc.Mapping
-
-
-class ContainerAdapter(MappingType[str, "AnyAdapter"], BaseAdapter):
+class ContainerAdapter(Mapping[str, "AnyAdapter"], BaseAdapter):
     structure_family: Literal[StructureFamily.container]
 
     @abstractmethod

--- a/tiled/adapters/xarray.py
+++ b/tiled/adapters/xarray.py
@@ -1,6 +1,5 @@
-import collections.abc
 import itertools
-import sys
+from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional
 
 import xarray
@@ -82,17 +81,7 @@ class DatasetAdapter(MapAdapter):
         return True
 
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Mapping
-
-    MappingType = Mapping
-else:
-    import collections
-
-    MappingType = collections.abc.Mapping
-
-
-class _DatasetMap(MappingType[str, Any]):
+class _DatasetMap(Mapping[str, Any]):
     def __init__(self, dataset: Any) -> None:
         """
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -1,7 +1,6 @@
 import builtins
-import collections.abc
 import os
-import sys
+from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import zarr.core
@@ -205,18 +204,8 @@ class ZarrArrayAdapter(ArrayAdapter):
         return new_shape_tuple, new_chunks_tuple
 
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Mapping
-
-    MappingType = Mapping
-else:
-    import collections
-
-    MappingType = collections.abc.Mapping
-
-
 class ZarrGroupAdapter(
-    MappingType[str, Union["ArrayAdapter", "ZarrGroupAdapter"]],
+    Mapping[str, Union["ArrayAdapter", "ZarrGroupAdapter"]],
     IndexersMixin,
 ):
     """ """

--- a/tiled/catalog/__init__.py
+++ b/tiled/catalog/__init__.py
@@ -1,1 +1,6 @@
-from .adapter import from_uri, in_memory  # noqa: F401
+from .adapter import from_uri, in_memory
+
+__all__ = [
+    "from_uri",
+    "in_memory",
+]

--- a/tiled/client/__init__.py
+++ b/tiled/client/__init__.py
@@ -1,6 +1,20 @@
-from ..utils import tree  # noqa: F401
-from .constructors import from_context, from_profile, from_uri  # noqa: F401
-from .container import ASCENDING, DESCENDING  # noqa: F401
-from .context import Context  # noqa: F401
-from .logger import hide_logs, record_history, show_logs  # noqa: F401
-from .metadata_update import DELETE_KEY  # noqa: F401
+from ..utils import tree
+from .constructors import from_context, from_profile, from_uri
+from .container import ASCENDING, DESCENDING
+from .context import Context
+from .logger import hide_logs, record_history, show_logs
+from .metadata_update import DELETE_KEY
+
+__all__ = [
+    "ASCENDING",
+    "Context",
+    "DESCENDING",
+    "DELETE_KEY",
+    "from_context",
+    "from_profile",
+    "from_uri",
+    "hide_logs",
+    "record_history",
+    "show_logs",
+    "tree",
+]

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -236,19 +236,15 @@ class Context:
             # where the context starts and stops and the wrapped ASGI app.
             # We are abusing it slightly to enable interactive use of the
             # TestClient.
-            if sys.version_info < (3, 9):
-                import atexit
 
-                atexit.register(client.__exit__)
-            else:
-                import threading
+            import threading
 
-                # The threading module has its own (internal) atexit
-                # mechanism that runs at thread shutdown, prior to the atexit
-                # mechanism that runs at interpreter shutdown.
-                # We need to intervene at that layer to close the portal, or else
-                # we will wait forever for a thread run by the portal to join().
-                threading._register_atexit(client.__exit__)
+            # The threading module has its own (internal) atexit
+            # mechanism that runs at thread shutdown, prior to the atexit
+            # mechanism that runs at interpreter shutdown.
+            # We need to intervene at that layer to close the portal, or else
+            # we will wait forever for a thread run by the portal to join().
+            threading._register_atexit(client.__exit__)
 
         self.http_client = client
         self._verify = verify


### PR DESCRIPTION
As support for python < 3.9 has been dropped, removed the branching imports for versions < 3.9.

This allows defining a type hint for `tree` in `build_app`: of Mapping[str, Any]

It may also be possible to make the FastAPI instance app generic[T] on Mapping[str, T]?

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
