### PR TITLE
Control `page_size` more carefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Added
+
+- It is now possible to explicitly control the page size used for fetching
+  batches of metadata, e.g. `client.values().page_size(N)`.
+
 ### Fixed
 
 - An auth bug that prevented a user to create a table with empty access_tags.
+- When accessing a small number of results, the page size is set appropriately
+  to avoid needlessly downloading additional results.
 
 ## v0.1.0-b28 (2025-05-21)
 

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -63,6 +63,7 @@ batched across requests, which affects performance.
    :toctree: generated
 
    tiled.iterviews.ValuesView.page_size
+```
 
 Likewise for `.keys()` and `.items()`.
 

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -55,6 +55,15 @@ and several convenience methods:
    tiled.iterviews.ValuesView.tail
 ```
 
+as well as a method for controlling the "page size" in which results will be
+batched across requests, which affects performance.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+
+   tiled.iterviews.ValuesView.page_size
+
 Likewise for `.keys()` and `.items()`.
 
 Beyond the Mapping interface, Container adds the following attributes

--- a/tiled/_tests/test_pagination.py
+++ b/tiled/_tests/test_pagination.py
@@ -90,3 +90,14 @@ def test_manual_page_size(client):
     actual_nums = [item.metadata["num"] for item in items]
     expected_nums = [0, 1, 2, 3, 4]
     assert actual_nums == expected_nums
+
+
+def test_manual_page_size_truncated(client):
+    "If the manual page size is larger than the result set, it is truncated."
+    with record_history() as history:
+        items = client.values().page_size(6).head(5)
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "5"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [0, 1, 2, 3, 4]
+    assert actual_nums == expected_nums

--- a/tiled/_tests/test_pagination.py
+++ b/tiled/_tests/test_pagination.py
@@ -186,3 +186,25 @@ def test_manual_page_size_truncated_keys(client):
     actual_nums = [int(key) for key in keys]
     expected_nums = [0, 1, 2, 3, 4]
     assert actual_nums == expected_nums
+
+
+def test_unbounded_values_slice(client):
+    "An unbounded slice lets the server set the page size."
+    with record_history() as history:
+        items = client.values()[3:]
+    assert len(history.requests) == 1
+    assert "page[limit]" not in history.requests[0].url.params
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [3, 4, 5, 6, 7, 8, 9]
+    assert actual_nums == expected_nums
+
+
+def test_unbounded_keys_slice(client):
+    "An unbounded slice lets the server set the page size."
+    with record_history() as history:
+        keys = client.keys()[3:]
+    assert len(history.requests) == 1
+    assert "page[limit]" not in history.requests[0].url.params
+    actual_nums = [int(key) for key in keys]
+    expected_nums = [3, 4, 5, 6, 7, 8, 9]
+    assert actual_nums == expected_nums

--- a/tiled/_tests/test_pagination.py
+++ b/tiled/_tests/test_pagination.py
@@ -1,0 +1,92 @@
+import pytest
+
+from tiled.catalog import in_memory
+from tiled.client import Context, from_context, record_history
+from tiled.server.app import build_app
+
+N = 10  # number of items generated in sample
+
+
+@pytest.fixture(scope="module")
+def client(tmpdir_module):
+    catalog = in_memory(writable_storage=[tmpdir_module])
+    app = build_app(catalog)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+        for i in range(N):
+            client.create_container(metadata={"num": i})
+        yield client
+
+
+def test_first(client):
+    "Fetching the first element requests a page of size 1."
+    with record_history() as history:
+        item = client.values().first()
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "1"
+    assert item.metadata["num"] == 0
+
+
+def test_last(client):
+    "Fetching the last element requests a page of size 1."
+    with record_history() as history:
+        item = client.values().last()
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "1"
+    assert item.metadata["num"] == N - 1
+
+
+def test_head(client):
+    "Fetching the 'head' requests a page of size 5."
+    with record_history() as history:
+        items = client.values().head(5)
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "5"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [0, 1, 2, 3, 4]
+    assert actual_nums == expected_nums
+
+
+def test_tail(client):
+    "Fetching the 'tail' requests a page of size 5."
+    with record_history() as history:
+        items = client.values().tail(5)
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "5"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [5, 6, 7, 8, 9]
+    assert actual_nums == expected_nums
+
+
+def test_middle_forward(client):
+    "Fetching a slice in the middle requests a page of the correct size."
+    with record_history() as history:
+        items = client.values()[2:6]
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "4"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [2, 3, 4, 5]
+    assert actual_nums == expected_nums
+
+
+def test_middle_backward(client):
+    "Fetching a slice in the middle requests a page of the correct size."
+    with record_history() as history:
+        items = client.values()[-2:-6:-1]
+    assert len(history.requests) == 1
+    assert history.requests[0].url.params["page[limit]"] == "4"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [8, 7, 6, 5]
+    assert actual_nums == expected_nums
+
+
+def test_manual_page_size(client):
+    "The page_size method can set the page size manually."
+    with record_history() as history:
+        items = client.values().page_size(2).head(5)
+    assert len(history.requests) == 3
+    for request in history.requests:
+        assert request.url.params["page[limit]"] == "2"
+    actual_nums = [item.metadata["num"] for item in items]
+    expected_nums = [0, 1, 2, 3, 4]
+    assert actual_nums == expected_nums

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -506,14 +506,16 @@ class HDF5Adapter(Mapping[str, Union["HDF5Adapter", HDF5ArrayAdapter]], Indexers
 
     # The following two methods are used by keys(), values(), items().
 
-    def _keys_slice(self, start: int, stop: int, direction: int) -> List[Any]:
+    def _keys_slice(
+        self, start: int, stop: int, direction: int, page_size: int | None = None
+    ) -> List[Any]:
         keys = list(self._tree.keys())
         if direction < 0:
             keys = list(reversed(keys))
         return keys[start:stop]
 
     def _items_slice(
-        self, start: int, stop: int, direction: int
+        self, start: int, stop: int, direction: int, page_size: int | None = None
     ) -> List[Tuple[Any, Any]]:
         """
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -507,7 +507,7 @@ class HDF5Adapter(Mapping[str, Union["HDF5Adapter", HDF5ArrayAdapter]], Indexers
     # The following two methods are used by keys(), values(), items().
 
     def _keys_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> List[Any]:
         keys = list(self._tree.keys())
         if direction < 0:
@@ -515,7 +515,7 @@ class HDF5Adapter(Mapping[str, Union["HDF5Adapter", HDF5ArrayAdapter]], Indexers
         return keys[start:stop]
 
     def _items_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> List[Tuple[Any, Any]]:
         """
 

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -420,7 +420,7 @@ class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
     # The following two methods are used by keys(), values(), items().
 
     def _keys_slice(
-        self, start: int, stop: int, direction: int
+        self, start: int, stop: int, direction: int, page_size: int | None = None
     ) -> Union[Iterator[str], List[str]]:
         """
 
@@ -450,7 +450,7 @@ class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
             return keys
 
     def _items_slice(
-        self, start: int, stop: int, direction: int
+        self, start: int, stop: int, direction: int, page_size: int | None = None
     ) -> Iterator[Tuple[str, Any]]:
         """
 

--- a/tiled/adapters/mapping.py
+++ b/tiled/adapters/mapping.py
@@ -420,7 +420,7 @@ class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
     # The following two methods are used by keys(), values(), items().
 
     def _keys_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> Union[Iterator[str], List[str]]:
         """
 
@@ -450,7 +450,7 @@ class MapAdapter(Mapping[str, AnyAdapter], IndexersMixin):
             return keys
 
     def _items_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> Iterator[Tuple[str, Any]]:
         """
 

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -315,7 +315,9 @@ class ZarrGroupAdapter(
 
     # The following two methods are used by keys(), values(), items().
 
-    def _keys_slice(self, start: int, stop: int, direction: int) -> List[Any]:
+    def _keys_slice(
+        self, start: int, stop: int, direction: int, page_size: int | None = None
+    ) -> List[Any]:
         """
 
         Parameters
@@ -333,7 +335,9 @@ class ZarrGroupAdapter(
             keys = list(reversed(keys))
         return keys[start:stop]
 
-    def _items_slice(self, start: int, stop: int, direction: int) -> List[Any]:
+    def _items_slice(
+        self, start: int, stop: int, direction: int, page_size: int | None = None
+    ) -> List[Any]:
         """
 
         Parameters

--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -316,7 +316,7 @@ class ZarrGroupAdapter(
     # The following two methods are used by keys(), values(), items().
 
     def _keys_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> List[Any]:
         """
 
@@ -336,7 +336,7 @@ class ZarrGroupAdapter(
         return keys[start:stop]
 
     def _items_slice(
-        self, start: int, stop: int, direction: int, page_size: int | None = None
+        self, start: int, stop: int, direction: int, page_size: Optional[int] = None
     ) -> List[Any]:
         """
 

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -437,9 +437,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 time.monotonic() + LENGTH_CACHE_TTL,
             )
             for item in content["data"]:
-                if stop is not None and next(item_counter) == stop:
-                    return
                 yield item["id"]
+                if stop is not None and next(item_counter) == stop - 1:
+                    return
             next_page_url = content["links"]["next"]
 
     def _items_slice(

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -498,8 +498,6 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 time.monotonic() + LENGTH_CACHE_TTL,
             )
             for item in content["data"]:
-                if stop is not None and next(item_counter) == stop:
-                    return
                 key = item["id"]
                 yield key, client_for_item(
                     self.context,
@@ -507,6 +505,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                     item,
                     include_data_sources=self._include_data_sources,
                 )
+                if stop is not None and next(item_counter) == stop - 1:
+                    return
             next_page_url = content["links"]["next"]
 
     def keys(self):

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -390,7 +390,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
     # The following two methods are used by keys(), values(), items().
 
-    def _keys_slice(self, start, stop, direction, _ignore_inlined_contents=False):
+    def _keys_slice(
+        self, start, stop, direction, page_size=None, *, _ignore_inlined_contents=False
+    ):
         # If the contents of this node was provided in-line, and we don't need
         # to apply any filtering or sorting, we can slice the in-lined data
         # without fetching anything from the server.
@@ -412,6 +414,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         assert start >= 0
         assert (stop is None) or (stop >= 0)
         next_page_url = f"{self.item['links']['search']}?page[offset]={start}"
+        if page_size is not None:
+            next_page_url += f"&page[limit]={page_size}"
         item_counter = itertools.count(start)
         while next_page_url is not None:
             for attempt in retry_context():
@@ -438,7 +442,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 yield item["id"]
             next_page_url = content["links"]["next"]
 
-    def _items_slice(self, start, stop, direction, _ignore_inlined_contents=False):
+    def _items_slice(
+        self, start, stop, direction, page_size=None, *, _ignore_inlined_contents=False
+    ):
         # If the contents of this node was provided in-line, and we don't need
         # to apply any filtering or sorting, we can slice the in-lined data
         # without fetching anything from the server.
@@ -467,6 +473,8 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         assert start >= 0
         assert (stop is None) or (stop >= 0)
         next_page_url = f"{self.item['links']['search']}?page[offset]={start}"
+        if page_size is not None:
+            next_page_url += f"&page[limit]={page_size}"
         item_counter = itertools.count(start)
         while next_page_url is not None:
             params = {

--- a/tiled/iterviews.py
+++ b/tiled/iterviews.py
@@ -72,9 +72,12 @@ class KeysView(IterViewBase):
             return key
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
-            page_size = abs(start - stop)
-            if self._page_size is not None:
-                page_size = min(page_size, self._page_size)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
             return list(self._keys_slice(start, stop, direction, page_size))
         else:
             raise TypeError(
@@ -121,9 +124,12 @@ class ItemsView(IterViewBase):
             return item
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
-            page_size = abs(start - stop)
-            if self._page_size is not None:
-                page_size = min(page_size, self._page_size)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
             return list(self._items_slice(start, stop, direction, page_size))
         else:
             raise TypeError(
@@ -171,9 +177,12 @@ class ValuesView(IterViewBase):
             return value
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
-            page_size = abs(start - stop)
-            if self._page_size is not None:
-                page_size = min(page_size, self._page_size)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
             return [
                 value
                 for _key, value in self._items_slice(start, stop, direction, page_size)

--- a/tiled/iterviews.py
+++ b/tiled/iterviews.py
@@ -63,9 +63,7 @@ class KeysView(IterViewBase):
             else:
                 direction = 1
             keys = list(
-                self._keys_slice(
-                    index_or_slice, 1 + index_or_slice, direction, self._page_size
-                )
+                self._keys_slice(index_or_slice, 1 + index_or_slice, direction, 1)
             )
             try:
                 (key,) = keys
@@ -74,7 +72,10 @@ class KeysView(IterViewBase):
             return key
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
-            return list(self._keys_slice(start, stop, direction, self._page_size))
+            page_size = abs(start - stop)
+            if self._page_size is not None:
+                page_size = min(page_size, self._page_size)
+            return list(self._keys_slice(start, stop, direction, page_size))
         else:
             raise TypeError(
                 f"{index_or_slice} must be an int or slice, not {type(index_or_slice)}"
@@ -111,9 +112,7 @@ class ItemsView(IterViewBase):
             else:
                 direction = 1
             items = list(
-                self._items_slice(
-                    index_or_slice, 1 + index_or_slice, direction, self._page_size
-                )
+                self._items_slice(index_or_slice, 1 + index_or_slice, direction, 1)
             )
             try:
                 (item,) = items
@@ -122,7 +121,10 @@ class ItemsView(IterViewBase):
             return item
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
-            return list(self._items_slice(start, stop, direction, self._page_size))
+            page_size = abs(start - stop)
+            if self._page_size is not None:
+                page_size = min(page_size, self._page_size)
+            return list(self._items_slice(start, stop, direction, page_size))
         else:
             raise TypeError(
                 f"{index_or_slice} must be an int or slice, not {type(index_or_slice)}"
@@ -159,9 +161,7 @@ class ValuesView(IterViewBase):
             else:
                 direction = 1
             items = list(
-                self._items_slice(
-                    index_or_slice, 1 + index_or_slice, direction, self._page_size
-                )
+                self._items_slice(index_or_slice, 1 + index_or_slice, direction, 1)
             )
             try:
                 (item,) = items
@@ -171,11 +171,12 @@ class ValuesView(IterViewBase):
             return value
         elif isinstance(index_or_slice, slice):
             start, stop, direction = slice_to_interval(index_or_slice)
+            page_size = abs(start - stop)
+            if self._page_size is not None:
+                page_size = min(page_size, self._page_size)
             return [
                 value
-                for _key, value in self._items_slice(
-                    start, stop, direction, self._page_size
-                )
+                for _key, value in self._items_slice(start, stop, direction, page_size)
             ]
         else:
             raise TypeError(


### PR DESCRIPTION
This resolves the issue where `c.values().last()`—and likewise the back-compat wrapper `db[-1]`—is slow at CHX. Since the fix is entirely client-side, it is easy to test this against NSLS-II production (`tiled.nsls2.bnl.gov`).

```py
In [4]: %time chx.values().last()
CPU times: user 10.2 ms, sys: 1.92 ms, total: 12.1 ms
Wall time: 16.6 s
Out[4]: <BlueskyRun v2.0 {'primary'} scan_id=167143 uid='ded4a92e' 2025-05-13 14:05>
```

On this PR branch:

```py
In [5]: %time chx.values().last()
CPU times: user 11.5 ms, sys: 1.06 ms, total: 12.5 ms
Wall time: 851 ms
Out[5]: <BlueskyRun v2.0 {'primary'} scan_id=167143 uid='ded4a92e' 2025-05-13 14:05>
```

I noticed that HEX was also looking slow. This is `main` again:

```py
In [8]: %time hex.values().last()
CPU times: user 5.6 ms, sys: 956 μs, total: 6.56 ms
Wall time: 5.58 s
Out[8]: <BlueskyRun v3.0 streams: {'tomo', 'baseline'} scan_id=85 uid='d343682b' 2025-05-27 15:22>
```

and the PR branch:

```py
In [4]: %time hex.values().last()
CPU times: user 290 ms, sys: 75.5 ms, total: 365 ms
Wall time: 936 ms
Out[4]: <BlueskyRun v3.0 streams: {'baseline', 'tomo'} scan_id=85 uid='d343682b' 2025-05-27 15:22>
```

Closes #645 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
