### PR TITLE
fix: Correct indentation in service config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ tiled catalog upgrade-database [postgresql://.. | sqlite:///...]
 - The database migration in v0.1.0-b27 was incomplete, and missed an update to
   the `revisions` table necessary to make metadata updates work correctly.
   This is resolved by an additional database migration.
+- Correct indentation of authenticator args field in the service config schema
+  and ensure it correctly validates configurations.
 
 ## v0.1.0-b32 (2025-08-04)
 

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -132,7 +132,7 @@ properties:
     properties:
       providers:
         type: array
-        item:
+        items:
           type: object
           additionalProperties: false
           required:
@@ -161,19 +161,19 @@ properties:
                 ```yaml
                 authenticator: tiled.examples.DummyAuthenticator
                 ```
+            args:
+              type: object
+              description: |
+                Named arguments to pass to Authenticator. If there are none,
+                `args` may be omitted or empty.
+
+                Example:
+
+                ```yaml
+                authenticator: tiled.examples.PAMAuthenticator
                 args:
-                  type: [object, "null"]
-                  description: |
-                    Named arguments to pass to Authenticator. If there are none,
-                    `args` may be omitted or empty.
-
-                    Example:
-
-                    ```yaml
-                    authenticator: tiled.examples.PAMAuthenticator
-                    args:
-                      service: "custom_service"
-                    ```
+                  service: "custom_service"
+                ```
       tiled_admins:
         type: array
         items:


### PR DESCRIPTION
The 'args' field was over indented making it part of the description of
the authenticator property. This would have prevented configurations
from being validated correctly if not for the item/items typo that meant
none of the authentication configuration was being checked.