### PR TITLE
In AuthN database, use localized datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
-
 ### Added
 
-- Added `SQLAdapter` which can save and interact with table structured data in `sqlite` , `postgresql` and `duckdb` databases using `arrow-adbc` API calls.
+- Added `SQLAdapter` which can save and interact with table structured data in
+  `sqlite` , `postgresql` and `duckdb` databases using `arrow-adbc` API calls.
 
 ### Changed
 
@@ -19,6 +19,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Publish Container image and Helm chart only during a tagged release.
 - Stop warning when `data_sources()` are fetched after the item was already
   fetched. (Too noisy.)
+- In Tiled's authentication database, when PostgreSQL is used, all datetimes
+  are stored explicitly localized to UTC. This requires a database migration
+  to update existing rows.
 
 ## v0.1.0-b17 (2024-01-29)
 

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -12,6 +12,7 @@ from .orm import APIKey, Identity, PendingSession, Principal, Role, Session
 
 # This is list of all valid alembic revisions (from current to oldest).
 ALL_REVISIONS = [
+    "d88e91ea03f9",
     "13024b8a6b74",
     "769180ce732e",
     "c7bd2573716d",

--- a/tiled/authn_database/migrations/versions/d88e91ea03f9_localize_all_timestamps.py
+++ b/tiled/authn_database/migrations/versions/d88e91ea03f9_localize_all_timestamps.py
@@ -1,0 +1,120 @@
+"""Localize all timestamps
+
+Revision ID: d88e91ea03f9
+Revises: 13024b8a6b74
+Create Date: 2025-02-18 14:15:48.967976
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d88e91ea03f9"
+down_revision = "13024b8a6b74"
+branch_labels = None
+depends_on = None
+
+
+# mapping table names to list of column given as (name, nullable)
+datetime_columns = {
+    "principals": [("time_created", True), ("time_updated", True)],
+    "identities": [
+        ("latest_login", True),
+        ("time_created", False),
+        ("time_updated", True),
+    ],
+    "roles": [("time_created", True), ("time_updated", True)],
+    "api_keys": [
+        ("expiration_time", True),
+        ("latest_activity", True),
+        ("time_created", False),
+        ("time_updated", True),
+    ],
+    "sessions": [
+        ("expiration_time", False),
+        ("time_created", False),
+        ("time_last_refreshed", True),
+        ("time_updated", True),
+    ],
+    "pending_sessions": [("expiration_time", False)],
+}
+
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "sqlite":
+        # No action required. SQLAlchemy handles timezones at the application
+        # level and does not store anything like +00 or +Z in the database.
+        return
+
+    for table, columns in datetime_columns.items():
+        for column, nullable in columns:
+            # Create a temporary column with localized datetimes.
+            # Hardcode nullable=True because the values are not initialized.
+            # We will set nullable properly at the end.
+            op.add_column(
+                table,
+                sa.Column(
+                    f"{column}_localized", sa.DateTime(timezone=True), nullable=True
+                ),
+            )
+
+            # Copy date from naive to localized column.
+            connection.execute(
+                sa.text(
+                    f"""
+                    UPDATE {table}
+                    SET {column}_localized = {column} AT TIME ZONE 'UTC'
+                    WHERE {column} IS NOT NULL
+                """
+                )
+            )
+
+            # Drop the original (naive) column.
+            op.drop_column(table, column)
+
+            # Rename the new column to the original name, and set nullable to
+            # the correct value.
+            op.alter_column(
+                table, f"{column}_localized", new_column_name=column, nullable=nullable
+            )
+
+
+def downgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "sqlite":
+        # No action required. SQLAlchemy handles timezones at the application
+        # level and does not store anything like +00 or +Z in the database.
+        return
+
+    for table, columns in datetime_columns.items():
+        for column, nullable in columns:
+            # Create a temporary column with naive datetimes.
+            # Hardcode nullable=True because the values are not initialized.
+            # We will set nullable properly at the end.
+            op.add_column(
+                table,
+                sa.Column(
+                    f"{column}_naive", sa.DateTime(timezone=False), nullable=False
+                ),
+            )
+
+            # Copy date from localized to naive column.
+            connection.execute(
+                sa.text(
+                    f"""
+                    UPDATE {table}
+                    SET {column}_naive = {column} AT TIME ZONE 'UTC'
+                    WHERE {column} IS NOT NULL
+                """
+                )
+            )
+
+            # Drop the original (localized) column.
+            op.drop_column(table, column)
+
+            # Rename the new column to the original name, and set nullable to
+            # the correct value.
+            op.alter_column(
+                table, f"{column}_naive", new_column_name=column, nullable=nullable
+            )

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -86,9 +86,11 @@ class Timestamped:
 
     __mapper_args__ = {"eager_defaults": True}
 
-    time_created = Column(DateTime(timezone=False), server_default=func.now())
+    time_created = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     time_updated = Column(
-        DateTime(timezone=False), onupdate=func.now()
+        DateTime(timezone=True), onupdate=func.now()
     )  # null until first update
 
     def __repr__(self):
@@ -144,7 +146,7 @@ class Identity(Timestamped, Base):
     id = Column(Unicode(255), primary_key=True, nullable=False)
     provider = Column(Unicode(255), primary_key=True, nullable=False)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
-    latest_login = Column(DateTime(timezone=False), nullable=True)
+    latest_login = Column(DateTime(timezone=True), nullable=True)
     # In the future we may add a notion of "primary" identity.
 
     principal = relationship("Principal", back_populates="identities")
@@ -174,8 +176,8 @@ class APIKey(Timestamped, Base):
     hashed_secret = Column(
         LargeBinary(32), primary_key=True, index=True, nullable=False
     )
-    expiration_time = Column(DateTime(timezone=False), nullable=True)
-    latest_activity = Column(DateTime(timezone=False), nullable=True)
+    expiration_time = Column(DateTime(timezone=True), nullable=True)
+    latest_activity = Column(DateTime(timezone=True), nullable=True)
     note = Column(Unicode(1023), nullable=True)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
     scopes = Column(JSONList(511), nullable=False)
@@ -201,9 +203,9 @@ class Session(Timestamped, Base):
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     # This uuid is exposed to the client.
     uuid = Column(UUID, index=True, nullable=False, default=uuid_module.uuid4)
-    time_last_refreshed = Column(DateTime(timezone=False), nullable=True)
+    time_last_refreshed = Column(DateTime(timezone=True), nullable=True)
     refresh_count = Column(Integer, nullable=False, default=0)
-    expiration_time = Column(DateTime(timezone=False), nullable=False)
+    expiration_time = Column(DateTime(timezone=True), nullable=False)
     principal_id = Column(Integer, ForeignKey("principals.id"), nullable=False)
     revoked = Column(Boolean, default=False, nullable=False)
     # State allows for custom  authenticator information to be stored in the session.
@@ -222,7 +224,7 @@ class PendingSession(Base):
         LargeBinary(32), primary_key=True, index=True, nullable=False
     )
     user_code = Column(Unicode(8), index=True, nullable=False)
-    expiration_time = Column(DateTime(timezone=False), nullable=False)
+    expiration_time = Column(DateTime(timezone=True), nullable=False)
     session_id = Column(Integer, ForeignKey("sessions.id"), nullable=True)
 
     session = relationship("Session", lazy="joined")

--- a/tiled/commandline/_admin.py
+++ b/tiled/commandline/_admin.py
@@ -76,8 +76,10 @@ def upgrade_database(
     from ..authn_database.core import ALL_REVISIONS
     from ..utils import ensure_specified_sql_driver
 
+    database_uri = ensure_specified_sql_driver(database_uri)
+
     async def do_setup():
-        engine = create_async_engine(ensure_specified_sql_driver(database_uri))
+        engine = create_async_engine(database_uri)
         redacted_url = engine.url._replace(password="[redacted]")
         current_revision = await get_current_revision(engine, ALL_REVISIONS)
         await engine.dispose()
@@ -113,8 +115,10 @@ def downgrade_database(
     from ..authn_database.core import ALL_REVISIONS
     from ..utils import ensure_specified_sql_driver
 
+    database_uri = ensure_specified_sql_driver(database_uri)
+
     async def do_setup():
-        engine = create_async_engine(ensure_specified_sql_driver(database_uri))
+        engine = create_async_engine(database_uri)
         redacted_url = engine.url._replace(password="[redacted]")
         current_revision = await get_current_revision(engine, ALL_REVISIONS)
         if current_revision is None:


### PR DESCRIPTION
In https://github.com/bluesky/tiled/pull/842 we followed Python's recommendation to use localized timestamps (`datetime.now(timezone.utc)`) instead of naive (`datetime.utcnow()`). This created an incompatibility with existing AuthN PG databases, when SQLAlchemy tried to insert localized datetimes into naive datetime columns. (The catalog databases are not affected by the change.)

After discussion with @dylanmcreynolds, @padraic-shafer, and @callumforrester, the consensus was that the right choice was to store localized timestamps. "Label your units!" is a good rule, timestamps are common source of confusion, and this could be helpful for developers inspecting the database. This PR:

- Changes the table definitions to use `DateTime(timezone=True)` in all cases. They formerly used `DateTime(timezone=False`) in all cases.
- Adds a migration script to update existing DATETIME columns from naive UTC to explicitly-localized UTC
- Maintains existing `NULL / NOT NULL` designations, except for `time_created`, which is switch from `NULL` to `NOT NULL`. (It always gets a server-provided default value at creation time.)

Note that, in SQLite, SQLAlchmy stores UTC-localized timestamps as naive strings, so the migration only affects SQLite

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
