### PR TITLE
Add Python 3.14 RCs to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14.0rc2"
+          - "3.14.0rc2t"
       fail-fast: false
     steps:
 


### PR DESCRIPTION
This adds two builds, `3.14.0rc2` and the free-threaded variant, `3.14.0rc2t`.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
