### PR TITLE
Do not specify include_data_soures unless true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Changed
 - Added an hdf5plugin import to handle reading lzf-compressed data from Dectris Eiger HDF5 files.
+- Removed no-op `?include_data_sources=false` (which is the default) from some
+  requests issued by the Python client.
 
 ## 0.1.0-b19 (2025-02-19)
 

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -189,14 +189,16 @@ class BaseClient:
         return self._context
 
     def refresh(self):
+        params = {
+            **parse_qs(urlparse(self.uri).query),
+        }
+        if self._include_data_sources:
+            params["include_data_sources"] = self._include_data_sources
         content = handle_error(
             self.context.http_client.get(
                 self.uri,
                 headers={"Accept": MSGPACK_MIME_TYPE},
-                params={
-                    **parse_qs(urlparse(self.uri).query),
-                    "include_data_sources": self._include_data_sources,
-                },
+                params=params,
             )
         ).json()
         self._item = content["data"]

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -142,14 +142,13 @@ def from_context(
                 context.authenticate(remember_me=remember_me)
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"
+    params = parse_qs(urlparse(item_uri).query)
+    if include_data_sources:
+        params["include_data_sources"] = include_data_sources
     content = handle_error(
         context.http_client.get(
             item_uri,
             headers={"Accept": MSGPACK_MIME_TYPE},
-            params={
-                **parse_qs(urlparse(item_uri).query),
-                "include_data_sources": include_data_sources,
-            },
         )
     ).json()
     item = content["data"]


### PR DESCRIPTION
This fixes a very minor annoyance: `?include_data_sources=false` adding clutter to the server logs. This is the default value and need not be specified.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
