### PR TITLE
tree util may skip errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Added
 
-- Added `SQLAdapter` which can save and interact with table structured data in `sqlite` , `postgresql` and `duckdb` databases using `arrow-adbc` API calls.
+- Added `SQLAdapter` which can save and interact with table structured data in
+  `sqlite` , `postgresql` and `duckdb` databases using `arrow-adbc` API calls.
+- New parameter to `tiled.client.tree` `on_error` defaults to skipping errors
+  and printing the error message. To restore original strict behavior, pass
+  `on_error="raise"`.
 
 ### Changed
 


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

Closes #888 

Tested on a directory with a single HDF5 file with a broken external link. In `main`, I can reproduce #888:

```
❯ tiled tree --profile local
└── stuff
    └── main
<snipped traceback>
HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:8000/api/v1/search/stuff/main?page%5Boffset%5D=0&sort='
```

In this PR branch:

```
❯ tiled tree --profile local
└── stuff
    └── main
SKIPPING due to error: Server error '500 Internal Server Error' for url 'http://localhost:8000/api/v1/search/stuff/main?page%5Boffset%5D=0&sort='
For more information, server admin can search server logs for correlation ID 87d503846a48e9c3.
```

In both cases, server logs:

```
KeyError: "Unable to synchronously open object (unable to open external file, external link file name = 'source.h5')"
```