### PR TITLE
Fix incognito mode when there are no tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - Do not attempt to use auth tokens if the server declares no authentication
   providers.
+- Prevent "incognito mode" (remember_me=False) from failing after a previous
+  login session has since been logged out (no token files)
 
 ### Maintenance
 

--- a/tiled/client/auth.py
+++ b/tiled/client/auth.py
@@ -83,7 +83,7 @@ class TiledAuth(httpx.Auth):
         with self._sync_lock:
             if self.token_directory is not None:
                 filepath = self.token_directory / key
-                filepath.unlink(missing_ok=False)
+                filepath.unlink(missing_ok=True)
             self.tokens.pop(key, None)  # Clear cached value.
 
     def sync_auth_flow(self, request, attempt=0):


### PR DESCRIPTION
After a successful Tiled login with `remember_me=True` (the default), a directory is made in e.g. `~/.cache` which corresponds to the server URI and holds a collection of authN tokens. If a client is created with `remember_me=False`, Tiled will try to delete these tokens.

However, if the URI directory exists but token files do not (such as after logging out from a successful login), then `remember_me=True` login will fail as it cannot find the tokens it wants to delete. Instead, if the token files do not exist, we should continue on and allow login.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
