### PR TITLE
FIX: apply user access_tag to tables when unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- An auth bug that prevented a user to create a table with empty access_tags.
+
 ## v0.1.0-b28 (2025-05-21)
 
 ### Changed

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -1105,7 +1105,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             key=key,
             metadata=metadata or {},
             specs=specs or [],
-            access_tags=access_tags or [],
+            access_tags=access_tags,
         )
 
         return client
@@ -1162,7 +1162,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             key=key,
             metadata=metadata or {},
             specs=specs or [],
-            access_tags=access_tags or [],
+            access_tags=access_tags,
         )
 
         if hasattr(dataframe, "partitions"):


### PR DESCRIPTION
Fixing an issue where a table can not be created if an access pass is not set.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
