### PR TITLE
Rename write_dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Changed
+
+- Client method for writing tabular data into external files, `write_dataframe`,
+  is deprecated and renamed `write_table`.
+
 ### Fixed
 
 - Handling for certain catalog edge cases when building the nodes_closure table.

--- a/docs/source/reference/python-client.md
+++ b/docs/source/reference/python-client.md
@@ -109,7 +109,7 @@ And, finally, there are convenience methods for writing:
    tiled.client.container.Container.create_container
    tiled.client.container.Container.write_array
    tiled.client.container.Container.write_awkward
-   tiled.client.container.Container.write_dataframe
+   tiled.client.container.Container.write_table
    tiled.client.container.Container.write_sparse
 ```
 

--- a/docs/source/tutorials/writing.md
+++ b/docs/source/tutorials/writing.md
@@ -72,7 +72,7 @@ Write tabular data in a pandas DataFrame.
 ```python
 >>> import pandas
 >>> df = pandas.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
->>> client.write_dataframe(df, metadata={"color": "green", "barcode": 12})
+>>> client.write_table(df, metadata={"color": "green", "barcode": 12})
 <DataFrameClient ['x', 'y']>
 ```
 

--- a/tiled/_tests/test_asset_access.py
+++ b/tiled/_tests/test_asset_access.py
@@ -75,7 +75,7 @@ def test_raw_export(client, tmpdir):
 def test_asset_range_request(client, tmpdir):
     "Access part of an asset using an HTTP Range header."
     df = pandas.DataFrame({"A": [1, 2, 3], "B": [4.0, 5.0, 6.0]})
-    client.write_dataframe(df, key="x")
+    client.write_table(df, key="x")
     # Fetch the first byte.
     first_byte_response = client.context.http_client.get(
         "/api/v1/asset/bytes/x?id=1",

--- a/tiled/_tests/test_catalog.py
+++ b/tiled/_tests/test_catalog.py
@@ -242,7 +242,7 @@ async def test_write_array_external(a, tmpdir):
 
 
 @pytest.mark.asyncio
-async def test_write_dataframe_external_direct(a, tmpdir):
+async def test_write_table_external_direct(a, tmpdir):
     df = pandas.DataFrame(numpy.ones((5, 3)), columns=list("abc"))
     filepath = str(tmpdir / "file.csv")
     data_uri = ensure_uri(filepath)
@@ -316,9 +316,9 @@ def test_write_array_internal_via_client(client):
     assert numpy.array_equal(actual, expected)
 
 
-def test_write_dataframe_internal_via_client(client):
+def test_write_table_internal_via_client(client):
     expected = pandas.DataFrame(numpy.ones((5, 3)), columns=list("abc"))
-    x = client.write_dataframe(expected)
+    x = client.write_table(expected)
     actual = x.read()
     pandas.testing.assert_frame_equal(actual, expected)
 

--- a/tiled/_tests/test_sync.py
+++ b/tiled/_tests/test_sync.py
@@ -61,7 +61,7 @@ def populate_internal(client):
     client.write_array([1, 2, 3], key="a", metadata={"color": "red"}, specs=["alpha"])
     # table
     df = pandas.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
-    client.write_dataframe(df, key="b", metadata={"color": "green"}, specs=["beta"])
+    client.write_table(df, key="b", metadata={"color": "green"}, specs=["beta"])
     # awkward
     client.write_awkward(
         awkward.Array([1, [2, 3]]), key="d", metadata={"color": "red"}, specs=["alpha"]
@@ -77,7 +77,7 @@ def populate_internal(client):
     container.write_array(
         [1, 2, 3], key="A", metadata={"color": "red"}, specs=["alpha"]
     )
-    container.write_dataframe(df, key="B", metadata={"color": "green"}, specs=["beta"])
+    container.write_table(df, key="B", metadata={"color": "green"}, specs=["beta"])
     container.write_awkward(
         awkward.Array([1, [2, 3]]), key="D", metadata={"color": "red"}, specs=["alpha"]
     )

--- a/tiled/_tests/test_validation.py
+++ b/tiled/_tests/test_validation.py
@@ -70,7 +70,7 @@ def client(tmpdir_module):
 def test_validators(client):
     # valid example
     df = pd.DataFrame({"a": np.zeros(10), "b": np.zeros(10)})
-    client.write_dataframe(df, metadata={"foo": 1}, specs=["foo"])
+    client.write_table(df, metadata={"foo": 1}, specs=["foo"])
 
     with fail_with_status_code(HTTP_400_BAD_REQUEST):
         # not expected structure family
@@ -80,23 +80,23 @@ def test_validators(client):
     with fail_with_status_code(HTTP_400_BAD_REQUEST):
         # column names are not expected
         df = pd.DataFrame({"x": np.zeros(10), "y": np.zeros(10)})
-        client.write_dataframe(df, metadata={}, specs=["foo"])
+        client.write_table(df, metadata={}, specs=["foo"])
 
     with fail_with_status_code(HTTP_400_BAD_REQUEST):
         # missing expected metadata
         df = pd.DataFrame({"a": np.zeros(10), "b": np.zeros(10)})
-        client.write_dataframe(df, metadata={}, specs=["foo"])
+        client.write_table(df, metadata={}, specs=["foo"])
 
     metadata = {"id": 1, "foo": "bar"}
     df = pd.DataFrame({"a": np.zeros(10), "b": np.zeros(10)})
-    result = client.write_dataframe(df, metadata=metadata, specs=["foo"])
+    result = client.write_table(df, metadata=metadata, specs=["foo"])
     assert result.metadata == metadata
     result_df = result.read()
     pd.testing.assert_frame_equal(result_df, df)
 
     metadata_upper = {"ID": 2, "FOO": "bar"}
     metadata_lower, _ = lower_case_dict(metadata_upper)
-    result = client.write_dataframe(df, metadata=metadata_upper, specs=["foo"])
+    result = client.write_table(df, metadata=metadata_upper, specs=["foo"])
     assert result.metadata == metadata_lower
     result_df = result.read()
     pd.testing.assert_frame_equal(result_df, df)

--- a/tiled/_tests/test_writing.py
+++ b/tiled/_tests/test_writing.py
@@ -184,7 +184,7 @@ def test_extend_array(tree):
             ac.patch(ones.astype("uint8"), offset=9, extend=True)
 
 
-def test_write_dataframe_full(tree):
+def test_write_table_full(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)
     ) as context:
@@ -196,7 +196,7 @@ def test_write_dataframe_full(tree):
         specs = [Spec("SomeSpec")]
 
         with record_history() as history:
-            client.write_dataframe(df, metadata=metadata, specs=specs)
+            client.write_table(df, metadata=metadata, specs=specs)
         # one request for metadata, one for data
         assert len(history.requests) == 1 + 1
 
@@ -209,7 +209,7 @@ def test_write_dataframe_full(tree):
         assert result.specs == specs
 
 
-def test_write_dataframe_partitioned(tree):
+def test_write_table_partitioned(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)
     ) as context:
@@ -222,7 +222,7 @@ def test_write_dataframe_partitioned(tree):
         specs = [Spec("SomeSpec")]
 
         with record_history() as history:
-            client.write_dataframe(ddf, metadata=metadata, specs=specs)
+            client.write_table(ddf, metadata=metadata, specs=specs)
         # one request for metadata, multiple for data
         assert len(history.requests) == 1 + 3
 
@@ -235,7 +235,7 @@ def test_write_dataframe_partitioned(tree):
         assert result.specs == specs
 
 
-def test_write_dataframe_dict(tree):
+def test_write_table_dict(tree):
     with Context.from_app(
         build_app(tree, validation_registry=validation_registry)
     ) as context:
@@ -247,7 +247,7 @@ def test_write_dataframe_dict(tree):
         specs = [Spec("SomeSpec")]
 
         with record_history() as history:
-            client.write_dataframe(data, metadata=metadata, specs=specs)
+            client.write_table(data, metadata=metadata, specs=specs)
         # one request for metadata, one for data
         assert len(history.requests) == 1 + 1
 
@@ -593,7 +593,7 @@ async def test_write_in_container(tree):
 
         a = client.create_container("a")
         df = pandas.DataFrame({"a": [1, 2, 3]})
-        b = a.write_dataframe(df, key="b")
+        b = a.write_table(df, key="b")
         b.read()
         a.delete_contents("b", external_only=False)
         client.delete_contents("a")

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -239,13 +239,13 @@ class CompositeClient(Container):
             access_tags=access_tags,
         )
 
-    def write_dataframe(
-        self, dataframe, *, key=None, metadata=None, specs=None, access_tags=None
+    def write_table(
+        self, data, *, key=None, metadata=None, specs=None, access_tags=None
     ):
-        if set(self.keys()).intersection(dataframe.columns):
+        if set(self.keys()).intersection(data.columns):
             raise ValueError(
                 "DataFrame columns must not overlap with existing keys in the composite node."
             )
-        return super().write_dataframe(
-            dataframe, key=key, metadata=metadata, specs=specs, access_tags=access_tags
+        return super().write_table(
+            data, key=key, metadata=metadata, specs=specs, access_tags=access_tags
         )


### PR DESCRIPTION
The client-side method, `write_dataframe`, has been deprecated and renamed `write_table`.

Issue: #1112 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
