### PR TITLE
FIX: purge stale sessions beyond refresh-ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
+### Fixed
+
+- Ensured that stale sessions that can no longer be refreshed are purged from the auth database prior to the expiration time (default 1 year) to avoid bloat. Updated tests accordingly and fixed related SQLite bugs for the purge_expired function.
 
 ## 0.1.0-b20 (2025-03-07)
 

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -1,7 +1,6 @@
 import hashlib
 import uuid as uuid_module
 from datetime import datetime, timedelta, timezone
-from math import exp
 
 from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -70,6 +70,8 @@ CSRF_QUERY_PARAMETER = "csrf"
 
 MINIMUM_SUPPORTED_PYTHON_CLIENT_VERSION = packaging.version.parse("0.1.0a104")
 
+PURGE_INTERVAL = 600  # seconds
+
 logger = logging.getLogger(__name__)
 logger.setLevel("INFO")
 handler = logging.StreamHandler()
@@ -638,7 +640,7 @@ Back up the database, and then run:
                     )
 
             async def purge_expired_sessions_and_api_keys():
-                PURGE_INTERVAL = 600  # seconds
+
                 while True:
                     async with AsyncSession(
                         engine, autoflush=False, expire_on_commit=False

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -644,7 +644,7 @@ Back up the database, and then run:
                         engine, autoflush=False, expire_on_commit=False
                     ) as db_session:
                         num_expired_sessions = await purge_expired(
-                            db_session, orm.Session
+                            db_session, orm.Session, settings.refresh_token_max_age
                         )
                         if num_expired_sessions:
                             logger.info(
@@ -782,9 +782,9 @@ Back up the database, and then run:
         def override_get_serialization_registry():
             return serialization_registry
 
-        app.dependency_overrides[
-            get_serialization_registry
-        ] = override_get_serialization_registry
+        app.dependency_overrides[get_serialization_registry] = (
+            override_get_serialization_registry
+        )
 
     if validation_registry is not None:
 
@@ -792,9 +792,9 @@ Back up the database, and then run:
         def override_get_validation_registry():
             return validation_registry
 
-        app.dependency_overrides[
-            get_validation_registry
-        ] = override_get_validation_registry
+        app.dependency_overrides[get_validation_registry] = (
+            override_get_validation_registry
+        )
 
     @app.middleware("http")
     async def capture_metrics(request: Request, call_next):


### PR DESCRIPTION
Closes 922

This extends the `purge_expired` call to accept an optional `refresh_token_max_age`. The `PURGE_INTERVAL` was elevated to  the module level to enable testing. Testing exposed some silent issue with the previous purge function that were solved by two changes: 
1. Doing UTC time comparison filters differently between postgres and sqlite.
2. Adding a `.unique()` call to the result following the query to handle any eager loading of joined tables.

The tests were run first against the original `purge_expired` function with these modifications, before updating the function.

Since all testing was done locally against SQLite, I expect this will need to be tested against a PostgresSQL auth database before approval and merge (not sure if this is in the CI).

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
