### PR TITLE
Added new registries to export tables and arrays as csv files on Windows

### DIFF
--- a/tiled/serialization/array.py
+++ b/tiled/serialization/array.py
@@ -51,6 +51,9 @@ default_serialization_registry.register(
     "array", "text/x-comma-separated-values", serialize_csv
 )
 default_serialization_registry.register("array", "text/plain", serialize_csv)
+default_serialization_registry.register(
+    "array", "application/vnd.ms-excel", serialize_csv
+)
 default_deserialization_registry.register(
     "array",
     "application/octet-stream",

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -71,6 +71,9 @@ default_serialization_registry.register(
 default_serialization_registry.register(
     StructureFamily.table, "text/plain", serialize_csv
 )
+default_serialization_registry.register(
+    StructureFamily.table, "application/vnd.ms-excel", serialize_csv
+)
 
 
 @default_serialization_registry.register(StructureFamily.table, "text/html")


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry

While running some tests for PR #991, I noticed that some export tests failed when I tried to run them in a Windows machine. After debugging the problem, I noticed that Windows uses application/vnd.ms-excel as a valid media type. I registered this media type for arrays and tables to fix the problem