### PR TITLE
FIX: set default None for optional patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## v0.1.0-b39 (Unreleased)
+
+### Fixed
+
+- Default paraneter (`None`) for the `patch` parameter in `PUT /data_source` endpoint.
+
+
 ## v0.1.0-b38 (2025-08-28)
 
 ### Fixed

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -464,7 +464,7 @@ class PostMetadataRequest(pydantic.BaseModel):
 
 class PutDataSourceRequest(pydantic.BaseModel):
     data_source: DataSource
-    patch: Optional[Patch]
+    patch: Optional[Patch] = None
 
 
 class PostMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):


### PR DESCRIPTION
Fixes an issue with PUT /data_source endpoint that requires a default values for the optional `patch` parameter to be set.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
