### PR TITLE
Update data_source from the server response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   or DuckDB files as if they were directories of readable files, and
   included them superfluously in a check on whether assets were situated
   in a readable area.
+- Update data_sources in the client after receiving a response from the server.
 
 ## 0.1.0-b23 (2025-04-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   included them superfluously in a check on whether assets were situated
   in a readable area.
 - Update data_sources in the client after receiving a response from the server.
+  Removed the (unused) `data_source` parameter from the `PUT /data_source/`
+  endpoint; the id of the updated data source must be included in the structure
+  within the body of the request.
 
 ## 0.1.0-b23 (2025-04-24)
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -771,11 +771,9 @@ class CatalogNodeAdapter:
 
         return asset_id
 
-    async def put_data_source(self, data_source, data_source_id=None):
+    async def put_data_source(self, data_source):
         # Obtain and hash the canonical (RFC 8785) representation of
         # the JSON structure.
-        if data_source.id is None:
-            data_source.id = data_source_id or self.data_sources[0].id
         structure = _prepare_structure(
             data_source.structure_family, data_source.structure
         )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -771,9 +771,11 @@ class CatalogNodeAdapter:
 
         return asset_id
 
-    async def put_data_source(self, data_source):
+    async def put_data_source(self, data_source, data_source_id=None):
         # Obtain and hash the canonical (RFC 8785) representation of
         # the JSON structure.
+        if data_source.id is None:
+            data_source.id = data_source_id or self.data_sources[0].id
         structure = _prepare_structure(
             data_source.structure_family, data_source.structure
         )

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -714,6 +714,10 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 document.pop("structure")
             )
 
+        # And for data sources
+        if "data_sources" in document:
+            item["attributes"]["data_sources"] = [ds for ds in document.pop("data_sources")]
+
         # Merge in "id" and "links" returned by the server.
         item.update(document)
 

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -716,7 +716,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         # And for data sources
         if "data_sources" in document:
-            item["attributes"]["data_sources"] = [ds for ds in document.pop("data_sources")]
+            item["attributes"]["data_sources"] = [
+                ds for ds in document.pop("data_sources")
+            ]
 
         # Merge in "id" and "links" returned by the server.
         item.update(document)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1218,7 +1218,7 @@ def get_router(
         ),
     ):
         await entry.put_data_source(
-            data_source=body.data_source,
+            data_source=body.data_source, data_source_id=data_source
         )
 
     @router.delete("/metadata/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1126,7 +1126,7 @@ def get_router(
             if data_source.assets:
                 raise HTTPException(
                     "Externally-managed assets cannot be registered "
-                    "using POST /metadata/{path} Use POST /register/{path} instead."
+                    "using POST /metadata/{path}. Use POST /register/{path} instead."
                 )
         if body.data_sources and not getattr(entry, "writable", False):
             raise HTTPException(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1211,15 +1211,12 @@ def get_router(
         request: Request,
         path: str,
         body: schemas.PutDataSourceRequest,
-        data_source: Optional[int] = None,
         settings: Settings = Depends(get_settings),
         entry: MapAdapter = Security(
             get_entry(), scopes=["write:metadata", "register"]
         ),
     ):
-        await entry.put_data_source(
-            data_source=body.data_source, data_source_id=data_source
-        )
+        await entry.put_data_source(data_source=body.data_source)
 
     @router.delete("/metadata/{path:path}")
     async def delete(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1210,8 +1210,8 @@ def get_router(
     async def put_data_source(
         request: Request,
         path: str,
-        data_source: int,
         body: schemas.PutDataSourceRequest,
+        data_source: Optional[int] = None,
         settings: Settings = Depends(get_settings),
         entry: MapAdapter = Security(
             get_entry(), scopes=["write:metadata", "register"]


### PR DESCRIPTION
This is to make sure that the `data_source` in the clients is updated by the received response from the server (similar to `metadata` and `structure`).

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
