### PR TITLE
Type hints for Database objects

### DIFF
--- a/tiled/authn_database/base.py
+++ b/tiled/authn_database/base.py
@@ -1,5 +1,7 @@
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase
+
 
 # Everything imports this so we put it in its own module to
 # avoid circular imports.
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -33,7 +33,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, REGCONFIG, TEXT
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import selectinload
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from sqlalchemy.sql.expression import cast
@@ -769,7 +769,7 @@ class CatalogNodeAdapter:
             ).scalar()
             return key, type(self)(self.context, refreshed_node)
 
-    async def _put_asset(self, db, asset):
+    async def _put_asset(self, db: AsyncSession, asset):
         # Find an asset_id if it exists, otherwise create a new one
         statement = select(orm.Asset.id).where(orm.Asset.data_uri == asset.data_uri)
         result = await db.execute(statement)

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -423,7 +423,7 @@ async def create_pending_session(db):
 
 
 async def create_session(
-    settings, db, identity_provider, id, state: UserSessionState = None
+    settings, db: AsyncSession, identity_provider, id, state: UserSessionState = None
 ):
     # Have we seen this Identity before?
     identity = (
@@ -482,7 +482,7 @@ async def create_session(
     return fully_loaded_session
 
 
-async def create_tokens_from_session(settings, db, session, provider):
+async def create_tokens_from_session(settings, db: AsyncSession, session, provider):
     # Provide enough information in the access token to reconstruct Principal
     # and its Identities sufficient for access policy enforcement without a
     # database hit.
@@ -747,7 +747,7 @@ def add_internal_routes(
         return tokens
 
 
-async def generate_apikey(db, principal, apikey_params, request):
+async def generate_apikey(db: AsyncSession, principal, apikey_params, request):
     if apikey_params.scopes is None:
         scopes = ["inherit"]
     else:


### PR DESCRIPTION
Uses the DeclarativeBase class as a the base for ORM models, which is the recommended SQLAlchemy 2.0 way of getting type hinting. Additionally type hints methods that take an AsyncSession or AsyncEngine.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
