### PR TITLE
Publish container image when merged to main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.ref == 'refs/heads/main'
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
### Checklist
- [ ] Add a Changelog entry

It is often handy to test containers from main. I really think Tiled used to do this.