### PR TITLE
Expose auth-state information in Session model schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Exposed `Session.state` information from database to enhance custom access
+  control developments.
+
 ## 0.1.0-b22 (2025-04-21)
 
 ### Added

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -239,6 +239,7 @@ async def lookup_valid_api_key(db, secret):
             .options(
                 selectinload(APIKey.principal).selectinload(Principal.roles),
                 selectinload(APIKey.principal).selectinload(Principal.identities),
+                selectinload(APIKey.principal).selectinload(Principal.sessions),
             )
             .filter(APIKey.first_eight == secret.hex()[:8])
             .filter(APIKey.hashed_secret == hashed_secret)

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -350,11 +350,15 @@ class Session(pydantic.BaseModel):
     uuid: uuid.UUID
     expiration_time: datetime
     revoked: bool
+    state: Optional[Dict[Any, Any]]
 
     @classmethod
     def from_orm(cls, orm: tiled.authn_database.orm.Session) -> Session:
         return cls(
-            uuid=orm.uuid, expiration_time=orm.expiration_time, revoked=orm.revoked
+            uuid=orm.uuid,
+            expiration_time=orm.expiration_time,
+            revoked=orm.revoked,
+            state=orm.state,
         )
 
 


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

Closes #956

This updates the session model to expose state information stored at login-time, such that it may be used in the access control stack. Added integration tests, more so to demonstrate varying levels of access based on the user attributes.