### PR TITLE
Tolerate missing access blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
   of Closure Table to track ancestors and descendands of the nodes.
 - Shorter string representation of chunks in `ArrayClient`.
 - Refactored internal Zarr version detection
+- For compatibility with older clients, do not require metadata updates to include
+  an `access_blob` in the body of the request.
 
 ### Fixed
 

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -533,7 +533,9 @@ class PatchMetadataRequest(HyphenizedBaseModel):
     # These fields are optional because None means "no changes; do not update".
     # Dict for merge-patch:
     # Define an alias to override parent class alias generator
-    access_blob: Optional[Union[List[JSONPatchAny], Dict]] = Field(alias="access_blob")
+    access_blob: Optional[Union[List[JSONPatchAny], Dict]] = Field(
+        alias="access_blob", default=None
+    )
 
     @pydantic.field_validator("specs")
     def specs_uniqueness_validator(cls, v):


### PR DESCRIPTION
Closes #1079 

This is not easy to test with unit tests, with our current harness at least, because it must be tested with an older version of Tiled. I tested it interactively with hand-crafted requests.

On the `main` branch I can reproduce the reported error:

```
❯ echo '{"specs": [], "content-type": "application/json-merge-patch"}' | http PATCH :8000/api/v1/metadata/x 'Authorization:Apikey secret'
HTTP/1.1 422 Unprocessable Entity
content-length: 150
content-type: application/json
date: Tue, 12 Aug 2025 20:06:21 GMT
server: uvicorn
server-timing: app;dur=4.5
set-cookie: tiled_csrf=Yu7EiRepAUpr5g-d3TFWItFxXZNHwqks9iMOtAvbemo; HttpOnly; Path=/; SameSite=lax
x-tiled-request-id: 9d21ca949a1b9eb9

{
    "detail": [
        {
            "input": {
                "content-type": "application/json-merge-patch",
                "specs": []
            },
            "loc": [
                "body",
                "access_blob"
            ],
            "msg": "Field required",
            "type": "missing"
        }
    ]
}
```

With this PR branch, updating the `metadata` but omitted an `access_blob`:

```
echo '{"specs": [], "metadata": [{"op": "add", "path": "/test", "value": "hi"}], "content-type": "application/json-patch+json"}' | http PATCH :8000/api/v1/metadata/x 'Authorization:Apikey secret'
HTTP/1.1 200 OK
content-length: 10
content-type: application/json
date: Tue, 12 Aug 2025 20:10:19 GMT
etag: 2044bba0abcfe4f9f3eed13e80b07cfe
server: uvicorn
server-timing: tok;dur=0.0, pack;dur=0.0, app;dur=19.8
set-cookie: tiled_csrf=-o_S7mn4aoDYozq4oGA2ra06w-Be1tEzXEJCtEwrtvI; HttpOnly; Path=/; SameSite=lax
x-tiled-request-id: fa2890e1ca3c8122

{
    "id": "x"
}
```

Confirming that the update worked:

```
❯ http :8000/api/v1/metadata/x 'Authorization:Apikey secret' | jq .data.attributes.metadata
{
  "test": "hi"
}
```

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
