### PR TITLE
feat: add option for additional default in json serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - A new method `DataFrameClient.append_partition`.
 - Support for registering Groups and Datasets _within_ an HDF5 file
 - Tiled version is logged by server at startup.
+- Option for additional json serialization defaults in utils.
 
 ### Fixed
 


### PR DESCRIPTION
This addresses the change in `orjson` that no longer serializes NamedTuples by default to dictionaries. This is potentially the correct behavior, so the approach taken was to give an option for additional defaults in the serializer (which already does some work for numpy).
A related [PR in databroker ](https://github.com/bluesky/databroker/pull/837) takes advantage of this. 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section (None present)
