### PR TITLE
Opt in to dropping revision on metadata update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 Write the date in place of the "Unreleased" in the case a new version is released. -->
 # Changelog
 
+## Unreleased
+
+### Added
+
+- New query parameter `drop_revision` on endpoints `PUT /metadata/{path}`
+  and `PATCH /metadata/{path}`. If set to true, the version replaced by
+  the update is _not_ saved as a revision. This is exposed in the Python
+  client via a new keyword-only argument `drop_revision` in
+  `update_metadata`, `patch_metadata`, and `replace_metadata`.
+
 ## 0.1.0-b25 (2025-05-06)
 
 ### Added

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -407,18 +407,19 @@ def test_metadata_revisions(tree):
 
 
 def test_drop_revision(tree):
+    key = "test_drop_revision"
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
         # Set metadata color=blue.
-        ac = client.write_array([1, 2, 3], metadata={"color": "blue"}, key="revise_me")
+        ac = client.write_array([1, 2, 3], metadata={"color": "blue"}, key=key)
         assert ac.metadata["color"] == "blue"
-        assert client["revise_me"].metadata["color"] == "blue"
+        assert client[key].metadata["color"] == "blue"
         assert len(ac.metadata_revisions[:]) == 0
         # Update metadata to color=red, but drop revision.
         ac.update_metadata(metadata={"color": "red"}, drop_revision=True)
         # Metadata is updated; no revision is saved.
         assert ac.metadata["color"] == "red"
-        assert client["revise_me"].metadata["color"] == "red"
+        assert client[key].metadata["color"] == "red"
         assert len(ac.metadata_revisions) == 0
 
 

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -406,6 +406,22 @@ def test_metadata_revisions(tree):
             ac.metadata_revisions.delete_revision(1)
 
 
+def test_drop_revision(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        # Set metadata color=blue.
+        ac = client.write_array([1, 2, 3], metadata={"color": "blue"}, key="revise_me")
+        assert ac.metadata["color"] == "blue"
+        assert client["revise_me"].metadata["color"] == "blue"
+        assert len(ac.metadata_revisions[:]) == 0
+        # Update metadata to color=red, but drop revision.
+        ac.update_metadata(metadata={"color": "red"}, drop_revision=True)
+        # Metadata is updated; no revision is saved.
+        assert ac.metadata["color"] == "red"
+        assert client["revise_me"].metadata["color"] == "red"
+        assert len(ac.metadata_revisions) == 0
+
+
 def test_merge_patching(tree):
     "Test merge patching of metadata and specs"
     with Context.from_app(build_app(tree)) as context:

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1429,6 +1429,7 @@ def get_router(
         body: schemas.PatchMetadataRequest,
         settings: Settings = Depends(get_settings),
         entry: MapAdapter = Security(get_entry(), scopes=["write:metadata"]),
+        drop_revision: bool = False,
     ):
         if not hasattr(entry, "replace_metadata"):
             raise HTTPException(
@@ -1476,7 +1477,9 @@ def get_router(
             settings=settings,
         )
 
-        await entry.replace_metadata(metadata=metadata, specs=specs)
+        await entry.replace_metadata(
+            metadata=metadata, specs=specs, drop_revision=drop_revision
+        )
 
         response_data = {"id": entry.key}
         if metadata_modified:
@@ -1489,6 +1492,7 @@ def get_router(
         body: schemas.PutMetadataRequest,
         settings: Settings = Depends(get_settings),
         entry: MapAdapter = Security(get_entry(), scopes=["write:metadata"]),
+        drop_revision: bool = False,
     ):
         if not hasattr(entry, "replace_metadata"):
             raise HTTPException(
@@ -1511,7 +1515,9 @@ def get_router(
             settings=settings,
         )
 
-        await entry.replace_metadata(metadata=metadata, specs=specs)
+        await entry.replace_metadata(
+            metadata=metadata, specs=specs, drop_revision=drop_revision
+        )
 
         response_data = {"id": entry.key}
         if metadata_modified:


### PR DESCRIPTION
New query parameter `drop_revision` on endpoints `PUT /metadata/{path}`
  and `PATCH /metadata/{path}`. If set to true, the version replaced by
  the update is _not_ saved as a revision. This is exposed in the Python
  client via a new keyword-only argument `drop_revision` in
  `update_metadata`, `patch_metadata`, and `replace_metadata`.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
