### PR TITLE
Fix for nodes_closure migration when node name matches parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Handling for certain catalog edge cases when building the nodes_closure table.
 
 ## v0.1.0-b39 (2025-08-28)
 

--- a/tiled/catalog/migrations/versions/e05e918092c3_add_closure_table.py
+++ b/tiled/catalog/migrations/versions/e05e918092c3_add_closure_table.py
@@ -147,17 +147,6 @@ def upgrade():
     )
     logger.info("Inserted root node with id=0.")
 
-    # 4. Insert self-referential records into nodes_closure for each node, including the "root" node
-    connection.execute(
-        sa.text(
-            """
-        INSERT INTO nodes_closure(ancestor, descendant, depth)
-        SELECT id, id, 0 FROM nodes;
-        """
-        )
-    )
-    logger.info("Inserted self-referential records into 'nodes_closure' for each node.")
-
     # 5. Populate the 'parent' column of the 'nodes' table based on the 'ancestors' column
     json_len_func = (
         "jsonb_array_length"
@@ -226,6 +215,20 @@ def upgrade():
             f"Updated 'parent' column and 'nodes_closure' for depth {depth + 1}."
         )
     logger.info("Completed updating 'parent' column recursively.")
+
+    # 7½. Insert self-referential records into nodes_closure for each node, including the "root" node
+    #     (Any conflicts here are clearly a mistake, so we just clobber them)
+    connection.execute(
+        sa.text(
+            """
+        INSERT INTO nodes_closure(ancestor, descendant, depth)
+        SELECT id, id, 0 FROM nodes
+        ON CONFLICT (ancestor, descendant) DO UPDATE
+        SET depth = EXCLUDED.depth;
+        """
+        )
+    )
+    logger.info("Inserted self-referential records into 'nodes_closure' for each node.")
 
     # 8. Update index in the 'nodes' table: drop old, add new
     op.drop_index("top_level_metadata", table_name="nodes")


### PR DESCRIPTION
Modifies the alembic migration that builds the initial `nodes_closure` table to handle a catalog with edge cases. See the linked issue for details.

Fixes:
- https://github.com/bluesky/tiled/issues/1114

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
