### PR TITLE
fix: Allow release notes to propagate into automated update PRs

### DIFF
--- a/helm/tiled/Chart.yaml
+++ b/helm/tiled/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: tiled
+home: https://github.com/bluesky/tiled
 description: Tiled is a data access service for data-aware portals and data science tools.
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
By adding `home` field to the Helm chart, we allow Renovate to propagate either a link to the chart or release notes into the automated PR it makes.

cite: https://github.com/renovatebot/renovate/blob/39fb4207bc268ea83114b58bc0414339620c7416/lib/modules/datasource/helm/index.ts#L29

Draft until an example PR gets raised by Renovate so I can point to it.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
