### PR TITLE
Reinstate `server_default` for `time_created`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Run authentication tests againts PostgreSQL as well as SQLite.
 - Tighten up handling of `time_created` and `time_updated` in authentication
   database.
+- New authentication database migration fixes error in migration in previous release.
 
 ## 0.1.0-b18 (2024-02-18)
 

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -12,6 +12,7 @@ from .orm import APIKey, Identity, PendingSession, Principal, Role, Session
 
 # This is list of all valid alembic revisions (from current to oldest).
 ALL_REVISIONS = [
+    "0c705a02954c",
     "d88e91ea03f9",
     "13024b8a6b74",
     "769180ce732e",

--- a/tiled/authn_database/migrations/versions/0c705a02954c_restore_server_default_for_time_created.py
+++ b/tiled/authn_database/migrations/versions/0c705a02954c_restore_server_default_for_time_created.py
@@ -1,0 +1,39 @@
+"""Restore server_default for time_created
+
+Revision ID: 0c705a02954c
+Revises: d88e91ea03f9
+Create Date: 2025-02-19 13:03:35.067755
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0c705a02954c"
+down_revision = "d88e91ea03f9"
+branch_labels = None
+depends_on = None
+
+tables = ["principals", "identities", "roles", "api_keys", "sessions"]
+
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "sqlite":
+        return
+    for table in tables:
+        connection.execute(
+            sa.text(
+                f"""
+ALTER TABLE {table}
+ALTER COLUMN time_created
+SET DEFAULT CURRENT_TIMESTAMP;
+            """
+            )
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "sqlite":
+        return

--- a/tiled/authn_database/migrations/versions/0c705a02954c_restore_server_default_for_time_created.py
+++ b/tiled/authn_database/migrations/versions/0c705a02954c_restore_server_default_for_time_created.py
@@ -34,6 +34,5 @@ SET DEFAULT CURRENT_TIMESTAMP;
 
 
 def downgrade():
-    connection = op.get_bind()
-    if connection.engine.dialect.name == "sqlite":
-        return
+    # No action required
+    pass

--- a/tiled/authn_database/migrations/versions/d88e91ea03f9_localize_all_timestamps.py
+++ b/tiled/authn_database/migrations/versions/d88e91ea03f9_localize_all_timestamps.py
@@ -54,6 +54,8 @@ def upgrade():
             # We will set nullable properly at the end.
             op.add_column(
                 table,
+                # NOTE: Later it was noticed that server_default was missed here.
+                # The following migration (0c705a02954c) fixed this.
                 sa.Column(
                     f"{column}_localized", sa.DateTime(timezone=True), nullable=True
                 ),

--- a/tiled/authn_database/orm.py
+++ b/tiled/authn_database/orm.py
@@ -1,6 +1,5 @@
 import json
 import uuid as uuid_module
-from datetime import datetime, timezone
 
 from sqlalchemy import (
     JSON,
@@ -89,10 +88,6 @@ class Timestamped:
 
     time_created = Column(
         DateTime(timezone=True),
-        # server default is applied too late for SQLAlchemy...
-        default=datetime.now(timezone.utc),
-        # but a server default is good to have for other clients
-        # so add that as well
         server_default=func.now(),
         nullable=False,
     )


### PR DESCRIPTION
This walks back one aspect of #893 which misdiagnosed a problem observed in prod. The database migration that localized datetimes neglected to set a `server_default` on the new, localized `time_created` column. In #893 I worked around this by setting a client-side `default` in addition to a `server_default` because I misunderstood the issue.

A cleaner solution is to reinstate a `server_default`.

I was able to reproduce the issue I observed in prod locally by:

1. Creating a database at tiled version `v0.1.0-b13`
2. Migrating to `v0.1.0-b18` (previous release)
3. Starting a server

Then on attempted login (i.e. attempted `Session` creation) I saw:

```
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.NotNullViolationError'>: null value in column "time_created" of relation "identities" violates not-null constraint
DETAIL:  Failing row contains (alice, toy, 1, null, null, null).
[SQL: INSERT INTO identities (id, provider, principal_id, latest_login, time_updated) VALUES ($1::VARCHAR, $2::VARCHAR, $3::INTEGER, $4::TIMESTAMP WITH TIME ZONE, $5::TIMESTAMP WITH TIME ZONE) RETURNING identities.time_created]
[parameters: ('alice', 'toy', 1, None, None)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```

The migration in this PR resolved the issue.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
