### PR TITLE
Composite Validity Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Handling for certain catalog edge cases when building the nodes_closure table.
+- Enforce validity checks when adding appendable tables to "composite"-spec'ed containers.
 
 ## v0.1.0-b39 (2025-08-28)
 

--- a/tiled/_tests/test_composite.py
+++ b/tiled/_tests/test_composite.py
@@ -1,6 +1,7 @@
 import awkward
 import numpy
 import pandas
+import pyarrow
 import pytest
 import sparse
 import tifffile as tf
@@ -38,6 +39,8 @@ df3 = pandas.DataFrame(
 )
 arr1 = rng.random(size=(3, 5), dtype="float64")
 arr2 = rng.integers(0, 255, size=(5, 7, 3), dtype="uint8")
+tab1 = pyarrow.Table.from_pydict({"H": [1, 2, 3], "I": [4, 5, 6]})
+tab2 = pyarrow.Table.from_pydict({"J": [1, 2], "K": [3, 4], "L": [5, 6]})
 img_data = rng.integers(0, 255, size=(5, 13, 17, 3), dtype="uint8")
 
 # An awkward array
@@ -417,6 +420,16 @@ def test_write_dataframe_and_warn(tree):
         assert len(client["z"]) == 2  # Two columns
 
 
+def test_write_one_appendable_table(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        client.create_container(key="z", specs=["composite"])
+        tab = pyarrow.Table.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+        client["z"].create_appendable_table(schema=tab.schema)
+        assert len(client["z"].base) == 1  # One table
+        assert len(client["z"]) == 2  # Two columns
+
+
 def test_write_two_tables(tree):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
@@ -425,8 +438,22 @@ def test_write_two_tables(tree):
         z = client.create_container(key="z", specs=["composite"])
         z.write_table(df1, key="table1")
         z.write_table(df2, key="table2")
-        z.base["table1"].read()
-        z.base["table2"].read()
+        assert z.base["table1"].read() is not None
+        assert z.base["table2"].read() is not None
+
+
+def test_write_two_appendable_tables(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        tab1 = pyarrow.Table.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+        tab2 = pyarrow.Table.from_pydict({"C": [1, 2], "D": [3, 4], "E": [5, 6]})
+        z = client.create_container(key="z", specs=["composite"])
+        tab1_client = z.create_appendable_table(schema=tab1.schema, key="table1")
+        tab2_client = z.create_appendable_table(schema=tab2.schema, key="table2")
+        tab1_client.append_partition(tab1, 0)
+        tab2_client.append_partition(tab2, 0)
+        assert z.base["table1"].read() is not None
+        assert z.base["table2"].read() is not None
 
 
 def test_write_two_tables_colliding_names(tree):
@@ -440,6 +467,17 @@ def test_write_two_tables_colliding_names(tree):
             z.write_table(df2, key="table1")
 
 
+def test_write_two_appendable_tables_colliding_names(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        tab1 = pyarrow.Table.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+        tab2 = pyarrow.Table.from_pydict({"C": [1, 2], "D": [3, 4], "E": [5, 6]})
+        z = client.create_container(key="z", specs=["composite"])
+        z.create_appendable_table(schema=tab1.schema, key="table1")
+        with fail_with_status_code(HTTP_409_CONFLICT):
+            z.create_appendable_table(schema=tab2.schema, key="table1")
+
+
 def test_write_two_tables_colliding_keys(tree):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
@@ -451,30 +489,62 @@ def test_write_two_tables_colliding_keys(tree):
             z.write_table(df2, key="table2")
 
 
-def test_write_two_tables_two_arrays(tree):
+def test_write_two_appendable_tables_colliding_keys(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        tab1 = pyarrow.Table.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+        tab2 = pyarrow.Table.from_pydict({"A": [1, 2], "C": [3, 4], "D": [5, 6]})
+        z = client.create_container(key="z", specs=["composite"])
+        z.create_appendable_table(schema=tab1.schema, key="table1")
+        with pytest.raises(ValueError):
+            z.create_appendable_table(schema=tab2.schema, key="table2")
+
+
+def test_write_two_tables_two_appendable_two_arrays(tree):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)
         df1 = pandas.DataFrame({"A": [], "B": []})
         df2 = pandas.DataFrame({"C": [], "D": [], "E": []})
         arr1 = numpy.ones((5, 5), dtype=numpy.float64)
         arr2 = 2 * numpy.ones((5, 5), dtype=numpy.int8)
+        tab1 = pyarrow.Table.from_pydict({"F": [1, 2, 3], "G": [4, 5, 6]})
+        tab2 = pyarrow.Table.from_pydict({"H": [1, 2], "I": [3, 4], "J": [5, 6]})
         z = client.create_container(key="z", specs=["composite"])
 
         # Write by data source.
-        z.write_table(df1, key="table1")
-        z.write_table(df2, key="table2")
-        z.write_array(arr1, key="F")
-        z.write_array(arr2, key="G")
+        z.write_table(df1, key="df1")
+        z.write_table(df2, key="df2")
+        z.write_array(arr1, key="arr1")
+        z.write_array(arr2, key="arr2")
+        tab1_client = z.create_appendable_table(schema=tab1.schema, key="tab1")
+        tab2_client = z.create_appendable_table(schema=tab2.schema, key="tab2")
+        tab1_client.append_partition(tab1, 0)
+        tab2_client.append_partition(tab2, 0)
 
         # Read by data source.
-        z.base["table1"].read()
-        z.base["table2"].read()
-        z.base["F"].read()
-        z.base["G"].read()
+        assert z.base["df1"].read() is not None
+        assert z.base["df2"].read() is not None
+        assert z.base["arr1"].read() is not None
+        assert z.base["arr2"].read() is not None
+        assert z.base["tab1"].read() is not None
+        assert z.base["tab2"].read() is not None
 
         # Read by column.
-        for column in ["A", "B", "C", "D", "E", "F", "G"]:
-            z[column].read()
+        for column in {
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "J",
+            "arr1",
+            "arr2",
+        }:
+            assert z[column].read() is not None
 
 
 def test_write_table_column_array_key_collision(tree):
@@ -482,16 +552,37 @@ def test_write_table_column_array_key_collision(tree):
         client = from_context(context)
         df = pandas.DataFrame({"A": [], "B": []})
         arr = numpy.array([1, 2, 3], dtype=numpy.float64)
+        tab = pyarrow.Table.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
 
         z1 = client.create_container(key="z1", specs=["composite"])
-        z1.write_table(df, key="table1")
+        z1.write_table(df, key="df1")
         with pytest.raises(ValueError):
             z1.write_array(arr, key="A")
 
         z2 = client.create_container(key="z2", specs=["composite"])
         z2.write_array(arr, key="A")
         with pytest.raises(ValueError):
-            z2.write_table(df, key="table1")
+            z2.write_table(df, key="df1")
+
+        z3 = client.create_container(key="z3", specs=["composite"])
+        z3.write_array(arr, key="A")
+        with pytest.raises(ValueError):
+            z3.create_appendable_table(schema=tab.schema, key="table1")
+
+        z4 = client.create_container(key="z4", specs=["composite"])
+        z4.write_table(df, key="df1")
+        with pytest.raises(ValueError):
+            z4.create_appendable_table(schema=tab.schema, key="table1")
+
+        z5 = client.create_container(key="z5", specs=["composite"])
+        z5.create_appendable_table(schema=tab.schema, key="table1")
+        with pytest.raises(ValueError):
+            z5.write_array(arr, key="A")
+
+        z6 = client.create_container(key="z6", specs=["composite"])
+        z6.create_appendable_table(schema=tab.schema, key="table1")
+        with pytest.raises(ValueError):
+            z6.write_table(df, key="df1")
 
 
 def test_composite_validator(tree):
@@ -553,6 +644,10 @@ def test_composite_validator(tree):
         with pytest.raises(ClientError, match="Found conflicting names"):
             y.update_metadata(specs=["composite"])
         y.delete_contents("df1_copy", external_only=False)
+        y.create_appendable_table(schema=tab1.schema, key="tab1_copy")
+        with pytest.raises(ClientError, match="Found conflicting names"):
+            y.update_metadata(specs=["composite"])
+        y.delete_contents("tab1_copy", external_only=False)
 
         # 7. Composite spec cannot be used for tables or arrays
         err_message = "Composite spec can be assigned only to containers"

--- a/tiled/_tests/test_composite.py
+++ b/tiled/_tests/test_composite.py
@@ -623,9 +623,11 @@ def test_composite_validator(tree):
         assert isinstance(client["y"], CompositeClient)
         y.update_metadata(specs=[])
 
-        # 4. Add two valid tables
+        # 4. Add two valid tables and two valid appendable tables
         y.write_table(df1, key="df1")
         y.write_table(df2, key="df2")
+        y.create_appendable_table(schema=tab1.schema, key="tab1")
+        y.create_appendable_table(schema=tab2.schema, key="tab2")
 
         # Composite spec can be assigned to a container with arrays and tables
         y.update_metadata(specs=["composite"])
@@ -639,7 +641,7 @@ def test_composite_validator(tree):
             y.update_metadata(specs=["composite"])
         y.delete_contents("A", external_only=False)
 
-        # 6. Add a table with a conflicting column names
+        # 6. Add tables with conflicting column names
         y.write_table(df1, key="df1_copy")
         with pytest.raises(ClientError, match="Found conflicting names"):
             y.update_metadata(specs=["composite"])

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -264,8 +264,6 @@ class CompositeClient(Container):
         access_tags=None,
         table_name: Optional[str] = None,
     ):
-        import pyarrow
-
         if set(self.keys()).intersection(schema.names):
             raise ValueError(
                 "Table columns must not overlap with existing keys in the composite node."


### PR DESCRIPTION
This adds enforcement for validity checks (client- and server-side) when adding appendable tables to containers marked with the "composite" spec. Similar checks have been already in place for writing usual dataframes.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
