### PR TITLE
Add Authenticator for when serving OIDC as a proxy

### DIFF
--- a/example_configs/external_service/custom.py
+++ b/example_configs/external_service/custom.py
@@ -1,3 +1,5 @@
+from typing import Any, Self
+
 import numpy
 
 from tiled.adapters.array import ArrayAdapter
@@ -55,7 +57,7 @@ class Adapter:
         self.client = MockClient(base_url)
         self.metadata = metadata
 
-    def with_session_state(self, state):
+    def with_session_state(self, state: dict[str, Any]) -> Self:
         return AuthenticatedAdapter(self.client, state["token"], metadata=self.metadata)
 
 

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -112,7 +112,7 @@ if os.getenv("TILED_DEBUG_LEAKED_THREADS"):
 # docker run --name tiled-test-postgres -p 5432:5432 -e POSTGRES_PASSWORD=secret -d docker.io/postgres:16
 # and set this env var like:
 #
-# TILED_TEST_POSTGRESQL_URI=postgresql+asyncpg://postgres:secret@localhost:5432
+# TILED_TEST_POSTGRESQL_URI=postgresql://postgres:secret@localhost:5432
 
 TILED_TEST_POSTGRESQL_URI = os.getenv("TILED_TEST_POSTGRESQL_URI")
 

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping, Optional, cast
 
 import httpx
 from fastapi import APIRouter, Request
+from fastapi.security import OAuth2AuthorizationCodeBearer
 from jose import JWTError, jwt
 from pydantic import Secret
 from starlette.responses import RedirectResponse
@@ -181,6 +182,16 @@ properties:
             cast(str, self._config_from_oidc_url.get("authorization_endpoint"))
         )
 
+    async def decode_access_token(self, access_token: str) -> dict[str, Any]:
+        keys = httpx.get(self.jwks_uri).raise_for_status().json().get("keys", [])
+        return jwt.decode(
+            token=access_token,
+            key=keys,
+            algorithms=self.id_token_signing_alg_values_supported,
+            audience=self._audience,
+            access_token=access_token,
+        )
+
     async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         code = request.query_params["code"]
         # A proxy in the middle may make the request into something like
@@ -199,24 +210,47 @@ properties:
             logger.error("Authentication error: %r", response_body)
             return None
         response_body = response.json()
-        id_token = response_body["id_token"]
         access_token = response_body["access_token"]
-        keys = httpx.get(self.jwks_uri).raise_for_status().json().get("keys", [])
         try:
-            verified_body = jwt.decode(
-                token=id_token,
-                key=keys,
-                algorithms=self.id_token_signing_alg_values_supported,
-                audience=self._audience,
-                access_token=access_token,
-            )
+            verified_body = self.decode_access_token(access_token)
+            return UserSessionState(verified_body["sub"], {})
+
         except JWTError:
             logger.exception(
                 "Authentication error. Unverified token: %r",
-                jwt.get_unverified_claims(id_token),
+                jwt.get_unverified_claims(access_token),
             )
             return None
-        return UserSessionState(verified_body["sub"], {})
+
+
+class ProxiedOIDCAuthenticator(OIDCAuthenticator):
+    def __init__(
+        self,
+        audience: str,
+        client_id: str,
+        client_secret: str,
+        well_known_uri: str,
+        confirmation_message: str = "",
+    ):
+        super().__init__(
+            audience, client_id, client_secret, well_known_uri, confirmation_message
+        )
+        self._oidc_bearer = OAuth2AuthorizationCodeBearer(
+            authorizationUrl=self.authorization_endpoint, tokenUrl=self.token_endpoint
+        )
+
+    async def authenticate(self, request: Request) -> Optional[UserSessionState]:
+        access_token = self._oidc_bearer(request)
+        try:
+            verified_body = self.decode_access_token(access_token)
+            return UserSessionState(verified_body["sub"], {})
+
+        except JWTError:
+            logger.exception(
+                "Authentication error. Unverified token: %r",
+                jwt.get_unverified_claims(access_token),
+            )
+            return None
 
 
 async def exchange_code(

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -212,7 +212,7 @@ properties:
         response_body = response.json()
         access_token = response_body["access_token"]
         try:
-            verified_body = self.decode_access_token(access_token)
+            verified_body = await self.decode_access_token(access_token)
             return UserSessionState(verified_body["sub"], {})
 
         except JWTError:
@@ -246,7 +246,7 @@ class ProxiedOIDCAuthenticator(OIDCAuthenticator):
     async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         access_token = self._oidc_bearer(request)
         try:
-            verified_body = self.decode_access_token(access_token)
+            verified_body = await self.decode_access_token(access_token)
             return UserSessionState(verified_body["sub"], {})
 
         except JWTError:

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -5,7 +5,7 @@ import logging
 import re
 import secrets
 from collections.abc import Iterable
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Callable, Mapping, Optional, cast
 
 import httpx
 from fastapi import APIRouter, Request
@@ -238,6 +238,10 @@ class ProxiedOIDCAuthenticator(OIDCAuthenticator):
         self._oidc_bearer = OAuth2AuthorizationCodeBearer(
             authorizationUrl=self.authorization_endpoint, tokenUrl=self.token_endpoint
         )
+
+    @property
+    def oauth2_scheme(self) -> Callable[[Request], str]:
+        return self._oidc_bearer
 
     async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         access_token = self._oidc_bearer(request)

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -182,7 +182,7 @@ properties:
             cast(str, self._config_from_oidc_url.get("authorization_endpoint"))
         )
 
-    async def decode_access_token(self, access_token: str) -> dict[str, Any]:
+    async def decode_token(self, access_token: str) -> dict[str, Any]:
         keys = httpx.get(self.jwks_uri).raise_for_status().json().get("keys", [])
         return jwt.decode(
             token=access_token,
@@ -212,7 +212,7 @@ properties:
         response_body = response.json()
         access_token = response_body["access_token"]
         try:
-            verified_body = await self.decode_access_token(access_token)
+            verified_body = await self.decode_token(access_token)
             return UserSessionState(verified_body["sub"], {})
 
         except JWTError:
@@ -246,7 +246,7 @@ class ProxiedOIDCAuthenticator(OIDCAuthenticator):
     async def authenticate(self, request: Request) -> Optional[UserSessionState]:
         access_token = self._oidc_bearer(request)
         try:
-            verified_body = await self.decode_access_token(access_token)
+            verified_body = await self.decode_token(access_token)
             return UserSessionState(verified_body["sub"], {})
 
         except JWTError:

--- a/tiled/authn_database/connection_pool.py
+++ b/tiled/authn_database/connection_pool.py
@@ -1,16 +1,12 @@
-from fastapi import Depends
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from typing import Optional
 
-from ..server.settings import Settings, get_settings
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+
 from ..utils import ensure_specified_sql_driver
 
-# A given process probably only has one of these at a time, but we
-# key on database_settings just case in some testing context or something
-# we have two servers running in the same process.
-_connection_pools = {}
 
-
-def open_database_connection_pool(database_settings):
+def open_database_connection_pool(database_settings) -> AsyncEngine:
     connect_args = {}
     kwargs = {}  # extra kwargs passed to create_engine
     # kwargs["pool_size"] = database_settings.pool_size
@@ -21,29 +17,22 @@ def open_database_connection_pool(database_settings):
         connect_args=connect_args,
         **kwargs,
     )
-    _connection_pools[database_settings] = engine
     return engine
 
 
-async def close_database_connection_pool(database_settings):
-    engine = _connection_pools.pop(database_settings, None)
+async def close_database_connection_pool(engine) -> None:
     if engine is not None:
         await engine.dispose()
 
 
-async def get_database_engine(settings: Settings = Depends(get_settings)):
-    # Special case for single-user mode
-    if settings.database_uri is None:
-        return None
-    try:
-        return _connection_pools[settings.database_settings]
-    except KeyError:
-        raise RuntimeError(
-            f"Could not find connection pool for {settings.database_settings}"
-        )
+async def get_database_engine(request: Request) -> Optional[AsyncEngine]:
+    "Return engine if multi-user server, None is single-user server."
+    return request.app.state.authn_database_engine
 
 
-async def get_database_session(engine=Depends(get_database_engine)):
+async def get_database_session(
+    engine=Depends(get_database_engine),
+) -> Optional[AsyncSession]:
     # Special case for single-user mode
     if engine is None:
         yield None

--- a/tiled/authn_database/connection_pool.py
+++ b/tiled/authn_database/connection_pool.py
@@ -3,7 +3,7 @@ from typing import Optional
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
-from ..settings import DatabaseSettings
+from ..server.settings import DatabaseSettings
 from ..utils import ensure_specified_sql_driver
 
 

--- a/tiled/authn_database/connection_pool.py
+++ b/tiled/authn_database/connection_pool.py
@@ -1,7 +1,7 @@
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
-from ..server.settings import get_settings
+from ..server.settings import Settings, get_settings
 from ..utils import ensure_specified_sql_driver
 
 # A given process probably only has one of these at a time, but we
@@ -31,7 +31,7 @@ async def close_database_connection_pool(database_settings):
         await engine.dispose()
 
 
-async def get_database_engine(settings=Depends(get_settings)):
+async def get_database_engine(settings: Settings = Depends(get_settings)):
     # Special case for single-user mode
     if settings.database_uri is None:
         return None

--- a/tiled/authn_database/connection_pool.py
+++ b/tiled/authn_database/connection_pool.py
@@ -3,10 +3,11 @@ from typing import Optional
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
+from ..settings import DatabaseSettings
 from ..utils import ensure_specified_sql_driver
 
 
-def open_database_connection_pool(database_settings) -> AsyncEngine:
+def open_database_connection_pool(database_settings: DatabaseSettings) -> AsyncEngine:
     connect_args = {}
     kwargs = {}  # extra kwargs passed to create_engine
     # kwargs["pool_size"] = database_settings.pool_size
@@ -20,7 +21,7 @@ def open_database_connection_pool(database_settings) -> AsyncEngine:
     return engine
 
 
-async def close_database_connection_pool(engine) -> None:
+async def close_database_connection_pool(engine: AsyncEngine) -> None:
     if engine is not None:
         await engine.dispose()
 
@@ -31,7 +32,7 @@ async def get_database_engine(request: Request) -> Optional[AsyncEngine]:
 
 
 async def get_database_session(
-    engine=Depends(get_database_engine),
+    engine: AsyncEngine = Depends(get_database_engine),
 ) -> Optional[AsyncSession]:
     # Special case for single-user mode
     if engine is None:

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -15,7 +15,7 @@ import httpx
 from ..adapters.utils import IndexersMixin
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..queries import KeyLookup
-from ..query_registration import query_registry
+from ..query_registration import default_query_registry
 from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
 from ..utils import UNCHANGED, OneShotCachedMap, Sentinel, node_repr, safe_json_dump
@@ -1055,7 +1055,7 @@ def _queries_to_params(*queries):
     "Compute GET params from the queries."
     params = collections.defaultdict(list)
     for query in queries:
-        name = query_registry.query_type_to_name[type(query)]
+        name = default_query_registry.query_type_to_name[type(query)]
         for field, value in query.encode().items():
             if value is not None:
                 params[f"filter[{name}][condition][{field}]"].append(value)

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -454,8 +454,7 @@ class Context:
                 # Extract the API key from the app and set it.
                 from ..server.settings import get_settings
 
-                settings = app.dependency_overrides[get_settings]()
-                api_key = settings.single_user_api_key or None
+                api_key = get_settings().single_user_api_key or None
             else:
                 # This is a multi-user server but no API key was passed,
                 # so we will leave it as None on the Context.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -454,7 +454,7 @@ class Context:
                 # Extract the API key from the app and set it.
                 from ..server.settings import get_settings
 
-                api_key = get_settings().single_user_api_key or None
+                api_key = get_settings().single_user_api_key
             else:
                 # This is a multi-user server but no API key was passed,
                 # so we will leave it as None on the Context.

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -15,14 +15,12 @@ import jsonschema
 
 from .adapters.mapping import MapAdapter
 from .media_type_registration import (
-    compression_registry as default_compression_registry,
+    default_compression_registry,
+    default_serialization_registry,
 )
-from .media_type_registration import (
-    serialization_registry as default_serialization_registry,
-)
-from .query_registration import query_registry as default_query_registry
+from .query_registration import default_query_registry
 from .utils import import_object, parse, prepend_to_sys_path
-from .validation_registration import validation_registry as default_validation_registry
+from .validation_registration import default_validation_registry
 
 
 @cache

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -197,13 +197,13 @@ class CompressionRegistry:
         return self.dispatch(media_type, encoder)(*args, **kwargs)
 
 
-serialization_registry = SerializationRegistry()
+default_serialization_registry = SerializationRegistry()
 "Global serialization registry. See Registry for usage examples."
 
-deserialization_registry = SerializationRegistry()
+default_deserialization_registry = SerializationRegistry()
 "Global deserialization registry. See Registry for usage examples."
 
-compression_registry = CompressionRegistry()
+default_compression_registry = CompressionRegistry()
 "Global compression registry. See Registry for usage examples."
 
 
@@ -211,7 +211,7 @@ for media_type in [
     "application/json",
     "application/x-msgpack",
 ]:
-    compression_registry.register(
+    default_compression_registry.register(
         media_type,
         "gzip",
         lambda buffer: gzip.GzipFile(mode="wb", fileobj=buffer, compresslevel=9),
@@ -225,7 +225,7 @@ for media_type in [
     "text/plain",
     "text/html",
 ]:
-    compression_registry.register(
+    default_compression_registry.register(
         media_type,
         "gzip",
         # Use a lower compression level. High compression is extremely slow
@@ -270,7 +270,7 @@ if modules_available("zstandard"):
         "text/html",
         "text/plain",
     ]:
-        compression_registry.register(media_type, "zstd", ZstdBuffer)
+        default_compression_registry.register(media_type, "zstd", ZstdBuffer)
 
 if modules_available("lz4"):
     import lz4
@@ -326,7 +326,7 @@ if modules_available("lz4"):
         "text/html",
         "text/plain",
     ]:
-        compression_registry.register(media_type, "lz4", LZ4Buffer)
+        default_compression_registry.register(media_type, "lz4", LZ4Buffer)
 
 if modules_available("blosc2"):
     import blosc2
@@ -355,4 +355,4 @@ if modules_available("blosc2"):
             pass
 
     for media_type in ["application/octet-stream", APACHE_ARROW_FILE_MIME_TYPE]:
-        compression_registry.register(media_type, "blosc2", BloscBuffer)
+        default_compression_registry.register(media_type, "blosc2", BloscBuffer)

--- a/tiled/query_registration.py
+++ b/tiled/query_registration.py
@@ -79,8 +79,8 @@ class QueryRegistry:
 
 
 # Make a global registry.
-query_registry = QueryRegistry()
-register = query_registry.register
+default_query_registry = QueryRegistry()
+register = default_query_registry.register
 """Register a new type of query."""
 
 

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -3,12 +3,15 @@ import zipfile
 
 import awkward
 
-from ..media_type_registration import deserialization_registry, serialization_registry
+from ..media_type_registration import (
+    default_deserialization_registry,
+    default_serialization_registry,
+)
 from ..structures.core import StructureFamily
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE, modules_available
 
 
-@serialization_registry.register(StructureFamily.awkward, "application/zip")
+@default_serialization_registry.register(StructureFamily.awkward, "application/zip")
 def to_zipped_buffers(components, metadata):
     (form, length, container) = components
     file = io.BytesIO()
@@ -22,7 +25,7 @@ def to_zipped_buffers(components, metadata):
     return file.getbuffer()
 
 
-@deserialization_registry.register(StructureFamily.awkward, "application/zip")
+@default_deserialization_registry.register(StructureFamily.awkward, "application/zip")
 def from_zipped_buffers(buffer, form, length):
     file = io.BytesIO(buffer)
     with zipfile.ZipFile(file, "r") as zip:
@@ -33,7 +36,7 @@ def from_zipped_buffers(buffer, form, length):
     return container
 
 
-@serialization_registry.register(StructureFamily.awkward, "application/json")
+@default_serialization_registry.register(StructureFamily.awkward, "application/json")
 def to_json(components, metadata):
     (form, length, container) = components
     file = io.StringIO()
@@ -44,7 +47,7 @@ def to_json(components, metadata):
 
 if modules_available("pyarrow"):
 
-    @serialization_registry.register(
+    @default_serialization_registry.register(
         StructureFamily.awkward, APACHE_ARROW_FILE_MIME_TYPE
     )
     def to_arrow(components, metadata):
@@ -60,7 +63,9 @@ if modules_available("pyarrow"):
 
     # There seems to be no official Parquet MIME type.
     # https://issues.apache.org/jira/browse/PARQUET-1889
-    @serialization_registry.register(StructureFamily.awkward, "application/x-parquet")
+    @default_serialization_registry.register(
+        StructureFamily.awkward, "application/x-parquet"
+    )
     def to_parquet(components, metadata):
         import pyarrow.parquet
 

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -1,6 +1,6 @@
 import io
 
-from ..media_type_registration import serialization_registry
+from ..media_type_registration import default_serialization_registry
 from ..structures.core import StructureFamily
 from ..utils import (
     SerializationError,
@@ -78,7 +78,7 @@ if modules_available("h5py"):
                     dataset.attrs.create(k, v)
         return buffer.getbuffer()
 
-    serialization_registry.register(
+    default_serialization_registry.register(
         StructureFamily.container, "application/x-hdf5", serialize_hdf5
     )
 
@@ -101,6 +101,6 @@ if modules_available("orjson"):
                 d = d[key]["contents"]
         return safe_json_dump(to_serialize)
 
-    serialization_registry.register(
+    default_serialization_registry.register(
         StructureFamily.container, "application/json", serialize_json
     )

--- a/tiled/serialization/sparse.py
+++ b/tiled/serialization/sparse.py
@@ -1,6 +1,9 @@
 import io
 
-from ..media_type_registration import deserialization_registry, serialization_registry
+from ..media_type_registration import (
+    default_deserialization_registry,
+    default_serialization_registry,
+)
 from ..utils import modules_available
 
 if modules_available("h5py"):
@@ -19,7 +22,9 @@ if modules_available("h5py"):
                 file.attrs.create(k, v)
         return buffer.getbuffer()
 
-    serialization_registry.register("sparse", "application/x-hdf5", serialize_hdf5)
+    default_serialization_registry.register(
+        "sparse", "application/x-hdf5", serialize_hdf5
+    )
 
 if modules_available("pandas", "pyarrow"):
     import pandas
@@ -37,7 +42,7 @@ if modules_available("pandas", "pyarrow"):
     if modules_available("openpyxl"):
         from .table import serialize_excel
 
-        serialization_registry.register(
+        default_serialization_registry.register(
             "sparse",
             XLSX_MIME_TYPE,
             lambda sparse_arr, metadata: serialize_excel(
@@ -52,38 +57,38 @@ if modules_available("pandas", "pyarrow"):
         d["data"] = sparse_arr.data
         return pandas.DataFrame(d)
 
-    deserialization_registry.register(
+    default_deserialization_registry.register(
         "sparse", APACHE_ARROW_FILE_MIME_TYPE, deserialize_arrow
     )
-    serialization_registry.register(
+    default_serialization_registry.register(
         "sparse",
         APACHE_ARROW_FILE_MIME_TYPE,
         lambda sparse_arr, metadata: serialize_arrow(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
-    serialization_registry.register(
+    default_serialization_registry.register(
         "sparse",
         "application/x-parquet",
         lambda sparse_arr, metadata: serialize_parquet(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
-    serialization_registry.register(
+    default_serialization_registry.register(
         "sparse",
         "text/csv",
         lambda sparse_arr, metadata: serialize_csv(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
-    serialization_registry.register(
+    default_serialization_registry.register(
         "sparse",
         "text/plain",
         lambda sparse_arr, metadata: serialize_csv(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
-    serialization_registry.register(
+    default_serialization_registry.register(
         "sparse",
         "text/html",
         lambda sparse_arr, metadata: serialize_html(
@@ -99,7 +104,7 @@ if modules_available("pandas", "pyarrow"):
                 {column: df[column].tolist() for column in df},
             )
 
-        serialization_registry.register(
+        default_serialization_registry.register(
             "sparse",
             "application/json",
             serialize_json,

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -1,6 +1,6 @@
 import io
 
-from ..media_type_registration import serialization_registry
+from ..media_type_registration import default_serialization_registry
 from ..utils import ensure_awaitable, modules_available
 from .container import walk
 from .table import (
@@ -49,7 +49,7 @@ class _BytesIOThatIgnoresClose(io.BytesIO):
 if modules_available("scipy"):
     # Both application/netcdf and application/x-netcdf are used.
     # https://en.wikipedia.org/wiki/NetCDF
-    @serialization_registry.register(
+    @default_serialization_registry.register(
         "xarray_dataset", ["application/netcdf", "application/x-netcdf"]
     )
     async def serialize_netcdf(node, metadata, filter_for_access):
@@ -65,29 +65,29 @@ if modules_available("scipy"):
 # 1-dimensional variables it is useful.
 
 
-@serialization_registry.register("xarray_dataset", APACHE_ARROW_FILE_MIME_TYPE)
+@default_serialization_registry.register("xarray_dataset", APACHE_ARROW_FILE_MIME_TYPE)
 async def serialize_dataset_arrow(node, metadata, filter_for_access):
     return serialize_arrow((await as_dataset(node)).to_dataframe(), metadata)
 
 
-@serialization_registry.register("xarray_dataset", "application/x-parquet")
+@default_serialization_registry.register("xarray_dataset", "application/x-parquet")
 async def serialize_dataset_parquet(node, metadata, filter_for_access):
     return serialize_parquet((await as_dataset(node)).to_dataframe(), metadata)
 
 
-@serialization_registry.register(
+@default_serialization_registry.register(
     "xarray_dataset", ["text/csv", "text/comma-separated-values", "text/plain"]
 )
 async def serialize_dataset_csv(node, metadata, filter_for_access):
     return serialize_csv((await as_dataset(node)).to_dataframe(), metadata)
 
 
-@serialization_registry.register("xarray_dataset", "text/html")
+@default_serialization_registry.register("xarray_dataset", "text/html")
 async def serialize_dataset_html(node, metadata, filter_for_access):
     return serialize_html((await as_dataset(node)).to_dataframe(), metadata)
 
 
-@serialization_registry.register("xarray_dataset", XLSX_MIME_TYPE)
+@default_serialization_registry.register("xarray_dataset", XLSX_MIME_TYPE)
 async def serialize_dataset_excel(node, metadata, filter_for_access):
     return serialize_excel((await as_dataset(node)).to_dataframe(), metadata)
 
@@ -95,7 +95,7 @@ async def serialize_dataset_excel(node, metadata, filter_for_access):
 if modules_available("orjson"):
     import orjson
 
-    @serialization_registry.register("xarray_dataset", "application/json")
+    @default_serialization_registry.register("xarray_dataset", "application/json")
     async def serialize_json(node, metadata, filter_for_access):
         df = (await as_dataset(node)).to_dataframe()
         return orjson.dumps(
@@ -105,7 +105,7 @@ if modules_available("orjson"):
 
 if modules_available("h5py"):
 
-    @serialization_registry.register("xarray_dataset", "application/x-hdf5")
+    @default_serialization_registry.register("xarray_dataset", "application/x-hdf5")
     async def serialize_hdf5(node, metadata, filter_for_access):
         """
         Like for node, but encode everything under 'attrs' in attrs.

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -140,6 +140,7 @@ def build_app(
         spec["provider"]: spec["authenticator"]
         for spec in authentication.get("providers", [])
     }
+    first_authenticator = authentication["providers"][0]["provider"]
     server_settings = server_settings or {}
     query_registry = query_registry or default_query_registry
     compression_registry = compression_registry or default_compression_registry
@@ -403,18 +404,20 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         )
 
         authentication_router = build_authentication_router(
-            authenticators, merged_settings
+            authenticators, merged_settings, first_authenticator
         )
         # And add this authentication_router itself to the app.
         app.include_router(authentication_router, prefix="/api/v1/auth")
         get_current_principal = current_principal_getter(
-            authenticators, merged_settings
+            authenticators, merged_settings, first_authenticator
         )
 
     else:
         get_current_principal = get_current_principal_from_api_key
 
-    get_session_state = session_state_getter(authenticators, merged_settings)
+    get_session_state = session_state_getter(
+        authenticators, merged_settings, first_authenticator
+    )
 
     app.include_router(
         get_router(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -428,14 +428,14 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
 
     app.include_router(
         get_router(
-            query_registry,
-            authenticators,
-            get_current_principal,
             tree,
-            get_session_state,
+            query_registry,
             serialization_registry,
             deserialization_registry,
             validation_registry,
+            authenticators,
+            get_current_principal,
+            get_session_state,
         ),
         prefix="/api/v1",
     )

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -411,18 +411,20 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             token_decoder, authenticators, oauth2_scheme
         )
         get_current_principal = current_principal_getter(
+            token_decoder,
             authenticators,
             oauth2_scheme,
-            token_decoder,
         )
 
         # And add this authentication_router itself to the app.
         app.include_router(authentication_router, prefix="/api/v1/auth")
+        get_session_state = session_state_getter(token_decoder, oauth2_scheme)
 
     else:
         get_current_principal = get_current_principal_from_api_key
 
-    get_session_state = session_state_getter(token_decoder)
+        def get_session_state():
+            return None
 
     app.include_router(
         get_router(

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -41,17 +41,16 @@ from tiled.server.authentication import (
 from tiled.server.protocols import Authenticator
 
 from ..config import construct_build_app_kwargs
-from ..media_type_registration import CompressionRegistry, SerializationRegistry
 from ..media_type_registration import (
-    compression_registry as default_compression_registry,
+    CompressionRegistry,
+    SerializationRegistry,
+    default_compression_registry,
+    default_deserialization_registry,
+    default_serialization_registry,
 )
-from ..media_type_registration import (
-    deserialization_registry as default_deserialization_registry,
-)
-from ..query_registration import QueryRegistry
-from ..query_registration import query_registry as default_query_registry
+from ..query_registration import QueryRegistry, default_query_registry
 from ..utils import SHARE_TILED_PATH, Conflicts, SpecialUsers, UnsupportedQueryType
-from ..validation_registration import validation_registry as default_validation_registry
+from ..validation_registration import default_validation_registry
 from .compression import CompressionMiddleware
 from .router import get_router
 from .settings import get_settings
@@ -145,6 +144,7 @@ def build_app(
     query_registry = query_registry or default_query_registry
     compression_registry = compression_registry or default_compression_registry
     validation_registry = validation_registry or default_validation_registry
+    serialization_registry = serialization_registry or default_serialization_registry
     deserialization_registry = (
         deserialization_registry or default_deserialization_registry
     )
@@ -410,7 +410,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         principal_getter = current_principal_getter(authenticators, merged_settings)
 
     else:
-        principal_getter = get_current_principal_from_api_key()
+        principal_getter = get_current_principal_from_api_key
 
     get_session_state = session_state_getter(authenticators, merged_settings)
 
@@ -419,7 +419,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
             query_registry,
             authenticators,
             principal_getter,
-            lambda: tree,
+            tree,
             get_session_state,
             serialization_registry,
             deserialization_registry,

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -10,6 +10,7 @@ import warnings
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 import anyio
 import packaging.version
@@ -114,10 +115,10 @@ def build_app(
     tree,
     authentication=None,
     server_settings=None,
-    query_registry: QueryRegistry | None = None,
-    serialization_registry: SerializationRegistry | None = None,
-    compression_registry: CompressionRegistry | None = None,
-    deserialization_registry: SerializationRegistry | None = None,
+    query_registry: Optional[QueryRegistry] = None,
+    serialization_registry: Optional[SerializationRegistry] = None,
+    compression_registry: Optional[CompressionRegistry] = None,
+    deserialization_registry: Optional[SerializationRegistry] = None,
     validation_registry=None,
     tasks=None,
     scalable=False,

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -407,10 +407,12 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         )
         # And add this authentication_router itself to the app.
         app.include_router(authentication_router, prefix="/api/v1/auth")
-        principal_getter = current_principal_getter(authenticators, merged_settings)
+        get_current_principal = current_principal_getter(
+            authenticators, merged_settings
+        )
 
     else:
-        principal_getter = get_current_principal_from_api_key
+        get_current_principal = get_current_principal_from_api_key
 
     get_session_state = session_state_getter(authenticators, merged_settings)
 
@@ -418,7 +420,7 @@ or via the environment variable TILED_SINGLE_USER_API_KEY.""",
         get_router(
             query_registry,
             authenticators,
-            principal_getter,
+            get_current_principal,
             tree,
             get_session_state,
             serialization_registry,

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -133,7 +133,7 @@ def decode_token_for_authenticators(
     ):
         return auth.decode_access_token
 
-    def decode_token(token: str):
+    def decode_token(access_token: str):
         credentials_exception = HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
@@ -144,7 +144,7 @@ def decode_token_for_authenticators(
         # fail. They supports key rotation.
         for secret_key in settings.secret_keys:
             try:
-                payload = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
+                payload = jwt.decode(access_token, secret_key, algorithms=[ALGORITHM])
                 break
             except ExpiredSignatureError:
                 # Do not let this be caught below with the other JWTError types.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -19,7 +19,6 @@ from fastapi import (
     Security,
 )
 from fastapi.security import (
-    OAuth2,
     OAuth2AuthorizationCodeBearer,
     OAuth2PasswordBearer,
     OAuth2PasswordRequestForm,
@@ -821,7 +820,7 @@ async def generate_apikey(db, principal, apikey_params, request):
 def build_base_authentication_router(
     decode_token: Callable[[str], dict[str, Any]],
     authenticators: dict[str, Authenticator],
-    settings: Settings
+    settings: Settings,
 ) -> APIRouter:
     authentication_router = APIRouter()
     get_current_principal = current_principal_getter(authenticators, settings)
@@ -1234,7 +1233,6 @@ def build_base_authentication_router(
     async def logout(
         request: Request,
         response: Response,
-        _: str | None = Security(move_api_key),
     ):
         "Deprecated. See revoke_session: POST /session/revoke."
         request.state.endpoint = "auth"
@@ -1256,11 +1254,13 @@ def get_oauth2_scheme(authenticators: dict[str, Authenticator], first_provider: 
 
 
 def build_authentication_router(
-    authenticators: dict[str, Authenticator], first_provider: str, settings: Settings
+    authenticators: dict[str, Authenticator], settings: Settings
 ) -> APIRouter:
     decode_access_token = decode_token_for_authenticators(authenticators, settings)
 
-    authentication_router = build_base_authentication_router(decode_access_token, authenticators, settings)
+    authentication_router = build_base_authentication_router(
+        decode_access_token, authenticators, settings
+    )
     for provider, authenticator in authenticators.items():
         if isinstance(authenticator, ExternalAuthenticator):
             add_external_authenticator_routes(

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -121,7 +121,7 @@ def create_refresh_token(session_id, secret_key, expires_delta):
 
 
 def decode_token_for_authenticators(
-    authenticators: dict[str, Any] | None, settings: Settings
+    authenticators: Optional[dict[str, Any]], settings: Settings
 ):
     if (
         authenticators is not None
@@ -187,7 +187,7 @@ async def create_pending_session(db):
 async def get_current_principal_from_api_key(
     request: Request,
     security_scopes: SecurityScopes,
-    api_key: str | None = Depends(get_api_key),
+    api_key: Optional[str] = Depends(get_api_key),
     settings: Settings = Depends(get_settings),
     db=Depends(get_database_session),
 ):
@@ -264,7 +264,7 @@ def session_state_getter(authenticators: dict[str, Authenticator], settings: Set
     decode_token = decode_token_for_authenticators(authenticators, settings)
 
     async def get_session_state(
-        decoded_access_token: dict[str, Any] | None = Depends(decode_token)
+        decoded_access_token: Optional[dict[str, Any]] = Depends(decode_token)
     ):
         if decoded_access_token:
             return decoded_access_token.get("state")
@@ -281,8 +281,8 @@ def current_principal_getter(
     async def get_current_principal(
         request: Request,
         security_scopes: SecurityScopes,
-        decoded_access_token: dict[str, Any] | None = Depends(decode_token),
-        api_key: str | None = Depends(get_api_key),
+        decoded_access_token: Optional[dict[str, Any]] = Depends(decode_token),
+        api_key: Optional[str] = Depends(get_api_key),
         settings: Settings = Depends(get_settings),
         db=Depends(get_database_session),
     ):
@@ -741,7 +741,9 @@ def build_handle_credentials_route(authenticator: InternalAuthenticator, provide
         db=Depends(get_database_session),
     ):
         request.state.endpoint = "auth"
-        user_session_state: UserSessionState | None = await authenticator.authenticate(
+        user_session_state: Optional[
+            UserSessionState
+        ] = await authenticator.authenticate(
             username=form_data.username, password=form_data.password
         )
         if not user_session_state or not user_session_state.user_name:
@@ -906,7 +908,7 @@ def build_base_authentication_router(
     async def principal(
         request: Request,
         uuid: uuid_module.UUID,
-        _: str | None = Security(move_api_key, scopes=["read:principals"]),
+        _: Optional[str] = Security(move_api_key, scopes=["read:principals"]),
         db=Depends(get_database_session),
     ):
         "Get information about one Principal (user or service)."
@@ -941,7 +943,7 @@ def build_base_authentication_router(
         request: Request,
         uuid: uuid_module.UUID,
         first_eight: str,
-        _: str | None = Security(move_api_key, scopes=["admin:apikeys"]),
+        _: Optional[str] = Security(move_api_key, scopes=["admin:apikeys"]),
         db=Depends(get_database_session),
     ):
         "Allow Tiled Admins to delete any user's apikeys e.g."

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -257,17 +257,6 @@ async def get_current_principal_from_api_key(
     return principal
 
 
-def token_decoder(
-    decode_access_token: Callable[[Request], Awaitable[str]], oauth2_scheme: OAuth2
-) -> Callable[[str], Awaitable[Optional[dict[str, Any]]]]:
-    async def token_from_request(
-        access_token: str = Depends(oauth2_scheme),
-    ) -> Awaitable[Optional[dict[str, Any]]]:
-        return await decode_access_token(access_token)
-
-    return token_from_request
-
-
 def session_state_getter(
     token_decoder: Callable[[str], Awaitable[Optional[dict[str, Any]]]],
     oauth2_scheme: OAuth2,

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -270,12 +270,13 @@ def token_decoder(
 
 def session_state_getter(
     token_decoder: Callable[[str], Awaitable[Optional[dict[str, Any]]]],
+    oauth2_scheme: OAuth2,
 ):
-    async def get_session_state(
-        decoded_access_token: Optional[dict[str, Any]] = Depends(token_decoder)
-    ):
-        if decoded_access_token:
-            return decoded_access_token.get("state")
+    async def get_session_state(access_token: Optional[str] = Depends(oauth2_scheme)):
+        if access_token:
+            decoded_access_token = await token_decoder(access_token)
+            if decoded_access_token:
+                return decoded_access_token.get("state")
 
     return get_session_state
 

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -194,7 +194,6 @@ async def get_current_principal_from_api_key(
     security_scopes: SecurityScopes,
     api_key: Optional[str] = Depends(get_api_key),
     settings: Settings = Depends(get_settings),
-    db=Depends(get_database_session),
 ):
     """
     Get current Principal from:
@@ -1020,7 +1019,6 @@ def build_base_authentication_router(
     async def revoke_session(
         request: Request,
         refresh_token: schemas.RefreshToken,
-        settings: Settings = Depends(get_settings),
         db=Depends(get_database_session),
     ):
         "Mark a Session as revoked so it cannot be refreshed again."

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -297,7 +297,14 @@ def current_principal_getter(
         the Principal will be SpecialUsers.admin always.
         """
 
-        access_token = await token_decoder(encoded_token)
+        try:
+            access_token = await token_decoder(encoded_token)
+        except ExpiredSignatureError:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Access token has expired. Refresh token.",
+                headers=headers_for_401(request, security_scopes),
+            )
         if api_key is not None:
             if authenticators:
                 # Tiled is in a multi-user configuration with authentication providers.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -100,7 +100,7 @@ class TokenData(BaseModel):
     username: Optional[str] = None
 
 
-def create_access_token(data, secret_key, expires_delta):
+def create_access_token(data: dict[str, Any], secret_key: str, expires_delta: float):
     to_encode = data.copy()
     expire = utcnow() + expires_delta
     to_encode.update({"exp": expire, "type": "access"})
@@ -108,7 +108,7 @@ def create_access_token(data, secret_key, expires_delta):
     return encoded_jwt
 
 
-def create_refresh_token(session_id, secret_key, expires_delta):
+def create_refresh_token(session_id: str, secret_key: str, expires_delta: float):
     expire = utcnow() + expires_delta
     to_encode = {
         "type": "refresh",

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -1018,7 +1018,7 @@ def build_base_authentication_router(
     ):
         "Mark a Session as revoked so it cannot be refreshed again."
         request.state.endpoint = "auth"
-        payload = decode_access_token(refresh_token.refresh_token)
+        payload = await decode_access_token(refresh_token.refresh_token)
         session_id = payload["sid"]
         # Find this session in the database.
         session = await lookup_valid_session(db, session_id)

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -100,7 +100,9 @@ class TokenData(BaseModel):
     username: Optional[str] = None
 
 
-def create_access_token(data: dict[str, Any], secret_key: str, expires_delta: float):
+def create_access_token(
+    data: dict[str, Any], secret_key: str, expires_delta: timedelta
+):
     to_encode = data.copy()
     expire = utcnow() + expires_delta
     to_encode.update({"exp": expire, "type": "access"})
@@ -108,7 +110,7 @@ def create_access_token(data: dict[str, Any], secret_key: str, expires_delta: fl
     return encoded_jwt
 
 
-def create_refresh_token(session_id: str, secret_key: str, expires_delta: float):
+def create_refresh_token(session_id: str, secret_key: str, expires_delta: timedelta):
     expire = utcnow() + expires_delta
     to_encode = {
         "type": "refresh",

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Tuple, Union
 
 from fastapi import Depends, HTTPException, Query, Request, Security
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
@@ -13,13 +13,17 @@ DIM_REGEX = r"(?:(?:-?\d+)?:){0,2}(?:-?\d+)?"
 SLICE_REGEX = rf"^{DIM_REGEX}(?:,{DIM_REGEX})*$"
 
 
-def SecureEntryBuilder(get_current_principal, tree, get_session_state):
+def SecureEntryBuilder(
+    tree: Mapping[str, Any],
+    get_current_principal: Callable[..., Optional[str]],
+    get_session_state: Callable[..., Optional[dict[str, Any]]],
+):
     def SecureEntry(scopes, structure_families=None):
         async def inner(
             path: str,
             request: Request,
-            principal: str = Depends(get_current_principal),
-            session_state: dict = Depends(get_session_state),
+            principal: Optional[str] = Depends(get_current_principal),
+            session_state: Optional[dict[str, Any]] = Depends(get_session_state),
         ):
             """
             Obtain a node in the tree from its path.

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -1,19 +1,9 @@
-from functools import cache
 from typing import Optional, Tuple, Union
 
 import pydantic_settings
 from fastapi import Depends, HTTPException, Query, Request, Security
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
-from ..media_type_registration import (
-    deserialization_registry as default_deserialization_registry,
-)
-from ..media_type_registration import (
-    serialization_registry as default_serialization_registry,
-)
-from ..query_registration import query_registry as default_query_registry
-from ..validation_registration import validation_registry as default_validation_registry
-from .authentication import get_current_principal, get_session_state
 from .core import NoEntry
 from .utils import filter_for_access, record_timing
 
@@ -24,149 +14,122 @@ DIM_REGEX = r"(?:(?:-?\d+)?:){0,2}(?:-?\d+)?"
 SLICE_REGEX = rf"^{DIM_REGEX}(?:,{DIM_REGEX})*$"
 
 
-@cache
-def get_query_registry():
-    "This may be overridden via dependency_overrides."
-    return default_query_registry
-
-
-@cache
-def get_deserialization_registry():
-    "This may be overridden via dependency_overrides."
-    return default_deserialization_registry
-
-
-@cache
-def get_serialization_registry():
-    "This may be overridden via dependency_overrides."
-    return default_serialization_registry
-
-
-@cache
-def get_validation_registry():
-    "This may be overridden via dependency_overrides."
-    return default_validation_registry
-
-
-def get_root_tree():
-    raise NotImplementedError(
-        "This should be overridden via dependency_overrides. "
-        "See tiled.server.app.build_app()."
-    )
-
-
-def SecureEntry(scopes, structure_families=None):
-    async def inner(
-        path: str,
-        request: Request,
-        principal: str = Depends(get_current_principal),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
-        session_state: dict = Depends(get_session_state),
-    ):
-        """
-        Obtain a node in the tree from its path.
-
-        Walk down the path from the root tree, discover the access policy
-        to be used for access to the destination node, and finally filter
-        access by the specified scope.
-
-        The access policy used for access to the destination node will be
-        the last one found while walking the tree or, in the case of a catalog adapter,
-        the access policy of the catalog adapter node.
-
-        session_state is an optional dictionary passed in the session token
-        """
-        path_parts = [segment for segment in path.split("/") if segment]
-        path_parts_relative = path_parts
-        entry = root_tree
-        entry_with_access_policy = (
-            entry if getattr(root_tree, "access_policy", None) is not None else None
-        )
-
-        # If the entry/adapter can take a session state, pass it in.
-        # The entry/adapter may return itself or a different object.
-        if hasattr(entry, "with_session_state") and session_state:
-            entry = entry.with_session_state(session_state)
-        # start at the root
-        # filter and keep only what we are allowed to see from here
-        entry = await filter_for_access(
-            entry,
-            principal,
-            ["read:metadata"],
-            request.state.metrics,
-            path_parts_relative,
-        )
-        try:
-            for i, segment in enumerate(path_parts):
-                if hasattr(entry, "lookup_adapter"):
-                    # New catalog adapter - only has access control at the top level
-                    # Top level means the basename of the path as defined in the config
-                    # This adapter can jump directly to the node of interest
-                    entry = await entry.lookup_adapter(path_parts[i:])
-                    if entry is None:
-                        raise NoEntry(path_parts)
-                    break
-                else:
-                    # Old-style dict-like interface
-                    # Traverse into sub-tree(s) to reach the desired entry, and
-                    # to discover the access policy to use for the request
-                    try:
-                        entry = entry[segment]
-                    except (KeyError, TypeError):
-                        raise NoEntry(path_parts)
-                    if getattr(entry, "access_policy", None) is not None:
-                        path_parts_relative = path_parts[i + 1 :]  # noqa: E203
-                        entry_with_access_policy = entry
-                        # filter and keep only what we are allowed to see from here
-                        entry = await filter_for_access(
-                            entry,
-                            principal,
-                            ["read:metadata"],
-                            request.state.metrics,
-                            path_parts_relative,
-                        )
-
-            # Now check that we have the requested scope according to the discovered access policy
-            access_policy = getattr(entry_with_access_policy, "access_policy", None)
-            if access_policy is not None:
-                with record_timing(request.state.metrics, "acl"):
-                    allowed_scopes = await access_policy.allowed_scopes(
-                        entry_with_access_policy, principal, path_parts_relative
-                    )
-                    if not set(scopes).issubset(allowed_scopes):
-                        if "read:metadata" not in allowed_scopes:
-                            # If you can't read metadata, it does not exist for you.
-                            raise NoEntry(path_parts)
-                        else:
-                            # You can see this, but you cannot perform the requested
-                            # operation on it.
-                            raise HTTPException(
-                                status_code=HTTP_403_FORBIDDEN,
-                                detail=(
-                                    "Not enough permissions to perform this action on this node. "
-                                    f"Requires scopes {scopes}. "
-                                    f"Principal had scopes {list(allowed_scopes)} on this node."
-                                ),
-                            )
-        except NoEntry:
-            raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND, detail=f"No such entry: {path_parts}"
-            )
-        # Fast path for the common successful case
-        if (structure_families is None) or (
-            entry.structure_family in structure_families
+def SecureEntryBuilder(get_current_principal, get_root_tree, get_session_state):
+    def SecureEntry(scopes, structure_families=None):
+        async def inner(
+            path: str,
+            request: Request,
+            principal: str = Depends(get_current_principal),
+            root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+            session_state: dict = Depends(get_session_state),
         ):
-            return entry
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=(
-                f"The node at {path} has structure family {entry.structure_family} "
-                "and this endpoint is compatible with structure families "
-                f"{structure_families}"
-            ),
-        )
+            """
+            Obtain a node in the tree from its path.
 
-    return Security(inner, scopes=scopes)
+            Walk down the path from the root tree, discover the access policy
+            to be used for access to the destination node, and finally filter
+            access by the specified scope.
+
+            The access policy used for access to the destination node will be
+            the last one found while walking the tree or, in the case of a catalog adapter,
+            the access policy of the catalog adapter node.
+
+            session_state is an optional dictionary passed in the session token
+            """
+            path_parts = [segment for segment in path.split("/") if segment]
+            path_parts_relative = path_parts
+            entry = root_tree
+            entry_with_access_policy = (
+                entry if getattr(root_tree, "access_policy", None) is not None else None
+            )
+
+            # If the entry/adapter can take a session state, pass it in.
+            # The entry/adapter may return itself or a different object.
+            if hasattr(entry, "with_session_state") and session_state:
+                entry = entry.with_session_state(session_state)
+            # start at the root
+            # filter and keep only what we are allowed to see from here
+            entry = await filter_for_access(
+                entry,
+                principal,
+                ["read:metadata"],
+                request.state.metrics,
+                path_parts_relative,
+            )
+            try:
+                for i, segment in enumerate(path_parts):
+                    if hasattr(entry, "lookup_adapter"):
+                        # New catalog adapter - only has access control at the top level
+                        # Top level means the basename of the path as defined in the config
+                        # This adapter can jump directly to the node of interest
+                        entry = await entry.lookup_adapter(path_parts[i:])
+                        if entry is None:
+                            raise NoEntry(path_parts)
+                        break
+                    else:
+                        # Old-style dict-like interface
+                        # Traverse into sub-tree(s) to reach the desired entry, and
+                        # to discover the access policy to use for the request
+                        try:
+                            entry = entry[segment]
+                        except (KeyError, TypeError):
+                            raise NoEntry(path_parts)
+                        if getattr(entry, "access_policy", None) is not None:
+                            path_parts_relative = path_parts[i + 1 :]  # noqa: E203
+                            entry_with_access_policy = entry
+                            # filter and keep only what we are allowed to see from here
+                            entry = await filter_for_access(
+                                entry,
+                                principal,
+                                ["read:metadata"],
+                                request.state.metrics,
+                                path_parts_relative,
+                            )
+
+                # Now check that we have the requested scope according to the discovered access policy
+                access_policy = getattr(entry_with_access_policy, "access_policy", None)
+                if access_policy is not None:
+                    with record_timing(request.state.metrics, "acl"):
+                        allowed_scopes = await access_policy.allowed_scopes(
+                            entry_with_access_policy, principal, path_parts_relative
+                        )
+                        if not set(scopes).issubset(allowed_scopes):
+                            if "read:metadata" not in allowed_scopes:
+                                # If you can't read metadata, it does not exist for you.
+                                raise NoEntry(path_parts)
+                            else:
+                                # You can see this, but you cannot perform the requested
+                                # operation on it.
+                                raise HTTPException(
+                                    status_code=HTTP_403_FORBIDDEN,
+                                    detail=(
+                                        "Not enough permissions to perform this action on this node. "
+                                        f"Requires scopes {scopes}. "
+                                        f"Principal had scopes {list(allowed_scopes)} on this node."
+                                    ),
+                                )
+            except NoEntry:
+                raise HTTPException(
+                    status_code=HTTP_404_NOT_FOUND,
+                    detail=f"No such entry: {path_parts}",
+                )
+            # Fast path for the common successful case
+            if (structure_families is None) or (
+                entry.structure_family in structure_families
+            ):
+                return entry
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=(
+                    f"The node at {path} has structure family {entry.structure_family} "
+                    "and this endpoint is compatible with structure families "
+                    f"{structure_families}"
+                ),
+            )
+
+        return Security(inner, scopes=scopes)
+
+    return SecureEntry
 
 
 def block(

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -1,6 +1,5 @@
 from typing import Optional, Tuple, Union
 
-import pydantic_settings
 from fastapi import Depends, HTTPException, Query, Request, Security
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
@@ -14,13 +13,12 @@ DIM_REGEX = r"(?:(?:-?\d+)?:){0,2}(?:-?\d+)?"
 SLICE_REGEX = rf"^{DIM_REGEX}(?:,{DIM_REGEX})*$"
 
 
-def SecureEntryBuilder(get_current_principal, get_root_tree, get_session_state):
+def SecureEntryBuilder(get_current_principal, tree, get_session_state):
     def SecureEntry(scopes, structure_families=None):
         async def inner(
             path: str,
             request: Request,
             principal: str = Depends(get_current_principal),
-            root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
             session_state: dict = Depends(get_session_state),
         ):
             """
@@ -38,9 +36,9 @@ def SecureEntryBuilder(get_current_principal, get_root_tree, get_session_state):
             """
             path_parts = [segment for segment in path.split("/") if segment]
             path_parts_relative = path_parts
-            entry = root_tree
+            entry = tree
             entry_with_access_policy = (
-                entry if getattr(root_tree, "access_policy", None) is not None else None
+                entry if getattr(tree, "access_policy", None) is not None else None
             )
 
             # If the entry/adapter can take a session state, pass it in.

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -6,12 +6,9 @@ conventions for metrics & labels. We generally prefer naming them
 
 import os
 from functools import cache
-from typing import Optional
 
 from fastapi import APIRouter, Request, Response, Security
 from prometheus_client import CONTENT_TYPE_LATEST, Histogram, generate_latest
-
-from tiled.server.utils import move_api_key
 
 router = APIRouter()
 
@@ -157,10 +154,8 @@ def prometheus_registry():
     return registry
 
 
-@router.get("/metrics")
-async def metrics(
-    request: Request, _: Optional[str] = Security(move_api_key, scopes=["metrics"])
-):
+@router.get("/metrics", dependencies=[Security(lambda: None, scopes=["metrics"])])
+async def metrics(request: Request):
     """
     Prometheus metrics
     """

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -6,6 +6,7 @@ conventions for metrics & labels. We generally prefer naming them
 
 import os
 from functools import cache
+from typing import Optional
 
 from fastapi import APIRouter, Request, Response, Security
 from prometheus_client import CONTENT_TYPE_LATEST, Histogram, generate_latest
@@ -158,7 +159,7 @@ def prometheus_registry():
 
 @router.get("/metrics")
 async def metrics(
-    request: Request, _: str | None = Security(move_api_key, scopes=["metrics"])
+    request: Request, _: Optional[str] = Security(move_api_key, scopes=["metrics"])
 ):
     """
     Prometheus metrics

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -10,7 +10,7 @@ from functools import cache
 from fastapi import APIRouter, Request, Response, Security
 from prometheus_client import CONTENT_TYPE_LATEST, Histogram, generate_latest
 
-from .authentication import get_current_principal
+from tiled.server.utils import move_api_key
 
 router = APIRouter()
 
@@ -158,7 +158,7 @@ def prometheus_registry():
 
 @router.get("/metrics")
 async def metrics(
-    request: Request, principal=Security(get_current_principal, scopes=["metrics"])
+    request: Request, _: str | None = Security(move_api_key, scopes=["metrics"])
 ):
     """
     Prometheus metrics

--- a/tiled/server/protocols.py
+++ b/tiled/server/protocols.py
@@ -13,11 +13,15 @@ class UserSessionState:
     state: dict = None
 
 
-class InternalAuthenticator(ABC):
+class Authenticator(ABC):
+    ...
+
+
+class InternalAuthenticator(Authenticator, ABC):
     def authenticate(self, username: str, password: str) -> Optional[UserSessionState]:
         raise NotImplementedError
 
 
-class ExternalAuthenticator(ABC):
+class ExternalAuthenticator(Authenticator, ABC):
     def authenticate(self, request: Request) -> Optional[UserSessionState]:
         raise NotImplementedError

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -24,6 +24,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 
+from tiled.media_type_registration import SerializationRegistry
 from tiled.schemas import About
 from tiled.server.protocols import (
     Authenticator,
@@ -34,7 +35,7 @@ from tiled.server.protocols import (
 from .. import __version__
 from ..structures.core import Spec, StructureFamily
 from ..utils import ensure_awaitable, patch_mimetypes, path_from_uri
-from ..validation_registration import ValidationError
+from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from .core import (
     DEFAULT_PAGE_SIZE,
@@ -71,9 +72,9 @@ def get_router(
     get_current_principal,
     tree: Mapping[str, Any],
     get_session_state,
-    serialization_registry,
-    deserialization_registry,
-    validation_registry,
+    serialization_registry: SerializationRegistry,
+    deserialization_registry: SerializationRegistry,
+    validation_registry: ValidationRegistry,
 ) -> APIRouter:
     router = APIRouter()
     SecureEntry = SecureEntryBuilder(get_current_principal, tree, get_session_state)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1055,7 +1055,6 @@ def get_router(
             request=request,
             path=path,
             body=body,
-            validation_registry=validation_registry,
             settings=settings,
             entry=entry,
         )
@@ -1072,7 +1071,6 @@ def get_router(
             request=request,
             path=path,
             body=body,
-            validation_registry=validation_registry,
             settings=settings,
             entry=entry,
         )
@@ -1081,7 +1079,6 @@ def get_router(
         request: Request,
         path: str,
         body: schemas.PostMetadataRequest,
-        validation_registry,
         settings: Settings,
         entry,
     ):
@@ -1127,11 +1124,7 @@ def get_router(
 
     @router.put("/data_source/{path:path}")
     async def put_data_source(
-        request: Request,
-        path: str,
-        data_source: int,
         body: schemas.PutDataSourceRequest,
-        settings: Settings = Depends(get_settings),
         entry=SecureEntry(scopes=["write:metadata", "register"]),
     ):
         await entry.put_data_source(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1,5 +1,3 @@
-import dataclasses
-import inspect
 import os
 import re
 import warnings
@@ -27,14 +25,17 @@ from starlette.status import (
 )
 
 from tiled.schemas import About
-from tiled.server.protocols import ExternalAuthenticator, InternalAuthenticator
+from tiled.server.protocols import (
+    Authenticator,
+    ExternalAuthenticator,
+    InternalAuthenticator,
+)
 
 from .. import __version__
 from ..structures.core import Spec, StructureFamily
 from ..utils import ensure_awaitable, patch_mimetypes, path_from_uri
 from ..validation_registration import ValidationError
 from . import schemas
-from .authentication import get_authenticators, get_current_principal
 from .core import (
     DEFAULT_PAGE_SIZE,
     DEPTH_LIMIT,
@@ -51,13 +52,9 @@ from .core import (
     resolve_media_type,
 )
 from .dependencies import (
-    SecureEntry,
+    SecureEntryBuilder,
     block,
     expected_shape,
-    get_deserialization_registry,
-    get_query_registry,
-    get_serialization_registry,
-    get_validation_registry,
     offset_param,
     shape_param,
     slice_,
@@ -65,359 +62,380 @@ from .dependencies import (
 from .file_response_with_range import FileResponseWithRange
 from .links import links_for_node
 from .settings import Settings, get_settings
-from .utils import filter_for_access, get_base_url, record_timing
-
-router = APIRouter()
+from .utils import filter_for_access, get_base_url, move_api_key, record_timing
 
 
-@router.get("/", response_model=About)
-async def about(
-    request: Request,
-    settings: Settings = Depends(get_settings),
-    authenticators=Depends(get_authenticators),
-    serialization_registry=Depends(get_serialization_registry),
-    query_registry=Depends(get_query_registry),
-    # This dependency is here because it runs the code that moves
-    # API key from the query parameter to a cookie (if it is valid).
-    principal=Security(get_current_principal, scopes=[]),
-):
-    # TODO The lazy import of entry modules and serializers means that the
-    # lists of formats are not populated until they are first used. Not very
-    # helpful for discovery! The registration can be made non-lazy, while the
-    # imports of the underlying I/O libraries themselves (openpyxl, pillow,
-    # etc.) can remain lazy.
-    request.state.endpoint = "about"
-    base_url = get_base_url(request)
-    authentication = {
-        "required": not settings.allow_anonymous_access,
-    }
-    provider_specs = []
-    user_agent = request.headers.get("user-agent", "")
-    # The name of the "internal" mode used to be "password".
-    # This ensures back-compat with older Python clients.
-    internal_mode_name = "internal"
-    MINIMUM_INTERNAL_PYTHON_CLIENT_VERSION = packaging.version.parse("0.1.0b17")
-    if user_agent.startswith("python-tiled/"):
-        agent, _, raw_version = user_agent.partition("/")
-        try:
-            parsed_version = packaging.version.parse(raw_version)
-        except Exception:
-            pass
-        else:
-            if parsed_version < MINIMUM_INTERNAL_PYTHON_CLIENT_VERSION:
-                internal_mode_name = "password"
-    for provider, authenticator in authenticators.items():
-        if isinstance(authenticator, InternalAuthenticator):
-            spec = {
-                "provider": provider,
-                "mode": internal_mode_name,
-                "links": {
-                    "auth_endpoint": f"{base_url}/auth/provider/{provider}/token"
-                },
-                "confirmation_message": getattr(
-                    authenticator, "confirmation_message", None
-                ),
-            }
-        elif isinstance(authenticator, ExternalAuthenticator):
-            spec = {
-                "provider": provider,
-                "mode": "external",
-                "links": {
-                    "auth_endpoint": f"{base_url}/auth/provider/{provider}/authorize"
-                },
-                "confirmation_message": getattr(
-                    authenticator, "confirmation_message", None
-                ),
-            }
-        else:
-            # It should be impossible to reach here.
-            assert False
-        provider_specs.append(spec)
-    if provider_specs:
-        # If there are *any* authenticaiton providers, these
-        # endpoints will be added.
-        authentication["links"] = {
-            "whoami": f"{base_url}/auth/whoami",
-            "apikey": f"{base_url}/auth/apikey",
-            "refresh_session": f"{base_url}/auth/session/refresh",
-            "revoke_session": f"{base_url}/auth/session/revoke/{{session_id}}",
-            "logout": f"{base_url}/auth/logout",
-        }
-    authentication["providers"] = provider_specs
-
-    return json_or_msgpack(
-        request,
-        About(
-            library_version=__version__,
-            api_version=0,
-            formats={
-                structure_family: list(
-                    serialization_registry.media_types(structure_family)
-                )
-                for structure_family in serialization_registry.structure_families
-            },
-            aliases={
-                structure_family: serialization_registry.aliases(structure_family)
-                for structure_family in serialization_registry.structure_families
-            },
-            queries=list(query_registry.name_to_query_type),
-            authentication=authentication,
-            links={
-                "self": base_url,
-                "documentation": f"{base_url}/docs",
-            },
-            meta={"root_path": request.scope.get("root_path") or "" + "/api"},
-        ).model_dump(),
-        expires=datetime.now(timezone.utc) + timedelta(seconds=600),
+def get_router(
+    query_registry,
+    authenticators: dict[str, Authenticator],
+    get_current_principal,
+    get_root_tree,
+    get_session_state,
+    serialization_registry,
+    deserialization_registry,
+    validation_registry,
+) -> APIRouter:
+    router = APIRouter()
+    SecureEntry = SecureEntryBuilder(
+        get_current_principal, get_root_tree, get_session_state
     )
 
+    @router.get("/", response_model=About)
+    async def about(
+        request: Request,
+        settings: Settings = Depends(get_settings),
+        _: str | None = Security(move_api_key),
+    ):
+        # TODO The lazy import of entry modules and serializers means that the
+        # lists of formats are not populated until they are first used. Not very
+        # helpful for discovery! The registration can be made non-lazy, while the
+        # imports of the underlying I/O libraries themselves (openpyxl, pillow,
+        # etc.) can remain lazy.
+        request.state.endpoint = "about"
+        base_url = get_base_url(request)
+        authentication = {
+            "required": not settings.allow_anonymous_access,
+        }
+        provider_specs = []
+        user_agent = request.headers.get("user-agent", "")
+        # The name of the "internal" mode used to be "password".
+        # This ensures back-compat with older Python clients.
+        internal_mode_name = "internal"
+        MINIMUM_INTERNAL_PYTHON_CLIENT_VERSION = packaging.version.parse("0.1.0b17")
+        if user_agent.startswith("python-tiled/"):
+            agent, _, raw_version = user_agent.partition("/")
+            try:
+                parsed_version = packaging.version.parse(raw_version)
+            except Exception:
+                pass
+            else:
+                if parsed_version < MINIMUM_INTERNAL_PYTHON_CLIENT_VERSION:
+                    internal_mode_name = "password"
+        for provider, authenticator in authenticators.items():
+            if isinstance(authenticator, InternalAuthenticator):
+                spec = {
+                    "provider": provider,
+                    "mode": internal_mode_name,
+                    "links": {
+                        "auth_endpoint": f"{base_url}/auth/provider/{provider}/token"
+                    },
+                    "confirmation_message": getattr(
+                        authenticator, "confirmation_message", None
+                    ),
+                }
+            elif isinstance(authenticator, ExternalAuthenticator):
+                spec = {
+                    "provider": provider,
+                    "mode": "external",
+                    "links": {
+                        "auth_endpoint": f"{base_url}/auth/provider/{provider}/authorize"
+                    },
+                    "confirmation_message": getattr(
+                        authenticator, "confirmation_message", None
+                    ),
+                }
+            else:
+                # It should be impossible to reach here.
+                assert False
+            provider_specs.append(spec)
+        if provider_specs:
+            # If there are *any* authenticaiton providers, these
+            # endpoints will be added.
+            authentication["links"] = {
+                "whoami": f"{base_url}/auth/whoami",
+                "apikey": f"{base_url}/auth/apikey",
+                "refresh_session": f"{base_url}/auth/session/refresh",
+                "revoke_session": f"{base_url}/auth/session/revoke/{{session_id}}",
+                "logout": f"{base_url}/auth/logout",
+            }
+        authentication["providers"] = provider_specs
 
-async def search(
-    request: Request,
-    path: str,
-    fields: Optional[List[schemas.EntryFields]] = Query(list(schemas.EntryFields)),
-    select_metadata: Optional[str] = Query(None),
-    offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
-    limit: Optional[int] = Query(
-        DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
-    ),
-    sort: Optional[str] = Query(None),
-    max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
-    omit_links: bool = Query(False),
-    include_data_sources: bool = Query(False),
-    entry: Any = SecureEntry(scopes=["read:metadata"]),
-    query_registry=Depends(get_query_registry),
-    principal: str = Depends(get_current_principal),
-    **filters,
-):
-    request.state.endpoint = "search"
-    if entry.structure_family != StructureFamily.container:
-        raise WrongTypeForRoute("This is not a Node; it cannot be searched or listed.")
-    try:
-        resource, metadata_stale_at, must_revalidate = await construct_entries_response(
-            query_registry,
-            entry,
-            "/search",
-            path,
-            offset,
-            limit,
-            fields,
-            select_metadata,
-            omit_links,
-            include_data_sources,
-            filters,
-            sort,
-            get_base_url(request),
-            resolve_media_type(request),
-            max_depth=max_depth,
-        )
-        # We only get one Expires header, so if different parts
-        # of this response become stale at different times, we
-        # cite the earliest one.
-        entries_stale_at = getattr(entry, "entries_stale_at", None)
-        headers = {}
-        if (metadata_stale_at is None) or (entries_stale_at is None):
-            expires = None
-        else:
-            expires = min(metadata_stale_at, entries_stale_at)
-        if must_revalidate:
-            headers["Cache-Control"] = "must-revalidate"
         return json_or_msgpack(
             request,
-            resource.model_dump(),
-            expires=expires,
-            headers=headers,
-        )
-    except NoEntry:
-        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="No such entry.")
-    except WrongTypeForRoute as err:
-        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=err.args[0])
-    except JMESPathError as err:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Malformed 'select_metadata' parameter raised JMESPathError: {err}",
-        )
-
-
-async def distinct(
-    request: Request,
-    structure_families: bool = False,
-    specs: bool = False,
-    metadata: Optional[List[str]] = Query(default=[]),
-    counts: bool = False,
-    entry: Any = SecureEntry(scopes=["read:metadata"]),
-    query_registry=Depends(get_query_registry),
-    **filters,
-):
-    if hasattr(entry, "get_distinct"):
-        filtered = await apply_search(entry, filters, query_registry)
-        distinct = await ensure_awaitable(
-            filtered.get_distinct, metadata, structure_families, specs, counts
+            About(
+                library_version=__version__,
+                api_version=0,
+                formats={
+                    structure_family: list(
+                        serialization_registry.media_types(structure_family)
+                    )
+                    for structure_family in serialization_registry.structure_families
+                },
+                aliases={
+                    structure_family: serialization_registry.aliases(structure_family)
+                    for structure_family in serialization_registry.structure_families
+                },
+                queries=list(query_registry.name_to_query_type),
+                authentication=authentication,
+                links={
+                    "self": base_url,
+                    "documentation": f"{base_url}/docs",
+                },
+                meta={"root_path": request.scope.get("root_path") or "" + "/api"},
+            ).model_dump(),
+            expires=datetime.now(timezone.utc) + timedelta(seconds=600),
         )
 
-        return json_or_msgpack(
-            request, schemas.GetDistinctResponse.model_validate(distinct).model_dump()
-        )
-    else:
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support distinct.",
-        )
-
-
-def patch_route_signature(route, query_registry):
-    """
-    This is done dynamically at router startup.
-
-    We check the registry of known search query types, which is user
-    configurable, and use that to define the allowed HTTP query parameters for
-    this route.
-
-    Take a route that accept unspecified search queries as **filters.
-    Return a wrapped version of the route that has the supported
-    search queries explicitly spelled out in the function signature.
-
-    This has no change in the actual behavior of the function,
-    but it enables FastAPI to generate good OpenAPI documentation
-    showing the supported search queries.
-
-    """
-
-    # Build a wrapper so that we can modify the signature
-    # without mutating the wrapped original.
-
-    async def route_with_sig(*args, **kwargs):
-        return await route(*args, **kwargs)
-
-    # Black magic here! FastAPI bases its validation and auto-generated swagger
-    # documentation on the signature of the route function. We do not know what
-    # that signature should be at compile-time. We only know it once we have a
-    # chance to check the user-configurable registry of query types. Therefore,
-    # we modify the signature here, at runtime, just before handing it to
-    # FastAPI in the usual way.
-
-    # When FastAPI calls the function with these added parameters, they will be
-    # accepted via **filters.
-
-    # Make a copy of the original parameters.
-    signature = inspect.signature(route)
-    parameters = list(signature.parameters.values())
-    # Drop the **filters parameter from the signature.
-    del parameters[-1]
-    # Add a parameter for each field in each type of query.
-    for name, query in query_registry.name_to_query_type.items():
-        for field in dataclasses.fields(query):
-            # The structured "alias" here is based on
-            # https://mglaman.dev/blog/using-json-router-query-your-search-router-indexes
-            if getattr(field.type, "__origin__", None) is list:
-                field_type = str
-            else:
-                field_type = field.type
-            injected_parameter = inspect.Parameter(
-                name=f"filter___{name}___{field.name}",
-                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                default=Query(None, alias=f"filter[{name}][condition][{field.name}]"),
-                annotation=Optional[List[field_type]],
-            )
-            parameters.append(injected_parameter)
-    route_with_sig.__signature__ = signature.replace(parameters=parameters)
-    # End black magic
-
-    return route_with_sig
-
-
-@router.get(
-    "/metadata/{path:path}",
-    response_model=schemas.Response[
-        schemas.Resource[schemas.NodeAttributes, dict, dict], dict, dict
-    ],
-)
-async def metadata(
-    request: Request,
-    path: str,
-    fields: Optional[List[schemas.EntryFields]] = Query(list(schemas.EntryFields)),
-    select_metadata: Optional[str] = Query(None),
-    max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
-    omit_links: bool = Query(False),
-    include_data_sources: bool = Query(False),
-    entry: Any = SecureEntry(scopes=["read:metadata"]),
-    root_path: bool = Query(False),
-):
-    """Fetch the metadata and structure information for one entry"""
-
-    request.state.endpoint = "metadata"
-    base_url = get_base_url(request)
-    path_parts = [segment for segment in path.split("/") if segment]
-    try:
-        resource = await construct_resource(
-            base_url,
-            path_parts,
-            entry,
-            fields,
-            select_metadata,
-            omit_links,
-            include_data_sources,
-            resolve_media_type(request),
-            max_depth=max_depth,
-        )
-    except JMESPathError as err:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Malformed 'select_metadata' parameter raised JMESPathError: {err}",
-        )
-    meta = {"root_path": request.scope.get("root_path") or "/"} if root_path else {}
-
-    return json_or_msgpack(
-        request,
-        schemas.Response(data=resource, meta=meta).model_dump(),
-        expires=getattr(entry, "metadata_stale_at", None),
+    @router.get(
+        "/api/v1/search/{path:path}",
+        response_model=schemas.Response[
+            List[schemas.Resource[schemas.NodeAttributes, dict, dict]],
+            schemas.PaginationLinks,
+            dict,
+        ],
     )
-
-
-@router.get(
-    "/array/block/{path:path}", response_model=schemas.Response, name="array block"
-)
-async def array_block(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"],
-        structure_families={StructureFamily.array, StructureFamily.sparse},
-    ),
-    block=Depends(block),
-    slice=Depends(slice_),
-    expected_shape=Depends(expected_shape),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a chunk of array-like data.
-    """
-    shape = entry.structure().shape
-    # Check that block dimensionality matches array dimensionality.
-    ndim = len(shape)
-    if len(block) != ndim:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Block parameter must have {ndim} comma-separated parameters, "
-                f"corresponding to the dimensions of this {ndim}-dimensional array."
-            ),
-        )
-    if block == ():
-        # Handle special case of numpy scalar.
-        if shape != ():
+    async def search(
+        request: Request,
+        path: str,
+        fields: Optional[List[schemas.EntryFields]] = Query(list(schemas.EntryFields)),
+        select_metadata: Optional[str] = Query(None),
+        offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
+        limit: Optional[int] = Query(
+            DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
+        ),
+        sort: Optional[str] = Query(None),
+        max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
+        omit_links: bool = Query(False),
+        include_data_sources: bool = Query(False),
+        entry: Any = SecureEntry(scopes=["read:metadata"]),
+        _: str | None = Depends(move_api_key),
+        **filters,
+    ):
+        request.state.endpoint = "search"
+        if entry.structure_family != StructureFamily.container:
+            raise WrongTypeForRoute(
+                "This is not a Node; it cannot be searched or listed."
+            )
+        try:
+            (
+                resource,
+                metadata_stale_at,
+                must_revalidate,
+            ) = await construct_entries_response(
+                query_registry,
+                entry,
+                "/search",
+                path,
+                offset,
+                limit,
+                fields,
+                select_metadata,
+                omit_links,
+                include_data_sources,
+                filters,
+                sort,
+                get_base_url(request),
+                resolve_media_type(request),
+                max_depth=max_depth,
+            )
+            # We only get one Expires header, so if different parts
+            # of this response become stale at different times, we
+            # cite the earliest one.
+            entries_stale_at = getattr(entry, "entries_stale_at", None)
+            headers = {}
+            if (metadata_stale_at is None) or (entries_stale_at is None):
+                expires = None
+            else:
+                expires = min(metadata_stale_at, entries_stale_at)
+            if must_revalidate:
+                headers["Cache-Control"] = "must-revalidate"
+            return json_or_msgpack(
+                request,
+                resource.model_dump(),
+                expires=expires,
+                headers=headers,
+            )
+        except NoEntry:
+            raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="No such entry.")
+        except WrongTypeForRoute as err:
+            raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=err.args[0])
+        except JMESPathError as err:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST,
-                detail=f"Requested scalar but shape is {entry.structure().shape}",
+                detail=f"Malformed 'select_metadata' parameter raised JMESPathError: {err}",
             )
-        with record_timing(request.state.metrics, "read"):
-            array = await ensure_awaitable(entry.read)
-    else:
+
+    @router.get(
+        "/api/v1/distinct/{path:path}",
+        response_model=schemas.GetDistinctResponse,
+    )
+    async def distinct(
+        request: Request,
+        structure_families: bool = False,
+        specs: bool = False,
+        metadata: Optional[List[str]] = Query(default=[]),
+        counts: bool = False,
+        entry: Any = SecureEntry(scopes=["read:metadata"]),
+        **filters,
+    ):
+        if hasattr(entry, "get_distinct"):
+            filtered = await apply_search(entry, filters, query_registry)
+            distinct = await ensure_awaitable(
+                filtered.get_distinct, metadata, structure_families, specs, counts
+            )
+
+            return json_or_msgpack(
+                request,
+                schemas.GetDistinctResponse.model_validate(distinct).model_dump(),
+            )
+        else:
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support distinct.",
+            )
+
+    @router.get(
+        "/metadata/{path:path}",
+        response_model=schemas.Response[
+            schemas.Resource[schemas.NodeAttributes, dict, dict], dict, dict
+        ],
+    )
+    async def metadata(
+        request: Request,
+        path: str,
+        fields: Optional[List[schemas.EntryFields]] = Query(list(schemas.EntryFields)),
+        select_metadata: Optional[str] = Query(None),
+        max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
+        omit_links: bool = Query(False),
+        include_data_sources: bool = Query(False),
+        entry: Any = SecureEntry(scopes=["read:metadata"]),
+        root_path: bool = Query(False),
+    ):
+        """Fetch the metadata and structure information for one entry"""
+
+        request.state.endpoint = "metadata"
+        base_url = get_base_url(request)
+        path_parts = [segment for segment in path.split("/") if segment]
+        try:
+            resource = await construct_resource(
+                base_url,
+                path_parts,
+                entry,
+                fields,
+                select_metadata,
+                omit_links,
+                include_data_sources,
+                resolve_media_type(request),
+                max_depth=max_depth,
+            )
+        except JMESPathError as err:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=f"Malformed 'select_metadata' parameter raised JMESPathError: {err}",
+            )
+        meta = {"root_path": request.scope.get("root_path") or "/"} if root_path else {}
+
+        return json_or_msgpack(
+            request,
+            schemas.Response(data=resource, meta=meta).model_dump(),
+            expires=getattr(entry, "metadata_stale_at", None),
+        )
+
+    @router.get(
+        "/array/block/{path:path}", response_model=schemas.Response, name="array block"
+    )
+    async def array_block(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"],
+            structure_families={StructureFamily.array, StructureFamily.sparse},
+        ),
+        block=Depends(block),
+        slice=Depends(slice_),
+        expected_shape=Depends(expected_shape),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a chunk of array-like data.
+        """
+        shape = entry.structure().shape
+        # Check that block dimensionality matches array dimensionality.
+        ndim = len(shape)
+        if len(block) != ndim:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Block parameter must have {ndim} comma-separated parameters, "
+                    f"corresponding to the dimensions of this {ndim}-dimensional array."
+                ),
+            )
+        if block == ():
+            # Handle special case of numpy scalar.
+            if shape != ():
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail=f"Requested scalar but shape is {entry.structure().shape}",
+                )
+            with record_timing(request.state.metrics, "read"):
+                array = await ensure_awaitable(entry.read)
+        else:
+            try:
+                with record_timing(request.state.metrics, "read"):
+                    array = await ensure_awaitable(entry.read_block, block, slice)
+            except IndexError:
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST, detail="Block index out of range"
+                )
+            if (expected_shape is not None) and (expected_shape != array.shape):
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail=f"The expected_shape {expected_shape} does not match the actual shape {array.shape}",
+                )
+        if array.nbytes > settings.response_bytesize_limit:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Use slicing ('?slice=...') to request smaller chunks."
+                ),
+            )
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    entry.structure_family,
+                    serialization_registry,
+                    array,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                )
+        except UnsupportedMediaTypes as err:
+            # raise HTTPException(status_code=406, detail=", ".join(err.supported))
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.get(
+        "/array/full/{path:path}", response_model=schemas.Response, name="full array"
+    )
+    async def array_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"],
+            structure_families={StructureFamily.array, StructureFamily.sparse},
+        ),
+        slice=Depends(slice_),
+        expected_shape=Depends(expected_shape),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a slice of array-like data.
+        """
+        structure_family = entry.structure_family
+        # Deferred import because this is not a required dependency of the server
+        # for some use cases.
+        import numpy
+
         try:
             with record_timing(request.state.metrics, "read"):
-                array = await ensure_awaitable(entry.read_block, block, slice)
+                array = await ensure_awaitable(entry.read, slice)
+            if structure_family == StructureFamily.array:
+                array = numpy.asarray(array)  # Force dask or PIMS or ... to do I/O.
         except IndexError:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST, detail="Block index out of range"
@@ -427,1330 +445,1227 @@ async def array_block(
                 status_code=HTTP_400_BAD_REQUEST,
                 detail=f"The expected_shape {expected_shape} does not match the actual shape {array.shape}",
             )
-    if array.nbytes > settings.response_bytesize_limit:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Use slicing ('?slice=...') to request smaller chunks."
-            ),
-        )
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                entry.structure_family,
-                serialization_registry,
-                array,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
+        if array.nbytes > settings.response_bytesize_limit:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Use slicing ('?slice=...') to request smaller chunks."
+                ),
             )
-    except UnsupportedMediaTypes as err:
-        # raise HTTPException(status_code=406, detail=", ".join(err.supported))
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    structure_family,
+                    serialization_registry,
+                    array,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
 
-
-@router.get(
-    "/array/full/{path:path}", response_model=schemas.Response, name="full array"
-)
-async def array_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"],
-        structure_families={StructureFamily.array, StructureFamily.sparse},
-    ),
-    slice=Depends(slice_),
-    expected_shape=Depends(expected_shape),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a slice of array-like data.
-    """
-    structure_family = entry.structure_family
-    # Deferred import because this is not a required dependency of the server
-    # for some use cases.
-    import numpy
-
-    try:
-        with record_timing(request.state.metrics, "read"):
-            array = await ensure_awaitable(entry.read, slice)
-        if structure_family == StructureFamily.array:
-            array = numpy.asarray(array)  # Force dask or PIMS or ... to do I/O.
-    except IndexError:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail="Block index out of range"
-        )
-    if (expected_shape is not None) and (expected_shape != array.shape):
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=f"The expected_shape {expected_shape} does not match the actual shape {array.shape}",
-        )
-    if array.nbytes > settings.response_bytesize_limit:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Use slicing ('?slice=...') to request smaller chunks."
-            ),
-        )
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                structure_family,
-                serialization_registry,
-                array,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.get(
-    "/table/partition/{path:path}",
-    response_model=schemas.Response,
-    name="table partition",
-)
-async def get_table_partition(
-    request: Request,
-    partition: int,
-    entry=SecureEntry(scopes=["read:data"], structure_families={StructureFamily.table}),
-    column: Optional[List[str]] = Query(None, min_length=1),
-    field: Optional[List[str]] = Query(None, min_length=1, deprecated=True),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a partition (continuous block of rows) from a DataFrame [GET route].
-    """
-    if (field is not None) and (column is not None):
-        redundant_field_and_column = " ".join(
-            (
-                "Cannot accept both 'column' and 'field' query parameters",
-                "in the same /table/partition request.",
-                "Include these query values using only the 'column' parameter.",
-            )
-        )
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail=redundant_field_and_column
-        )
-    elif field is not None:
-        field_is_deprecated = " ".join(
-            (
-                "Query parameter 'field' is deprecated for the /table/partition route.",
-                "Instead use the query parameter 'column'.",
-            )
-        )
-        warnings.warn(field_is_deprecated, DeprecationWarning)
-    return await table_partition(
-        request=request,
-        partition=partition,
-        entry=entry,
-        column=(column or field),
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
+    @router.get(
+        "/table/partition/{path:path}",
+        response_model=schemas.Response,
+        name="table partition",
     )
-
-
-@router.post(
-    "/table/partition/{path:path}",
-    response_model=schemas.Response,
-    name="table partition",
-)
-async def post_table_partition(
-    request: Request,
-    partition: int,
-    entry=SecureEntry(scopes=["read:data"], structure_families={StructureFamily.table}),
-    column: Optional[List[str]] = Body(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a partition (continuous block of rows) from a DataFrame [POST route].
-    """
-    return await table_partition(
-        request=request,
-        partition=partition,
-        entry=entry,
-        column=column,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
-    )
-
-
-async def table_partition(
-    request: Request,
-    partition: int,
-    entry,
-    column: Optional[List[str]],
-    format: Optional[str],
-    filename: Optional[str],
-    serialization_registry,
-    settings: Settings,
-):
-    """
-    Fetch a partition (continuous block of rows) from a DataFrame.
-    """
-    try:
-        # The singular/plural mismatch here of "fields" and "field" is
-        # due to the ?field=A&field=B&field=C... encodes in a URL.
-        with record_timing(request.state.metrics, "read"):
-            df = await ensure_awaitable(entry.read_partition, partition, column)
-    except IndexError:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail="Partition out of range"
-        )
-    except KeyError as err:
-        (key,) = err.args
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
-        )
-    if df.memory_usage().sum() > settings.response_bytesize_limit:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Select a subset of the columns ('?field=...') to "
-                "request a smaller chunks."
-            ),
-        )
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                StructureFamily.table,
-                serialization_registry,
-                df,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.get(
-    "/table/full/{path:path}",
-    response_model=schemas.Response,
-    name="full 'table' data",
-)
-async def get_table_full(
-    request: Request,
-    entry=SecureEntry(scopes=["read:data"], structure_families={StructureFamily.table}),
-    column: Optional[List[str]] = Query(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch the data for the given table [GET route].
-    """
-    return await table_full(
-        request=request,
-        entry=entry,
-        column=column,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
-    )
-
-
-@router.post(
-    "/table/full/{path:path}",
-    response_model=schemas.Response,
-    name="full 'table' data",
-)
-async def post_table_full(
-    request: Request,
-    entry=SecureEntry(scopes=["read:data"], structure_families={StructureFamily.table}),
-    column: Optional[List[str]] = Body(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch the data for the given table [POST route].
-    """
-    return await table_full(
-        request=request,
-        entry=entry,
-        column=column,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
-    )
-
-
-async def table_full(
-    request: Request,
-    entry,
-    column: Optional[List[str]],
-    format: Optional[str],
-    filename: Optional[str],
-    serialization_registry,
-    settings: Settings,
-):
-    """
-    Fetch the data for the given table.
-    """
-    try:
-        with record_timing(request.state.metrics, "read"):
-            data = await ensure_awaitable(entry.read, column)
-    except KeyError as err:
-        (key,) = err.args
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
-        )
-    if data.memory_usage().sum() > settings.response_bytesize_limit:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Select a subset of the columns to "
-                "request a smaller chunks."
-            ),
-        )
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                entry.structure_family,
-                serialization_registry,
-                data,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-                filter_for_access=None,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.get(
-    "/container/full/{path:path}",
-    response_model=schemas.Response,
-    name="full 'container' metadata and data",
-)
-async def get_container_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"], structure_families={StructureFamily.container}
-    ),
-    principal: str = Depends(get_current_principal),
-    field: Optional[List[str]] = Query(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-):
-    """
-    Fetch the data for the given container via a GET request.
-    """
-    return await container_full(
-        request=request,
-        entry=entry,
-        principal=principal,
-        field=field,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-    )
-
-
-@router.post(
-    "/container/full/{path:path}",
-    response_model=schemas.Response,
-    name="full 'container' metadata and data",
-)
-async def post_container_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"], structure_families={StructureFamily.container}
-    ),
-    principal: str = Depends(get_current_principal),
-    field: Optional[List[str]] = Body(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-):
-    """
-    Fetch the data for the given container via a POST request.
-    """
-    return await container_full(
-        request=request,
-        entry=entry,
-        principal=principal,
-        field=field,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-    )
-
-
-async def container_full(
-    request: Request,
-    entry,
-    principal: str,
-    field: Optional[List[str]],
-    format: Optional[str],
-    filename: Optional[str],
-    serialization_registry,
-):
-    """
-    Fetch the data for the given container.
-    """
-    try:
-        with record_timing(request.state.metrics, "read"):
-            data = await ensure_awaitable(entry.read, fields=field)
-    except KeyError as err:
-        (key,) = err.args
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
-        )
-    curried_filter = partial(
-        filter_for_access,
-        principal=principal,
-        scopes=["read:data"],
-        metrics=request.state.metrics,
-    )
-    # TODO Walk node to determine size before handing off to serializer.
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                entry.structure_family,
-                serialization_registry,
-                data,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-                filter_for_access=curried_filter,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.get(
-    "/node/full/{path:path}",
-    response_model=schemas.Response,
-    name="full 'container' or 'table'",
-    deprecated=True,
-)
-async def node_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"],
-        structure_families={StructureFamily.table, StructureFamily.container},
-    ),
-    principal: str = Depends(get_current_principal),
-    field: Optional[List[str]] = Query(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch the data below the given node.
-    """
-    try:
-        with record_timing(request.state.metrics, "read"):
-            data = await ensure_awaitable(entry.read, field)
-    except KeyError as err:
-        (key,) = err.args
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
-        )
-    if (entry.structure_family == StructureFamily.table) and (
-        data.memory_usage().sum() > settings.response_bytesize_limit
+    async def get_table_partition(
+        request: Request,
+        partition: int,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.table}
+        ),
+        column: Optional[List[str]] = Query(None, min_length=1),
+        field: Optional[List[str]] = Query(None, min_length=1, deprecated=True),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
     ):
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Select a subset of the columns ('?field=...') to "
-                "request a smaller chunks."
-            ),
+        """
+        Fetch a partition (continuous block of rows) from a DataFrame [GET route].
+        """
+        if (field is not None) and (column is not None):
+            redundant_field_and_column = " ".join(
+                (
+                    "Cannot accept both 'column' and 'field' query parameters",
+                    "in the same /table/partition request.",
+                    "Include these query values using only the 'column' parameter.",
+                )
+            )
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST, detail=redundant_field_and_column
+            )
+        elif field is not None:
+            field_is_deprecated = " ".join(
+                (
+                    "Query parameter 'field' is deprecated for the /table/partition route.",
+                    "Instead use the query parameter 'column'.",
+                )
+            )
+            warnings.warn(field_is_deprecated, DeprecationWarning)
+        return await table_partition(
+            request=request,
+            partition=partition,
+            entry=entry,
+            column=(column or field),
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
         )
-    if entry.structure_family == StructureFamily.container:
+
+    @router.post(
+        "/table/partition/{path:path}",
+        response_model=schemas.Response,
+        name="table partition",
+    )
+    async def post_table_partition(
+        request: Request,
+        partition: int,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.table}
+        ),
+        column: Optional[List[str]] = Body(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a partition (continuous block of rows) from a DataFrame [POST route].
+        """
+        return await table_partition(
+            request=request,
+            partition=partition,
+            entry=entry,
+            column=column,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
+        )
+
+    async def table_partition(
+        request: Request,
+        partition: int,
+        entry,
+        column: Optional[List[str]],
+        format: Optional[str],
+        filename: Optional[str],
+        serialization_registry,
+        settings: Settings,
+    ):
+        """
+        Fetch a partition (continuous block of rows) from a DataFrame.
+        """
+        try:
+            # The singular/plural mismatch here of "fields" and "field" is
+            # due to the ?field=A&field=B&field=C... encodes in a URL.
+            with record_timing(request.state.metrics, "read"):
+                df = await ensure_awaitable(entry.read_partition, partition, column)
+        except IndexError:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST, detail="Partition out of range"
+            )
+        except KeyError as err:
+            (key,) = err.args
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
+            )
+        if df.memory_usage().sum() > settings.response_bytesize_limit:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Select a subset of the columns ('?field=...') to "
+                    "request a smaller chunks."
+                ),
+            )
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    StructureFamily.table,
+                    serialization_registry,
+                    df,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.get(
+        "/table/full/{path:path}",
+        response_model=schemas.Response,
+        name="full 'table' data",
+    )
+    async def get_table_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.table}
+        ),
+        column: Optional[List[str]] = Query(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch the data for the given table [GET route].
+        """
+        return await table_full(
+            request=request,
+            entry=entry,
+            column=column,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
+        )
+
+    @router.post(
+        "/table/full/{path:path}",
+        response_model=schemas.Response,
+        name="full 'table' data",
+    )
+    async def post_table_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.table}
+        ),
+        column: Optional[List[str]] = Body(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch the data for the given table [POST route].
+        """
+        return await table_full(
+            request=request,
+            entry=entry,
+            column=column,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
+        )
+
+    async def table_full(
+        request: Request,
+        entry,
+        column: Optional[List[str]],
+        format: Optional[str],
+        filename: Optional[str],
+        serialization_registry,
+        settings: Settings,
+    ):
+        """
+        Fetch the data for the given table.
+        """
+        try:
+            with record_timing(request.state.metrics, "read"):
+                data = await ensure_awaitable(entry.read, column)
+        except KeyError as err:
+            (key,) = err.args
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
+            )
+        if data.memory_usage().sum() > settings.response_bytesize_limit:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Select a subset of the columns to "
+                    "request a smaller chunks."
+                ),
+            )
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    entry.structure_family,
+                    serialization_registry,
+                    data,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                    filter_for_access=None,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.get(
+        "/container/full/{path:path}",
+        response_model=schemas.Response,
+        name="full 'container' metadata and data",
+    )
+    async def get_container_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.container}
+        ),
+        principal: str = Depends(get_current_principal),
+        field: Optional[List[str]] = Query(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+    ):
+        """
+        Fetch the data for the given container via a GET request.
+        """
+        return await container_full(
+            request=request,
+            entry=entry,
+            principal=principal,
+            field=field,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+        )
+
+    @router.post(
+        "/container/full/{path:path}",
+        response_model=schemas.Response,
+        name="full 'container' metadata and data",
+    )
+    async def post_container_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.container}
+        ),
+        principal: str = Depends(get_current_principal),
+        field: Optional[List[str]] = Body(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+    ):
+        """
+        Fetch the data for the given container via a POST request.
+        """
+        return await container_full(
+            request=request,
+            entry=entry,
+            principal=principal,
+            field=field,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+        )
+
+    async def container_full(
+        request: Request,
+        entry,
+        principal: str,
+        field: Optional[List[str]],
+        format: Optional[str],
+        filename: Optional[str],
+        serialization_registry,
+    ):
+        """
+        Fetch the data for the given container.
+        """
+        try:
+            with record_timing(request.state.metrics, "read"):
+                data = await ensure_awaitable(entry.read, fields=field)
+        except KeyError as err:
+            (key,) = err.args
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
+            )
         curried_filter = partial(
             filter_for_access,
             principal=principal,
             scopes=["read:data"],
             metrics=request.state.metrics,
         )
-    else:
-        curried_filter = None
         # TODO Walk node to determine size before handing off to serializer.
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                entry.structure_family,
-                serialization_registry,
-                data,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-                filter_for_access=curried_filter,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    entry.structure_family,
+                    serialization_registry,
+                    data,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                    filter_for_access=curried_filter,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
 
-
-@router.get(
-    "/awkward/buffers/{path:path}",
-    response_model=schemas.Response,
-    name="AwkwardArray buffers",
-)
-async def get_awkward_buffers(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"], structure_families={StructureFamily.awkward}
-    ),
-    form_key: Optional[List[str]] = Query(None, min_length=1),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a slice of AwkwardArray data.
-
-    Note that there is a POST route on this same path with equivalent functionality.
-    HTTP caches tends to engage with GET but not POST, so that GET route may be
-    preferred for that reason. However, HTTP clients, servers, and proxies
-    typically impose a length limit on URLs. (The HTTP spec does not specify
-    one, but this is a pragmatic measure.) For requests with large numbers of
-    form_key parameters, POST may be the only option.
-    """
-    return await _awkward_buffers(
-        request=request,
-        entry=entry,
-        form_key=form_key,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
+    @router.get(
+        "/node/full/{path:path}",
+        response_model=schemas.Response,
+        name="full 'container' or 'table'",
+        deprecated=True,
     )
-
-
-@router.post(
-    "/awkward/buffers/{path:path}",
-    response_model=schemas.Response,
-    name="AwkwardArray buffers",
-)
-async def post_awkward_buffers(
-    request: Request,
-    body: List[str],
-    entry=SecureEntry(
-        scopes=["read:data"], structure_families={StructureFamily.awkward}
-    ),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a slice of AwkwardArray data.
-
-    Note that there is a GET route on this same path with equivalent functionality.
-    HTTP caches tends to engage with GET but not POST, so that GET route may be
-    preferred for that reason. However, HTTP clients, servers, and proxies
-    typically impose a length limit on URLs. (The HTTP spec does not specify
-    one, but this is a pragmatic measure.) For requests with large numbers of
-    form_key parameters, POST may be the only option.
-    """
-    return await _awkward_buffers(
-        request=request,
-        entry=entry,
-        form_key=body,
-        format=format,
-        filename=filename,
-        serialization_registry=serialization_registry,
-        settings=settings,
-    )
-
-
-async def _awkward_buffers(
-    request: Request,
-    entry,
-    form_key: Optional[List[str]],
-    format: Optional[str],
-    filename: Optional[str],
-    serialization_registry,
-    settings: Settings,
-):
-    structure_family = entry.structure_family
-    structure = entry.structure()
-    with record_timing(request.state.metrics, "read"):
-        # The plural vs. singular mismatch is due to the way query parameters
-        # are given as ?form_key=A&form_key=B&form_key=C.
-        container = await ensure_awaitable(entry.read_buffers, form_key)
-    if (
-        sum(len(buffer) for buffer in container.values())
-        > settings.response_bytesize_limit
+    async def node_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"],
+            structure_families={StructureFamily.table, StructureFamily.container},
+        ),
+        principal: str = Depends(get_current_principal),
+        field: Optional[List[str]] = Query(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
     ):
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Use slicing ('?slice=...') to request smaller chunks."
-            ),
-        )
-    components = (structure.form, structure.length, container)
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                structure_family,
-                serialization_registry,
-                components,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.get(
-    "/awkward/full/{path:path}",
-    response_model=schemas.Response,
-    name="Full AwkwardArray",
-)
-async def awkward_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["read:data"], structure_families={StructureFamily.awkward}
-    ),
-    # slice=Depends(slice_),
-    format: Optional[str] = None,
-    filename: Optional[str] = None,
-    serialization_registry=Depends(get_serialization_registry),
-    settings: Settings = Depends(get_settings),
-):
-    """
-    Fetch a slice of AwkwardArray data.
-    """
-    structure_family = entry.structure_family
-    # Deferred import because this is not a required dependency of the server
-    # for some use cases.
-    import awkward
-
-    with record_timing(request.state.metrics, "read"):
-        container = await ensure_awaitable(entry.read)
-    structure = entry.structure()
-    components = (structure.form, structure.length, container)
-    array = awkward.from_buffers(*components)
-    if array.nbytes > settings.response_bytesize_limit:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Response would exceed {settings.response_bytesize_limit}. "
-                "Use slicing ('?slice=...') to request smaller chunks."
-            ),
-        )
-    try:
-        with record_timing(request.state.metrics, "pack"):
-            return await construct_data_response(
-                structure_family,
-                serialization_registry,
-                components,
-                entry.metadata(),
-                request,
-                format,
-                specs=getattr(entry, "specs", []),
-                expires=getattr(entry, "content_stale_at", None),
-                filename=filename,
-            )
-    except UnsupportedMediaTypes as err:
-        raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
-
-
-@router.post("/metadata/{path:path}", response_model=schemas.PostMetadataResponse)
-async def post_metadata(
-    request: Request,
-    path: str,
-    body: schemas.PostMetadataRequest,
-    validation_registry=Depends(get_validation_registry),
-    settings: Settings = Depends(get_settings),
-    entry=SecureEntry(scopes=["write:metadata", "create"]),
-):
-    for data_source in body.data_sources:
-        if data_source.assets:
+        """
+        Fetch the data below the given node.
+        """
+        try:
+            with record_timing(request.state.metrics, "read"):
+                data = await ensure_awaitable(entry.read, field)
+        except KeyError as err:
+            (key,) = err.args
             raise HTTPException(
-                "Externally-managed assets cannot be registered "
-                "using POST /metadata/{path} Use POST /register/{path} instead."
+                status_code=HTTP_400_BAD_REQUEST, detail=f"No such field {key}."
             )
-    if body.data_sources and not getattr(entry, "writable", False):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail=f"Data cannot be written at the path {path}",
-        )
-    return await _create_node(
-        request=request,
-        path=path,
-        body=body,
-        validation_registry=validation_registry,
-        settings=settings,
-        entry=entry,
+        if (entry.structure_family == StructureFamily.table) and (
+            data.memory_usage().sum() > settings.response_bytesize_limit
+        ):
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Select a subset of the columns ('?field=...') to "
+                    "request a smaller chunks."
+                ),
+            )
+        if entry.structure_family == StructureFamily.container:
+            curried_filter = partial(
+                filter_for_access,
+                principal=principal,
+                scopes=["read:data"],
+                metrics=request.state.metrics,
+            )
+        else:
+            curried_filter = None
+            # TODO Walk node to determine size before handing off to serializer.
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    entry.structure_family,
+                    serialization_registry,
+                    data,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                    filter_for_access=curried_filter,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.get(
+        "/awkward/buffers/{path:path}",
+        response_model=schemas.Response,
+        name="AwkwardArray buffers",
     )
+    async def get_awkward_buffers(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.awkward}
+        ),
+        form_key: Optional[List[str]] = Query(None, min_length=1),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a slice of AwkwardArray data.
 
+        Note that there is a POST route on this same path with equivalent functionality.
+        HTTP caches tends to engage with GET but not POST, so that GET route may be
+        preferred for that reason. However, HTTP clients, servers, and proxies
+        typically impose a length limit on URLs. (The HTTP spec does not specify
+        one, but this is a pragmatic measure.) For requests with large numbers of
+        form_key parameters, POST may be the only option.
+        """
+        return await _awkward_buffers(
+            request=request,
+            entry=entry,
+            form_key=form_key,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
+        )
 
-@router.post("/register/{path:path}", response_model=schemas.PostMetadataResponse)
-async def post_register(
-    request: Request,
-    path: str,
-    body: schemas.PostMetadataRequest,
-    validation_registry=Depends(get_validation_registry),
-    settings: Settings = Depends(get_settings),
-    entry=SecureEntry(scopes=["write:metadata", "create", "register"]),
-):
-    return await _create_node(
-        request=request,
-        path=path,
-        body=body,
-        validation_registry=validation_registry,
-        settings=settings,
-        entry=entry,
+    @router.post(
+        "/awkward/buffers/{path:path}",
+        response_model=schemas.Response,
+        name="AwkwardArray buffers",
     )
+    async def post_awkward_buffers(
+        request: Request,
+        body: List[str],
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.awkward}
+        ),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a slice of AwkwardArray data.
 
-
-async def _create_node(
-    request: Request,
-    path: str,
-    body: schemas.PostMetadataRequest,
-    validation_registry,
-    settings: Settings,
-    entry,
-):
-    metadata, structure_family, specs = (
-        body.metadata,
-        body.structure_family,
-        body.specs,
-    )
-    if structure_family == StructureFamily.container:
-        structure = None
-    else:
-        if len(body.data_sources) != 1:
-            raise NotImplementedError
-        structure = body.data_sources[0].structure
-
-    metadata_modified, metadata = await validate_metadata(
-        metadata=metadata,
-        structure_family=structure_family,
-        structure=structure,
-        specs=specs,
-        validation_registry=validation_registry,
-        settings=settings,
-    )
-
-    key, node = await entry.create_node(
-        metadata=body.metadata,
-        structure_family=body.structure_family,
-        key=body.id,
-        specs=body.specs,
-        data_sources=body.data_sources,
-    )
-    links = links_for_node(
-        structure_family, structure, get_base_url(request), path + f"/{key}"
-    )
-    response_data = {
-        "id": key,
-        "links": links,
-        "data_sources": [ds.model_dump() for ds in node.data_sources],
-    }
-    if metadata_modified:
-        response_data["metadata"] = metadata
-
-    return json_or_msgpack(request, response_data)
-
-
-@router.put("/data_source/{path:path}")
-async def put_data_source(
-    request: Request,
-    path: str,
-    data_source: int,
-    body: schemas.PutDataSourceRequest,
-    settings: Settings = Depends(get_settings),
-    entry=SecureEntry(scopes=["write:metadata", "register"]),
-):
-    await entry.put_data_source(
-        data_source=body.data_source,
-    )
-
-
-@router.delete("/metadata/{path:path}")
-async def delete(
-    request: Request,
-    entry=SecureEntry(scopes=["write:data", "write:metadata"]),
-):
-    if hasattr(entry, "delete"):
-        await entry.delete()
-    else:
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support deletion.",
-        )
-    return json_or_msgpack(request, None)
-
-
-@router.delete("/nodes/{path:path}")
-async def bulk_delete(
-    request: Request,
-    entry=SecureEntry(scopes=["write:data", "write:metadata"]),
-):
-    if hasattr(entry, "delete_tree"):
-        await entry.delete_tree()
-    else:
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support bulk deletion.",
-        )
-    return json_or_msgpack(request, None)
-
-
-@router.put("/array/full/{path:path}")
-async def put_array_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["write:data"],
-        structure_families={StructureFamily.array, StructureFamily.sparse},
-    ),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    body = await request.body()
-    if not hasattr(entry, "write"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node cannot accept array data.",
-        )
-    media_type = request.headers["content-type"]
-    if entry.structure_family == "array":
-        dtype = entry.structure().data_type.to_numpy_dtype()
-        shape = entry.structure().shape
-        deserializer = deserialization_registry.dispatch("array", media_type)
-        data = await ensure_awaitable(deserializer, body, dtype, shape)
-    elif entry.structure_family == "sparse":
-        deserializer = deserialization_registry.dispatch("sparse", media_type)
-        data = await ensure_awaitable(deserializer, body)
-    else:
-        raise NotImplementedError(entry.structure_family)
-    await ensure_awaitable(entry.write, data)
-    return json_or_msgpack(request, None)
-
-
-@router.put("/array/block/{path:path}")
-async def put_array_block(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["write:data"],
-        structure_families={StructureFamily.array, StructureFamily.sparse},
-    ),
-    deserialization_registry=Depends(get_deserialization_registry),
-    block=Depends(block),
-):
-    if not hasattr(entry, "write_block"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node cannot accept array data.",
-        )
-    from tiled.adapters.array import slice_and_shape_from_block_and_chunks
-
-    body = await request.body()
-    media_type = request.headers["content-type"]
-    if entry.structure_family == "array":
-        dtype = entry.structure().data_type.to_numpy_dtype()
-        _, shape = slice_and_shape_from_block_and_chunks(
-            block, entry.structure().chunks
-        )
-        deserializer = deserialization_registry.dispatch("array", media_type)
-        data = await ensure_awaitable(deserializer, body, dtype, shape)
-    elif entry.structure_family == "sparse":
-        deserializer = deserialization_registry.dispatch("sparse", media_type)
-        data = await ensure_awaitable(deserializer, body)
-    else:
-        raise NotImplementedError(entry.structure_family)
-    await ensure_awaitable(entry.write_block, data, block)
-    return json_or_msgpack(request, None)
-
-
-@router.patch("/array/full/{path:path}")
-async def patch_array_full(
-    request: Request,
-    offset=Depends(offset_param),
-    shape=Depends(shape_param),
-    extend: bool = False,
-    entry=SecureEntry(
-        scopes=["write:data"],
-        structure_families={StructureFamily.array},
-    ),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    if not hasattr(entry, "patch"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node cannot accept array data.",
+        Note that there is a GET route on this same path with equivalent functionality.
+        HTTP caches tends to engage with GET but not POST, so that GET route may be
+        preferred for that reason. However, HTTP clients, servers, and proxies
+        typically impose a length limit on URLs. (The HTTP spec does not specify
+        one, but this is a pragmatic measure.) For requests with large numbers of
+        form_key parameters, POST may be the only option.
+        """
+        return await _awkward_buffers(
+            request=request,
+            entry=entry,
+            form_key=body,
+            format=format,
+            filename=filename,
+            serialization_registry=serialization_registry,
+            settings=settings,
         )
 
-    dtype = entry.structure().data_type.to_numpy_dtype()
-    body = await request.body()
-    media_type = request.headers["content-type"]
-    deserializer = deserialization_registry.dispatch("array", media_type)
-    data = await ensure_awaitable(deserializer, body, dtype, shape)
-    structure = await ensure_awaitable(entry.patch, data, offset, extend)
-    return json_or_msgpack(request, structure)
-
-
-@router.put("/table/full/{path:path}")
-@router.put("/node/full/{path:path}", deprecated=True)
-async def put_node_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["write:data"], structure_families={StructureFamily.table}
-    ),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    if not hasattr(entry, "write"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support writing.",
-        )
-    body = await request.body()
-    media_type = request.headers["content-type"]
-    deserializer = deserialization_registry.dispatch(StructureFamily.table, media_type)
-    data = await ensure_awaitable(deserializer, body)
-    await ensure_awaitable(entry.write, data)
-    return json_or_msgpack(request, None)
-
-
-@router.put("/table/partition/{path:path}")
-async def put_table_partition(
-    partition: int,
-    request: Request,
-    entry=SecureEntry(scopes=["write:data"]),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    if not hasattr(entry, "write_partition"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not supporting writing a partition.",
-        )
-    body = await request.body()
-    media_type = request.headers["content-type"]
-    deserializer = deserialization_registry.dispatch(StructureFamily.table, media_type)
-    data = await ensure_awaitable(deserializer, body)
-    await ensure_awaitable(entry.write_partition, data, partition)
-    return json_or_msgpack(request, None)
-
-
-@router.patch("/table/partition/{path:path}")
-async def patch_table_partition(
-    partition: int,
-    request: Request,
-    entry=SecureEntry(scopes=["write:data"]),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    if not hasattr(entry, "write_partition"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not supporting writing a partition.",
-        )
-    body = await request.body()
-    media_type = request.headers["content-type"]
-    deserializer = deserialization_registry.dispatch(StructureFamily.table, media_type)
-    data = await ensure_awaitable(deserializer, body)
-    await ensure_awaitable(entry.append_partition, data, partition)
-    return json_or_msgpack(request, None)
-
-
-@router.put("/awkward/full/{path:path}")
-async def put_awkward_full(
-    request: Request,
-    entry=SecureEntry(
-        scopes=["write:data"], structure_families={StructureFamily.awkward}
-    ),
-    deserialization_registry=Depends(get_deserialization_registry),
-):
-    body = await request.body()
-    if not hasattr(entry, "write"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node cannot be written to.",
-        )
-    media_type = request.headers["content-type"]
-    deserializer = deserialization_registry.dispatch(
-        StructureFamily.awkward, media_type
-    )
-    structure = entry.structure()
-    data = await ensure_awaitable(deserializer, body, structure.form, structure.length)
-    await ensure_awaitable(entry.write, data)
-    return json_or_msgpack(request, None)
-
-
-@router.patch("/metadata/{path:path}", response_model=schemas.PatchMetadataResponse)
-async def patch_metadata(
-    request: Request,
-    body: schemas.PatchMetadataRequest,
-    validation_registry=Depends(get_validation_registry),
-    settings: Settings = Depends(get_settings),
-    entry=SecureEntry(scopes=["write:metadata"]),
-):
-    if not hasattr(entry, "replace_metadata"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support update of metadata.",
-        )
-    if body.content_type == patch_mimetypes.JSON_PATCH:
-        metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
-        specs = apply_json_patch((entry.specs or []), (body.specs or []))
-    elif body.content_type == patch_mimetypes.MERGE_PATCH:
-        metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
-        # body.specs = [] clears specs, as per json merge patch specification
-        # but we treat body.specs = None as "no modifications"
-        current_specs = entry.specs or []
-        target_specs = current_specs if body.specs is None else body.specs
-        specs = apply_merge_patch(current_specs, target_specs)
-    else:
-        raise HTTPException(
-            status_code=HTTP_406_NOT_ACCEPTABLE,
-            detail=f"valid content types: {', '.join(patch_mimetypes)}",
-        )
-
-    # Manually validate limits that bypass pydantic validation via patch
-    if len(specs) > schemas.MAX_ALLOWED_SPECS:
-        raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Update cannot result in more than {schemas.MAX_ALLOWED_SPECS} specs",
-        )
-    if len(specs) != len(set(specs)):
-        raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Update cannot result in non-unique specs",
-        )
-
-    structure_family, structure = (
-        entry.structure_family,
-        entry.structure(),
-    )
-
-    metadata_modified, metadata = await validate_metadata(
-        metadata=metadata,
-        structure_family=structure_family,
-        structure=structure,
-        specs=[Spec(x) for x in specs],
-        validation_registry=validation_registry,
-        settings=settings,
-    )
-
-    await entry.replace_metadata(metadata=metadata, specs=specs)
-
-    response_data = {"id": entry.key}
-    if metadata_modified:
-        response_data["metadata"] = metadata
-    return json_or_msgpack(request, response_data)
-
-
-@router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
-async def put_metadata(
-    request: Request,
-    body: schemas.PutMetadataRequest,
-    validation_registry=Depends(get_validation_registry),
-    settings: Settings = Depends(get_settings),
-    entry=SecureEntry(scopes=["write:metadata"]),
-):
-    if not hasattr(entry, "replace_metadata"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support update of metadata.",
-        )
-
-    metadata, structure_family, structure, specs = (
-        body.metadata if body.metadata is not None else entry.metadata(),
-        entry.structure_family,
-        entry.structure(),
-        body.specs if body.specs is not None else entry.specs,
-    )
-
-    metadata_modified, metadata = await validate_metadata(
-        metadata=metadata,
-        structure_family=structure_family,
-        structure=structure,
-        specs=specs,
-        validation_registry=validation_registry,
-        settings=settings,
-    )
-
-    await entry.replace_metadata(metadata=metadata, specs=specs)
-
-    response_data = {"id": entry.key}
-    if metadata_modified:
-        response_data["metadata"] = metadata
-    return json_or_msgpack(request, response_data)
-
-
-@router.get("/revisions/{path:path}")
-async def get_revisions(
-    request: Request,
-    path: str,
-    offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
-    limit: Optional[int] = Query(
-        DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
-    ),
-    entry=SecureEntry(scopes=["read:metadata"]),
-):
-    if not hasattr(entry, "revisions"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support revisions.",
-        )
-
-    base_url = get_base_url(request)
-    resource = await construct_revisions_response(
+    async def _awkward_buffers(
+        request: Request,
         entry,
-        base_url,
-        "/revisions",
-        path,
-        offset,
-        limit,
-        resolve_media_type(request),
-    )
-    return json_or_msgpack(request, resource.model_dump())
-
-
-@router.delete("/revisions/{path:path}")
-async def delete_revision(
-    request: Request,
-    number: int,
-    entry=SecureEntry(scopes=["write:metadata"]),
-):
-    if not hasattr(entry, "revisions"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support a del request for revisions.",
-        )
-
-    await entry.delete_revision(number)
-    return json_or_msgpack(request, None)
-
-
-# For simplicity of implementation, we support a restricted subset of the full
-# Range spec. This could be extended if the need arises.
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
-RANGE_HEADER_PATTERN = re.compile(r"^bytes=(\d+)-(\d+)$")
-
-
-@router.get("/asset/bytes/{path:path}")
-async def get_asset(
-    request: Request,
-    id: int,
-    relative_path: Optional[Path] = None,
-    entry=SecureEntry(scopes=["read:data"]),  # TODO: Separate scope for assets?
-    settings: Settings = Depends(get_settings),
-):
-    if not settings.expose_raw_assets:
-        raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN,
-            detail=(
-                "This Tiled server is configured not to allow "
-                "downloading raw assets."
-            ),
-        )
-    if not hasattr(entry, "asset_by_id"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support downloading assets.",
-        )
-
-    asset = await entry.asset_by_id(id)
-    if asset is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=f"This node exists but it does not have an Asset with id {id}",
-        )
-    if asset.is_directory:
-        if relative_path is None:
+        form_key: Optional[List[str]],
+        format: Optional[str],
+        filename: Optional[str],
+        serialization_registry,
+        settings: Settings,
+    ):
+        structure_family = entry.structure_family
+        structure = entry.structure()
+        with record_timing(request.state.metrics, "read"):
+            # The plural vs. singular mismatch is due to the way query parameters
+            # are given as ?form_key=A&form_key=B&form_key=C.
+            container = await ensure_awaitable(entry.read_buffers, form_key)
+        if (
+            sum(len(buffer) for buffer in container.values())
+            > settings.response_bytesize_limit
+        ):
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST,
                 detail=(
-                    "This asset is a directory. Must specify relative path, "
-                    f"from manifest provided by /asset/manifest/...?id={id}"
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Use slicing ('?slice=...') to request smaller chunks."
                 ),
             )
-        if relative_path.is_absolute():
-            raise HTTPException(
-                status_code=HTTP_400_BAD_REQUEST,
-                detail="relative_path query parameter must be a *relative* path",
-            )
-    else:
-        if relative_path is not None:
-            raise HTTPException(
-                status_code=HTTP_400_BAD_REQUEST,
-                detail="This asset is not a directory. The relative_path query parameter must not be set.",
-            )
-    if not asset.data_uri.startswith("file:"):
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail="Only download assets stored as file:// is currently supported.",
-        )
-    path = path_from_uri(asset.data_uri)
-    if relative_path is not None:
-        # Be doubly sure that this is under the Asset's data_uri directory
-        # and not sneakily escaping it.
-        if not os.path.commonpath([path, path / relative_path]) != path:
-            # This should not be possible.
-            raise RuntimeError(
-                f"Refusing to serve {path / relative_path} because it is outside "
-                "of the Asset's directory"
-            )
-        full_path = path / relative_path
-    else:
-        full_path = path
-    stat_result = await anyio.to_thread.run_sync(os.stat, full_path)
-    filename = full_path.name
-    if "range" in request.headers:
-        range_header = request.headers["range"]
-        match = RANGE_HEADER_PATTERN.match(range_header)
-        if match is None:
+        components = (structure.form, structure.length, container)
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    structure_family,
+                    serialization_registry,
+                    components,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.get(
+        "/awkward/full/{path:path}",
+        response_model=schemas.Response,
+        name="Full AwkwardArray",
+    )
+    async def awkward_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["read:data"], structure_families={StructureFamily.awkward}
+        ),
+        # slice=Depends(slice_),
+        format: Optional[str] = None,
+        filename: Optional[str] = None,
+        settings: Settings = Depends(get_settings),
+    ):
+        """
+        Fetch a slice of AwkwardArray data.
+        """
+        structure_family = entry.structure_family
+        # Deferred import because this is not a required dependency of the server
+        # for some use cases.
+        import awkward
+
+        with record_timing(request.state.metrics, "read"):
+            container = await ensure_awaitable(entry.read)
+        structure = entry.structure()
+        components = (structure.form, structure.length, container)
+        array = awkward.from_buffers(*components)
+        if array.nbytes > settings.response_bytesize_limit:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST,
                 detail=(
-                    "Only a Range headers of the form 'bytes=start-end' are supported. "
-                    f"Could not parse Range header: {range_header}",
+                    f"Response would exceed {settings.response_bytesize_limit}. "
+                    "Use slicing ('?slice=...') to request smaller chunks."
                 ),
             )
-        range = start, _ = (int(match.group(1)), int(match.group(2)))
-        if start > stat_result.st_size:
+        try:
+            with record_timing(request.state.metrics, "pack"):
+                return await construct_data_response(
+                    structure_family,
+                    serialization_registry,
+                    components,
+                    entry.metadata(),
+                    request,
+                    format,
+                    specs=getattr(entry, "specs", []),
+                    expires=getattr(entry, "content_stale_at", None),
+                    filename=filename,
+                )
+        except UnsupportedMediaTypes as err:
+            raise HTTPException(status_code=HTTP_406_NOT_ACCEPTABLE, detail=err.args[0])
+
+    @router.post("/metadata/{path:path}", response_model=schemas.PostMetadataResponse)
+    async def post_metadata(
+        request: Request,
+        path: str,
+        body: schemas.PostMetadataRequest,
+        settings: Settings = Depends(get_settings),
+        entry=SecureEntry(scopes=["write:metadata", "create"]),
+    ):
+        for data_source in body.data_sources:
+            if data_source.assets:
+                raise HTTPException(
+                    "Externally-managed assets cannot be registered "
+                    "using POST /metadata/{path} Use POST /register/{path} instead."
+                )
+        if body.data_sources and not getattr(entry, "writable", False):
             raise HTTPException(
-                status_code=HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
-                headers={"content-range": f"bytes */{stat_result.st_size}"},
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail=f"Data cannot be written at the path {path}",
             )
-        status_code = HTTP_206_PARTIAL_CONTENT
-    else:
-        range = None
-        status_code = HTTP_200_OK
-    return FileResponseWithRange(
-        full_path,
-        stat_result=stat_result,
-        status_code=status_code,
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-        range=range,
-    )
-
-
-@router.get("/asset/manifest/{path:path}")
-async def get_asset_manifest(
-    request: Request,
-    id: int,
-    entry=SecureEntry(scopes=["read:data"]),  # TODO: Separate scope for assets?
-    settings: Settings = Depends(get_settings),
-):
-    if not settings.expose_raw_assets:
-        raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN,
-            detail=(
-                "This Tiled server is configured not to allow "
-                "downloading raw assets."
-            ),
-        )
-    if not hasattr(entry, "asset_by_id"):
-        raise HTTPException(
-            status_code=HTTP_405_METHOD_NOT_ALLOWED,
-            detail="This node does not support downloading assets.",
+        return await _create_node(
+            request=request,
+            path=path,
+            body=body,
+            validation_registry=validation_registry,
+            settings=settings,
+            entry=entry,
         )
 
-    asset = await entry.asset_by_id(id)
-    if asset is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=f"This node exists but it does not have an Asset with id {id}",
+    @router.post("/register/{path:path}", response_model=schemas.PostMetadataResponse)
+    async def post_register(
+        request: Request,
+        path: str,
+        body: schemas.PostMetadataRequest,
+        settings: Settings = Depends(get_settings),
+        entry=SecureEntry(scopes=["write:metadata", "create", "register"]),
+    ):
+        return await _create_node(
+            request=request,
+            path=path,
+            body=body,
+            validation_registry=validation_registry,
+            settings=settings,
+            entry=entry,
         )
-    if not asset.is_directory:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail="This asset is not a directory. There is no manifest.",
+
+    async def _create_node(
+        request: Request,
+        path: str,
+        body: schemas.PostMetadataRequest,
+        validation_registry,
+        settings: Settings,
+        entry,
+    ):
+        metadata, structure_family, specs = (
+            body.metadata,
+            body.structure_family,
+            body.specs,
         )
-    if not asset.data_uri.startswith("file:"):
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail="Only download assets stored as file:// is currently supported.",
+        if structure_family == StructureFamily.container:
+            structure = None
+        else:
+            if len(body.data_sources) != 1:
+                raise NotImplementedError
+            structure = body.data_sources[0].structure
+
+        metadata_modified, metadata = await validate_metadata(
+            metadata=metadata,
+            structure_family=structure_family,
+            structure=structure,
+            specs=specs,
+            validation_registry=validation_registry,
+            settings=settings,
         )
-    path = path_from_uri(asset.data_uri)
-    manifest = []
-    # Walk the directory and any subdirectories. Aggregate a list of all the
-    # files, given as paths relative to the directory root.
-    for root, _directories, files in os.walk(path):
-        manifest.extend(Path(root, file) for file in files)
-    return json_or_msgpack(request, {"manifest": manifest})
 
+        key, node = await entry.create_node(
+            metadata=body.metadata,
+            structure_family=body.structure_family,
+            key=body.id,
+            specs=body.specs,
+            data_sources=body.data_sources,
+        )
+        links = links_for_node(
+            structure_family, structure, get_base_url(request), path + f"/{key}"
+        )
+        response_data = {
+            "id": key,
+            "links": links,
+            "data_sources": [ds.model_dump() for ds in node.data_sources],
+        }
+        if metadata_modified:
+            response_data["metadata"] = metadata
 
-async def validate_metadata(
-    metadata: dict,
-    structure_family: StructureFamily,
-    structure,
-    specs: List[Spec],
-    validation_registry=Depends(get_validation_registry),
-    settings: Settings = Depends(get_settings),
-):
-    metadata_modified = False
+        return json_or_msgpack(request, response_data)
 
-    # Specs should be ordered from most specific/constrained to least.
-    # Validate them in reverse order, with the least constrained spec first,
-    # because it may do normalization that helps pass the more constrained one.
-    # Known Issue:
-    # When there is more than one spec, it's possible for the validator for
-    # Spec 2 to make a modification that breaks the validation for Spec 1.
-    # For now we leave it to the server maintainer to ensure that validators
-    # won't step on each other in this way, but this may need revisiting.
-    for spec in reversed(specs):
-        if spec.name not in validation_registry:
-            if settings.reject_undeclared_specs:
+    @router.put("/data_source/{path:path}")
+    async def put_data_source(
+        request: Request,
+        path: str,
+        data_source: int,
+        body: schemas.PutDataSourceRequest,
+        settings: Settings = Depends(get_settings),
+        entry=SecureEntry(scopes=["write:metadata", "register"]),
+    ):
+        await entry.put_data_source(
+            data_source=body.data_source,
+        )
+
+    @router.delete("/metadata/{path:path}")
+    async def delete(
+        request: Request,
+        entry=SecureEntry(scopes=["write:data", "write:metadata"]),
+    ):
+        if hasattr(entry, "delete"):
+            await entry.delete()
+        else:
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support deletion.",
+            )
+        return json_or_msgpack(request, None)
+
+    @router.delete("/nodes/{path:path}")
+    async def bulk_delete(
+        request: Request,
+        entry=SecureEntry(scopes=["write:data", "write:metadata"]),
+    ):
+        if hasattr(entry, "delete_tree"):
+            await entry.delete_tree()
+        else:
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support bulk deletion.",
+            )
+        return json_or_msgpack(request, None)
+
+    @router.put("/array/full/{path:path}")
+    async def put_array_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["write:data"],
+            structure_families={StructureFamily.array, StructureFamily.sparse},
+        ),
+    ):
+        body = await request.body()
+        if not hasattr(entry, "write"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node cannot accept array data.",
+            )
+        media_type = request.headers["content-type"]
+        if entry.structure_family == "array":
+            dtype = entry.structure().data_type.to_numpy_dtype()
+            shape = entry.structure().shape
+            deserializer = deserialization_registry.dispatch("array", media_type)
+            data = await ensure_awaitable(deserializer, body, dtype, shape)
+        elif entry.structure_family == "sparse":
+            deserializer = deserialization_registry.dispatch("sparse", media_type)
+            data = await ensure_awaitable(deserializer, body)
+        else:
+            raise NotImplementedError(entry.structure_family)
+        await ensure_awaitable(entry.write, data)
+        return json_or_msgpack(request, None)
+
+    @router.put("/array/block/{path:path}")
+    async def put_array_block(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["write:data"],
+            structure_families={StructureFamily.array, StructureFamily.sparse},
+        ),
+        block=Depends(block),
+    ):
+        if not hasattr(entry, "write_block"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node cannot accept array data.",
+            )
+        from tiled.adapters.array import slice_and_shape_from_block_and_chunks
+
+        body = await request.body()
+        media_type = request.headers["content-type"]
+        if entry.structure_family == "array":
+            dtype = entry.structure().data_type.to_numpy_dtype()
+            _, shape = slice_and_shape_from_block_and_chunks(
+                block, entry.structure().chunks
+            )
+            deserializer = deserialization_registry.dispatch("array", media_type)
+            data = await ensure_awaitable(deserializer, body, dtype, shape)
+        elif entry.structure_family == "sparse":
+            deserializer = deserialization_registry.dispatch("sparse", media_type)
+            data = await ensure_awaitable(deserializer, body)
+        else:
+            raise NotImplementedError(entry.structure_family)
+        await ensure_awaitable(entry.write_block, data, block)
+        return json_or_msgpack(request, None)
+
+    @router.patch("/array/full/{path:path}")
+    async def patch_array_full(
+        request: Request,
+        offset=Depends(offset_param),
+        shape=Depends(shape_param),
+        extend: bool = False,
+        entry=SecureEntry(
+            scopes=["write:data"],
+            structure_families={StructureFamily.array},
+        ),
+    ):
+        if not hasattr(entry, "patch"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node cannot accept array data.",
+            )
+
+        dtype = entry.structure().data_type.to_numpy_dtype()
+        body = await request.body()
+        media_type = request.headers["content-type"]
+        deserializer = deserialization_registry.dispatch("array", media_type)
+        data = await ensure_awaitable(deserializer, body, dtype, shape)
+        structure = await ensure_awaitable(entry.patch, data, offset, extend)
+        return json_or_msgpack(request, structure)
+
+    @router.put("/table/full/{path:path}")
+    @router.put("/node/full/{path:path}", deprecated=True)
+    async def put_node_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["write:data"], structure_families={StructureFamily.table}
+        ),
+    ):
+        if not hasattr(entry, "write"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support writing.",
+            )
+        body = await request.body()
+        media_type = request.headers["content-type"]
+        deserializer = deserialization_registry.dispatch(
+            StructureFamily.table, media_type
+        )
+        data = await ensure_awaitable(deserializer, body)
+        await ensure_awaitable(entry.write, data)
+        return json_or_msgpack(request, None)
+
+    @router.put("/table/partition/{path:path}")
+    async def put_table_partition(
+        partition: int,
+        request: Request,
+        entry=SecureEntry(scopes=["write:data"]),
+    ):
+        if not hasattr(entry, "write_partition"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not supporting writing a partition.",
+            )
+        body = await request.body()
+        media_type = request.headers["content-type"]
+        deserializer = deserialization_registry.dispatch(
+            StructureFamily.table, media_type
+        )
+        data = await ensure_awaitable(deserializer, body)
+        await ensure_awaitable(entry.write_partition, data, partition)
+        return json_or_msgpack(request, None)
+
+    @router.patch("/table/partition/{path:path}")
+    async def patch_table_partition(
+        partition: int,
+        request: Request,
+        entry=SecureEntry(scopes=["write:data"]),
+    ):
+        if not hasattr(entry, "write_partition"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not supporting writing a partition.",
+            )
+        body = await request.body()
+        media_type = request.headers["content-type"]
+        deserializer = deserialization_registry.dispatch(
+            StructureFamily.table, media_type
+        )
+        data = await ensure_awaitable(deserializer, body)
+        await ensure_awaitable(entry.append_partition, data, partition)
+        return json_or_msgpack(request, None)
+
+    @router.put("/awkward/full/{path:path}")
+    async def put_awkward_full(
+        request: Request,
+        entry=SecureEntry(
+            scopes=["write:data"], structure_families={StructureFamily.awkward}
+        ),
+    ):
+        body = await request.body()
+        if not hasattr(entry, "write"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node cannot be written to.",
+            )
+        media_type = request.headers["content-type"]
+        deserializer = deserialization_registry.dispatch(
+            StructureFamily.awkward, media_type
+        )
+        structure = entry.structure()
+        data = await ensure_awaitable(
+            deserializer, body, structure.form, structure.length
+        )
+        await ensure_awaitable(entry.write, data)
+        return json_or_msgpack(request, None)
+
+    @router.patch("/metadata/{path:path}", response_model=schemas.PatchMetadataResponse)
+    async def patch_metadata(
+        request: Request,
+        body: schemas.PatchMetadataRequest,
+        settings: Settings = Depends(get_settings),
+        entry=SecureEntry(scopes=["write:metadata"]),
+    ):
+        if not hasattr(entry, "replace_metadata"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support update of metadata.",
+            )
+        if body.content_type == patch_mimetypes.JSON_PATCH:
+            metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
+            specs = apply_json_patch((entry.specs or []), (body.specs or []))
+        elif body.content_type == patch_mimetypes.MERGE_PATCH:
+            metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
+            # body.specs = [] clears specs, as per json merge patch specification
+            # but we treat body.specs = None as "no modifications"
+            current_specs = entry.specs or []
+            target_specs = current_specs if body.specs is None else body.specs
+            specs = apply_merge_patch(current_specs, target_specs)
+        else:
+            raise HTTPException(
+                status_code=HTTP_406_NOT_ACCEPTABLE,
+                detail=f"valid content types: {', '.join(patch_mimetypes)}",
+            )
+
+        # Manually validate limits that bypass pydantic validation via patch
+        if len(specs) > schemas.MAX_ALLOWED_SPECS:
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Update cannot result in more than {schemas.MAX_ALLOWED_SPECS} specs",
+            )
+        if len(specs) != len(set(specs)):
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Update cannot result in non-unique specs",
+            )
+
+        structure_family, structure = (
+            entry.structure_family,
+            entry.structure(),
+        )
+
+        metadata_modified, metadata = await validate_metadata(
+            metadata=metadata,
+            structure_family=structure_family,
+            structure=structure,
+            specs=[Spec(x) for x in specs],
+            validation_registry=validation_registry,
+            settings=settings,
+        )
+
+        await entry.replace_metadata(metadata=metadata, specs=specs)
+
+        response_data = {"id": entry.key}
+        if metadata_modified:
+            response_data["metadata"] = metadata
+        return json_or_msgpack(request, response_data)
+
+    @router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
+    async def put_metadata(
+        request: Request,
+        body: schemas.PutMetadataRequest,
+        settings: Settings = Depends(get_settings),
+        entry=SecureEntry(scopes=["write:metadata"]),
+    ):
+        if not hasattr(entry, "replace_metadata"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support update of metadata.",
+            )
+
+        metadata, structure_family, structure, specs = (
+            body.metadata if body.metadata is not None else entry.metadata(),
+            entry.structure_family,
+            entry.structure(),
+            body.specs if body.specs is not None else entry.specs,
+        )
+
+        metadata_modified, metadata = await validate_metadata(
+            metadata=metadata,
+            structure_family=structure_family,
+            structure=structure,
+            specs=specs,
+            validation_registry=validation_registry,
+            settings=settings,
+        )
+
+        await entry.replace_metadata(metadata=metadata, specs=specs)
+
+        response_data = {"id": entry.key}
+        if metadata_modified:
+            response_data["metadata"] = metadata
+        return json_or_msgpack(request, response_data)
+
+    @router.get("/revisions/{path:path}")
+    async def get_revisions(
+        request: Request,
+        path: str,
+        offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
+        limit: Optional[int] = Query(
+            DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
+        ),
+        entry=SecureEntry(scopes=["read:metadata"]),
+    ):
+        if not hasattr(entry, "revisions"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support revisions.",
+            )
+
+        base_url = get_base_url(request)
+        resource = await construct_revisions_response(
+            entry,
+            base_url,
+            "/revisions",
+            path,
+            offset,
+            limit,
+            resolve_media_type(request),
+        )
+        return json_or_msgpack(request, resource.model_dump())
+
+    @router.delete("/revisions/{path:path}")
+    async def delete_revision(
+        request: Request,
+        number: int,
+        entry=SecureEntry(scopes=["write:metadata"]),
+    ):
+        if not hasattr(entry, "revisions"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support a del request for revisions.",
+            )
+
+        await entry.delete_revision(number)
+        return json_or_msgpack(request, None)
+
+    # For simplicity of implementation, we support a restricted subset of the full
+    # Range spec. This could be extended if the need arises.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
+    RANGE_HEADER_PATTERN = re.compile(r"^bytes=(\d+)-(\d+)$")
+
+    @router.get("/asset/bytes/{path:path}")
+    async def get_asset(
+        request: Request,
+        id: int,
+        relative_path: Optional[Path] = None,
+        entry=SecureEntry(scopes=["read:data"]),  # TODO: Separate scope for assets?
+        settings: Settings = Depends(get_settings),
+    ):
+        if not settings.expose_raw_assets:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail=(
+                    "This Tiled server is configured not to allow "
+                    "downloading raw assets."
+                ),
+            )
+        if not hasattr(entry, "asset_by_id"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support downloading assets.",
+            )
+
+        asset = await entry.asset_by_id(id)
+        if asset is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"This node exists but it does not have an Asset with id {id}",
+            )
+        if asset.is_directory:
+            if relative_path is None:
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST,
-                    detail=f"Unrecognized spec: {spec.name}",
+                    detail=(
+                        "This asset is a directory. Must specify relative path, "
+                        f"from manifest provided by /asset/manifest/...?id={id}"
+                    ),
+                )
+            if relative_path.is_absolute():
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail="relative_path query parameter must be a *relative* path",
                 )
         else:
-            validator = validation_registry(spec.name)
-            try:
-                result = validator(metadata, structure_family, structure, spec)
-            except ValidationError as e:
+            if relative_path is not None:
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST,
-                    detail=f"failed validation for spec {spec.name}:\n{e}",
+                    detail="This asset is not a directory. The relative_path query parameter must not be set.",
                 )
-            if result is not None:
-                metadata_modified = True
-                metadata = result
+        if not asset.data_uri.startswith("file:"):
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="Only download assets stored as file:// is currently supported.",
+            )
+        path = path_from_uri(asset.data_uri)
+        if relative_path is not None:
+            # Be doubly sure that this is under the Asset's data_uri directory
+            # and not sneakily escaping it.
+            if not os.path.commonpath([path, path / relative_path]) != path:
+                # This should not be possible.
+                raise RuntimeError(
+                    f"Refusing to serve {path / relative_path} because it is outside "
+                    "of the Asset's directory"
+                )
+            full_path = path / relative_path
+        else:
+            full_path = path
+        stat_result = await anyio.to_thread.run_sync(os.stat, full_path)
+        filename = full_path.name
+        if "range" in request.headers:
+            range_header = request.headers["range"]
+            match = RANGE_HEADER_PATTERN.match(range_header)
+            if match is None:
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Only a Range headers of the form 'bytes=start-end' are supported. "
+                        f"Could not parse Range header: {range_header}",
+                    ),
+                )
+            range = start, _ = (int(match.group(1)), int(match.group(2)))
+            if start > stat_result.st_size:
+                raise HTTPException(
+                    status_code=HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
+                    headers={"content-range": f"bytes */{stat_result.st_size}"},
+                )
+            status_code = HTTP_206_PARTIAL_CONTENT
+        else:
+            range = None
+            status_code = HTTP_200_OK
+        return FileResponseWithRange(
+            full_path,
+            stat_result=stat_result,
+            status_code=status_code,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            range=range,
+        )
 
-    return metadata_modified, metadata
+    @router.get("/asset/manifest/{path:path}")
+    async def get_asset_manifest(
+        request: Request,
+        id: int,
+        entry=SecureEntry(scopes=["read:data"]),  # TODO: Separate scope for assets?
+        settings: Settings = Depends(get_settings),
+    ):
+        if not settings.expose_raw_assets:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail=(
+                    "This Tiled server is configured not to allow "
+                    "downloading raw assets."
+                ),
+            )
+        if not hasattr(entry, "asset_by_id"):
+            raise HTTPException(
+                status_code=HTTP_405_METHOD_NOT_ALLOWED,
+                detail="This node does not support downloading assets.",
+            )
+
+        asset = await entry.asset_by_id(id)
+        if asset is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"This node exists but it does not have an Asset with id {id}",
+            )
+        if not asset.is_directory:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="This asset is not a directory. There is no manifest.",
+            )
+        if not asset.data_uri.startswith("file:"):
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="Only download assets stored as file:// is currently supported.",
+            )
+        path = path_from_uri(asset.data_uri)
+        manifest = []
+        # Walk the directory and any subdirectories. Aggregate a list of all the
+        # files, given as paths relative to the directory root.
+        for root, _directories, files in os.walk(path):
+            manifest.extend(Path(root, file) for file in files)
+        return json_or_msgpack(request, {"manifest": manifest})
+
+    async def validate_metadata(
+        metadata: dict,
+        structure_family: StructureFamily,
+        structure,
+        specs: List[Spec],
+        settings: Settings = Depends(get_settings),
+    ):
+        metadata_modified = False
+
+        # Specs should be ordered from most specific/constrained to least.
+        # Validate them in reverse order, with the least constrained spec first,
+        # because it may do normalization that helps pass the more constrained one.
+        # Known Issue:
+        # When there is more than one spec, it's possible for the validator for
+        # Spec 2 to make a modification that breaks the validation for Spec 1.
+        # For now we leave it to the server maintainer to ensure that validators
+        # won't step on each other in this way, but this may need revisiting.
+        for spec in reversed(specs):
+            if spec.name not in validation_registry:
+                if settings.reject_undeclared_specs:
+                    raise HTTPException(
+                        status_code=HTTP_400_BAD_REQUEST,
+                        detail=f"Unrecognized spec: {spec.name}",
+                    )
+            else:
+                validator = validation_registry(spec.name)
+                try:
+                    result = validator(metadata, structure_family, structure, spec)
+                except ValidationError as e:
+                    raise HTTPException(
+                        status_code=HTTP_400_BAD_REQUEST,
+                        detail=f"failed validation for spec {spec.name}:\n{e}",
+                    )
+                if result is not None:
+                    metadata_modified = True
+                    metadata = result
+
+        return metadata_modified, metadata
+
+    return router

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 
 import anyio
 import packaging
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Security
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from jmespath.exceptions import JMESPathError
 from json_merge_patch import merge as apply_merge_patch
 from jsonpatch import apply_patch as apply_json_patch
@@ -62,7 +62,7 @@ from .dependencies import (
 from .file_response_with_range import FileResponseWithRange
 from .links import links_for_node
 from .settings import Settings, get_settings
-from .utils import filter_for_access, get_base_url, move_api_key, record_timing
+from .utils import filter_for_access, get_base_url, record_timing
 
 
 def get_router(
@@ -84,7 +84,6 @@ def get_router(
     async def about(
         request: Request,
         settings: Settings = Depends(get_settings),
-        _: str | None = Security(move_api_key),
     ):
         # TODO The lazy import of entry modules and serializers means that the
         # lists of formats are not populated until they are first used. Not very
@@ -198,7 +197,6 @@ def get_router(
         omit_links: bool = Query(False),
         include_data_sources: bool = Query(False),
         entry: Any = SecureEntry(scopes=["read:metadata"]),
-        _: str | None = Depends(move_api_key),
         **filters,
     ):
         request.state.endpoint = "search"

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -77,7 +77,7 @@ def get_router(
     validation_registry: ValidationRegistry,
 ) -> APIRouter:
     router = APIRouter()
-    SecureEntry = SecureEntryBuilder(get_current_principal, tree, get_session_state)
+    SecureEntry = SecureEntryBuilder(tree, get_current_principal, get_session_state)
 
     @router.get("/", response_model=About)
     async def about(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -248,7 +248,7 @@ def get_router(
         )
 
     @router.get(
-        "/api/v1/search/{path:path}",
+        "/search/{path:path}",
         response_model=schemas.Response[
             List[schemas.Resource[schemas.NodeAttributes, dict, dict]],
             schemas.PaginationLinks,
@@ -327,7 +327,7 @@ def get_router(
             )
 
     @router.get(
-        "/api/v1/distinct/{path:path}",
+        "/distinct/{path:path}",
         response_model=schemas.GetDistinctResponse,
     )
     @patch_route_signature(query_registry=query_registry)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -135,14 +135,14 @@ def patch_route_signature(query_registry: QueryRegistry) -> Callable[[Callable[P
     return inner
 
 def get_router(
-    query_registry,
-    authenticators: dict[str, Authenticator],
-    get_current_principal,
     tree: Mapping[str, Any],
-    get_session_state,
+    query_registry: QueryRegistry,
     serialization_registry: SerializationRegistry,
     deserialization_registry: SerializationRegistry,
     validation_registry: ValidationRegistry,
+    authenticators: dict[str, Authenticator],
+    get_current_principal: Callable[..., Optional[str]],
+    get_session_state: Callable[..., Optional[dict[str, Any]]],
 ) -> APIRouter:
     router = APIRouter()
     SecureEntry = SecureEntryBuilder(tree, get_current_principal, get_session_state)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -4,7 +4,7 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
 import anyio
 import packaging
@@ -69,16 +69,14 @@ def get_router(
     query_registry,
     authenticators: dict[str, Authenticator],
     get_current_principal,
-    get_root_tree,
+    tree: Mapping[str, Any],
     get_session_state,
     serialization_registry,
     deserialization_registry,
     validation_registry,
 ) -> APIRouter:
     router = APIRouter()
-    SecureEntry = SecureEntryBuilder(
-        get_current_principal, get_root_tree, get_session_state
-    )
+    SecureEntry = SecureEntryBuilder(get_current_principal, tree, get_session_state)
 
     @router.get("/", response_model=About)
     async def about(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -6,7 +6,7 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, Optional, ParamSpec, TypeVar
+from typing import Any, Callable, List, Mapping, Optional, TypeVar
 
 import anyio
 import packaging
@@ -68,11 +68,12 @@ from .links import links_for_node
 from .settings import Settings, get_settings
 from .utils import filter_for_access, get_base_url, record_timing
 
-
-P = ParamSpec("P")
 T = TypeVar("T")
 
-def patch_route_signature(query_registry: QueryRegistry) -> Callable[[Callable[P, T]], Callable[P, T]]:
+
+def patch_route_signature(
+    query_registry: QueryRegistry,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     This is done dynamically at router startup.
 
@@ -90,7 +91,7 @@ def patch_route_signature(query_registry: QueryRegistry) -> Callable[[Callable[P
 
     """
 
-    def inner(route: Callable[P, T]) -> Callable[P, T]:
+    def inner(route: Callable[..., T]) -> Callable[..., T]:
         # Build a wrapper so that we can modify the signature
         # without mutating the wrapped original.
 
@@ -124,7 +125,9 @@ def patch_route_signature(query_registry: QueryRegistry) -> Callable[[Callable[P
                 injected_parameter = inspect.Parameter(
                     name=f"filter___{name}___{field.name}",
                     kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=Query(None, alias=f"filter[{name}][condition][{field.name}]"),
+                    default=Query(
+                        None, alias=f"filter[{name}][condition][{field.name}]"
+                    ),
                     annotation=Optional[List[field_type]],
                 )
                 parameters.append(injected_parameter)
@@ -132,7 +135,9 @@ def patch_route_signature(query_registry: QueryRegistry) -> Callable[[Callable[P
         # End black magic
 
         return route_with_sig
+
     return inner
+
 
 def get_router(
     tree: Mapping[str, Any],

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1102,7 +1102,6 @@ def get_router(
             structure_family=structure_family,
             structure=structure,
             specs=specs,
-            validation_registry=validation_registry,
             settings=settings,
         )
 
@@ -1389,7 +1388,6 @@ def get_router(
             structure_family=structure_family,
             structure=structure,
             specs=[Spec(x) for x in specs],
-            validation_registry=validation_registry,
             settings=settings,
         )
 
@@ -1425,7 +1423,6 @@ def get_router(
             structure_family=structure_family,
             structure=structure,
             specs=specs,
-            validation_registry=validation_registry,
             settings=settings,
         )
 

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -162,7 +162,7 @@ async def filter_for_access(entry, principal, scopes, metrics, path_parts):
 
 async def move_api_key(
     request: Request,
-    api_key: str | None = Depends(get_api_key),
+    api_key: Optional[str] = Depends(get_api_key),
 ):
     """
     Moves API key if given as a query parameter into a cookie

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -86,7 +86,7 @@ async def get_api_key(
     api_key_cookie: str = Security(
         APIKeyCookie(name=API_KEY_COOKIE_NAME, auto_error=False)
     ),
-):
+) -> Optional[str]:
     for api_key in [api_key_query, api_key_header, api_key_cookie]:
         if api_key is not None:
             return api_key

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -1,5 +1,14 @@
 import contextlib
 import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request, Security
+from fastapi.openapi.models import APIKey, APIKeyIn
+from fastapi.security import SecurityScopes
+from fastapi.security.api_key import APIKeyBase, APIKeyCookie, APIKeyQuery
+from fastapi.security.utils import get_authorization_scheme_param
+from starlette.status import HTTP_400_BAD_REQUEST
 
 from ..access_policies import NO_ACCESS
 from ..adapters.mapping import MapAdapter
@@ -10,11 +19,78 @@ API_KEY_QUERY_PARAMETER = "api_key"
 CSRF_COOKIE_NAME = "tiled_csrf"
 
 
-def get_authenticators():
-    raise NotImplementedError(
-        "This should be overridden via dependency_overrides. "
-        "See tiled.server.app.build_app()."
-    )
+def utcnow():
+    "UTC now with second resolution"
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def headers_for_401(request: Request, security_scopes: SecurityScopes):
+    # call directly from methods, rather than as a dependency, to avoid calling
+    # when not needed.
+    if security_scopes.scopes:
+        authenticate_value = f'Bearer scope="{security_scopes.scope_str}"'
+    else:
+        authenticate_value = "Bearer"
+    return {
+        "WWW-Authenticate": authenticate_value,
+        "X-Tiled-Root": get_base_url(request),
+    }
+
+
+class APIKeyAuthorizationHeader(APIKeyBase):
+    """
+    Expect a header like
+
+    Authorization: Apikey SECRET
+
+    where Apikey is case-insensitive.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        self.model: APIKey = APIKey(
+            **{"in": APIKeyIn.header}, name=name, description=description
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization: str = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() == "bearer":
+            return None
+        if scheme.lower() != "apikey":
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Authorization header must include the authorization type "
+                    "followed by a space and then the secret, as in "
+                    "'Bearer SECRET' or 'Apikey SECRET'. "
+                ),
+            )
+        return param
+
+
+async def get_api_key(
+    api_key_query: str = Security(APIKeyQuery(name="api_key", auto_error=False)),
+    api_key_header: str = Security(
+        APIKeyAuthorizationHeader(
+            name="Authorization",
+            description="Prefix value with 'Apikey ' as in, 'Apikey SECRET'",
+        )
+    ),
+    api_key_cookie: str = Security(
+        APIKeyCookie(name=API_KEY_COOKIE_NAME, auto_error=False)
+    ),
+):
+    for api_key in [api_key_query, api_key_header, api_key_cookie]:
+        if api_key is not None:
+            return api_key
+    return None
 
 
 @contextlib.contextmanager
@@ -82,3 +158,22 @@ async def filter_for_access(entry, principal, scopes, metrics, path_parts):
                 for query in queries:
                     entry = entry.search(query)
     return entry
+
+
+async def move_api_key(
+    request: Request,
+    api_key: str | None = Depends(get_api_key),
+):
+    """
+    Moves API key if given as a query parameter into a cookie
+    """
+
+    if (
+        api_key is not None
+        and "api_key" in request.query_params
+        and request.cookies.get(API_KEY_COOKIE_NAME) != api_key
+    ):
+        request.state.cookies_to_set.append(
+            {"key": API_KEY_COOKIE_NAME, "value": api_key}
+        )
+        return api_key

--- a/tiled/validation_registration.py
+++ b/tiled/validation_registration.py
@@ -23,7 +23,7 @@ class ValidationRegistry:
         return spec in self._lookup
 
 
-validation_registry = ValidationRegistry()
+default_validation_registry = ValidationRegistry()
 "Global validation registry"
 
 


### PR DESCRIPTION
WIP: adds an Authenticator implementation for use when serving Tiled behind a proxy.
This is intended be used to define an alternative `decode_access_token`
In order to inject the desired behaviour for decode_access_token has required a fairly weighty refactor, inverting the creation order of a lot of router objects.

- Removes injection of password into security obj
- Removes use of dependency_override which is intended for use in tests

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
