### PR TITLE
Remove redundant dep declaration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - Added an hdf5plugin import to handle reading lzf-compressed data from Dectris Eiger HDF5 files.
 
+### Maintenance
+
+- Remove a redundant dependency declaration.
+
 ## 0.1.0-b19 (2025-02-19)
 
 ### Maintenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,6 @@ minimal-server = [
     "python-multipart",
     "sqlalchemy[asyncio] >=2",
     "starlette >=0.38.0",
-    "starlette",
     "uvicorn[standard]",
     "zarr <3",
 ]


### PR DESCRIPTION
A dep was listed twice in the same section. You can see the correct (pinned) one on the line immediately above the line deleted here.

~~Trivial fix, not worth a CHANGELOG entry.~~

I added a CHANGELOG entry.