### PR TITLE
Do commonpath check on `file:` URIs only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- When using SQL-backed storage and file-backed storage, Tiled treated SQLite
+  or DuckDB files as if they were directories of readable files, and
+  included them superfluously in a check on whether assets were situated
+  in a readable area.
+
 ## 0.1.0-b23 (2025-04-24)
 
 ### Added

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -173,6 +173,9 @@ class Context:
         if storage.sql is not None:
             self.readable_storage.add(storage.sql)
         self.writable_storage = storage
+        self.readable_filesystem_storage = set(
+            item for item in self.readable_storage if urlparse(item).scheme == "file"
+        )
 
         self.key_maker = key_maker
         adapters_by_mimetype = adapters_by_mimetype or {}
@@ -479,7 +482,7 @@ class CatalogNodeAdapter:
             if scheme == "file":
                 # Protect against misbehaving clients reading from unintended parts of the filesystem.
                 asset_path = path_from_uri(asset.data_uri)
-                for readable_storage in self.context.readable_storage:
+                for readable_storage in self.context.readable_filesystem_storage:
                     if Path(
                         os.path.commonpath(
                             [path_from_uri(readable_storage), asset_path]


### PR DESCRIPTION
When using SQL-backed storage and file-backed storage, Tiled treated SQLite
  or DuckDB files as if they were directories of readable files, and
  included them superfluously in a check on whether assets were situated
  in a readable area.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
