### PR TITLE
Remove registry overrides when building app kwargs

### DIFF
--- a/tiled/config.py
+++ b/tiled/config.py
@@ -11,21 +11,18 @@ from collections import defaultdict
 from datetime import timedelta
 from functools import cache
 from pathlib import Path
-from typing import Optional
 
 import jsonschema
 
 from .adapters.mapping import MapAdapter
 from .media_type_registration import (
-    CompressionRegistry,
-    SerializationRegistry,
     default_compression_registry,
     default_deserialization_registry,
     default_serialization_registry,
 )
-from .query_registration import QueryRegistry, default_query_registry
+from .query_registration import default_query_registry
 from .utils import import_object, parse, prepend_to_sys_path
-from .validation_registration import ValidationRegistry, default_validation_registry
+from .validation_registration import default_validation_registry
 
 
 @cache
@@ -39,38 +36,17 @@ def schema():
         return yaml.safe_load(file)
 
 
-def construct_build_app_kwargs(
-    config,
-    *,
-    source_filepath=None,
-    query_registry: Optional[QueryRegistry] = None,
-    compression_registry: Optional[CompressionRegistry] = None,
-    serialization_registry: Optional[SerializationRegistry] = None,
-    deserialization_registry: Optional[SerializationRegistry] = None,
-    validation_registry: Optional[ValidationRegistry] = None,
-):
+def construct_build_app_kwargs(config, *, source_filepath=None):
     """
     Given parsed configuration, construct arguments for build_app(...).
 
-    The parameters query_registry, compression_registry, and
-    serialization_registry are used by the tests to inject separate registry
-    instances. By default, the singleton global instances of these registries
-    are used (and modified).
+    The singleton global instances of the registries are used (and modified).
     """
     config = copy.deepcopy(config)  # Avoid mutating input.
     startup_tasks = []
     shutdown_tasks = []
     background_tasks = []
-    if query_registry is None:
-        query_registry = default_query_registry
-    if serialization_registry is None:
-        serialization_registry = default_serialization_registry
-    if deserialization_registry is None:
-        deserialization_registry = default_deserialization_registry
-    if compression_registry is None:
-        compression_registry = default_compression_registry
-    if validation_registry is None:
-        validation_registry = default_validation_registry
+
     sys_path_additions = []
     if source_filepath:
         if os.path.isdir(source_filepath):
@@ -186,11 +162,11 @@ See documentation section "Serve a Directory of Files"."""
         for structure_family, values in config.get("media_types", {}).items():
             for media_type, import_path in values.items():
                 serializer = import_object(import_path, accept_live_object=True)
-                serialization_registry.register(
+                default_serialization_registry.register(
                     structure_family, media_type, serializer
                 )
         for ext, media_type in config.get("file_extensions", {}).items():
-            serialization_registry.register_alias(ext, media_type)
+            default_serialization_registry.register_alias(ext, media_type)
 
         for item in config.get("specs", []):
             if "validator" in item:
@@ -198,18 +174,18 @@ See documentation section "Serve a Directory of Files"."""
             else:
                 # no-op
                 validator = _no_op_validator
-            validation_registry.register(item["spec"], validator)
+            default_validation_registry.register(item["spec"], validator)
 
     # TODO Make compression_registry extensible via configuration.
     return {
         "tree": root_tree,
         "authentication": auth_spec,
         "server_settings": server_settings,
-        "query_registry": query_registry,
-        "serialization_registry": serialization_registry,
-        "deserialization_registry": deserialization_registry,
-        "compression_registry": compression_registry,
-        "validation_registry": validation_registry,
+        "query_registry": default_query_registry,
+        "serialization_registry": default_serialization_registry,
+        "deserialization_registry": default_deserialization_registry,
+        "compression_registry": default_compression_registry,
+        "validation_registry": default_validation_registry,
         "tasks": {
             "startup": startup_tasks,
             "shutdown": shutdown_tasks,


### PR DESCRIPTION
These were (per the comments) intended to be used for testing but do not
appear to be used anywhere.
