### PR TITLE
🔑 Add authenticated property to context

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -73,9 +73,19 @@ def test_password_auth(enter_username_password, config):
             from_context(context)
         # Reuse token from cache.
         client = from_context(context)
+        # Check user authentication status string
         assert "authenticated as 'alice'" in repr(client.context)
+        # Check authenticated property exists
+        assert "authenticated" in dir(client.context)
+        # Check authenticated property is True
+        assert client.context.authenticated
         client.logout()
+        # Check authentication status string
         assert "unauthenticated" in repr(client.context)
+        # Check authenticated property still exists
+        assert "authenticated" in dir(client.context)
+        # Check authenticated property is False
+        assert not client.context.authenticated
 
         # Log in as Bob.
         with enter_username_password("bob", "secret2"):
@@ -354,6 +364,10 @@ def test_api_key_activity(enter_username_password, config):
         context.api_key = key_info["secret"]
         assert "authenticated as 'alice'" in repr(context)
         assert "with API key" in repr(context)
+        # Check authenticated property exists
+        assert "authenticated" in dir(context)
+        # Check authenticated property is True
+        assert context.authenticated
         assert key_info["secret"][:8] in repr(context)
         assert key_info["secret"][8:] not in repr(context)
 
@@ -376,6 +390,10 @@ def test_api_key_activity(enter_username_password, config):
         context.api_key = None
         with pytest.raises(RuntimeError):
             context.which_api_key()
+        # Check authenticated property still exists
+        assert "authenticated" in dir(context)
+        # Check authenticated property is False
+        assert not context.authenticated
         # Set the API key.
         context.api_key = secret
         # Now this works again.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -666,12 +666,17 @@ class Context:
         """
         Boolean indicated whether session is authenticated (true) or anonymous (false)
 
-        >>> c.authenticated
+        Examples
+        --------
+
+        An anonymous session at first, after login, is authenticated.
+
+        >>> client.context.authenticated
         False
-        >>> c.login()
+        >>> client.login()
         Username: USERNAME
         Password: <input is hidden>
-        >>> c.authenticated
+        >>> client.context.authenticated
         True
 
         """

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -273,10 +273,8 @@ class Context:
         auth_info = []
         if (self.api_key is None) and (self.http_client.auth is None):
             auth_info.append("(unauthenticated)")
-            self.authenticated = False
         else:
             auth_info.append("authenticated")
-            self.authenticated = True
             if self.server_info.authentication.links:
                 whoami = self.whoami()
                 auth_info.append("as")
@@ -662,6 +660,11 @@ class Context:
         auth.sync_set_token("access_token", tokens["access_token"])
         auth.sync_set_token("refresh_token", tokens["refresh_token"])
         self.http_client.auth = auth
+
+    @property
+    def authenticated(self):
+        # Confirm the state of properties that authentication consists of
+        return (self.api_key is not None) or (self.http_client.auth is not None)
 
     def _token_directory(self):
         # e.g. ~/.config/tiled/tokens/{host:port}

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -273,8 +273,10 @@ class Context:
         auth_info = []
         if (self.api_key is None) and (self.http_client.auth is None):
             auth_info.append("(unauthenticated)")
+            self.authenticated = False
         else:
             auth_info.append("authenticated")
+            self.authenticated = True
             if self.server_info.authentication.links:
                 whoami = self.whoami()
                 auth_info.append("as")

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -662,7 +662,7 @@ class Context:
         self.http_client.auth = auth
 
     @property
-    def authenticated(self):
+    def authenticated(self) -> bool:
         # Confirm the state of properties that authentication consists of
         return (self.api_key is not None) or (self.http_client.auth is not None)
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -663,6 +663,19 @@ class Context:
 
     @property
     def authenticated(self) -> bool:
+        """
+        Compute and confirm a client's logged in status as a simple property
+        Checks if the client has either an api_key or an http_client.auth
+
+        >>> c.authenticated
+        False
+        >>> c.login()
+        Username: USERNAME
+        Password: <input is hidden>
+        >>> c.authenticated
+        True
+
+        """
         # Confirm the state of properties that authentication consists of
         return (self.api_key is not None) or (self.http_client.auth is not None)
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -664,8 +664,7 @@ class Context:
     @property
     def authenticated(self) -> bool:
         """
-        Compute and confirm a client's logged in status as a simple property
-        Checks if the client has either an api_key or an http_client.auth
+        Boolean indicated whether session is authenticated (true) or anonymous (false)
 
         >>> c.authenticated
         False


### PR DESCRIPTION
Resolves #818 
### Checklist
- [x] Have the `authenticated` property return `True` or `False` depending on the state of the client
- [x] Have the `authenticated` property show up in the tab context menu of ipython or in the output of  `dir(c.context)`

### Optional
- [x] Write a test for `authenticated` property
- [x] Type assertion
