### PR TITLE
Add Adapters for Numpy on-disk format (`.npy`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Added
+
+- Support for reading numpy's on-disk format, `.npy` files.
+
 ### Fixed
 
 - When using SQL-backed storage and file-backed storage, Tiled treated SQLite

--- a/tiled/_tests/test_npy.py
+++ b/tiled/_tests/test_npy.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+
+import numpy
+import pytest
+
+from ..adapters.mapping import MapAdapter
+from ..adapters.npy import NPYAdapter, NPYSequenceAdapter
+from ..catalog import in_memory
+from ..client import Context, from_context
+from ..client.register import IMG_SEQUENCE_EMPTY_NAME_ROOT, register
+from ..server.app import build_app
+from ..utils import ensure_uri
+
+SINGLE_SHAPE = (11, 17, 3)
+
+
+@pytest.fixture(scope="module")
+def client(tmpdir_module):
+    sequence_directory = Path(tmpdir_module, "sequence")
+    sequence_directory.mkdir()
+    filepaths = []
+    for i in range(3):
+        data = numpy.random.randint(0, 255, (5, 7), dtype="uint8")
+        filepath = sequence_directory / f"temp{i:05}.npy"
+        numpy.save(filepath, data)
+        filepaths.append(filepath)
+    single_data = numpy.random.randint(0, 255, SINGLE_SHAPE, dtype="uint8")
+    path = Path(tmpdir_module, "single.npy")
+    numpy.save(path, single_data)
+
+    tree = MapAdapter(
+        {
+            "sequence": NPYSequenceAdapter.from_uris(
+                *[ensure_uri(filepath) for filepath in filepaths]
+            ),
+            "single": NPYAdapter.from_uris(ensure_uri(path)),
+        }
+    )
+    app = build_app(tree)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+        yield client
+
+
+def test_npy(client):
+    "Test a single npy file."
+    arr = client["single"].read()
+    assert arr.shape == SINGLE_SHAPE
+
+
+@pytest.mark.parametrize(
+    "slice_input, correct_shape",
+    [
+        (None, (3, 5, 7)),
+        (0, (5, 7)),
+        (slice(0, 3, 2), (2, 5, 7)),
+        ((1, slice(0, 3), slice(0, 3)), (3, 3)),
+        ((slice(0, 3), slice(0, 3), slice(0, 3)), (3, 3, 3)),
+        ((..., 0, 0), (3,)),
+        ((0, slice(0, 1), slice(0, 2), ...), (1, 2)),
+        ((0, ..., slice(0, 2)), (5, 2)),
+        ((..., slice(0, 1)), (3, 5, 1)),
+    ],
+)
+def test_npy_sequence(client, slice_input, correct_shape):
+    arr = client["sequence"].read(slice=slice_input)
+    assert arr.shape == correct_shape
+
+
+@pytest.mark.parametrize("block_input, correct_shape", [((0, 0, 0), (1, 5, 7))])
+def test_npy_sequence_block(client, block_input, correct_shape):
+    arr = client["sequence"].read_block(block_input)
+    assert arr.shape == correct_shape
+
+
+@pytest.mark.asyncio
+async def test_npy_sequence_order(tmpdir):
+    """
+    directory/
+      00001.npy
+      00002.npy
+      ...
+      00010.npy
+    """
+    data = numpy.ones((4, 5))
+    num_files = 10
+    for i in range(num_files):
+        numpy.save(Path(tmpdir / f"image{i:05}.npy"), data * i)
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(adapter)) as context:
+        client = from_context(context)
+        await register(client, tmpdir)
+        for i in range(num_files):
+            numpy.testing.assert_equal(client["image"][i], data * i)
+
+
+@pytest.mark.asyncio
+async def test_npy_sequence_with_directory_walker(tmpdir):
+    """
+    directory/
+      00001.npy
+      00002.npy
+      ...
+      00010.npy
+      single_image.npy
+      image00001.npy
+      image00002.npy
+      ...
+      image00010.npy
+      other_image00001.npy
+      other_image00002.npy
+      ...
+      other_image00010.npy
+      other_image2_00001.npy
+      other_image2_00002.npy
+      ...
+      other_image2_00010.npy
+      other_file1.csv
+      other_file2.csv
+      stuff.csv
+    """
+    data = numpy.random.randint(0, 255, (3, 5), dtype="uint8")
+    for i in range(10):
+        numpy.save(Path(tmpdir / f"image{i:05}.npy"), data)
+        numpy.save(Path(tmpdir / f"other_image{i:05}.npy"), data)
+        numpy.save(Path(tmpdir / f"{i:05}.npy"), data)
+        numpy.save(Path(tmpdir / f"other_image2_{i:05}.npy"), data)
+    numpy.save(Path(tmpdir / "single_image.npy"), data)
+    for target in ["stuff.csv", "other_file1.csv", "other_file2.csv"]:
+        with open(Path(tmpdir / target), "w") as file:
+            file.write(
+                """
+a,b,c
+1,2,3
+"""
+            )
+    adapter = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(adapter)) as context:
+        client = from_context(context)
+        await register(client, tmpdir)
+        # Single image is its own node.
+        assert client["single_image"].shape == (3, 5)
+        # Each sequence is grouped into a node.
+        assert client[IMG_SEQUENCE_EMPTY_NAME_ROOT].shape == (10, 3, 5)
+        assert client["image"].shape == (10, 3, 5)
+        assert client["other_image"].shape == (10, 3, 5)
+        assert client["other_image2_"].shape == (10, 3, 5)
+        # The sequence grouping digit-only files appears with a uuid
+        named_keys = [
+            "single_image",
+            "image",
+            "other_image",
+            "other_image2_",
+            "other_file1",
+            "other_file2",
+            "stuff",
+        ]
+        no_name_keys = [key for key in client.keys() if key not in named_keys]
+        # There is only a single one of this type
+        assert len(no_name_keys) == 1
+        assert client[no_name_keys[0]].shape == (10, 3, 5)
+        # Other files are single nodes.
+        assert client["stuff"].columns == ["a", "b", "c"]
+        assert client["other_file1"].columns == ["a", "b", "c"]
+        assert client["other_file2"].columns == ["a", "b", "c"]
+
+
+def test_npy_sequence_cache(client):
+    from numpy.testing import assert_raises
+
+    # The two requests go through the same method in the server (read_block) to
+    # call the same object
+    indexed_array = client["sequence"][0]
+    read_array = client["sequence"].read(0)
+
+    # Using a different index to confirm that the previous cache doesn't affect the new array
+    other_read_array = client["sequence"].read(1)
+
+    numpy.testing.assert_equal(indexed_array, read_array)
+    assert_raises(
+        AssertionError, numpy.testing.assert_equal, read_array, other_read_array
+    )

--- a/tiled/adapters/npy.py
+++ b/tiled/adapters/npy.py
@@ -1,0 +1,116 @@
+import builtins
+from typing import Any, List, Optional, Tuple, Union
+
+import numpy
+from numpy._typing import NDArray
+
+from ..catalog.orm import Node
+from ..ndslice import NDSlice
+from ..structures.array import ArrayStructure, BuiltinDtype
+from ..structures.core import Spec, StructureFamily
+from ..structures.data_source import DataSource
+from ..type_aliases import JSON
+from ..utils import path_from_uri
+from .resource_cache import with_resource_cache
+from .sequence import FileSequenceAdapter
+from .utils import init_adapter_from_catalog
+
+
+class NPYAdapter:
+    """
+    Read the Numpy on-disk format, NPY (.npy).
+
+    Examples
+    --------
+
+    >>> NPYAdapter("path/to/file.npy")
+    """
+
+    structure_family = StructureFamily.array
+
+    def __init__(
+        self,
+        data_uri: str,
+        *,
+        structure: ArrayStructure,
+        metadata: Optional[JSON] = None,
+        specs: Optional[List[Spec]] = None,
+    ) -> None:
+        """
+
+        Parameters
+        ----------
+        data_uri :
+        structure :
+        metadata :
+        specs :
+        """
+        self._filepath = path_from_uri(data_uri)
+        self.specs = specs or []
+        self._provided_metadata = metadata or {}
+        self._structure = structure
+
+    @classmethod
+    def from_catalog(
+        cls,
+        data_source: DataSource[ArrayStructure],
+        node: Node,
+        /,
+        **kwargs: Optional[Any],
+    ) -> "NPYAdapter":
+        return init_adapter_from_catalog(cls, data_source, node, **kwargs)  # type: ignore
+
+    @classmethod
+    def from_uris(
+        cls,
+        data_uri: str,
+        **kwargs: Optional[Any],
+    ) -> "NPYAdapter":
+        filepath = path_from_uri(data_uri)
+        cache_key = (numpy.load, filepath)
+        arr = with_resource_cache(cache_key, numpy.load, filepath)
+
+        structure = ArrayStructure(
+            shape=arr.shape,
+            chunks=tuple((dim,) for dim in arr.shape),
+            data_type=BuiltinDtype.from_numpy_dtype(arr.dtype),
+        )
+
+        return cls(
+            data_uri,
+            structure=structure,
+        )
+
+    def metadata(self) -> JSON:
+        return self._provided_metadata.copy()
+
+    def read(self, slice: NDSlice = NDSlice(...)) -> NDArray[Any]:
+        cache_key = (numpy.load, self._filepath)
+        arr = with_resource_cache(cache_key, numpy.load, self._filepath)
+        arr = arr[slice] if slice else arr
+        return arr
+
+    def read_block(
+        self, block: Tuple[int, ...], slice: Optional[builtins.slice] = None
+    ) -> NDArray[Any]:
+        if sum(block) != 0:
+            raise IndexError(block)
+        cache_key = (numpy.load, self._filepath)
+        arr = with_resource_cache(cache_key, numpy.load, self._filepath)
+        arr = arr[slice] if slice else arr
+        if slice is not None:
+            arr = arr[slice]
+        return arr
+
+    def structure(self) -> ArrayStructure:
+        return self._structure
+
+
+class NPYSequenceAdapter(FileSequenceAdapter):
+    def _load_from_files(
+        self, slice: Union[builtins.slice, int] = slice(None)
+    ) -> NDArray[Any]:
+        if isinstance(slice, int):
+            return numpy.load(self.filepaths[slice])[None, ...]
+        else:
+            return numpy.asarray([numpy.load(file) for file in self.filepaths[slice]])

--- a/tiled/client/register.py
+++ b/tiled/client/register.py
@@ -347,14 +347,16 @@ IMG_SEQUENCE_STEM_PATTERNS = {
     ".tiff": re.compile(r"^(.*?)(\d+)\.(?:tif|tiff)$"),
     ".jpg": re.compile(r"^(.*?)(\d+)\.(?:jpg|jpeg)$"),
     ".jpeg": re.compile(r"^(.*?)(\d+)\.(?:jpg|jpeg)$"),
+    ".npy": re.compile(r"^(.*?)(\d+)\.npy$"),
 }
 IMG_SEQUENCE_EMPTY_NAME_ROOT = "_unnamed"
 
 IMG_SEQUENCE_MIMETYPES = {
     ".tif": "multipart/related;type=image/tiff",
     ".tiff": "multipart/related;type=image/tiff",
-    ".jpg": "multipart/related;type=image/jpeg",
+    ".jpg": "multipart/related;type=image/npy",
     ".jpeg": "multipart/related;type=image/jpeg",
+    ".npy": "multipart/related;type=application/x-npy",
 }
 
 

--- a/tiled/mimetypes.py
+++ b/tiled/mimetypes.py
@@ -48,6 +48,12 @@ DEFAULT_ADAPTERS_BY_MIMETYPE = OneShotCachedMap(
         "application/x-netcdf": lambda: importlib.import_module(
             "..adapters.netcdf", __name__
         ).NetCDFAdapter,
+        "application/x-npy": lambda: importlib.import_module(
+            "..adapters.npy", __name__
+        ).NPYAdapter,
+        "multipart/related;type=application/x-npy": lambda: importlib.import_module(
+            "..adapters.npy", __name__
+        ).NPYSequenceAdapter,
         PARQUET_MIMETYPE: lambda: importlib.import_module(
             "..adapters.parquet", __name__
         ).ParquetDatasetAdapter,
@@ -83,6 +89,8 @@ DEFAULT_REGISTERATION_ADAPTERS_BY_MIMETYPE.set(
 DEFAULT_MIMETYPES_BY_FILE_EXT = {
     # This is the "official" file extension.
     ".h5": "application/x-hdf5",
+    # This is the Numpy on-disk format.
+    ".npy": "application/x-npy",
     # This is NeXus. We may want to invent a special media type
     # like 'application/x-nexus' for this, but I'll punt that for now.
     # Needs thought about how to encode the various types of NeXus


### PR DESCRIPTION
This adds Adapters for [Numpy's on-disk format](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html). It handles single `.npy` files or sequences of `.npy` files, similar to TIFF or JPEG sequences. The simulated device `ophyd.sim.img` produces such sequences.

The tests are modeled on those for the JPEG adapters. There is some duplication, but in the context of unit tests, "DRY" is less important that self-contained code that is easy to quickly grasp.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
