### PR TITLE
Support optional params in mimetypes with serializers

### DIFF
--- a/tiled/_tests/test_array.py
+++ b/tiled/_tests/test_array.py
@@ -202,5 +202,5 @@ def test_unparsable_nested_array_stringified(kind, context):
 
 @pytest.mark.parametrize("kind", list(array_cases))
 def test_as_buffer(kind):
-    output = as_buffer(array_cases[kind], {})
+    output = as_buffer("application/octet-stream", array_cases[kind], {})
     assert len(output) == len(bytes(output))

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -1,5 +1,5 @@
-import json
 import csv
+import json
 from pathlib import Path
 
 import numpy

--- a/tiled/_tests/test_export.py
+++ b/tiled/_tests/test_export.py
@@ -78,12 +78,14 @@ def client():
 # but we mostly export for a buffer in memory because disk access
 # can be very cloud on cloud CI VMs.
 
+
 def has_csv_header(filepath):
-    with open(filepath, 'r') as csv_f:
+    with open(filepath, "r") as csv_f:
         sniffer = csv.Sniffer()
         has_header = sniffer.has_header(csv_f.read(2048))
         csv_f.seek(0)
     return has_header
+
 
 @pytest.mark.parametrize("filename", ["numbers.csv", "image.png", "image.tiff"])
 def test_export_2d_array(client, filename, tmpdir):

--- a/tiled/_tests/test_utils.py
+++ b/tiled/_tests/test_utils.py
@@ -8,6 +8,7 @@ from ..utils import (
     ListView,
     OneShotCachedMap,
     ensure_specified_sql_driver,
+    parse_mimetype,
     parse_time_string,
     sanitize_uri,
     walk,
@@ -339,3 +340,28 @@ def test_sanitize_uri(uri, expected_clean_uri, expected_username, expected_passw
     assert clean_uri == expected_clean_uri
     assert username == expected_username
     assert password == expected_password
+
+
+@pytest.mark.parametrize(
+    "mimetype, expected",
+    [
+        ("text/csv", ("text/csv", {})),
+        ("text/csv;header=absent", ("text/csv", {"header": "absent"})),
+        (
+            "text/csv;header=absent; charset=utf-8",
+            ("text/csv", {"header": "absent", "charset": "utf-8"}),
+        ),
+        (
+            "text/csv; header=absent; charset=utf-8",
+            ("text/csv", {"header": "absent", "charset": "utf-8"}),
+        ),
+    ],
+)
+def test_parse_valid_mimetype(mimetype, expected):
+    assert parse_mimetype(mimetype) == expected
+
+
+def test_parse_invalid_mimetype():
+    with pytest.raises(ValueError):
+        # Parameter does not have form 'key=value'
+        assert parse_mimetype("text/csv;oops")

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -13,6 +13,7 @@ from ..serialization.xarray import serialize_json
 from ..server.app import build_app
 from ..structures.core import Spec
 from .utils import URL_LIMITS
+from ..utils import APACHE_ARROW_FILE_MIME_TYPE
 
 image = numpy.random.random((3, 5))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
@@ -190,7 +191,7 @@ async def test_serialize_json(ds_node: DatasetAdapter):
     """
     metadata = None  # Not used
     filter_for_access = None  # Not used
-    result = await serialize_json(ds_node, metadata, filter_for_access)
+    result = await serialize_json(APACHE_ARROW_FILE_MIME_TYPE, ds_node, metadata, filter_for_access)
 
     result_data_keys = orjson.loads(result).keys()
     ds_coords_and_vars = set(ds_node)

--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -12,8 +12,8 @@ from ..client import Context, from_context, record_history
 from ..serialization.xarray import serialize_json
 from ..server.app import build_app
 from ..structures.core import Spec
-from .utils import URL_LIMITS
 from ..utils import APACHE_ARROW_FILE_MIME_TYPE
+from .utils import URL_LIMITS
 
 image = numpy.random.random((3, 5))
 temp = 15 + 8 * numpy.random.randn(2, 2, 3)
@@ -191,7 +191,9 @@ async def test_serialize_json(ds_node: DatasetAdapter):
     """
     metadata = None  # Not used
     filter_for_access = None  # Not used
-    result = await serialize_json(APACHE_ARROW_FILE_MIME_TYPE, ds_node, metadata, filter_for_access)
+    result = await serialize_json(
+        APACHE_ARROW_FILE_MIME_TYPE, ds_node, metadata, filter_for_access
+    )
 
     result_data_keys = orjson.loads(result).keys()
     ds_coords_and_vars = set(ds_node)

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -69,9 +69,7 @@ class AwkwardClient(BaseClient):
                         json=form_keys,
                     )
                 ).read()
-        container = from_zipped_buffers(
-            "application/zip", content, projected_form, structure.length
-        )
+        container = from_zipped_buffers(content, projected_form, structure.length)
         projected_array = awkward.from_buffers(
             projected_form, structure.length, container, allow_noncanonical_form=True
         )

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -43,7 +43,9 @@ class AwkwardClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["full"],
-                        content=bytes(to_zipped_buffers("application/zip", components, {})),
+                        content=bytes(
+                            to_zipped_buffers("application/zip", components, {})
+                        ),
                         headers={"Content-Type": "application/zip"},
                     )
                 )

--- a/tiled/client/awkward.py
+++ b/tiled/client/awkward.py
@@ -43,7 +43,7 @@ class AwkwardClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["full"],
-                        content=bytes(to_zipped_buffers(components, {})),
+                        content=bytes(to_zipped_buffers("application/zip", components, {})),
                         headers={"Content-Type": "application/zip"},
                     )
                 )
@@ -67,7 +67,9 @@ class AwkwardClient(BaseClient):
                         json=form_keys,
                     )
                 ).read()
-        container = from_zipped_buffers(content, projected_form, structure.length)
+        container = from_zipped_buffers(
+            "application/zip", content, projected_form, structure.length
+        )
         projected_array = awkward.from_buffers(
             projected_form, structure.length, container, allow_noncanonical_form=True
         )

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -138,7 +138,7 @@ class _DaskDataFrameClient(BaseClient):
                             params=params,
                         )
                     ).read()
-        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
+        return deserialize_arrow(content)
 
     def read_partition(self, partition, columns=None):
         """

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -138,7 +138,7 @@ class _DaskDataFrameClient(BaseClient):
                             params=params,
                         )
                     ).read()
-        return deserialize_arrow(content)
+        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
 
     def read_partition(self, partition, columns=None):
         """
@@ -222,7 +222,9 @@ class _DaskDataFrameClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["full"],
-                        content=bytes(serialize_arrow(dataframe, {})),
+                        content=bytes(
+                            serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, dataframe, {})
+                        ),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )
@@ -233,7 +235,9 @@ class _DaskDataFrameClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["partition"].format(index=partition),
-                        content=bytes(serialize_arrow(dataframe, {})),
+                        content=bytes(
+                            serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, dataframe, {})
+                        ),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )
@@ -246,7 +250,9 @@ class _DaskDataFrameClient(BaseClient):
                 handle_error(
                     self.context.http_client.patch(
                         self.item["links"]["partition"].format(index=partition),
-                        content=bytes(serialize_arrow(dataframe, {})),
+                        content=bytes(
+                            serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, dataframe, {})
+                        ),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -61,7 +61,7 @@ class SparseClient(BaseClient):
                         params=params,
                     )
                 ).read()
-        df = deserialize_arrow(content)
+        df = deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
         original_shape = structure.shape
         if slice is not None:
             sliced_shape = ndindex(slice).newshape(original_shape)
@@ -90,7 +90,7 @@ class SparseClient(BaseClient):
                         params=params,
                     )
                 ).read()
-        df = deserialize_arrow(content)
+        df = deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
         original_shape = structure.shape
         if slice is not None:
             sliced_shape = ndindex(slice).newshape(original_shape)
@@ -115,7 +115,7 @@ class SparseClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["full"],
-                        content=bytes(serialize_arrow(df, {})),
+                        content=bytes(serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )
@@ -131,7 +131,7 @@ class SparseClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["block"].format(*block),
-                        content=bytes(serialize_arrow(df, {})),
+                        content=bytes(serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -61,7 +61,7 @@ class SparseClient(BaseClient):
                         params=params,
                     )
                 ).read()
-        df = deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
+        df = deserialize_arrow(content)
         original_shape = structure.shape
         if slice is not None:
             sliced_shape = ndindex(slice).newshape(original_shape)
@@ -90,7 +90,7 @@ class SparseClient(BaseClient):
                         params=params,
                     )
                 ).read()
-        df = deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
+        df = deserialize_arrow(content)
         original_shape = structure.shape
         if slice is not None:
             sliced_shape = ndindex(slice).newshape(original_shape)

--- a/tiled/client/sparse.py
+++ b/tiled/client/sparse.py
@@ -115,7 +115,9 @@ class SparseClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["full"],
-                        content=bytes(serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})),
+                        content=bytes(
+                            serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})
+                        ),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )
@@ -131,7 +133,9 @@ class SparseClient(BaseClient):
                 handle_error(
                     self.context.http_client.put(
                         self.item["links"]["block"].format(*block),
-                        content=bytes(serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})),
+                        content=bytes(
+                            serialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, df, {})
+                        ),
                         headers={"Content-Type": APACHE_ARROW_FILE_MIME_TYPE},
                     )
                 )

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -185,7 +185,7 @@ class _WideTableFetcher:
                 },
             )
         ).read()
-        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
+        return deserialize_arrow(content)
 
     def _fetch_variables__post(self, variables):
         content = handle_error(
@@ -198,7 +198,7 @@ class _WideTableFetcher:
                 },
             )
         ).read()
-        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
+        return deserialize_arrow(content)
 
 
 def write_xarray_dataset(client_node, dataset, key=None):

--- a/tiled/client/xarray.py
+++ b/tiled/client/xarray.py
@@ -185,7 +185,7 @@ class _WideTableFetcher:
                 },
             )
         ).read()
-        return deserialize_arrow(content)
+        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
 
     def _fetch_variables__post(self, variables):
         content = handle_error(
@@ -198,7 +198,7 @@ class _WideTableFetcher:
                 },
             )
         ).read()
-        return deserialize_arrow(content)
+        return deserialize_arrow(APACHE_ARROW_FILE_MIME_TYPE, content)
 
 
 def write_xarray_dataset(client_node, dataset, key=None):

--- a/tiled/examples/xdi.py
+++ b/tiled/examples/xdi.py
@@ -203,7 +203,7 @@ def read_xdi(data_uri, structure=None, metadata=None, specs=None, access_policy=
     )
 
 
-def write_xdi(df, metadata):
+def write_xdi(mimetype, df, metadata):
     output = io.StringIO()
 
     xdi_version = metadata.get("xdi_version")

--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -62,9 +62,7 @@ default_serialization_registry.register(
 default_deserialization_registry.register(
     "array",
     "application/octet-stream",
-    lambda mimetype, buffer, dtype, shape: numpy.frombuffer(
-        buffer, dtype=dtype
-    ).reshape(shape),
+    lambda buffer, dtype, shape: numpy.frombuffer(buffer, dtype=dtype).reshape(shape),
 )
 if modules_available("PIL"):
 

--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -42,12 +42,7 @@ def serialize_csv(mimetype, array, metadata):
     if array.ndim > 2:
         raise UnsupportedShape(array.shape)
     file = io.StringIO()
-    if ";" in mimetype:
-        opt_param = mimetype.split(";")[1:]
-        if "header" in opt_param and "present" in opt_param:
-            numpy.savetxt(file, array, fmt="%s", delimiter=",", header=str(metadata))
-        else:
-            numpy.savetxt(file, array, fmt="%s", delimiter=",")
+    numpy.savetxt(file, array, fmt="%s", delimiter=",")
     return file.getvalue().encode()
 
 

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -26,7 +26,7 @@ def to_zipped_buffers(mimetype, components, metadata):
 
 
 @default_deserialization_registry.register(StructureFamily.awkward, "application/zip")
-def from_zipped_buffers(mimetype, buffer, form, length):
+def from_zipped_buffers(buffer, form, length):
     file = io.BytesIO(buffer)
     with zipfile.ZipFile(file, "r") as zip:
         form_keys = zip.namelist()

--- a/tiled/serialization/awkward.py
+++ b/tiled/serialization/awkward.py
@@ -12,7 +12,7 @@ from ..utils import APACHE_ARROW_FILE_MIME_TYPE, modules_available
 
 
 @default_serialization_registry.register(StructureFamily.awkward, "application/zip")
-def to_zipped_buffers(components, metadata):
+def to_zipped_buffers(mimetype, components, metadata):
     (form, length, container) = components
     file = io.BytesIO()
     # Pack multiple buffers into a zipfile, uncompressed. This enables
@@ -26,7 +26,7 @@ def to_zipped_buffers(components, metadata):
 
 
 @default_deserialization_registry.register(StructureFamily.awkward, "application/zip")
-def from_zipped_buffers(buffer, form, length):
+def from_zipped_buffers(mimetype, buffer, form, length):
     file = io.BytesIO(buffer)
     with zipfile.ZipFile(file, "r") as zip:
         form_keys = zip.namelist()
@@ -37,7 +37,7 @@ def from_zipped_buffers(buffer, form, length):
 
 
 @default_serialization_registry.register(StructureFamily.awkward, "application/json")
-def to_json(components, metadata):
+def to_json(mimetype, components, metadata):
     (form, length, container) = components
     file = io.StringIO()
     array = awkward.from_buffers(form, length, container)
@@ -50,7 +50,7 @@ if modules_available("pyarrow"):
     @default_serialization_registry.register(
         StructureFamily.awkward, APACHE_ARROW_FILE_MIME_TYPE
     )
-    def to_arrow(components, metadata):
+    def to_arrow(mimetype, components, metadata):
         import pyarrow
 
         (form, length, container) = components
@@ -66,7 +66,7 @@ if modules_available("pyarrow"):
     @default_serialization_registry.register(
         StructureFamily.awkward, "application/x-parquet"
     )
-    def to_parquet(components, metadata):
+    def to_parquet(mimetype, components, metadata):
         import pyarrow.parquet
 
         (form, length, container) = components

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -44,7 +44,7 @@ async def walk(node, filter_for_access, pre=None):
 
 if modules_available("h5py"):
 
-    async def serialize_hdf5(node, metadata, filter_for_access):
+    async def serialize_hdf5(mimetype, node, metadata, filter_for_access):
         """
         Encode everything below this node as HDF5.
 
@@ -94,7 +94,7 @@ if modules_available("h5py"):
 
 if modules_available("orjson"):
 
-    async def serialize_json(node, metadata, filter_for_access):
+    async def serialize_json(mimetype, node, metadata, filter_for_access):
         "Export node to JSON, with each node having a 'contents' and 'metadata' sub-key."
         root_node = node
         to_serialize = {"contents": {}, "metadata": dict(root_node.metadata())}

--- a/tiled/serialization/sparse.py
+++ b/tiled/serialization/sparse.py
@@ -8,7 +8,7 @@ from ..utils import modules_available
 
 if modules_available("h5py"):
 
-    def serialize_hdf5(sparse_arr, metadata):
+    def serialize_hdf5(mimetype, sparse_arr, metadata):
         """
         Place coords and data in HDF5 datasets with those names.
         """
@@ -45,7 +45,7 @@ if modules_available("pandas", "pyarrow"):
         default_serialization_registry.register(
             "sparse",
             XLSX_MIME_TYPE,
-            lambda sparse_arr, metadata: serialize_excel(
+            lambda mimetype, sparse_arr, metadata: serialize_excel(
                 to_dataframe(sparse_arr), metadata, preserve_index=False
             ),
         )
@@ -58,47 +58,49 @@ if modules_available("pandas", "pyarrow"):
         return pandas.DataFrame(d)
 
     default_deserialization_registry.register(
-        "sparse", APACHE_ARROW_FILE_MIME_TYPE, deserialize_arrow
+        "sparse",
+        APACHE_ARROW_FILE_MIME_TYPE,
+        lambda mimetype, buffer: deserialize_arrow(buffer),
     )
     default_serialization_registry.register(
         "sparse",
         APACHE_ARROW_FILE_MIME_TYPE,
-        lambda sparse_arr, metadata: serialize_arrow(
+        lambda mimetype, sparse_arr, metadata: serialize_arrow(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     default_serialization_registry.register(
         "sparse",
         "application/x-parquet",
-        lambda sparse_arr, metadata: serialize_parquet(
+        lambda mimetype, sparse_arr, metadata: serialize_parquet(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     default_serialization_registry.register(
         "sparse",
         "text/csv",
-        lambda sparse_arr, metadata: serialize_csv(
+        lambda mimetype, sparse_arr, metadata: serialize_csv(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     default_serialization_registry.register(
         "sparse",
         "text/plain",
-        lambda sparse_arr, metadata: serialize_csv(
+        lambda mimetype, sparse_arr, metadata: serialize_csv(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     default_serialization_registry.register(
         "sparse",
         "text/html",
-        lambda sparse_arr, metadata: serialize_html(
+        lambda mimetype, sparse_arr, metadata: serialize_html(
             to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     if modules_available("orjson"):
         import orjson
 
-        def serialize_json(sparse_arr, metadata):
+        def serialize_json(mimetype, sparse_arr, metadata):
             df = to_dataframe(sparse_arr)
             return orjson.dumps(
                 {column: df[column].tolist() for column in df},

--- a/tiled/serialization/sparse.py
+++ b/tiled/serialization/sparse.py
@@ -66,7 +66,7 @@ if modules_available("pandas", "pyarrow"):
         "sparse",
         APACHE_ARROW_FILE_MIME_TYPE,
         lambda mimetype, sparse_arr, metadata: serialize_arrow(
-            to_dataframe(sparse_arr), metadata, preserve_index=False
+            mimetype, to_dataframe(sparse_arr), metadata, preserve_index=False
         ),
     )
     default_serialization_registry.register(

--- a/tiled/serialization/sparse.py
+++ b/tiled/serialization/sparse.py
@@ -60,7 +60,7 @@ if modules_available("pandas", "pyarrow"):
     default_deserialization_registry.register(
         "sparse",
         APACHE_ARROW_FILE_MIME_TYPE,
-        lambda mimetype, buffer: deserialize_arrow(buffer),
+        lambda buffer: deserialize_arrow(buffer),
     )
     default_serialization_registry.register(
         "sparse",

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -12,7 +12,7 @@ from ..utils import APACHE_ARROW_FILE_MIME_TYPE, XLSX_MIME_TYPE, modules_availab
 @default_serialization_registry.register(
     StructureFamily.table, APACHE_ARROW_FILE_MIME_TYPE
 )
-def serialize_arrow(df, metadata, preserve_index=True):
+def serialize_arrow(mimetype, df, metadata, preserve_index=True):
     import pyarrow
 
     if isinstance(df, pyarrow.Table):
@@ -30,7 +30,7 @@ def serialize_arrow(df, metadata, preserve_index=True):
 @default_deserialization_registry.register(
     StructureFamily.table, APACHE_ARROW_FILE_MIME_TYPE
 )
-def deserialize_arrow(buffer):
+def deserialize_arrow(mimetype, buffer):
     import pyarrow
 
     return pyarrow.ipc.open_file(buffer).read_pandas()
@@ -39,7 +39,7 @@ def deserialize_arrow(buffer):
 # There seems to be no official Parquet MIME type.
 # https://issues.apache.org/jira/browse/PARQUET-1889
 @default_serialization_registry.register(StructureFamily.table, "application/x-parquet")
-def serialize_parquet(df, metadata, preserve_index=True):
+def serialize_parquet(mimetype, df, metadata, preserve_index=True):
     import pyarrow.parquet
 
     table = pyarrow.Table.from_pandas(df, preserve_index=preserve_index)
@@ -49,14 +49,14 @@ def serialize_parquet(df, metadata, preserve_index=True):
     return memoryview(sink.getvalue())
 
 
-def serialize_csv(df, metadata, preserve_index=False):
+def serialize_csv(mimetype, df, metadata, preserve_index=False):
     file = io.StringIO()
     df.to_csv(file, index=preserve_index)
     return file.getvalue().encode()
 
 
 @default_deserialization_registry.register(StructureFamily.table, "text/csv")
-def deserialize_csv(buffer):
+def deserialize_csv(mimetype, buffer):
     import pandas
 
     return pandas.read_csv(io.BytesIO(buffer), header=None)
@@ -77,7 +77,7 @@ default_serialization_registry.register(
 
 
 @default_serialization_registry.register(StructureFamily.table, "text/html")
-def serialize_html(df, metadata, preserve_index=False):
+def serialize_html(mimetype, df, metadata, preserve_index=False):
     file = io.StringIO()
     df.to_html(file, index=preserve_index)
     return file.getvalue().encode()
@@ -88,13 +88,15 @@ if modules_available("openpyxl", "pandas"):
     import pandas
 
     @default_serialization_registry.register(StructureFamily.table, XLSX_MIME_TYPE)
-    def serialize_excel(df, metadata, preserve_index=False):
+    def serialize_excel(mimetype, df, metadata, preserve_index=False):
         file = io.BytesIO()
         df.to_excel(file, index=preserve_index)
         return file.getbuffer()
 
     default_deserialization_registry.register(
-        StructureFamily.table, XLSX_MIME_TYPE, pandas.read_excel
+        StructureFamily.table,
+        XLSX_MIME_TYPE,
+        lambda mimetype, buffer: pandas.read_excel(buffer),
     )
     mimetypes.types_map.setdefault(".xlsx", XLSX_MIME_TYPE)
 if modules_available("orjson"):
@@ -103,7 +105,7 @@ if modules_available("orjson"):
     default_serialization_registry.register(
         StructureFamily.table,
         "application/json",
-        lambda df, metadata: orjson.dumps(
+        lambda mimetype, df, metadata: orjson.dumps(
             {column: df[column].tolist() for column in df},
         ),
     )
@@ -121,7 +123,7 @@ if modules_available("orjson"):
         StructureFamily.table,
         "application/json-seq",  # official mimetype for newline-delimited JSON
     )
-    def json_sequence(df, metadata):
+    def json_sequence(mimetype, df, metadata):
         if rows := df.to_dict(orient="records"):
             # The first row is a special case; the rest start with a newline.
             yield orjson.dumps(rows[0])

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -57,11 +57,8 @@ def serialize_parquet(mimetype, df, metadata, preserve_index=True):
 def serialize_csv(mimetype, df, metadata, preserve_index=False):
     file = io.StringIO()
     opt_params = parse_mimetype(mimetype)[1]
-    if "header" in opt_params:
-        if opt_params["header"] == "absent":
-            df.to_csv(file, index=preserve_index, header=False)
-            return file.getvalue().encode()
-    df.to_csv(file, index=preserve_index)
+    include_header = opt_params.get("header", "present") != "absent"
+    df.to_csv(file, header=include_header, index=preserve_index)
     return file.getvalue().encode()
 
 

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -51,6 +51,11 @@ def serialize_parquet(mimetype, df, metadata, preserve_index=True):
 
 def serialize_csv(mimetype, df, metadata, preserve_index=False):
     file = io.StringIO()
+    if ";" in mimetype:
+        opt_param = mimetype.split(";")[1:][0]
+        if "header" in opt_param and "absent" in opt_param:
+            df.to_csv(file, index=preserve_index, header=False)
+            return file.getvalue().encode()
     df.to_csv(file, index=preserve_index)
     return file.getvalue().encode()
 

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -6,7 +6,12 @@ from ..media_type_registration import (
     default_serialization_registry,
 )
 from ..structures.core import StructureFamily
-from ..utils import APACHE_ARROW_FILE_MIME_TYPE, XLSX_MIME_TYPE, modules_available
+from ..utils import (
+    APACHE_ARROW_FILE_MIME_TYPE,
+    XLSX_MIME_TYPE,
+    modules_available,
+    parse_mimetype,
+)
 
 
 @default_serialization_registry.register(
@@ -51,9 +56,9 @@ def serialize_parquet(mimetype, df, metadata, preserve_index=True):
 
 def serialize_csv(mimetype, df, metadata, preserve_index=False):
     file = io.StringIO()
-    if ";" in mimetype:
-        opt_param = mimetype.split(";")[1:][0]
-        if "header" in opt_param and "absent" in opt_param:
+    opt_params = parse_mimetype(mimetype)[1]
+    if "header" in opt_params:
+        if opt_params["header"] == "absent":
             df.to_csv(file, index=preserve_index, header=False)
             return file.getvalue().encode()
     df.to_csv(file, index=preserve_index)

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -30,7 +30,7 @@ def serialize_arrow(mimetype, df, metadata, preserve_index=True):
 @default_deserialization_registry.register(
     StructureFamily.table, APACHE_ARROW_FILE_MIME_TYPE
 )
-def deserialize_arrow(mimetype, buffer):
+def deserialize_arrow(buffer):
     import pyarrow
 
     return pyarrow.ipc.open_file(buffer).read_pandas()

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -52,7 +52,7 @@ if modules_available("scipy"):
     @default_serialization_registry.register(
         "xarray_dataset", ["application/netcdf", "application/x-netcdf"]
     )
-    async def serialize_netcdf(node, metadata, filter_for_access):
+    async def serialize_netcdf(mimetype, node, metadata, filter_for_access):
         file = _BytesIOThatIgnoresClose()
         # Per the xarray.Dataset.to_netcdf documentation,
         # file-like objects are only supported by the scipy engine.
@@ -66,29 +66,29 @@ if modules_available("scipy"):
 
 
 @default_serialization_registry.register("xarray_dataset", APACHE_ARROW_FILE_MIME_TYPE)
-async def serialize_dataset_arrow(node, metadata, filter_for_access):
+async def serialize_dataset_arrow(mimetype, node, metadata, filter_for_access):
     return serialize_arrow((await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", "application/x-parquet")
-async def serialize_dataset_parquet(node, metadata, filter_for_access):
+async def serialize_dataset_parquet(mimetype, node, metadata, filter_for_access):
     return serialize_parquet((await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register(
     "xarray_dataset", ["text/csv", "text/comma-separated-values", "text/plain"]
 )
-async def serialize_dataset_csv(node, metadata, filter_for_access):
+async def serialize_dataset_csv(mimetype, node, metadata, filter_for_access):
     return serialize_csv((await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", "text/html")
-async def serialize_dataset_html(node, metadata, filter_for_access):
+async def serialize_dataset_html(mimetype, node, metadata, filter_for_access):
     return serialize_html((await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", XLSX_MIME_TYPE)
-async def serialize_dataset_excel(node, metadata, filter_for_access):
+async def serialize_dataset_excel(mimetype, node, metadata, filter_for_access):
     return serialize_excel((await as_dataset(node)).to_dataframe(), metadata)
 
 
@@ -96,7 +96,7 @@ if modules_available("orjson"):
     import orjson
 
     @default_serialization_registry.register("xarray_dataset", "application/json")
-    async def serialize_json(node, metadata, filter_for_access):
+    async def serialize_json(mimetype, node, metadata, filter_for_access):
         df = (await as_dataset(node)).to_dataframe()
         return orjson.dumps(
             {column: df[column].tolist() for column in df},
@@ -106,7 +106,7 @@ if modules_available("orjson"):
 if modules_available("h5py"):
 
     @default_serialization_registry.register("xarray_dataset", "application/x-hdf5")
-    async def serialize_hdf5(node, metadata, filter_for_access):
+    async def serialize_hdf5(mimetype, node, metadata, filter_for_access):
         """
         Like for node, but encode everything under 'attrs' in attrs.
         """

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -67,29 +67,29 @@ if modules_available("scipy"):
 
 @default_serialization_registry.register("xarray_dataset", APACHE_ARROW_FILE_MIME_TYPE)
 async def serialize_dataset_arrow(mimetype, node, metadata, filter_for_access):
-    return serialize_arrow((await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_arrow(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", "application/x-parquet")
 async def serialize_dataset_parquet(mimetype, node, metadata, filter_for_access):
-    return serialize_parquet((await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_parquet(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register(
     "xarray_dataset", ["text/csv", "text/comma-separated-values", "text/plain"]
 )
 async def serialize_dataset_csv(mimetype, node, metadata, filter_for_access):
-    return serialize_csv((await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_csv(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", "text/html")
 async def serialize_dataset_html(mimetype, node, metadata, filter_for_access):
-    return serialize_html((await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_html(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
 
 
 @default_serialization_registry.register("xarray_dataset", XLSX_MIME_TYPE)
 async def serialize_dataset_excel(mimetype, node, metadata, filter_for_access):
-    return serialize_excel((await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_excel(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
 
 
 if modules_available("orjson"):

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -72,7 +72,9 @@ async def serialize_dataset_arrow(mimetype, node, metadata, filter_for_access):
 
 @default_serialization_registry.register("xarray_dataset", "application/x-parquet")
 async def serialize_dataset_parquet(mimetype, node, metadata, filter_for_access):
-    return serialize_parquet(mimetype, (await as_dataset(node)).to_dataframe(), metadata)
+    return serialize_parquet(
+        mimetype, (await as_dataset(node)).to_dataframe(), metadata
+    )
 
 
 @default_serialization_registry.register(

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -97,13 +97,13 @@ def pagination_links(base_url, route, path_parts, offset, limit, length_hint):
             }
         )
     if offset + limit < length_hint:
-        links["next"] = (
-            f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
-        )
+        links[
+            "next"
+        ] = f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
     if offset > 0:
-        links["prev"] = (
-            f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
-        )
+        links[
+            "prev"
+    ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
     return links
 
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -103,7 +103,7 @@ def pagination_links(base_url, route, path_parts, offset, limit, length_hint):
     if offset > 0:
         links[
             "prev"
-    ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
+        ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
     return links
 
 

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -850,14 +850,17 @@ class catch_warning_msg(warnings.catch_warnings):
 
 
 def parse_mimetype(mimetype: str) -> tuple[str, dict]:
-    params = mimetype.split(";")
-    mimetp = params[0]
-    opt_params_ls = params[1:]
-    opt_params_dict = {}
-    for item in opt_params_ls:
-        opt_param = item.split("=")
-        if len(opt_param) == 2:
-            opt_params_dict[opt_param[0]] = opt_param[1]
-        else:
-            raise ValueError(f"Incorrect value passed as opt parameter: {opt_param}")
-    return mimetp, opt_params_dict
+    """
+    Parse 'text/csv;header=absent' -> ('text/csv', {'header': 'absent'})
+    """
+    base, *param_tokens = mimetype.split(";")
+    params = {}
+    for item in param_tokens:
+        try:
+            key, value = item.strip().split("=", 2)
+        except Exception:
+            raise ValueError(
+                f"Could not parse {item} as 'key=value' mimetype parameter"
+            )
+        params[key] = value
+    return base, params

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -847,3 +847,17 @@ class catch_warning_msg(warnings.catch_warnings):
         super().__enter__()
         self.apply_filter()
         return self
+
+
+def parse_mimetype(mimetype: str) -> tuple[str, dict]:
+    params = mimetype.split(";")
+    mimetp = params[0]
+    opt_params_ls = params[1:]
+    opt_params_dict = {}
+    for item in opt_params_ls:
+        opt_param = item.split("=")
+        if len(opt_param) == 2:
+            opt_params_dict[opt_param[0]] = opt_param[1]
+        else:
+            raise ValueError(f"Incorrect value passed as opt parameter: {opt_param}")
+    return mimetp, opt_params_dict


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

This PR closes #919

With this PR, we are adding the option of passing additional/optional parameters for mimetypes that can be used to modify the export of data