### PR TITLE
Use clearer error message when server config is non-file

### DIFF
--- a/tiled/config.py
+++ b/tiled/config.py
@@ -349,7 +349,10 @@ def parse_configs(config_path):
     elif not config_path.exists():
         raise ValueError(f"The config path {config_path!s} doesn't exist.")
     else:
-        assert False, "It should be impossible to reach this line."
+        # the path points to something we don't support, eg fifo/block_device/etc
+        raise ValueError(
+            f"The config path {config_path!s} exists but is not a file or directory."
+        )
 
     parsed_configs = {}
     # The sorting here is just to make the order of the results deterministic.


### PR DESCRIPTION
`assert False` is currently used as the comment assumes it is
unreachable but the 'impossible to reach' state can be reached if a
non-normal file is passed as config, for instance

    mkfifo /tmp/demo
    TILED_CONFIG=/tmp/demo uvicorn tiled.server.app:app

would result in 'AssertionError: It should be impossible to reach this
line.'
