### PR TITLE
Add access_blob column to revisions table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## v0.1.0-b33 (Unreleased)
 
+_This release requires a database migration of the catalog database._
+
+```none
+tiled catalog upgrade-database [postgresql://.. | sqlite:///...]
+```
+
 ### Added
 
 - Endpoints for (read) data access with zarr v2 and v3 protocols.
@@ -25,7 +31,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Uniform array columns read from Postgres/DuckDB are now aggregated to an
   NDArray (e.g. scanned `waveform` PVs)
 - Support for deleting separate nodes and contents of containers in client API.
-
+- The database migration in v0.1.0-b27 was incomplete, and missed an update to
+  the `revisions` table necessary to make metadata updates work correctly.
+  This is resolved by an additional database migration.
 
 ## v0.1.0-b32 (2025-08-04)
 

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "a963a6c32a0c",
     "e05e918092c3",
     "7809873ea2c7",
     "9331ed94d6ac",

--- a/tiled/catalog/migrations/versions/a963a6c32a0c_add_access_blob_column_to_revisions.py
+++ b/tiled/catalog/migrations/versions/a963a6c32a0c_add_access_blob_column_to_revisions.py
@@ -1,0 +1,28 @@
+"""Add access_blob column to revisions
+
+Revision ID: a963a6c32a0c
+Revises: e05e918092c3
+Create Date: 2025-08-12 16:22:07.744963
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.catalog.orm import JSONVariant
+
+# revision identifiers, used by Alembic.
+revision = "a963a6c32a0c"
+down_revision = "e05e918092c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "revisions",
+        sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}"),
+    )
+
+
+def downgrade():
+    op.drop_column("revisions", "access_blob")


### PR DESCRIPTION
CI exercises this migration. I've also tested it interactively.

Closes #1080 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
