### PR TITLE
Adding Configs for Connection Pool Sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Added
 
 - The project ships with a pixi manifest (`pixi.toml`).
+- Connection pool settings for catalog and storage databases.
 
 ## v0.1.0-b34 (2025-08-14)
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1545,7 +1545,7 @@ def from_uri(
         # significant performance boost. For SQLite databases that exist
         # only in process memory, pooling is not applicable.
         poolclass = AsyncAdaptedQueuePool
-    elif parsed_url.get_dialect().name in {"postgresql", "postgresql+asyncpg"}:
+    elif parsed_url.get_dialect().name.startswith("postgresql"):
         poolclass = AsyncAdaptedQueuePool  # Default for PostgreSQL
     else:
         poolclass = None  # defer to sqlalchemy default

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1490,11 +1490,16 @@ def in_memory(
     echo=DEFAULT_ECHO,
     adapters_by_mimetype=None,
     top_level_access_blob=None,
+    storage_pool_size=None,
+    storage_max_overflow=None,
+    **kwargs,
 ):
     if not named_memory:
         uri = "sqlite:///:memory:"
     else:
         uri = f"sqlite:///file:{named_memory}?mode=memory&cache=shared&uri=true"
+    # NOTE: catalog_pool_size and catalog_max_overflow are ignored when using an
+    # in-memory catalog.
     return from_uri(
         uri=uri,
         metadata=metadata,
@@ -1505,6 +1510,8 @@ def in_memory(
         echo=echo,
         adapters_by_mimetype=adapters_by_mimetype,
         top_level_access_blob=top_level_access_blob,
+        storage_pool_size=storage_pool_size,
+        storage_max_overflow=storage_max_overflow,
     )
 
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1560,6 +1560,8 @@ def from_uri(
         echo=echo,
         json_serializer=json_serializer,
         poolclass=poolclass,
+        pool_size=10,
+        max_overflow=10,
     )
     if engine.dialect.name == "sqlite":
         event.listens_for(engine.sync_engine, "connect")(_set_sqlite_pragma)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1490,9 +1490,6 @@ def in_memory(
     echo=DEFAULT_ECHO,
     adapters_by_mimetype=None,
     top_level_access_blob=None,
-    storage_pool_size=None,
-    storage_max_overflow=None,
-    **kwargs,
 ):
     if not named_memory:
         uri = "sqlite:///:memory:"
@@ -1510,8 +1507,6 @@ def in_memory(
         echo=echo,
         adapters_by_mimetype=adapters_by_mimetype,
         top_level_access_blob=top_level_access_blob,
-        storage_pool_size=storage_pool_size,
-        storage_max_overflow=storage_max_overflow,
     )
 
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -22,8 +22,8 @@ from .media_type_registration import (
     default_serialization_registry,
 )
 from .query_registration import default_query_registry
-from .structures.core import Spec
 from .server.settings import Settings
+from .structures.core import Spec
 from .utils import import_object, parse, prepend_to_sys_path
 from .validation_registration import default_validation_registry
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -162,6 +162,10 @@ See documentation section "Serve a Directory of Files"."""
         )
         server_settings["expose_raw_assets"] = config.get("expose_raw_assets")
         server_settings["metrics"] = config.get("metrics", {})
+        server_settings["catalog_pool_size"] = config.get("catalog_pool_size")
+        server_settings["storage_pool_size"] = config.get("storage_pool_size")
+        server_settings["catalog_max_overflow"] = config.get("catalog_max_overflow")
+        server_settings["storage_max_overflow"] = config.get("storage_max_overflow")
         for structure_family, values in config.get("media_types", {}).items():
             for media_type, import_path in values.items():
                 serializer = import_object(import_path, accept_live_object=True)

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -23,6 +23,7 @@ from .media_type_registration import (
 )
 from .query_registration import default_query_registry
 from .structures.core import Spec
+from .server.settings import Settings
 from .utils import import_object, parse, prepend_to_sys_path
 from .validation_registration import default_validation_registry
 
@@ -59,6 +60,7 @@ def construct_build_app_kwargs(
             directory = os.path.dirname(source_filepath)
         sys_path_additions.append(directory)
     with prepend_to_sys_path(*sys_path_additions):
+        # Process auth settings
         auth_spec = config.get("authentication", {}) or {}
         for age in ["refresh_token_max_age", "session_max_age", "access_token_max_age"]:
             if age in auth_spec:
@@ -87,6 +89,28 @@ def construct_build_app_kwargs(
         else:
             access_policy = None
         # TODO Enable entrypoint to extend aliases?
+
+        # Process server settings
+        server_settings = {}
+        if root_path := config.get("root_path", ""):
+            server_settings["root_path"] = root_path
+        server_settings["allow_origins"] = config.get("allow_origins")
+        server_settings["response_bytesize_limit"] = config.get(
+            "response_bytesize_limit"
+        )
+        server_settings["exact_count_limit"] = config.get("exact_count_limit")
+        server_settings["database"] = config.get("database", {})
+        server_settings["reject_undeclared_specs"] = config.get(
+            "reject_undeclared_specs"
+        )
+        server_settings["expose_raw_assets"] = config.get("expose_raw_assets")
+        server_settings["metrics"] = config.get("metrics", {})
+        server_settings["catalog_pool_size"] = config.get("catalog_pool_size")
+        server_settings["storage_pool_size"] = config.get("storage_pool_size")
+        server_settings["catalog_max_overflow"] = config.get("catalog_max_overflow")
+        server_settings["storage_max_overflow"] = config.get("storage_max_overflow")
+
+        # Process trees
         tree_aliases = {
             "catalog": "tiled.catalog:from_uri",
         }
@@ -111,6 +135,20 @@ See documentation section "Serve a Directory of Files"."""
                 # Interpret obj as a tree *factory*.
                 args = {}
                 args.update(item.get("args", {}))
+
+                # Add other server-related settings falling back to Settings defaults
+                # TODO: To be removed after refactoring
+                default_settings = Settings().model_dump()
+                from_server_settings = {
+                    k: server_settings.get(k, default_settings[k])
+                    for k in {
+                        "catalog_pool_size",
+                        "storage_pool_size",
+                        "catalog_max_overflow",
+                        "storage_max_overflow",
+                    }
+                }
+                args.update(from_server_settings)
                 tree = obj(**args)
             else:
                 # Interpret obj as a tree *instance*.
@@ -148,24 +186,8 @@ See documentation section "Serve a Directory of Files"."""
                         include_routers.append(router)
             root_tree = MapAdapter(root_mapping)
             root_tree.include_routers.extend(include_routers)
-        server_settings = {}
-        if root_path := config.get("root_path", ""):
-            server_settings["root_path"] = root_path
-        server_settings["allow_origins"] = config.get("allow_origins")
-        server_settings["response_bytesize_limit"] = config.get(
-            "response_bytesize_limit"
-        )
-        server_settings["exact_count_limit"] = config.get("exact_count_limit")
-        server_settings["database"] = config.get("database", {})
-        server_settings["reject_undeclared_specs"] = config.get(
-            "reject_undeclared_specs"
-        )
-        server_settings["expose_raw_assets"] = config.get("expose_raw_assets")
-        server_settings["metrics"] = config.get("metrics", {})
-        server_settings["catalog_pool_size"] = config.get("catalog_pool_size")
-        server_settings["storage_pool_size"] = config.get("storage_pool_size")
-        server_settings["catalog_max_overflow"] = config.get("catalog_max_overflow")
-        server_settings["storage_max_overflow"] = config.get("storage_max_overflow")
+
+        # Process other configuration items
         for structure_family, values in config.get("media_types", {}).items():
             for media_type, import_path in values.items():
                 serializer = import_object(import_path, accept_live_object=True)

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -350,7 +350,7 @@ properties:
   catalog_pool_size:
     type: integer
     description: |
-      Size of the connection pool for catalog databases. Default is 10.
+      Size of the connection pool for catalog databases. Default is 5.
   catalog_max_overflow:
     type: integer
     description: |
@@ -363,7 +363,7 @@ properties:
   storage_max_overflow:
     type: integer
     description: |
-      Maximum overflow size of the connection pool for storage databases. Default is 5.
+      Maximum overflow size of the connection pool for storage databases. Default is 10.
   allow_origins:
     type: array
     items:

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -347,6 +347,23 @@ properties:
       The largest number of items in a container, for which the `/metadata` and `/search`
       endpoints will return their exact count; this becomes the lower bound on the estimate if
       an approximate number can not be obtained otherwise. The default is 100.
+  catalog_pool_size:
+    type: integer
+    description: |
+      Size of the connection pool for catalog databases. Default is 10.
+  catalog_max_overflow:
+    type: integer
+    description: |
+      If supported, the maximum overflow size of the connection pool for catalog databases,
+      i.e. the number of connections that can be created beyond the pool size. Default is 10.
+  storage_pool_size:
+    type: integer
+    description: |
+      Size of the (ABDC) connection pool for storage databases. Default is 5.
+  storage_max_overflow:
+    type: integer
+    description: |
+      Maximum overflow size of the connection pool for storage databases. Default is 5.
   allow_origins:
     type: array
     items:

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -49,10 +49,10 @@ class Settings(BaseSettings):
         DatabaseSettings(), validation_alias="TILED_DATABASE"
     )
     # Connection pool configurations for catalog and storage DBs
-    catalog_pool_size: int = 10
+    catalog_pool_size: int = 5
     storage_pool_size: int = 5
     catalog_max_overflow: int = 10
-    storage_max_overflow: int = 5
+    storage_max_overflow: int = 10
     database_init_if_not_exists: bool = False
     expose_raw_assets: bool = True
 

--- a/tiled/server/settings.py
+++ b/tiled/server/settings.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     database_settings: DatabaseSettings = Field(
         DatabaseSettings(), validation_alias="TILED_DATABASE"
     )
+    # Connection pool configurations for catalog and storage DBs
+    catalog_pool_size: int = 10
+    storage_pool_size: int = 5
+    catalog_max_overflow: int = 10
+    storage_max_overflow: int = 5
     database_init_if_not_exists: bool = False
     expose_raw_assets: bool = True
 


### PR DESCRIPTION
This pull request introduces configuration options to control database connection pool sizes and overflow limits for catalog and storage databases.

**Configuration options for database connection pools:**

* Added new fields to the `Settings` class with defaults corresponding to typical sqlalchemy values:
    * `catalog_pool_size` (default = 5)
    * `storage_pool_size` (default = 5)
    * `catalog_max_overflow` (default = 10)
    * `storage_max_overflow` (default = 10)

Issue: #1002 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
