### PR TITLE
Metadata roundtrip

### DIFF
--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -457,9 +457,10 @@ def test_metadata_with_unsafe_objects(tree):
         ac = client.write_array(
             [1, 2, 3],
             metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
+            key="x",
         )
-        ac.metadata
-        ac.read()
+        # Local copy matches copy fetched from remote.
+        assert ac.metadata == client["x"].metadata
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If the user uploads metadata with objects that are not natively serializable, such as a datetime or a numpy array, the server gets normalized objects (date string, JSON array) but the client still holds the originals. In this PR, we round-trip the local copy through JSON serialization so that it matches what was actually sent to the server.

In the first commit, a test demonstrates the inconsistency between local and remote:

```
    def test_metadata_with_unsafe_objects(tree):
        with Context.from_app(build_app(tree)) as context:
            client = from_context(context)
            ac = client.write_array(
                [1, 2, 3],
                metadata={"date": datetime.now(), "array": numpy.array([1, 2, 3])},
                key="x",
            )
            # Local copy matches copy fetched from remote.
>           assert ac.metadata == client["x"].metadata
E           AssertionError: assert DictView({'da...y([1, 2, 3])}) == DictView({'da...': [1, 2, 3]})
E
E             Full diff:
E             - DictView({'date': '2025-04-30T09:15:01.785570', 'array': [1, 2, 3]})
E             + DictView({'date': datetime.datetime(2025, 4, 30, 9, 15, 1, 785570), 'array': array([1, 2, 3])})
```

In the second commit, the test is made to pass.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section