### PR TITLE
Add tabular SQL storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - It is now possible to explicitly control the page size used for fetching
   batches of metadata, e.g. `client.values().page_size(N)`.
+- Writable tabular SQL storage in SimpleTiledServer.
 
 ### Fixed
 

--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -100,9 +100,9 @@ class SimpleTiledServer:
             directory = pathlib.Path(tempfile.mkdtemp())
             self._cleanup_directory = True
         else:
-            directory = pathlib.Path(directory)
+            directory = pathlib.Path(directory).resolve()
             self._cleanup_directory = False
-        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "data").mkdir(parents=True, exist_ok=True)
         # In production we use a proper 32-bit token, but for brevity we
         # use just 8 here. This server only accepts connections on localhost
         # and is not intended for production use, so we think this is an
@@ -121,7 +121,10 @@ class SimpleTiledServer:
 
         self.catalog = catalog_from_uri(
             directory / "catalog.db",
-            writable_storage=directory / "data",
+            writable_storage=[
+                f"file://localhost{str(directory / 'data')}",
+                f"duckdb:///{str(directory / 'storage.duckdb')}",
+            ],
             init_if_not_exists=True,
         )
         self.app = build_app(


### PR DESCRIPTION
This pull request configures writable tabular SQL storage in the SimpleTiledServer (DuckDB by default); furthermore minor related changes were made to improve directory handling and expand test cases.

### Testing Updates:
* `tiled/_tests/test_simple_server.py`:
  - Enhanced `test_default` to include writing and reading tabular data using SQL storage.
  - Updated `test_persistent_data` to verify persistence of tabular data across server instances.

### Codebase Improvements:
* `tiled/server/simple.py`:
  - Resolved the directory path in `__init__` to ensure absolute paths and modified directory initialization to include a "data" subdirectory.
  - Updated writable storage configuration to support both file-based and DuckDB-based storage options.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
