### PR TITLE
Separate CLI client/server deps

### DIFF
--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -5,8 +5,6 @@ from typing import List, Optional
 
 import typer
 
-from tiled.server.settings import get_settings
-
 serve_app = typer.Typer(no_args_is_help=True)
 
 SQLITE_CATALOG_FILENAME = "catalog.db"
@@ -194,6 +192,10 @@ def serve_directory(
     if api_key is None:
         api_key = os.getenv("TILED_SINGLE_USER_API_KEY")
         if api_key is None:
+            # Lazily import server settings here to avoid server dependencies
+            # in client-only environments.
+            from tiled.server.settings import get_settings
+
             api_key = get_settings().single_user_api_key
             generated = True
 


### PR DESCRIPTION
The changes from #1011 introduce breaking changes to "client-only" deployments -- forcing server dependencies to be installed.

This PR updates the CLI `serve` command to import the server settings only when this command is called.  This enables client-only environments to use client CLI commands without installing `tiled[server]` dependencies.

Resolves #1029.

### Checklist
- [ ] Add a Changelog entry
- [X] Add the ticket number which this PR closes to the comment section
