### PR TITLE
ENH: Enhance Streaming Exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - `Composite` structure family to enable direct access to table columns in a single namespace.
 - Added a `parent` property to BaseClass that returns a client pointing to the parent node
 - New CLI flag `tiled --version` shows the current version and exits.
+- Support for `async` streaming serializers (exporters)
 
 ### Changed
 
 - Adjust arguments of `print_admin_api_key_if_generated` and rename `print_server_info`
 - Allow `SQLAdapter.append_partition` to accept `pyarrow.Table` as its argument
+- Fix streaming serialization of tables keeping the dtypes of individual columns
 
 ### Maintenance
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -1,5 +1,6 @@
 import collections.abc
 import dataclasses
+import inspect
 import itertools
 import math
 import operator
@@ -388,7 +389,7 @@ async def construct_data_response(
         raise UnsupportedMediaTypes(
             f"This type is supported in general but there was an error packing this specific data: {err.args[0]}",
         )
-    if isinstance(content, types.GeneratorType):
+    if isinstance(content, types.GeneratorType) or inspect.isasyncgen(content):
         response_class = StreamingResponse
     else:
         response_class = Response

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -6,7 +6,6 @@ import math
 import operator
 import re
 import sys
-import types
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -389,7 +388,7 @@ async def construct_data_response(
         raise UnsupportedMediaTypes(
             f"This type is supported in general but there was an error packing this specific data: {err.args[0]}",
         )
-    if isinstance(content, types.GeneratorType) or inspect.isasyncgen(content):
+    if inspect.isgenerator(content) or inspect.isasyncgen(content):
         response_class = StreamingResponse
     else:
         response_class = Response


### PR DESCRIPTION
Minor changes to streaming serializers/exporters:

1. Added support for async exporters;
2. Replaced `df.iterrows` with `df.to_dict` in `tiled/serialization/table.py:json_sequence` to preserve dtypes of individual columns.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
