### PR TITLE
Run authN tests against PG as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
+## Unreleased
+
+### Maintenance
+
+- Run authentication tests againts PostgreSQL as well as SQLite.
+
 ## 0.1.0-b18 (2024-02-18)
 
 ### Added

--- a/tiled/_tests/conftest.py
+++ b/tiled/_tests/conftest.py
@@ -118,6 +118,24 @@ TILED_TEST_POSTGRESQL_URI = os.getenv("TILED_TEST_POSTGRESQL_URI")
 
 
 @pytest_asyncio.fixture
+async def sqlite_database_uri(tmpdir):
+    yield f"sqlite:///{tmpdir}/tiled.sqlite"
+
+
+@pytest_asyncio.fixture
+async def postgresql_database_uri():
+    if not TILED_TEST_POSTGRESQL_URI:
+        raise pytest.skip("No TILED_TEST_POSTGRESQL_URI configured")
+    async with temp_postgres(TILED_TEST_POSTGRESQL_URI) as uri_with_database:
+        yield uri_with_database
+
+
+@pytest.fixture(params=["sqlite_database_uri", "postgresql_database_uri"])
+def sqlite_or_postgresql_database_uri(request):
+    yield request.getfixturevalue(request.param)
+
+
+@pytest_asyncio.fixture
 async def postgresql_adapter(request, tmpdir):
     """
     Adapter instance

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -25,14 +25,14 @@ tree = MapAdapter({"A1": arr, "A2": arr})
 
 
 @pytest.fixture
-def config(tmpdir):
+def config(sqlite_or_postgresql_database_uri):
     """
     Return config with
 
     - a unique temporary sqlite database location
     - a unique nested dict instance that the test can mutate
     """
-    database_uri = f"sqlite:///{tmpdir}/tiled.sqlite"
+    database_uri = sqlite_or_postgresql_database_uri
     subprocess.run(
         [sys.executable, "-m", "tiled", "admin", "initialize-database", database_uri],
         check=True,


### PR DESCRIPTION
Why didn't the bug fixed in #890 fail our test suite? The reason is, we were testing auth against SQLite only, and the issue affected PostgreSQL only. This PR parameterizes the core `config` fixture used by these tests to run against both.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
