### PR TITLE
Refactor Storage.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,6 @@ jobs:
         python -m pip install .[dev]
         python -m pip list
 
-    - name: "TEMP: Test problematic module first."
-      run: pytest -v tiled/_tests/test_writing.py
-
     - name: Test with pytest
       run: pytest -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
         python -m pip install .[dev]
         python -m pip list
 
+    - name: "TEMP: Test problematic module first."
+      run: pytest -v tiled/_tests/test_writing.py
+
     - name: Test with pytest
       run: pytest -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Changed
+
+- In server configuration, `writable_storage` now takes a list of URIs,
+  given in order of decreasing priority.
+- Adapters should implement a `supported_storage` attribute, as specified
+  in `tiled.adapters.protocols.BaseAdapter`. This is optional, for
+  backward-compatiblity with existing Adapters, which are assumed to
+  use file-based storage.
+
 ### Fixed
 
 - When using SQL-backed storage and file-backed storage, Tiled treated SQLite

--- a/tiled/_tests/adapters/test_arrow.py
+++ b/tiled/_tests/adapters/test_arrow.py
@@ -4,8 +4,9 @@ import pyarrow as pa
 import pytest
 
 from tiled.adapters.arrow import ArrowAdapter
+from tiled.storage import FileStorage
 from tiled.structures.core import StructureFamily
-from tiled.structures.data_source import DataSource, Management, Storage
+from tiled.structures.data_source import DataSource, Management
 from tiled.structures.table import TableStructure
 
 names = ["f0", "f1", "f2"]
@@ -38,7 +39,7 @@ def data_source_from_init_storage() -> DataSource[TableStructure]:
         structure=structure,
         assets=[],
     )
-    storage = Storage(filesystem=data_uri, sql=None)
+    storage = FileStorage(data_uri)
     return ArrowAdapter.init_storage(
         data_source=data_source, storage=storage, path_parts=[]
     )

--- a/tiled/_tests/adapters/test_sql.py
+++ b/tiled/_tests/adapters/test_sql.py
@@ -9,8 +9,9 @@ import pytest
 import pytest_asyncio
 
 from tiled.adapters.sql import SQLAdapter, check_table_name
+from tiled.storage import parse_storage
 from tiled.structures.core import StructureFamily
-from tiled.structures.data_source import DataSource, Management, Storage
+from tiled.structures.data_source import DataSource, Management
 from tiled.structures.table import TableStructure
 
 from ..utils import temp_postgres
@@ -55,7 +56,7 @@ def data_source_from_init_storage() -> Callable[[str, int], DataSource[TableStru
             assets=[],
         )
 
-        storage = Storage(filesystem=None, sql=data_uri)
+        storage = parse_storage(data_uri)
         return SQLAdapter.init_storage(
             data_source=data_source, storage=storage, path_parts=[]
         )

--- a/tiled/_tests/adapters/test_sql.py
+++ b/tiled/_tests/adapters/test_sql.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 
 from tiled.adapters.sql import SQLAdapter, check_table_name
-from tiled.storage import parse_storage
+from tiled.storage import parse_storage, register_storage
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import DataSource, Management
 from tiled.structures.table import TableStructure
@@ -57,6 +57,7 @@ def data_source_from_init_storage() -> Callable[[str, int], DataSource[TableStru
         )
 
         storage = parse_storage(data_uri)
+        register_storage(storage)
         return SQLAdapter.init_storage(
             data_source=data_source, storage=storage, path_parts=[]
         )
@@ -173,7 +174,7 @@ def adapter_psql_one_partition(
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(postgres_uri, 1)
     adapter = SQLAdapter(
-        postgres_uri,
+        data_source.assets[0].data_uri,
         data_source.structure,
         data_source.parameters["table_name"],
         data_source.parameters["dataset_id"],
@@ -189,7 +190,7 @@ def adapter_psql_many_partition(
 ) -> SQLAdapter:
     data_source = data_source_from_init_storage(postgres_uri, 3)
     return SQLAdapter(
-        postgres_uri,
+        data_source.assets[0].data_uri,
         data_source.structure,
         data_source.parameters["table_name"],
         data_source.parameters["dataset_id"],

--- a/tiled/_tests/test_protocols.py
+++ b/tiled/_tests/test_protocols.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
 import dask.dataframe
 import numpy
@@ -22,6 +22,7 @@ from ..adapters.protocols import (
 from ..ndslice import NDSlice
 from ..scopes import ALL_SCOPES
 from ..server.schemas import Principal, PrincipalType
+from ..storage import Storage
 from ..structures.array import ArrayStructure, BuiltinDtype
 from ..structures.awkward import AwkwardStructure
 from ..structures.core import Spec, StructureFamily
@@ -32,6 +33,7 @@ from ..type_aliases import JSON, Filters, Scopes
 
 class CustomArrayAdapter:
     structure_family: Literal[StructureFamily.array] = StructureFamily.array
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,
@@ -103,6 +105,7 @@ def test_arrayadapter_protocol(mocker: MockFixture) -> None:
 
 class CustomAwkwardAdapter:
     structure_family: Literal[StructureFamily.awkward] = StructureFamily.awkward
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,
@@ -179,6 +182,7 @@ def test_awkwardadapter_protocol(mocker: MockFixture) -> None:
 
 class CustomSparseAdapter:
     structure_family: Literal[StructureFamily.sparse] = StructureFamily.sparse
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,
@@ -265,6 +269,7 @@ def test_sparseadapter_protocol(mocker: MockFixture) -> None:
 
 class CustomTableAdapter:
     structure_family: Literal[StructureFamily.table] = StructureFamily.table
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -4,7 +4,6 @@ This tests tiled's writing routes with an in-memory store.
 Persistent stores are being developed externally to the tiled package.
 """
 import base64
-import time
 from datetime import datetime
 
 import awkward
@@ -470,7 +469,7 @@ async def test_delete(tree):
         client.write_array(
             [1, 2, 3],
             metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
-            key="x",
+            key="delete_me",
         )
         nodes_before_delete = (await tree.context.execute("SELECT * from nodes")).all()
         assert len(nodes_before_delete) == 1
@@ -488,10 +487,10 @@ async def test_delete(tree):
             client.write_array(
                 [1, 2, 3],
                 metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
-                key="x",
+                key="delete_me",
             )
 
-        client.delete("x")
+        client.delete("delete_me")
 
         nodes_after_delete = (await tree.context.execute("SELECT * from nodes")).all()
         assert len(nodes_after_delete) == 0
@@ -502,16 +501,11 @@ async def test_delete(tree):
         assets_after_delete = (await tree.context.execute("SELECT * from assets")).all()
         assert len(assets_after_delete) == 0
 
-        # Give the filesystem time to catch up.
-        # On CI, the Windows job can be flaky here, finding that the
-        # array has not been deleted yet if we try immediately to write.
-        time.sleep(1)
-
         # Writing again with the same name works now.
         client.write_array(
             [1, 2, 3],
             metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
-            key="x",
+            key="delete_me",
         )
 
 

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -43,10 +43,10 @@ validation_registry.register("SomeSpec", lambda *args, **kwargs: None)
 @pytest.fixture
 def tree(tmpdir):
     return in_memory(
-        writable_storage={
-            "filesystem": str(tmpdir / "data"),
-            "sql": f"duckdb:///{tmpdir / 'data.duckdb'}",
-        }
+        writable_storage=[
+            f"file://localhost{str(tmpdir / 'data')}",
+            f"duckdb:///{tmpdir / 'data.duckdb'}",
+        ]
     )
 
 

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -4,6 +4,7 @@ This tests tiled's writing routes with an in-memory store.
 Persistent stores are being developed externally to the tiled package.
 """
 import base64
+import time
 from datetime import datetime
 
 import awkward
@@ -500,6 +501,11 @@ async def test_delete(tree):
         assert len(data_sources_after_delete) == 0
         assets_after_delete = (await tree.context.execute("SELECT * from assets")).all()
         assert len(assets_after_delete) == 0
+
+        # Give the filesystem time to catch up.
+        # On CI, the Windows job can be flaky here, finding that the
+        # array has not been deleted yet if we try immediately to write.
+        time.sleep(1)
 
         # Writing again with the same name works now.
         client.write_array(

--- a/tiled/adapters/array.py
+++ b/tiled/adapters/array.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 import dask.array
 import numpy
@@ -6,6 +6,7 @@ import pandas
 from numpy.typing import NDArray
 
 from ..ndslice import NDSlice
+from ..storage import Storage
 from ..structures.array import ArrayStructure
 from ..structures.core import Spec, StructureFamily
 from ..type_aliases import JSON
@@ -27,6 +28,7 @@ class ArrayAdapter:
     """
 
     structure_family = StructureFamily.array
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,

--- a/tiled/adapters/arrow.py
+++ b/tiled/adapters/arrow.py
@@ -9,8 +9,9 @@ import pyarrow.feather as feather
 import pyarrow.fs
 
 from ..catalog.orm import Node
+from ..storage import FileStorage, Storage
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Management, Storage
+from ..structures.data_source import Asset, DataSource, Management
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
 from ..utils import ensure_uri, path_from_uri
@@ -22,6 +23,7 @@ class ArrowAdapter:
     """ArrowAdapter Class"""
 
     structure_family = StructureFamily.table
+    supported_storage = {FileStorage}
 
     def __init__(
         self,
@@ -81,7 +83,7 @@ class ArrowAdapter:
         The list of assets.
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
 

--- a/tiled/adapters/awkward.py
+++ b/tiled/adapters/awkward.py
@@ -4,6 +4,7 @@ import awkward
 import awkward.forms
 from numpy.typing import NDArray
 
+from ..storage import FileStorage
 from ..structures.awkward import AwkwardStructure
 from ..structures.core import Spec, StructureFamily
 from ..type_aliases import JSON
@@ -12,6 +13,7 @@ from .awkward_directory_container import DirectoryContainer
 
 class AwkwardAdapter:
     structure_family = StructureFamily.awkward
+    supported_storage = {FileStorage}
 
     def __init__(
         self,

--- a/tiled/adapters/awkward_buffers.py
+++ b/tiled/adapters/awkward_buffers.py
@@ -10,9 +10,10 @@ from urllib.parse import quote_plus
 import awkward.forms
 
 from ..catalog.orm import Node
+from ..storage import FileStorage, Storage
 from ..structures.awkward import AwkwardStructure
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Storage
+from ..structures.data_source import Asset, DataSource
 from ..type_aliases import JSON
 from ..utils import path_from_uri
 from .awkward import AwkwardAdapter
@@ -22,6 +23,7 @@ from .utils import init_adapter_from_catalog
 
 class AwkwardBuffersAdapter(AwkwardAdapter):
     structure_family = StructureFamily.awkward
+    supported_storage = {FileStorage}
 
     @classmethod
     def init_storage(
@@ -42,7 +44,7 @@ class AwkwardBuffersAdapter(AwkwardAdapter):
 
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
         directory: Path = path_from_uri(data_uri)

--- a/tiled/adapters/csv.py
+++ b/tiled/adapters/csv.py
@@ -7,9 +7,10 @@ import dask.dataframe
 import pandas
 
 from ..catalog.orm import Node
+from ..storage import FileStorage, Storage
 from ..structures.array import ArrayStructure
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Management, Storage
+from ..structures.data_source import Asset, DataSource, Management
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
 from ..utils import ensure_uri, path_from_uri
@@ -21,6 +22,7 @@ class CSVAdapter:
     """Adapter for tabular data stored as partitioned text (csv) files"""
 
     structure_family = StructureFamily.table
+    supported_storage = {FileStorage}
 
     def __init__(
         self,
@@ -98,7 +100,7 @@ class CSVAdapter:
             list of assets with each element corresponding to individual partition files
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
         directory = path_from_uri(data_uri)

--- a/tiled/adapters/jpeg.py
+++ b/tiled/adapters/jpeg.py
@@ -1,5 +1,5 @@
 import builtins
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Set, Tuple, Union
 
 import numpy as np
 from numpy._typing import NDArray
@@ -7,6 +7,7 @@ from PIL import Image
 
 from ..catalog.orm import Node
 from ..ndslice import NDSlice
+from ..storage import Storage
 from ..structures.array import ArrayStructure, BuiltinDtype
 from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
@@ -28,6 +29,7 @@ class JPEGAdapter:
     """
 
     structure_family = StructureFamily.array
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -10,6 +10,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
     cast,
@@ -36,6 +37,7 @@ from ..queries import (
 )
 from ..query_registration import QueryTranslationRegistry
 from ..server.schemas import SortingItem
+from ..storage import Storage
 from ..structures.core import Spec, StructureFamily
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
@@ -63,6 +65,7 @@ class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
     )
 
     structure_family = StructureFamily.container
+    supported_storage: Set[type[Storage]] = set()
 
     # Define classmethods for managing what queries this Adapter knows.
     query_registry = QueryTranslationRegistry()

--- a/tiled/adapters/netcdf.py
+++ b/tiled/adapters/netcdf.py
@@ -1,9 +1,10 @@
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Set, Union
 
 import xarray
 
 from ..catalog.orm import Node
+from ..storage import Storage
 from ..structures.data_source import DataSource
 from ..utils import path_from_uri
 from .xarray import DatasetAdapter
@@ -25,6 +26,8 @@ def read_netcdf(filepath: Union[str, List[str], Path]) -> DatasetAdapter:
 
 
 class NetCDFAdapter:
+    supported_storage: Set[type[Storage]] = set()
+
     @classmethod
     def from_catalog(
         cls,

--- a/tiled/adapters/parquet.py
+++ b/tiled/adapters/parquet.py
@@ -7,8 +7,9 @@ import dask.dataframe
 import pandas
 
 from ..catalog.orm import Node
+from ..storage import FileStorage, Storage
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Storage
+from ..structures.data_source import Asset, DataSource
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
 from ..utils import path_from_uri
@@ -21,6 +22,7 @@ class ParquetDatasetAdapter:
     """ """
 
     structure_family = StructureFamily.table
+    supported_storage = {FileStorage}
 
     def __init__(
         self,
@@ -91,7 +93,7 @@ class ParquetDatasetAdapter:
 
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
         directory = path_from_uri(data_uri)

--- a/tiled/adapters/protocols.py
+++ b/tiled/adapters/protocols.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from collections.abc import Mapping
-from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Protocol, Set, Tuple, Union
 
 import dask.dataframe
 import pandas
@@ -9,6 +9,7 @@ from numpy.typing import NDArray
 
 from ..ndslice import NDSlice
 from ..server.schemas import Principal
+from ..storage import Storage
 from ..structures.array import ArrayStructure
 from ..structures.awkward import AwkwardStructure
 from ..structures.core import Spec, StructureFamily
@@ -19,6 +20,8 @@ from .awkward_directory_container import DirectoryContainer
 
 
 class BaseAdapter(Protocol):
+    supported_storage: Set[type[Storage]]
+
     # @abstractmethod
     # @classmethod
     # def from_catalog(

--- a/tiled/adapters/sparse.py
+++ b/tiled/adapters/sparse.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import dask.dataframe
 import numpy
@@ -7,6 +7,7 @@ import sparse
 from numpy._typing import NDArray
 
 from ..ndslice import NDSlice
+from ..storage import Storage
 from ..structures.core import Spec, StructureFamily
 from ..structures.sparse import COOStructure
 from ..type_aliases import JSON
@@ -16,6 +17,7 @@ from .array import slice_and_shape_from_block_and_chunks
 class COOAdapter:
     "Wrap sparse Coordinate List (COO) arrays."
     structure_family = StructureFamily.sparse
+    supported_storage: Set[type[Storage]] = set()
 
     @classmethod
     def from_arrays(

--- a/tiled/adapters/sparse_blocks_parquet.py
+++ b/tiled/adapters/sparse_blocks_parquet.py
@@ -13,8 +13,9 @@ from numpy._typing import NDArray
 from ..adapters.array import slice_and_shape_from_block_and_chunks
 from ..catalog.orm import Node
 from ..ndslice import NDSlice
+from ..storage import FileStorage, Storage
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Storage
+from ..structures.data_source import Asset, DataSource
 from ..structures.sparse import COOStructure, SparseStructure
 from ..type_aliases import JSON
 from ..utils import path_from_uri
@@ -44,6 +45,7 @@ class SparseBlocksParquetAdapter:
     """ """
 
     structure_family = StructureFamily.sparse
+    supported_storage = {FileStorage}
 
     def __init__(
         self,
@@ -98,7 +100,7 @@ class SparseBlocksParquetAdapter:
 
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
         directory = path_from_uri(data_uri)

--- a/tiled/adapters/table.py
+++ b/tiled/adapters/table.py
@@ -1,9 +1,10 @@
-from typing import Any, Iterator, List, Optional, Tuple, Union
+from typing import Any, Iterator, List, Optional, Set, Tuple, Union
 
 import dask.base
 import dask.dataframe
 import pandas
 
+from ..storage import Storage
 from ..structures.core import Spec, StructureFamily
 from ..structures.table import TableStructure
 from ..type_aliases import JSON
@@ -23,6 +24,7 @@ class TableAdapter:
     """
 
     structure_family = StructureFamily.table
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -1,11 +1,12 @@
 import builtins
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import tifffile
 from numpy._typing import NDArray
 
 from ..catalog.orm import Node
 from ..ndslice import NDSlice
+from ..storage import Storage
 from ..structures.array import ArrayStructure, BuiltinDtype
 from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
@@ -27,6 +28,7 @@ class TiffAdapter:
     """
 
     structure_family = StructureFamily.array
+    supported_storage: Set[type[Storage]] = set()
 
     def __init__(
         self,

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -14,9 +14,10 @@ from ..adapters.utils import IndexersMixin
 from ..catalog.orm import Node
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..ndslice import NDSlice
+from ..storage import FileStorage, Storage
 from ..structures.array import ArrayStructure
 from ..structures.core import Spec, StructureFamily
-from ..structures.data_source import Asset, DataSource, Storage
+from ..structures.data_source import Asset, DataSource
 from ..type_aliases import JSON
 from ..utils import Conflicts, node_repr, path_from_uri
 from .array import ArrayAdapter, slice_and_shape_from_block_and_chunks
@@ -26,6 +27,8 @@ INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 
 class ZarrArrayAdapter(ArrayAdapter):
     """ """
+
+    supported_storage = {FileStorage}
 
     @classmethod
     def init_storage(
@@ -46,7 +49,7 @@ class ZarrArrayAdapter(ArrayAdapter):
 
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
-        data_uri = storage.get("filesystem") + "".join(
+        data_uri = storage.uri + "".join(
             f"/{quote_plus(segment)}" for segment in path_parts
         )
         # Zarr requires evenly-sized chunks within each dimension.

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -677,6 +677,13 @@ class CatalogNodeAdapter:
                     for storage in self.context.writable_storage:
                         if isinstance(storage, tuple(supported_storage)):
                             break
+                    else:
+                        raise RuntimeError(
+                            f"The adapter {adapter} supports storage types "
+                            f"{[cls.__name__ for cls in supported_storage]} "
+                            "but the only available storage types "
+                            f"are {self.context.writable_storage}."
+                        )
                     data_source = await ensure_awaitable(
                         adapter.init_storage,
                         storage,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -67,7 +67,7 @@ from ..mimetypes import (
 from ..query_registration import QueryTranslationRegistry
 from ..server.core import NoEntry
 from ..server.schemas import Asset, DataSource, Management, Revision, Spec
-from ..storage import FileStorage, parse_storage
+from ..storage import FileStorage, parse_storage, register_storage
 from ..structures.core import StructureFamily
 from ..utils import (
     UNCHANGED,
@@ -176,6 +176,10 @@ class Context:
             self.readable_storage.add(parse_storage(item))
         # Writable storage should also be readable.
         self.readable_storage.update(self.writable_storage)
+        # Register all storage in a registry that enables Adapters to access
+        # credentials (if applicable).
+        for item in self.readable_storage:
+            register_storage(item)
         # Stash a copy of filesystem-based readable storage.
         self.readable_filesystem_storage = set(
             item for item in self.readable_storage if isinstance(item, FileStorage)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -76,7 +76,6 @@ from ..utils import (
     UnsupportedQueryType,
     ensure_awaitable,
     ensure_specified_sql_driver,
-    ensure_uri,
     import_object,
     path_from_uri,
     safe_json_dump,
@@ -167,7 +166,7 @@ class Context:
             writable_storage = list(writable_storage.values())
         # Back-compat: `writable_storage` used to be a filepath.
         if isinstance(writable_storage, (str, Path)):
-            writable_storage = [ensure_uri(writable_storage)]
+            writable_storage = [writable_storage]
         if isinstance(readable_storage, str):
             raise ValueError("readable_storage should be a list of URIs or paths")
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -67,8 +67,8 @@ from ..mimetypes import (
 from ..query_registration import QueryTranslationRegistry
 from ..server.core import NoEntry
 from ..server.schemas import Asset, DataSource, Management, Revision, Spec
+from ..storage import FileStorage, parse_storage
 from ..structures.core import StructureFamily
-from ..structures.data_source import Storage
 from ..utils import (
     UNCHANGED,
     Conflicts,
@@ -158,23 +158,28 @@ class Context:
     ):
         self.engine = engine
 
+        self.writable_storage = []
+        self.readable_storage = set()
+        self.readable_filesystem_storage = []
+
+        # Back-compat: `writable_storage` used to be a dict: we want its values.
+        if isinstance(writable_storage, dict):
+            writable_storage = list(writable_storage.values())
+        # Back-compat: `writable_storage` used to be a filepath.
         if isinstance(writable_storage, (str, Path)):
-            storage = Storage.from_path(writable_storage)
-        else:
-            storage = Storage(**(writable_storage or {}))
+            writable_storage = [ensure_uri(writable_storage)]
         if isinstance(readable_storage, str):
             raise ValueError("readable_storage should be a list of URIs or paths")
-        self.readable_storage = set(
-            ensure_uri(path) for path in (readable_storage or [])
-        )
+
+        for item in writable_storage or []:
+            self.writable_storage.append(parse_storage(item))
+        for item in readable_storage or []:
+            self.readable_storage.add(parse_storage(item))
         # Writable storage should also be readable.
-        if storage.filesystem is not None:
-            self.readable_storage.add(storage.filesystem)
-        if storage.sql is not None:
-            self.readable_storage.add(storage.sql)
-        self.writable_storage = storage
+        self.readable_storage.update(self.writable_storage)
+        # Stash a copy of filesystem-based readable storage.
         self.readable_filesystem_storage = set(
-            item for item in self.readable_storage if urlparse(item).scheme == "file"
+            item for item in self.readable_storage if isinstance(item, FileStorage)
         )
 
         self.key_maker = key_maker
@@ -343,7 +348,7 @@ class CatalogNodeAdapter:
 
     @property
     def writable(self):
-        return any(dataclasses.asdict(self.context.writable_storage).values())
+        return bool(self.context.writable_storage)
 
     def __repr__(self):
         return f"<{type(self).__name__} /{'/'.join(self.segments)}>"
@@ -483,11 +488,10 @@ class CatalogNodeAdapter:
                 # Protect against misbehaving clients reading from unintended parts of the filesystem.
                 asset_path = path_from_uri(asset.data_uri)
                 for readable_storage in self.context.readable_filesystem_storage:
-                    if Path(
-                        os.path.commonpath(
-                            [path_from_uri(readable_storage), asset_path]
-                        )
-                    ) == path_from_uri(readable_storage):
+                    if (
+                        Path(os.path.commonpath([readable_storage.path, asset_path]))
+                        == readable_storage.path
+                    ):
                         break
                 else:
                     raise RuntimeError(
@@ -664,9 +668,19 @@ class CatalogNodeAdapter:
                             ),
                         )
                     adapter = STORAGE_ADAPTERS_BY_MIMETYPE[data_source.mimetype]
+                    # Choose writable storage. Use the first writable storage item
+                    # with a scheme that is supported by this adapter. # For
+                    # back-compat, if an adapter does not declare `supported_storage`
+                    # assume it supports file-based storage only.
+                    supported_storage = getattr(
+                        adapter, "supported_storage", {FileStorage}
+                    )
+                    for storage in self.context.writable_storage:
+                        if isinstance(storage, tuple(supported_storage)):
+                            break
                     data_source = await ensure_awaitable(
                         adapter.init_storage,
-                        self.context.writable_storage,
+                        storage,
                         data_source,
                         self.segments + [key],
                     )

--- a/tiled/catalog/utils.py
+++ b/tiled/catalog/utils.py
@@ -2,36 +2,9 @@ import hashlib
 
 import canonicaljson
 
-from ..utils import ensure_uri
-
 
 def compute_structure_id(structure):
     "Compute HEX digest of MD5 hash of RFC 8785 canonical form of JSON."
     canonical_structure = canonicaljson.encode_canonical_json(structure)
 
     return hashlib.md5(canonical_structure).hexdigest()
-
-
-def classify_writable_storage(uris: list[str]) -> dict[str, str]:
-    result = {}
-    for item in uris:
-        item_uri = ensure_uri(item)
-        if item_uri.startswith("file:"):
-            if "filesystem" in result:
-                raise NotImplementedError("Can only write to one filesystem location")
-            result["filesystem"] = item_uri
-        elif (
-            item_uri.startswith("duckdb:")
-            or item_uri.startswith("sqlite:")
-            or item_uri.startswith("postgresql:")
-        ):
-            if "sql" in result:
-                raise NotImplementedError("Can only write to one SQL database")
-            result["sql"] = item_uri
-        else:
-            raise ValueError(
-                "Unrecognized writable location {item}. "
-                "Input should be a filepath or URI beginning with "
-                "'file:', 'duckdb:', or 'postgresql:'."
-            )
-    return result

--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -362,7 +362,6 @@ def serve_catalog(
     import urllib.parse
 
     from ..catalog import from_uri
-    from ..catalog.utils import classify_writable_storage
     from ..server.app import build_app, print_server_info
 
     parsed_database = urllib.parse.urlparse(database)
@@ -464,7 +463,7 @@ or use an existing one:
     server_settings = {}
     tree = from_uri(
         database,
-        writable_storage=classify_writable_storage(write),
+        writable_storage=write,
         readable_storage=read,
         init_if_not_exists=init,
     )

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -22,7 +22,7 @@ class Storage:
     uri: str
 
     def __post_init__(self):
-        self.uri = ensure_uri(self.uri)
+        object.__setattr__(self, "uri", ensure_uri(self.uri))
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -1,0 +1,115 @@
+import dataclasses
+import functools
+from pathlib import Path
+from typing import Dict, Union
+from urllib.parse import urlparse, urlunparse
+
+from .utils import ensure_uri, path_from_uri
+
+__all__ = [
+    "EmbeddedSQLStorage",
+    "FileStorage",
+    "SQLStorage",
+    "Storage",
+    "get_storage",
+    "parse_storage",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class Storage:
+    "Base class for representing storage location"
+    uri: str
+
+    def __post_init__(self):
+        ensure_uri(self.uri)
+        register_storage(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class FileStorage(Storage):
+    "Filesystem storage location"
+    schemes = {"file"}
+
+    @functools.cached_property
+    def path(self):
+        return path_from_uri(self.uri)
+
+
+@dataclasses.dataclass(frozen=True)
+class EmbeddedSQLStorage(Storage):
+    "File-based SQL database storage location"
+    schemes = {"duckdb", "sqlite"}
+
+
+@dataclasses.dataclass(frozen=True)
+class SQLStorage(Storage):
+    "File-based SQL database storage location"
+    username: str
+    password: str
+    schemes = {"postgresql"}
+
+    def __post_init__(self):
+        # Extract username, password from URI if given in URI.
+        parsed_uri = urlparse(self.uri)
+        netloc = parsed_uri.netloc
+        if "@" in netloc:
+            auth, netloc = netloc.split("@")
+            username, password = auth.split(":")
+            if (self.username is not None) or (self.password is not None):
+                raise ValueError(
+                    "Credentials passed both in URI and in username/password fields."
+                )
+            object.__setattr__(self, "username", username)
+            object.__setattr__(self, "password", password)
+            # Create clean components with the updated netloc
+            clean_components = (
+                parsed_uri.scheme,
+                netloc,
+                parsed_uri.path,
+                parsed_uri.params,
+                parsed_uri.query,
+                parsed_uri.fragment,
+            )
+            object.__setattr__(self, "uri", urlunparse(clean_components))
+
+    @functools.cached_property
+    def authenticated_uri(self):
+        parsed_uri = urlparse(self.uri)
+        components = (
+            parsed_uri.scheme,
+            f"{self.username}:{self.password}@{parsed_uri.netloc}",
+            parsed_uri.path,
+            parsed_uri.params,
+            parsed_uri.query,
+            parsed_uri.fragment,
+        )
+
+        return urlunparse(components)
+
+
+def parse_storage(item: Union[Path, str]) -> Storage:
+    scheme = urlparse(item).scheme
+    if scheme == "file":
+        result = FileStorage(item)
+    elif scheme in {"postgresql", "sqlite", "duckdb"}:
+        result = EmbeddedSQLStorage(item)
+    else:
+        raise ValueError(f"writable_storage item {item} has unrecognized scheme")
+    return result
+
+
+# This global registry enables looking up Storage via URI, primarily for the
+# purpose of obtaining credentials, which are not stored in the catalog
+# database.
+_STORAGE: Dict[str, Storage] = {}
+
+
+def register_storage(storage: Storage) -> None:
+    "Stash Storage for later lookup by URI."
+    _STORAGE[storage.uri] = storage
+
+
+def get_storage(uri: str) -> Storage:
+    "Look up Storage by URI."
+    return _STORAGE[uri]

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -89,6 +89,7 @@ class SQLStorage(Storage):
 
 
 def parse_storage(item: Union[Path, str]) -> Storage:
+    item = ensure_uri(item)
     scheme = urlparse(item).scheme
     if scheme == "file":
         result = FileStorage(item)

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -90,7 +90,7 @@ def parse_storage(item: Union[Path, str]) -> Storage:
     scheme = urlparse(item).scheme
     if scheme == "file":
         result = FileStorage(item)
-    if scheme == "postgresql":
+    elif scheme == "postgresql":
         result = SQLStorage(item)
     elif scheme in {"sqlite", "duckdb"}:
         result = EmbeddedSQLStorage(item)

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -22,7 +22,7 @@ class Storage:
     uri: str
 
     def __post_init__(self):
-        ensure_uri(self.uri)
+        self.uri = ensure_uri(self.uri)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -29,7 +29,6 @@ class Storage:
 @dataclasses.dataclass(frozen=True)
 class FileStorage(Storage):
     "Filesystem storage location"
-    schemes = {"file"}
 
     @functools.cached_property
     def path(self):
@@ -39,7 +38,6 @@ class FileStorage(Storage):
 @dataclasses.dataclass(frozen=True)
 class EmbeddedSQLStorage(Storage):
     "File-based SQL database storage location"
-    schemes = {"duckdb", "sqlite"}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -47,7 +45,6 @@ class SQLStorage(Storage):
     "File-based SQL database storage location"
     username: str
     password: str
-    schemes = {"postgresql"}
 
     def __post_init__(self):
         # Extract username, password from URI if given in URI.

--- a/tiled/structures/data_source.py
+++ b/tiled/structures/data_source.py
@@ -1,10 +1,7 @@
 import dataclasses
 import enum
-from pathlib import Path
-from typing import Generic, List, Optional, TypeVar, Union
-from urllib.parse import urlparse
+from typing import Generic, List, Optional, TypeVar
 
-from ..utils import ensure_uri
 from .core import StructureFamily
 
 
@@ -42,31 +39,3 @@ class DataSource(Generic[StructureT]):
         d = d.copy()
         assets = [Asset(**a) for a in d.pop("assets")]
         return cls(assets=assets, **d)
-
-
-@dataclasses.dataclass
-class Storage:
-    filesystem: Optional[str] = None
-    sql: Optional[str] = None
-
-    def __post_init__(self):
-        if self.filesystem is not None:
-            self.filesystem = ensure_uri(self.filesystem)
-        if self.sql is not None:
-            self.sql = ensure_uri(self.sql)
-
-    @classmethod
-    def from_path(cls, path: Union[str, Path]):
-        # Interpret input as a filesystem path or 'file:' URI.
-        filesystem_storage = ensure_uri(str(path))
-        if not urlparse(filesystem_storage).scheme == "file":
-            raise ValueError(f"Could not parse as filepath: {path}")
-        return cls(filesystem=filesystem_storage)
-
-    def get(self, key: str) -> str:
-        value = getattr(self, key)
-        if not value:
-            raise RuntimeError(
-                f"Adapter requested {key} storage but none is configured."
-            )
-        return value


### PR DESCRIPTION
- Provide a formal protocol for Adapters to declare what writable storage types they support.
- Let writable storage be specified in priority order, where an adapter users the first supported storage listed.
- Handle credentials properly for SQL-backed storage.

This does not include support for blob (bucket) storage, but it should make implementing it straightforward.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
