### PR TITLE
Add Connection Pooling for Storage DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## v0.1.0-b31 (Unreleased)
 
+### Added
+
+- Pooling of ADBC connections to storage databases.
+
 ### Fixed
 
 - Tests were missing assertions to verify expected outcomes

--- a/tiled/_tests/adapters/test_sql_types.py
+++ b/tiled/_tests/adapters/test_sql_types.py
@@ -234,7 +234,8 @@ def test_data_types(
     query = arrow_schema_to_create_table(table.schema, test_table_name, dialect)
 
     storage_cls = RemoteSQLStorage if dialect == "postgresql" else EmbeddedSQLStorage
-    conn = storage_cls(uri=db_uri).connect()
+    storage = storage_cls(uri=db_uri)
+    conn = storage.connect()
 
     with conn.cursor() as cursor:
         cursor.execute(query)
@@ -266,3 +267,4 @@ def test_data_types(
     assert result.cast(table.schema) == table
 
     conn.close()
+    storage.dispose()  # Close all connections

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1572,10 +1572,6 @@ def from_uri(
         echo=echo,
         json_serializer=json_serializer,
         poolclass=poolclass,
-        pool_size=50,  # default is 5
-        max_overflow=10,  # additional connections beyond the pool size
-        pool_timeout=30,  # wait for 30 seconds if no connections are available
-        pool_recycle=3600,  # recycle connections after 1 hour
     )
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1572,6 +1572,10 @@ def from_uri(
         echo=echo,
         json_serializer=json_serializer,
         poolclass=poolclass,
+        pool_size=50,  # default is 5
+        max_overflow=10,  # additional connections beyond the pool size
+        pool_timeout=30,  # wait for 30 seconds if no connections are available
+        pool_recycle=3600,  # recycle connections after 1 hour
     )
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -55,7 +55,7 @@ def construct_build_app_kwargs(
     The parameters query_registry, compression_registry, and
     serialization_registry are used by the tests to inject separate registry
     instances. By default, the singleton global instances of these registries
-    and used (and modified).
+    are used (and modified).
     """
     config = copy.deepcopy(config)  # Avoid mutating input.
     startup_tasks = []

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -113,6 +113,11 @@ class EmbeddedSQLStorage(SQLStorage):
 
             return adbc_driver_sqlite.dbapi.connect(str(filepath))
 
+        else:
+            raise ValueError(
+                f"Unsupported URI scheme {self.uri}: use 'duckdb:' or 'sqlite:'"
+            )
+
 
 @dataclasses.dataclass(frozen=True)
 class RemoteSQLStorage(SQLStorage):
@@ -122,6 +127,9 @@ class RemoteSQLStorage(SQLStorage):
 
     def __post_init__(self):
         # Ensure the URI is sanitized and credentials are stored separately
+        if not self.uri.startswith("postgresql:"):
+            raise ValueError(f"Unsupported URI scheme {self.uri}: use 'postgresql:'")
+
         uri, username, password = sanitize_uri(self.uri)
         if (username is not None) or (password is not None):
             if (self.username is not None) or (self.password is not None):

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -1,8 +1,15 @@
 import dataclasses
 import functools
+import os
+from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 from urllib.parse import urlparse, urlunparse
+
+import sqlalchemy.pool
+
+if TYPE_CHECKING:
+    import adbc_driver_manager.dbapi
 
 from .utils import ensure_uri, path_from_uri
 
@@ -34,14 +41,71 @@ class FileStorage(Storage):
         return path_from_uri(self.uri)
 
 
-@dataclasses.dataclass(frozen=True)
-class EmbeddedSQLStorage(Storage):
-    "File-based SQL database storage location"
+def _ensure_writable_location(uri: str) -> Path:
+    "Ensure path is writable to avoid a confusing error message from driver."
+    filepath = path_from_uri(uri)
+    directory = Path(filepath).parent
+    if directory.exists():
+        if not os.access(directory, os.X_OK | os.W_OK):
+            raise ValueError(
+                f"The directory {directory} exists but is not writable and executable."
+            )
+        if Path(filepath).is_file() and (not os.access(filepath, os.W_OK)):
+            raise ValueError(f"The path {filepath} exists but is not writable.")
+    else:
+        raise ValueError(f"The directory {directory} does not exist.")
+    return filepath
 
 
 @dataclasses.dataclass(frozen=True)
 class SQLStorage(Storage):
+    "General purpose SQL database storage with connection pooling"
+
+    @abstractmethod
+    def create_adbc_connection(self) -> "adbc_driver_manager.dbapi.Connection":
+        "Create a connection to the database."
+
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    @property
+    def dialect(self) -> str:
+        "The database dialect (e.g. 'postgresql', 'sqlite', or 'duckdb')."
+        return urlparse(self.uri).scheme
+
+    @functools.cached_property
+    def _connection_pool(self) -> "sqlalchemy.pool.QueuePool":
+        source = self.create_adbc_connection().adbc_clone
+        if (self.dialect == "duckdb") or (":memory:" in self.uri):
+            return sqlalchemy.pool.StaticPool(source)
+        else:
+            return sqlalchemy.pool.QueuePool(source, pool_size=3, max_overflow=0)
+
+    def connect(self) -> "adbc_driver_manager.dbapi.Connection":
+        "Get a connection from the pool."
+        return self._connection_pool.connect()
+
+
+@dataclasses.dataclass(frozen=True)
+class EmbeddedSQLStorage(SQLStorage):
     "File-based SQL database storage location"
+
+    def create_adbc_connection(self) -> "adbc_driver_manager.dbapi.Connection":
+        filepath = _ensure_writable_location(self.uri)
+
+        if self.uri.startswith("duckdb:"):
+            import adbc_driver_duckdb.dbapi
+
+            return adbc_driver_duckdb.dbapi.connect(str(filepath))
+
+        elif self.uri.startswith("sqlite:"):
+            import adbc_driver_sqlite.dbapi
+
+            return adbc_driver_sqlite.dbapi.connect(str(filepath))
+
+
+@dataclasses.dataclass(frozen=True)
+class RemoteSQLStorage(SQLStorage):
+    "Authenticated server-based SQL database storage location"
     username: Optional[str] = None
     password: Optional[str] = None
 
@@ -84,8 +148,14 @@ class SQLStorage(Storage):
 
         return urlunparse(components)
 
+    def create_adbc_connection(self) -> "adbc_driver_manager.dbapi.Connection":
+        import adbc_driver_postgresql.dbapi
+
+        return adbc_driver_postgresql.dbapi.connect(self.authenticated_uri)
+
 
 def parse_storage(item: Union[Path, str]) -> Storage:
+    "Create a Storage object from a URI or Path."
     item = ensure_uri(item)
     scheme = urlparse(item).scheme
     if scheme == "file":

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -763,7 +763,6 @@ def ensure_uri(uri_or_path) -> str:
 
 def sanitize_uri(uri: str) -> tuple[str, Optional[str], Optional[str]]:
     "Remove the username and password from uri if they are present."
-    username, password = None, None
     parsed_uri = urlparse(uri)
     netloc = parsed_uri.netloc
     if "@" in netloc:
@@ -772,7 +771,7 @@ def sanitize_uri(uri: str) -> tuple[str, Optional[str], Optional[str]]:
         if ":" in auth:
             username, password = auth.split(":", 1)
         else:
-            username = auth
+            username, password = auth, None
         # Create clean components with the updated netloc
         clean_components = (
             parsed_uri.scheme,
@@ -782,8 +781,9 @@ def sanitize_uri(uri: str) -> tuple[str, Optional[str], Optional[str]]:
             parsed_uri.query,
             parsed_uri.fragment,
         )
+        return urlunparse(clean_components), username, password
 
-    return urlunparse(clean_components), username, password
+    return uri, None, None
 
 
 SCHEME_TO_SCHEME_PLUS_DRIVER = {


### PR DESCRIPTION
Add pooling for ADBC connections to storage databases. This implementation follows the official [suggested solution](https://github.com/apache/arrow-adbc/blob/main/docs/source/python/recipe/postgresql_pool.py) from Arrow, which instantiates a sqlalchemy `QueuePool` with a custom `creator` object set to an instance of an ADBC connection.

Furthermore, it is ensured that `SQLAdapter` closes (returns to the pool) the connection once it is done writing/reading the data. Additional method is added to the `SQLStorage` class to dispose of the pool when the server is shutting down to release the DB resources.

This prevents the Tiled server from swarming the DB with extra connections and significantly reduces the CPU load.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
