### PR TITLE
Xarray composite

### DIFF
--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -111,7 +111,7 @@ class Composite(Container):
                 if (variables is None) or (part in variables):
                     data_vars[part] = self.parts[part].read()  # [Dask]ArrayClient
             elif item["attributes"]["structure_family"] == StructureFamily.awkward:
-                if variables is None or part in variables:
+                if (variables is None) or (part in variables):
                     try:
                         data_vars[part] = self.parts[part].read().to_numpy()
                     except ValueError as e:

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -1,0 +1,135 @@
+import time
+from urllib.parse import parse_qs, urlparse
+
+from ..structures.core import StructureFamily
+from .container import LENGTH_CACHE_TTL, Container
+from .utils import MSGPACK_MIME_TYPE, client_for_item, handle_error
+
+
+class DaskComposite(Container):
+    def get_contents(self, maxlen=None, include_metadata=False):
+        result = {}
+        next_page_url = f"{self.item['links']['search']}"
+        while (next_page_url is not None) or (
+            maxlen is not None and len(result) < maxlen
+        ):
+            content = handle_error(
+                self.context.http_client.get(
+                    next_page_url,
+                    headers={"Accept": MSGPACK_MIME_TYPE},
+                    params={
+                        **parse_qs(urlparse(next_page_url).query),
+                        **self._queries_as_params,
+                    }
+                    | ({} if include_metadata else {"select_metadata": False}),
+                )
+            ).json()
+            result.update({item["id"]: item for item in content["data"]})
+
+            next_page_url = content["links"]["next"]
+
+        return result
+
+    @property
+    def _flat_keys_mapping(self):
+        result = {}
+        for key, item in self.get_contents().items():
+            if item["attributes"]["structure_family"] == StructureFamily.table:
+                for col in item["attributes"]["structure"]["columns"]:
+                    result[col] = item["id"] + "/" + col
+            else:
+                result[item["id"]] = item["id"]
+
+        self._cached_len = (len(result), time.monotonic() + LENGTH_CACHE_TTL)
+
+        return result
+
+    @property
+    def parts(self):
+        return CompositeParts(self)
+
+    def _keys_slice(self, start, stop, direction, _ignore_inlined_contents=False):
+        yield from self._flat_keys_mapping.keys()
+
+    def _items_slice(self, start, stop, direction, _ignore_inlined_contents=False):
+        for key in self._flat_keys_mapping.keys():
+            yield key, self[key]
+
+    def __len__(self):
+        if self._cached_len is not None:
+            length, deadline = self._cached_len
+            if time.monotonic() < deadline:
+                # Used the cached value and do not make any request.
+                return length
+
+        return len(self._flat_keys_mapping)
+
+    def __getitem__(self, key: str, _ignore_inlined_contents=False):
+        if isinstance(key, tuple):
+            key = "/".join(key)
+        if key in self._flat_keys_mapping:
+            key = self._flat_keys_mapping[key]
+        else:
+            raise KeyError(
+                f"Key '{key}' not found. If it refers to a table, use .parts['{key}'] instead."
+            )
+
+        return super().__getitem__(key, _ignore_inlined_contents)
+
+    def create_container(self, key=None, *, metadata=None, specs=None):
+        """Composite nodes can not include nested containers by design."""
+        raise NotImplementedError("Cannot create a container within a composite node.")
+
+    def create_composite(self, key=None, *, metadata=None, specs=None):
+        """Ccomposite nodes can not include nested composites by design."""
+        raise NotImplementedError("Cannot create a composite within a composite node.")
+
+    def read(self, variables=None):
+        import xarray
+
+        return xarray.Dataset(...)
+
+
+class CompositeParts:
+    def __init__(self, node):
+        self.contents = node.get_contents(include_metadata=True)
+        self.context = node.context
+        self.structure_clients = node.structure_clients
+        self._include_data_sources = node._include_data_sources
+
+    def __repr__(self):
+        return (
+            f"<{type(self).__name__} {{"
+            + ", ".join(f"'{item}'" for item in self.contents)
+            + "}>"
+        )
+
+    def __getitem__(self, key):
+        key, *tail = key.split("/")
+
+        if key not in self.contents:
+            raise KeyError(key)
+
+        client = client_for_item(
+            self.context,
+            self.structure_clients,
+            self.contents[key],
+            include_data_sources=self._include_data_sources,
+        )
+
+        if tail:
+            return client["/".join(tail)]
+        else:
+            return client
+
+    def __iter__(self):
+        for key in self.contents:
+            yield key
+
+    def __len__(self) -> int:
+        return len(self.contents)
+
+
+class Composite(DaskComposite):
+    def read(self, variables=None):
+        return super().read(variables=variables).load()

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -87,12 +87,16 @@ class Composite(Container):
     def read(self, variables=None, dim0=None):
         """Download the contents of a composite node as an xarray.Dataset.
 
-        Args:
-            variables (list, optional): List of variable names to read. If None, all
-                variables are read. Defaults to None.
+        Parameters
+        ----------
+        variables (list, optional) : List of variable names to read. If None, all
+            variables are read. Defaults to None.
+        dim0 (str, optional) : Name of the dimension to use for the first dimension;
+            if None (default), each array will have its own dimension name.
 
-        Returns:
-            xarray.Dataset: The dataset containing the requested variables.
+        Returns
+        -------
+        xarray.Dataset: The dataset containing the requested variables.
         """
         import pandas
         import xarray

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -108,7 +108,7 @@ class Composite(Container):
                 StructureFamily.array,
                 StructureFamily.sparse,
             }:
-                if variables is None or part in variables:
+                if (variables is None) or (part in variables):
                     data_vars[part] = self.parts[part].read()  # [Dask]ArrayClient
             elif item["attributes"]["structure_family"] == StructureFamily.awkward:
                 if variables is None or part in variables:

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -81,7 +81,7 @@ class DaskComposite(Container):
         raise NotImplementedError("Cannot create a container within a composite node.")
 
     def create_composite(self, key=None, *, metadata=None, specs=None):
-        """Ccomposite nodes can not include nested composites by design."""
+        """Composite nodes can not include nested composites by design."""
         raise NotImplementedError("Cannot create a composite within a composite node.")
 
     def read(self, variables=None):

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -1090,125 +1090,6 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         return client
 
 
-class Composite(Container):
-    def get_contents(self, maxlen=None, include_metadata=False):
-        result = {}
-        next_page_url = f"{self.item['links']['search']}"
-        while (next_page_url is not None) or (
-            maxlen is not None and len(result) < maxlen
-        ):
-            content = handle_error(
-                self.context.http_client.get(
-                    next_page_url,
-                    headers={"Accept": MSGPACK_MIME_TYPE},
-                    params={
-                        **parse_qs(urlparse(next_page_url).query),
-                        **self._queries_as_params,
-                    }
-                    | ({} if include_metadata else {"select_metadata": False}),
-                )
-            ).json()
-            result.update({item["id"]: item for item in content["data"]})
-
-            next_page_url = content["links"]["next"]
-
-        return result
-
-    @property
-    def _flat_keys_mapping(self):
-        result = {}
-        for key, item in self.get_contents().items():
-            if item["attributes"]["structure_family"] == StructureFamily.table:
-                for col in item["attributes"]["structure"]["columns"]:
-                    result[col] = item["id"] + "/" + col
-            else:
-                result[item["id"]] = item["id"]
-
-        self._cached_len = (len(result), time.monotonic() + LENGTH_CACHE_TTL)
-
-        return result
-
-    @property
-    def parts(self):
-        return CompositeParts(self)
-
-    def _keys_slice(self, start, stop, direction, _ignore_inlined_contents=False):
-        yield from self._flat_keys_mapping.keys()
-
-    def _items_slice(self, start, stop, direction, _ignore_inlined_contents=False):
-        for key in self._flat_keys_mapping.keys():
-            yield key, self[key]
-
-    def __len__(self):
-        if self._cached_len is not None:
-            length, deadline = self._cached_len
-            if time.monotonic() < deadline:
-                # Used the cached value and do not make any request.
-                return length
-
-        return len(self._flat_keys_mapping)
-
-    def __getitem__(self, key: str, _ignore_inlined_contents=False):
-        if isinstance(key, tuple):
-            key = "/".join(key)
-        if key in self._flat_keys_mapping:
-            key = self._flat_keys_mapping[key]
-        else:
-            raise KeyError(
-                f"Key '{key}' not found. If it refers to a table, use .parts['{key}'] instead."
-            )
-
-        return super().__getitem__(key, _ignore_inlined_contents)
-
-    def create_container(self, key=None, *, metadata=None, specs=None):
-        """Composite nodes can not include nested containers by design."""
-        raise NotImplementedError("Cannot create a container within a composite node.")
-
-    def create_composite(self, key=None, *, metadata=None, specs=None):
-        """Ccomposite nodes can not include nested composites by design."""
-        raise NotImplementedError("Cannot create a composite within a composite node.")
-
-
-class CompositeParts:
-    def __init__(self, node):
-        self.contents = node.get_contents(include_metadata=True)
-        self.context = node.context
-        self.structure_clients = node.structure_clients
-        self._include_data_sources = node._include_data_sources
-
-    def __repr__(self):
-        return (
-            f"<{type(self).__name__} {{"
-            + ", ".join(f"'{item}'" for item in self.contents)
-            + "}>"
-        )
-
-    def __getitem__(self, key):
-        key, *tail = key.split("/")
-
-        if key not in self.contents:
-            raise KeyError(key)
-
-        client = client_for_item(
-            self.context,
-            self.structure_clients,
-            self.contents[key],
-            include_data_sources=self._include_data_sources,
-        )
-
-        if tail:
-            return client["/".join(tail)]
-        else:
-            return client
-
-    def __iter__(self):
-        for key in self.contents:
-            yield key
-
-    def __len__(self) -> int:
-        return len(self.contents)
-
-
 def _queries_to_params(*queries):
     "Compute GET params from the queries."
     params = collections.defaultdict(list)
@@ -1273,7 +1154,7 @@ DEFAULT_STRUCTURE_CLIENT_DISPATCH = {
     "numpy": OneShotCachedMap(
         {
             "container": _Wrap(Container),
-            "composite": _Wrap(Composite),
+            "composite": _LazyLoad(("..composite", Container.__module__), "Composite"),
             "array": _LazyLoad(("..array", Container.__module__), "ArrayClient"),
             "awkward": _LazyLoad(("..awkward", Container.__module__), "AwkwardClient"),
             "dataframe": _LazyLoad(
@@ -1291,7 +1172,9 @@ DEFAULT_STRUCTURE_CLIENT_DISPATCH = {
     "dask": OneShotCachedMap(
         {
             "container": _Wrap(Container),
-            "composite": _Wrap(Composite),
+            "composite": _LazyLoad(
+                ("..composite", Container.__module__), "DaskComposite"
+            ),
             "array": _LazyLoad(("..array", Container.__module__), "DaskArrayClient"),
             # TODO Create DaskAwkwardClient
             # "awkward": _LazyLoad(("..awkward", Container.__module__), "DaskAwkwardClient"),

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -1172,9 +1172,7 @@ DEFAULT_STRUCTURE_CLIENT_DISPATCH = {
     "dask": OneShotCachedMap(
         {
             "container": _Wrap(Container),
-            "composite": _LazyLoad(
-                ("..composite", Container.__module__), "DaskComposite"
-            ),
+            "composite": _LazyLoad(("..composite", Container.__module__), "Composite"),
             "array": _LazyLoad(("..array", Container.__module__), "DaskArrayClient"),
             # TODO Create DaskAwkwardClient
             # "awkward": _LazyLoad(("..awkward", Container.__module__), "DaskAwkwardClient"),


### PR DESCRIPTION
The client object for representing `composite` structures was originally placed in `tiled.client.container` because it shares some code with the `container` object via inheritance. Now it is moved into a new module `tiled.client.composite`.

In addition, a `read()` method is implemented. It fetches data from the underlying structures (tables, arrays, etc.) via separate requests. If specific variables are passed to `read()` is selectively reads arrays or columns from tables. An xarray.Dataset is returned.

### Checklist
- [ ] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

Closes #948