### PR TITLE
Use Approximate Length for Large Containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         set -vxeuo pipefail
         uv run coverage run -m pytest -v
         uv run coverage report -m
+        uv run coverage xml -o cov.xml
       env:
         # Provide test suite with a PostgreSQL database to use.
         TILED_TEST_POSTGRESQL_URI: postgresql://postgres:secret@localhost:5432

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## v0.1.0-b35 (Unreleased)
+
+### Changed
+
+- Optimized the calculation of an approximate length of containers.
+
+
 ## v0.1.0-b34 (2025-08-14)
 
 ### Fixed
@@ -13,6 +20,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   database correct but unchanged. This release repairs the migration script; it
   should be re-run on any databases that could not be upgraded with the previous
   release.
+
 
 ## v0.1.0-b33 (2025-08-13)
 
@@ -49,6 +57,7 @@ tiled catalog upgrade-database [postgresql://.. | sqlite:///...]
   This is resolved by an additional database migration.
 - Correct indentation of authenticator args field in the service config schema
   and ensure it correctly validates configurations.
+
 
 ## v0.1.0-b32 (2025-08-04)
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -403,7 +403,7 @@ class CatalogNodeAdapter:
             # SQLite has no statistics tables, so we fall back to exact count.
             return None
 
-    async def lbound_len(self, threshold=5000) -> int:
+    async def lbound_len(self, threshold) -> int:
         """Get a fast lower bound on the number of child nodes.
 
         This only counts up to `threshold`+1 nodes, so is fast even for large

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -396,6 +396,8 @@ class CatalogNodeAdapter:
                             )
                         ).scalar_one()
                         return int(total * freq)
+                else:
+                    return None  # Statistics can not be obtained
 
         elif self.context.engine.dialect.name == "sqlite":
             # SQLite has no statistics tables, so we fall back to exact count.

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -348,9 +348,7 @@ class CatalogNodeAdapter:
         return statement
 
     async def async_len(self):
-        statement = select(func.count(orm.Node.key)).filter(
-            orm.Node.parent == self.node.id
-        )
+        statement = select(func.count()).filter(orm.Node.parent == self.node.id)
         statement = self.apply_conditions(statement)
         async with self.context.session() as db:
             return (await db.execute(statement)).scalar_one()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     exists,
     false,
     func,
+    literal,
     not_,
     or_,
     select,
@@ -347,9 +348,69 @@ class CatalogNodeAdapter:
             statement = statement.filter(condition)
         return statement
 
-    async def async_len(self):
+    async def exact_len(self):
+        "Get the exact number of child nodes."
         statement = select(func.count()).filter(orm.Node.parent == self.node.id)
         statement = self.apply_conditions(statement)
+        async with self.context.session() as db:
+            return (await db.execute(statement)).scalar_one()
+
+    async def approx_len(self) -> Optional[int]:
+        """Get an approximate number of child nodes using table statistics.
+
+        This only works for PostgreSQL databases and does not take into account
+        any filtering conditions. To be able to use these queries, the `nodes`
+        must be vacuumed and analyzed regularly (at least once).
+
+        If the database is not PostgreSQL, or if the statistics can not be
+        obtained, return None.
+        """
+
+        if self.context.engine.dialect.name == "postgresql":
+            async with self.context.session() as db:
+                parent_and_freqs = await db.execute(
+                    text(
+                        """
+                SELECT unnest(most_common_vals::text::int[])::int AS parent,
+                       unnest(most_common_freqs) AS freq
+                FROM pg_stats
+                WHERE schemaname = 'public' AND tablename = 'nodes' AND attname = 'parent';
+                                """
+                    )
+                )
+                for parent, freq in parent_and_freqs:
+                    if parent == self.node.id:
+                        total = (
+                            await db.execute(
+                                text(
+                                    """
+                            SELECT reltuples::bigint FROM pg_class
+                            WHERE  oid = 'public.nodes'::regclass;
+                                            """
+                                )
+                            )
+                        ).scalar_one()
+                        return int(total * freq)
+
+        elif self.context.engine.dialect.name == "sqlite":
+            # SQLite has no statistics tables, so we fall back to exact count.
+            return None
+
+    async def lbound_len(self, threshold=5000) -> int:
+        """Get a fast lower bound on the number of child nodes.
+
+        This only counts up to `threshold`+1 nodes, so is fast even for large
+        containers. If result is <= `threshold`, it is exact.
+        """
+
+        limited = (
+            select(literal(1))
+            .where(orm.Node.parent == self.node.id)
+            .limit(threshold + 1)
+        )
+        limited = self.apply_conditions(limited).cte("limited")
+        statement = select(func.count()).select_from(limited)
+
         async with self.context.session() as db:
             return (await db.execute(statement)).scalar_one()
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -350,8 +350,13 @@ class CatalogNodeAdapter:
 
     async def exact_len(self):
         "Get the exact number of child nodes."
-        statement = select(func.count()).filter(orm.Node.parent == self.node.id)
+        statement = (
+            select(func.count())
+            .select_from(orm.Node)
+            .filter(orm.Node.parent == self.node.id)
+        )
         statement = self.apply_conditions(statement)
+
         async with self.context.session() as db:
             return (await db.execute(statement)).scalar_one()
 
@@ -405,6 +410,7 @@ class CatalogNodeAdapter:
 
         limited = (
             select(literal(1))
+            .select_from(orm.Node)
             .where(orm.Node.parent == self.node.id)
             .limit(threshold + 1)
         )

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -171,9 +171,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         # If the contents of this node was provided in-line, there is an
         # implication that the contents are not expected to be dynamic. Used the
         # count provided in the structure.
-        structure = self.item["attributes"]["structure"]
-        if structure["contents"]:
-            return structure["count"]
+        if contents := self.item["attributes"]["structure"]["contents"]:
+            return len(contents)
+
         now = time.monotonic()
         if self._cached_len is not None:
             length, deadline = self._cached_len
@@ -189,7 +189,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                         headers={"Accept": MSGPACK_MIME_TYPE},
                         params={
                             **parse_qs(urlparse(link).query),
-                            "fields": "",
+                            "fields": "count",
                             **self._queries_as_params,
                             **self._sorting_params,
                         },

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -154,6 +154,7 @@ See documentation section "Serve a Directory of Files"."""
         server_settings["response_bytesize_limit"] = config.get(
             "response_bytesize_limit"
         )
+        server_settings["exact_count_limit"] = config.get("exact_count_limit")
         server_settings["database"] = config.get("database", {})
         server_settings["reject_undeclared_specs"] = config.get(
             "reject_undeclared_specs"

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -342,6 +342,12 @@ properties:
     description: |
       Maximum byte size of a response, given in bytes. The default is low (300 MB) keeping
       in mind that data is read into server memory and should generally be fetched in chunks.
+  exact_count_limit:
+    type: integer
+    description: |
+      The largest number of items in a container, for which the `/metadata` and `/search`
+      endpoints will return their exact count; this becomes the lower bound on the estimate if
+      an approximate number can not be obtained otherwise. The default is 100.
   allow_origins:
     type: array
     items:

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -454,6 +454,7 @@ def build_app(
         for item in [
             "allow_origins",
             "response_bytesize_limit",
+            "exact_count_limit",
             "reject_undeclared_specs",
             "expose_raw_assets",
         ]:

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -283,6 +283,7 @@ def get_router(
         root_tree=Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
         authn_scopes: Scopes = Depends(get_current_scopes),
+        settings: Settings = Depends(get_settings),
         _=Security(check_scopes, scopes=["read:metadata"]),
         **filters,
     ):
@@ -326,6 +327,7 @@ def get_router(
                 get_base_url(request),
                 resolve_media_type(request),
                 max_depth=max_depth,
+                exact_count_limit=settings.exact_count_limit,
             )
             # We only get one Expires header, so if different parts
             # of this response become stale at different times, we
@@ -421,6 +423,7 @@ def get_router(
         root_tree=Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
         authn_scopes: Scopes = Depends(get_current_scopes),
+        settings: Settings = Depends(get_settings),
         _=Security(check_scopes, scopes=["read:metadata"]),
     ):
         """Fetch the metadata and structure information for one entry"""
@@ -449,6 +452,7 @@ def get_router(
                 include_data_sources,
                 resolve_media_type(request),
                 max_depth=max_depth,
+                exact_count_limit=settings.exact_count_limit,
             )
         except BrokenLink as err:
             raise HTTPException(status_code=HTTP_410_GONE, detail=err.args[0])

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     # The largest number of items in a container for which the metadata endpoint
     # will return the exact count; this becomes the lower bound on the stimate if
     # an approximate number can not be obtained otherwise.
-    exact_count_limit: int = 5000
+    exact_count_limit: int = 100
     reject_undeclared_specs: bool = False
     # "env_prefix does not apply to fields with alias"
     # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#environment-variable-names

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     # that data should generally be chunked. When we implement async responses,
     # we can raise this global limit.
     response_bytesize_limit: int = 300_000_000  # 300 MB
+    # The largest number of items in a container for which the metadata endpoint
+    # will return the exact count; this becomes the lower bound on the stimate if
+    # an approximate number can not be obtained otherwise.
+    exact_count_limit: int = 5000
     reject_undeclared_specs: bool = False
     # "env_prefix does not apply to fields with alias"
     # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#environment-variable-names


### PR DESCRIPTION
This pull request introduces a more efficient way to determine the number of child nodes in a container by adding (1) approximate and (2) lower-bound counting methods. 

The approximate count is supported only in PostgreSQL catalogs and relies on using `pg_stats` and `reltuples`. It requires that the `nodes` table be vacuumed and analyzed at least once an re-analyzed regularly for more accurate results. Inspired by [this SO post](https://stackoverflow.com/a/7945274).

The logic in `len_or_approx` is updated to use these new methods, falling back to exact counts only when necessary.

Issue: #1078

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
