### PR TITLE
Remove data_sources performance warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
   have been removed. These were used internally by the server and should
   not affect user code.
 - Publish Container image and Helm chart only during a tagged release.
+- Stop warning when `data_sources()` are fetched after the item was already
+  fetched. (Too noisy.)
 
 ## v0.1.0-b17 (2024-01-29)
 

--- a/tiled/_tests/test_asset_access.py
+++ b/tiled/_tests/test_asset_access.py
@@ -35,13 +35,9 @@ def test_include_data_sources_method_on_self(client):
     "Calling include_data_sources() fetches data sources on self."
     x = client.write_array([1, 2, 3], key="x")
     # Fetch data_sources on x object directly.
-    with pytest.warns(UserWarning):
-        # This fetches the sources with an additional implicit request.
-        x.data_sources()
+    x.data_sources() is not None
     # Fetch data_sources on x object, looked up in client.
-    with pytest.warns(UserWarning):
-        # This fetches the sources with an additional implicit request.
-        client["x"].data_sources()
+    client["x"].data_sources() is not None
     assert client["x"].include_data_sources().data_sources() is not None
 
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -1,5 +1,4 @@
 import time
-import warnings
 from copy import copy, deepcopy
 from dataclasses import asdict
 from pathlib import Path
@@ -246,14 +245,6 @@ class BaseClient:
         return StructureFamily[self.item["attributes"]["structure_family"]]
 
     def data_sources(self):
-        if not self._include_data_sources:
-            warnings.warn(
-                """Calling include_data_sources().refresh().
-To fetch the data sources up front, call include_data_sources() on the
-client or pass the optional parameter `include_data_sources=True` to
-`from_uri(...)` or similar."""
-            )
-
         data_sources_json = (
             self.include_data_sources().item["attributes"].get("data_sources")
         )


### PR DESCRIPTION
We were 50/50 on whether to add this warning in the first place. (I recall @padraic-shafer politely questioned it.) With a little experience in the wild, I think it's too noisy.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
