### PR TITLE
Tighten up handling of time_created, time_updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Maintenance
 
 - Run authentication tests againts PostgreSQL as well as SQLite.
+- Tighten up handling of `time_created` and `time_updated` in authentication
+  database.
 
 ## 0.1.0-b18 (2024-02-18)
 

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -1,5 +1,6 @@
 import json
 import uuid as uuid_module
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     JSON,
@@ -87,10 +88,18 @@ class Timestamped:
     __mapper_args__ = {"eager_defaults": True}
 
     time_created = Column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
+        DateTime(timezone=True),
+        # server default is applied too late for SQLAlchemy...
+        default=datetime.now(timezone.utc),
+        # but a server default is good to have for other clients
+        # so add that as well
+        server_default=func.now(),
+        nullable=False,
     )
     time_updated = Column(
-        DateTime(timezone=True), onupdate=func.now()
+        DateTime(timezone=True),
+        onupdate=func.now(),
+        nullable=True,
     )  # null until first update
 
     def __repr__(self):


### PR DESCRIPTION
The goal here is to make the behavior more explicit and also to avoid a configuration-dependent failure I observed in production, where `server_default` can be applied too late to satisfy a `NOT NULL` constraint:

```
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.NotNullViolationError'>: null value in column "time_created" of relation "sessions" violates not-null constraint
```

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
