### PR TITLE
Enables reading of raw data from Dectris Eiger HDF5 files. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
-## 0.1.0-b19 (2024-02-19)
+## (2025-03-04)
+
+### Changed
+- Added an hdf5plugin import to handle reading lzf-compressed data from Dectris Eiger HDF5 files.
+
+## 0.1.0-b19 (2025-02-19)
 
 ### Maintenance
 
@@ -11,7 +16,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   database.
 - New authentication database migration fixes error in migration in previous release.
 
-## 0.1.0-b18 (2024-02-18)
+## 0.1.0-b18 (2025-02-18)
 
 ### Added
 
@@ -32,7 +37,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   are stored explicitly localized to UTC. This requires a database migration
   to update existing rows.
 
-## 0.1.0-b17 (2024-01-29)
+## 0.1.0-b17 (2025-01-29)
 
 ### Changed
 
@@ -66,19 +71,19 @@ Write the date in place of the "Unreleased" in the case a new version is release
   Python clients older than v0.1.0b17 will be sent `password` for back-compat.
 - Improved type hinting and efficiency of caching singleton values
 
-## 0.1.0-b16 (2024-01-23)
+## 0.1.0-b16 (2025-01-23)
 
 ### Maintenance
 
 - Update GitHub Actions `upload-artifact` and `download-artifact`.
 
-## 0.1.0-b15 (2024-01-23)
+## 0.1.0-b15 (2025-01-23)
 
 ### Maintenance
 
 - Adjust for backward-incompatible change in dependency Starlette 0.45.0.
 
-## 0.1.0-b14 (2024-01-21)
+## 0.1.0-b14 (2025-01-21)
 
 ### Changed
 
@@ -94,7 +99,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Update AccessPolicy Docs to match new filter arguments
 - Refactored intialization of dask DataFrame to be compatible with dask 2025.1
 
-## v0.1.0-b13 (2024-01-09)
+## v0.1.0-b13 (2025-01-09)
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ all = [
     "fastapi",
     "h5netcdf",
     "h5py",
+    "hdf5plugin",
     "jinja2",
     "jmespath",
     "lz4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ dev = [
 formats = [
     "h5netcdf",
     "h5py",
+    "hdf5plugin",
     "openpyxl",
     "pillow",
     "tifffile",
@@ -221,6 +222,7 @@ server = [
     "fastapi",
     "h5netcdf",
     "h5py",
+    "hdf5plugin",
     "jinja2",
     "jmespath",
     "lz4",

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -142,7 +142,12 @@ class HDF5Adapter(Mapping[str, Union["HDF5Adapter", ArrayAdapter]], IndexersMixi
         yield from self._file
 
     def __getitem__(self, key: str) -> Union["HDF5Adapter", ArrayAdapter]:
-        value = self._file[key]
+        try:
+            value = self._file[key]
+        except KeyError as e:
+            warnings.warn(f"KeyError: {e}, probably a broken external link. Returning a string with the warning as a value:")
+            return from_dataset(numpy.array([f"KeyError: {e}"]))
+
         if isinstance(value, h5py.Group):
             return HDF5Adapter(value)
         else:

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import h5py
-import hdf5plugin
+import hdf5plugin  # noqa: F401
 import numpy
 from numpy._typing import NDArray
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import h5py
+import hdf5plugin
 import numpy
 from numpy._typing import NDArray
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -142,12 +142,7 @@ class HDF5Adapter(Mapping[str, Union["HDF5Adapter", ArrayAdapter]], IndexersMixi
         yield from self._file
 
     def __getitem__(self, key: str) -> Union["HDF5Adapter", ArrayAdapter]:
-        try:
-            value = self._file[key]
-        except KeyError as e:
-            warnings.warn(f"KeyError: {e}, probably a broken external link. Returning a string with the warning as a value:")
-            return from_dataset(numpy.array([f"KeyError: {e}"]))
-
+        value = self._file[key]
         if isinstance(value, h5py.Group):
             return HDF5Adapter(value)
         else:


### PR DESCRIPTION
Fixes #902 by adding an import of hdf5plugin after h5py in the hdf5 adapter. Also adds this to the dependencies in pyproject.toml. 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
