### PR TITLE
FIX: accept scalar data in HDF5

### DIFF
--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -205,7 +205,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
             )
             for (val, (shape, chunk_shape, dtype)) in zip(delayed, shapes_chunks_dtypes)
         ]
-        array = dask.array.concatenate(arrs, axis=0)
+        array = dask.array.concatenate(arrs, axis=0) if len(arrs) > 1 else arrs[0]
 
         return array
 


### PR DESCRIPTION
Bug fix to treat the cases of scalar data in HDF5 datasets. Previously, passing them to `dask.array.concatenate` would have raised a ValueError.

Added tests for empty and scalar data in HDF5.

Issue: #943 

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
