### PR TITLE
Streaming (websocket) tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+
+### Added
+
+- Convenience method `subscribe` on client `Container` and `ArrayClient`
+  returns an experimental `Subscription`. See the new Streaming tutorial
+  for usage.
+
 ### Changed
 
 - Client method for writing tabular data into external files, `write_dataframe`,
   is deprecated and renamed `write_table`.
 - The order of arguments in the `write_partition` and `append_partition` methods.
+- The experiment `Subscription` object now takes where to start as an argument
+  to `Subscription.start` instead of at initialization time.
 
 ### Fixed
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,7 @@ tutorials/login
 tutorials/serving-files
 tutorials/search
 tutorials/writing
+tutorials/streaming
 tutorials/simple-server
 tutorials/plotly-integration
 tutorials/zarr-integration

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -85,7 +85,7 @@ where `sub` is our Subscription and `data` is a dict with information
 about what is new. In this case, it contains a detailed description of the
 new array named `x` that was created by the other client.
 
-If we are interested we can subscribe to updates about `x` and its data.
+If we are interested, we can subscribe to updates about `x` and its data.
 
 ```py
 x_sub = c['x'].subscribe()

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -130,7 +130,9 @@ As already mentioned above, `x.start(0)` means, "Start from the oldest record re
 Of course, clients can always fetch _all_ the data via the non-streaming
 interface.
 
-Subscribers can disconnect from a stream at any point, like so:
+## Disconnecting or Closing
+
+As subscriber can disconnect from a stream at any point, like so:
 
 ```py
 sub.stop()
@@ -150,13 +152,15 @@ Python client, this will stop the threads that are listening for updates and
 it will set `sub.closed` to `True`.
 
 Writing can still resume writing later---or even immediately. Closing a stream
-is just a signal that consumers should not _expect_ any more data soon, and
-they will need to re-subscribe if they want to watch for any. Live data
+signals that consumers should not _expect_ any more data soon, and forces them
+to affirmatively re-subscribe if they want to watch for any. Live data
 processing jobs may use this as a prompt to clean up and free up resources.
 
+## Sequence Number Guarantees
+
 While the sequence number is guaranteed to increment by 1 during an active
-stream, clients should expect that it _can_ reset back to 1 if a stream is
-idle. This happens quickly (1 hour, by default) if a stream is explicitly
+stream, clients should expect that it _may_ reset back to 1 after a stream has
+been idle. This happens quickly (1 hour, by default) if a stream is explicitly
 closed or slowly (30 days, by default) if a stream is left un-closed but
 dormant. These intervals are configurable via the settings `data_ttl` and
 `seq_ttl` respectively under `streaming_cach` configuration.  (In the `tiled

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -70,7 +70,7 @@ from tiled.client import from_uri
 import numpy
 
 c = from_uri('http://localhost:8000', api_key='secret')
-x = client.write_array(numpy.array([1, 2, 3]), key='x')
+x = c.write_array(numpy.array([1, 2, 3]), key='x')
 ```
 
 Back in the process with the subscription, you will see that something has been

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -149,10 +149,18 @@ that they were disconnected due to stream completion, not an error.) In the
 Python client, this will stop the threads that are listening for updates and
 it will set `sub.closed` to `True`.
 
-Writers can still resume writing later---or even immediately. Closing a stream
+Writing can still resume writing later---or even immediately. Closing a stream
 is just a signal that consumers should not _expect_ any more data soon, and
-they will need to re-subscribe. Live data processing jobs may use this as a
-prompt to clean up and free up resources.
+they will need to re-subscribe if they want to watch for any. Live data
+processing jobs may use this as a prompt to clean up and free up resources.
+
+While the sequence number is guaranteed to increment by 1 during an active
+stream, clients should expect that it _can_ reset back to 1 if a stream is
+idle. This happens quickly (1 hour, by default) if a stream is explicitly
+closed or slowly (30 days, by default) if a stream is left un-closed but
+dormant. These intervals are configurable via the settings `data_ttl` and
+`seq_ttl` respectively under `streaming_cach` configuration.  (In the `tiled
+serve` CLI they are `--cache-data-ttl` and `--cache-seq-ttl`.)
 
 ## Limitations
 

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -1,6 +1,6 @@
 # Streaming
 
-```warning
+```{warning}
 
 Streaming is an experimental feature in Tiled, subject to backward-compatible
 changes without notice.

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -102,8 +102,8 @@ x.patch(numpy.array([4, 5, 6]), offset=3, extend=True)
 
 We can ensure that subscriber sees the full (recent) picture by specifying that
 its subscription should start from as far back as the server has available.
-(By default, the server retains an hour of history in Redis for fast streaming access, but it may shed history
-earlier if it grows short on available RAM.)
+(By default, the server retains an hour of history in Redis for fast streaming
+access, but it may shed history earlier if it grows short on available RAM.)
 
 This feature is not designed to provide a comprehensive history, only to allow
 clients to catch up if they start late---such as a live data processing job

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -100,7 +100,7 @@ x.patch(numpy.array([4, 5, 6]), offset=3, extend=True)
 
 We can ensure that subscriber sees the full (recent) picture by specifying that
 its subscription should start from as far back as the server has available.
-(By default, the server retains an hour of history, but it may shed history
+(By default, the server retains an hour of history in Redis for fast streaming access, but it may shed history
 earlier if it grows short on available RAM.)
 
 This feature is not designed to provide a comprehensive history, only to allow

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -130,7 +130,7 @@ interface.
 
 The writer can let subscribers know that no more data is expected (for now).
 This does not prevent them from writing more later; it just signal that
-nothing more is expected. Live data data processing jobs may use this as
+nothing more is expected. Live data processing jobs may use this as
 a prompt to clean up and free up resources.
 
 ```py

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -123,7 +123,7 @@ and, from there, any new updates as well.
 Notice that content of the updates includes a `sequence` counter, starting from
 the number 1 (with 0 reserved to unambiguously define the "start of the stream"). Subscribers can use this if, for example, they need to recover
 from an interruption. They can subscribe from a specific counter index `sub.start(N)`.
-As already above, `x.start(0)` means, "Start from the oldest record retained."
+As already mentioned above, `x.start(0)` means, "Start from the oldest record retained."
 
 Of course, clients can always fetch _all_ the data via the non-streaming
 interface.

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -132,7 +132,7 @@ interface.
 
 ## Disconnecting or Closing
 
-As subscriber can disconnect from a stream at any point, like so:
+A subscriber can disconnect from a stream at any point, like so:
 
 ```py
 sub.stop()

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -31,8 +31,10 @@ For simple testing, this is a suitable command:
 tiled serve catalog --temp --api-key secret --cache redis://localhost:6379
 ```
 
-> [!CAUTION]
-> Never specify a guessable API key like `secret` in production; let Tiled generate a random one. This is just a convenience for testing.
+```{warning}
+Never specify a guessable API key like `secret` in production; let Tiled
+generate a random one. This is just a convenience for testing.
+```
 
 ````{note}
 

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -36,7 +36,7 @@ tiled serve catalog --temp --api-key secret --cache redis://localhost:6379
 
 ````{note}
 
-If using a config file, add this section.
+If using a config file, add this section:
 
     ```yaml
     streaming_cache:

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -1,0 +1,117 @@
+# Streaming
+
+```warning
+
+Streaming is an experimental feature in Tiled, subject to backward-compatible
+changes without notice.
+
+Additionally, it is only currently supported on arrays and tables.
+
+```
+
+## Prerequisite: Redis
+
+Tiled's streaming feature requires Redis, which it uses to cache
+recent fragments of data (or pointers to large data) and track
+when to notify subscribed clients about updates.
+
+You can run it however you wish. For simple testing, this works:
+
+```
+docker run -d --rm --name tiled-test-redis -p 6379:6379 docker.io/redis:7-alpine
+```
+
+(For production, we recommend configuring Redis with encryption and a password.)
+
+## Launch Tiled Server with Streaming Cache
+
+For simple testing, this is a suitable command:
+
+```
+tiled serve catalog --temp --api-key secret --cache redis://localhost:6379
+```
+
+(Never specify a guessable API key like `secret` in production; let Tiled
+generate a random one. This is just a convenience for testing.)
+
+````{note}
+
+If using a config file, add this section.
+
+    ```yaml
+    streaming_cache:
+      uri: redis://localhost:6379
+    ```
+````
+
+## Write and Stream Data
+
+```py
+from tiled.client import from_uri
+
+# Connect
+client = from_uri('http://localhost:8000', api_key='secret')
+
+# Create a Subscription
+sub = client.subscribe()
+
+# Register a callback, a function that will be called when updates are received.
+# For a simple example, we will just use the print function.
+sub.add_callback(print)
+
+# Start listening for updates.
+sub.start()
+```
+
+In a separate process (if you like) create a new array.
+
+```py
+from tiled.client import from_uri
+import numpy
+
+c = from_uri('http://localhost:8000', api_key='secret')
+x = client.write_array(numpy.array([1, 2, 3]), key='x')
+```
+
+Back in the process with the subscription, you will see that something has been
+printed.
+
+```none
+<Subscription / > {'sequence': 1, 'timestamp': '2025-09-03T16:58:59.682183', 'key': 'x', 'structure_family': 'array', 'specs': [], 'metadata': {}, 'data_sources': [{'id': None, 'structure_family': 'array', 'structure': {'data_type': {'endianness': 'little', 'kind': 'i', 'itemsize': 8, 'dt_units': None}, 'chunks': [[3]], 'shape': [3], 'dims': None, 'resizable': False}, 'mimetype': 'application/x-zarr', 'parameters': {}, 'assets': [], 'management': 'writable'}], 'uri': 'http://localhost:8000/api/v1/array/full/'}
+```
+
+Our callback, `print`, has been called with the arguments `print(sub, data)`
+where `sub` is our Subscription and `data` is a dict with information
+about what is new. In this case, it contains a detailed description of the
+new array named `x` that was created by the other client.
+
+If we are interested we can subscribe to updates about `x` and its data.
+
+```py
+x_sub = c['x'].subscribe()
+```
+
+Suppose that, while we are getting that set up, the other process extends the array with more data.
+the data in `x`:
+
+```py
+x.patch(numpy.array([4, 5, 6]), offset=3, extend=True)
+```
+
+We can ensure that our other client sees the full (recent) picture
+by specifying that its subscription should start from as far back
+as the server has cached.
+
+```py
+x_sub.start(0)
+```
+
+```none
+<Subscription /x > {'sequence': 1, 'timestamp': '2025-09-03T17:37:29.754038', 'content-type': 'application/octet-stream', 'shape': [3], 'offset': None, 'block': None, 'uri': 'http://localhost:8000/api/v1/array/full/x', 'payload': b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00'}
+<Subscription /x > {'sequence': 2, 'timestamp': '2025-09-03T17:37:36.678614', 'content-type': 'application/octet-stream', 'shape': [3], 'offset': [3], 'block': None, 'uri': 'http://localhost:8000/api/v1/array/full/x', 'payload': b'\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00'}
+```
+
+Notice that all these updates include a `sequence` counter, starting from 1.
+Starting the subscription from `0` means "Start from as far back as you have."
+Starting it from some positive integer will start from a specify update. This
+can be useful for resuming after some interruption.

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -31,8 +31,8 @@ For simple testing, this is a suitable command:
 tiled serve catalog --temp --api-key secret --cache redis://localhost:6379
 ```
 
-(Never specify a guessable API key like `secret` in production; let Tiled
-generate a random one. This is just a convenience for testing.)
+> [!CAUTION]
+> Never specify a guessable API key like `secret` in production; let Tiled generate a random one. This is just a convenience for testing.
 
 ````{note}
 

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -91,27 +91,63 @@ If we are interested we can subscribe to updates about `x` and its data.
 x_sub = c['x'].subscribe()
 ```
 
-Suppose that, while we are getting that set up, the other process extends the array with more data.
-the data in `x`:
+Suppose that, while we are getting that set up, the other process extends the
+array with more data.
 
 ```py
 x.patch(numpy.array([4, 5, 6]), offset=3, extend=True)
 ```
 
-We can ensure that our other client sees the full (recent) picture
-by specifying that its subscription should start from as far back
-as the server has cached.
+We can ensure that subscriber sees the full (recent) picture by specifying that
+its subscription should start from as far back as the server has available.
+(By default, the server retains an hour of history, but it may shed history
+earlier if it grows short on available RAM.)
+
+This feature is not designed to provide a comprehensive history, only to allow
+clients to catch up if they start late---such as a live data processing job
+launched after an experiment is already in progress.
 
 ```py
 x_sub.start(0)
 ```
+
+It will receive updates that have already happened:
 
 ```none
 <Subscription /x > {'sequence': 1, 'timestamp': '2025-09-03T17:37:29.754038', 'content-type': 'application/octet-stream', 'shape': [3], 'offset': None, 'block': None, 'uri': 'http://localhost:8000/api/v1/array/full/x', 'payload': b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00'}
 <Subscription /x > {'sequence': 2, 'timestamp': '2025-09-03T17:37:36.678614', 'content-type': 'application/octet-stream', 'shape': [3], 'offset': [3], 'block': None, 'uri': 'http://localhost:8000/api/v1/array/full/x', 'payload': b'\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00'}
 ```
 
-Notice that all these updates include a `sequence` counter, starting from 1.
-Starting the subscription from `0` means "Start from as far back as you have."
-Starting it from some positive integer will start from a specify update. This
-can be useful for resuming after some interruption.
+and, from there, any new updates as well.
+
+Notice that content of the updates includes a `sequence` counter, starting from
+the number 1. Subscribers can use this if, for example, they need to recover
+from an interruption. They can subscribe from a specify number `sub.start(N)`.
+As already above, `x.start(0)` means, "Start from the oldest record retained."
+
+Of course, clients can always fetch _all_ the data via the non-streaming
+interface.
+
+The writer can let subscribers know that no more data is expected (for now).
+This does not prevent them from writing more later; it just signal that
+nothing more is expected. Live data data processing jobs may use this as
+a prompt to clean up and free up resources.
+
+```py
+x.close_stream()
+```
+
+This will stop the threads that are listening for updates and set `sub.closed`
+to `True`. Alternatively, a subscriber can unsubscribe even if the stream
+is still going:
+
+```py
+sub.close()
+```
+
+## Limitations
+
+This feature is in a very early preview stage.
+
+- Other data structures (table, sparse, awkward) are not yet supported.
+- Updates to metadata and deletions of nodes are not yet visible to subscribers.

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -122,7 +122,7 @@ and, from there, any new updates as well.
 
 Notice that content of the updates includes a `sequence` counter, starting from
 the number 1. Subscribers can use this if, for example, they need to recover
-from an interruption. They can subscribe from a specify number `sub.start(N)`.
+from an interruption. They can subscribe from a specific counter index `sub.start(N)`.
 As already above, `x.start(0)` means, "Start from the oldest record retained."
 
 Of course, clients can always fetch _all_ the data via the non-streaming

--- a/docs/source/tutorials/streaming.md
+++ b/docs/source/tutorials/streaming.md
@@ -121,7 +121,7 @@ It will receive updates that have already happened:
 and, from there, any new updates as well.
 
 Notice that content of the updates includes a `sequence` counter, starting from
-the number 1. Subscribers can use this if, for example, they need to recover
+the number 1 (with 0 reserved to unambiguously define the "start of the stream"). Subscribers can use this if, for example, they need to recover
 from an interruption. They can subscribe from a specific counter index `sub.start(N)`.
 As already above, `x.start(0)` means, "Start from the oldest record retained."
 

--- a/tiled/_tests/test_subscription.py
+++ b/tiled/_tests/test_subscription.py
@@ -247,3 +247,4 @@ def test_subscribe_after_first_update_from_beginning_subscription(
 
     # Clean up the subscription
     subscription.stop()
+    assert subscription.closed

--- a/tiled/_tests/test_subscription.py
+++ b/tiled/_tests/test_subscription.py
@@ -207,11 +207,11 @@ def test_subscribe_after_first_update_from_beginning_subscription(
             received_event.set()
 
     # Create subscription for the streaming node with start=0
-    subscription = Subscription(context=context, segments=[unique_key], start=0)
+    subscription = Subscription(context=context, segments=[unique_key])
     subscription.add_callback(callback)
 
     # Start the subscription
-    subscription.start()
+    subscription.start(start=0)
 
     # Write more updates
     for i in range(2, 4):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -248,7 +248,7 @@ class Context:
             if self.cache_settings["uri"].startswith("redis"):
                 from redis import asyncio as redis
 
-                socket_timeout = self.cache_settings.get("socket_timeout", 10.0)
+                socket_timeout = self.cache_settings.get("socket_timeout", None)
                 socket_connect_timeout = self.cache_settings.get(
                     "socket_connect_timeout", 10.0
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1283,6 +1283,7 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
         sequence = await self.context.cache_client.incr(f"sequence:{self.node.id}")
         metadata = {
+            "sequence": sequence,
             "timestamp": datetime.now().isoformat(),
             "content-type": media_type,
             "shape": shape,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1175,9 +1175,9 @@ class CatalogNodeAdapter:
                                 live_seq = int(message["data"])
                                 await stream_buffer.put(live_seq)
                             except Exception as e:
-                                print(f"Error parsing live message: {e}")
+                                logger.exception(f"Error parsing live message: {e}")
                 except Exception as e:
-                    print(f"Live subscription error: {e}")
+                    logger.exception(f"Live subscription error: {e}")
                 finally:
                     await pubsub.unsubscribe(f"notify:{self.node.id}")
                     await pubsub.aclose()
@@ -1187,7 +1187,7 @@ class CatalogNodeAdapter:
             if sequence is not None:
                 current_seq = await cache_client.get(f"sequence:{self.node.id}")
                 current_seq = int(current_seq) if current_seq is not None else 0
-                print("Replaying old data...")
+                logger.debug("Replaying old data...")
                 for s in range(sequence, current_seq + 1):
                     await stream_data(s)
             # New data
@@ -1198,7 +1198,7 @@ class CatalogNodeAdapter:
                 else:
                     await websocket.close(code=1000, reason="Producer ended stream")
             except WebSocketDisconnect:
-                print(f"Client disconnected from node {self.node.id}")
+                logger.info(f"Client disconnected from node {self.node.id}")
             finally:
                 live_task.cancel()
 

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 from urllib.parse import parse_qs, urlparse
 
 import dask
@@ -349,18 +349,9 @@ class _DaskArrayClient(BaseClient):
             params=params,
         )
 
-    def subscribe(self, start: Optional[int] = None) -> "Subscription":
+    def subscribe(self) -> "Subscription":
         """
         Create a Subscription on writes to this node.
-
-        Parameters
-        ----------
-        start : int, optional
-            By default, the stream begins from the most recent update. Use this
-            parameter to replay from some earlier update. Use 1 to start from
-            the first item, 0 to start from as far back as available (which may
-            be later than the first item), or any positive integer to start
-            from a specific point in the sequence.
 
         Returns
         -------
@@ -369,7 +360,7 @@ class _DaskArrayClient(BaseClient):
         # Keep this import here to defer the websockets import until/unless needed.
         from .stream import Subscription
 
-        return Subscription(self.context, self.path_parts, start)
+        return Subscription(self.context, self.path_parts)
 
 
 # Subclass with a public class that adds the dask-specific methods.

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -285,6 +285,11 @@ class BaseClient:
         return self.item["links"]["self"]
 
     @property
+    def path_parts(self):
+        "Location of node in tree, given as list of path segments."
+        return self._item["attributes"]["ancestors"] + [self._item["id"]]
+
+    @property
     def structure_family(self):
         "Quick access to this entry"
         return StructureFamily[self.item["attributes"]["structure_family"]]

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -1196,18 +1196,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             data, key=key, metadata=metadata, specs=specs, access_tags=access_tags
         )
 
-    def subscribe(self, start: Optional[int] = None) -> "Subscription":
+    def subscribe(self) -> "Subscription":
         """
         Create a Subscription on writes to this node.
-
-        Parameters
-        ----------
-        start : int, optional
-            By default, the stream begins from the most recent update. Use this
-            parameter to replay from some earlier update. Use 1 to start from
-            the first item, 0 to start from as far back as available (which may
-            be later than the first item), or any positive integer to start
-            from a specific point in the sequence.
 
         Returns
         -------
@@ -1216,7 +1207,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         # Keep this import here to defer the websockets import until/unless needed.
         from .stream import Subscription
 
-        return Subscription(self.context, self.path_parts, start)
+        return Subscription(self.context, self.path_parts)
 
 
 def _queries_to_params(*queries):

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     import pandas
     import pyarrow
 
+    from .stream import Subscription
+
 
 class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
     # This maps the structure_family sent by the server to a client-side object that
@@ -1193,6 +1195,28 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
         return self.write_table(
             data, key=key, metadata=metadata, specs=specs, access_tags=access_tags
         )
+
+    def subscribe(self, start: Optional[int] = None) -> "Subscription":
+        """
+        Create a Subscription on writes to this node.
+
+        Parameters
+        ----------
+        start : int, optional
+            By default, the stream begins from the most recent update. Use this
+            parameter to replay from some earlier update. Use 1 to start from
+            the first item, 0 to start from as far back as available (which may
+            be later than the first item), or any positive integer to start
+            from a specific point in the sequence.
+
+        Returns
+        -------
+        subscription : Subscription
+        """
+        # Keep this import here to defer the websockets import until/unless needed.
+        from .stream import Subscription
+
+        return Subscription(self.context, self.path_parts, start)
 
 
 def _queries_to_params(*queries):

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -15,7 +15,7 @@ Callback = Callable[["Subscription", dict], None]
 "A Callback will be called with the Subscription calling it and a dict with the update."
 
 
-class TestClientWebsocketWrapper:
+class _TestClientWebsocketWrapper:
     """Wrapper for TestClient websockets."""
 
     def __init__(self, http_client, uri: httpx.URL):
@@ -41,7 +41,7 @@ class TestClientWebsocketWrapper:
         self._websocket.__exit__(None, None, None)
 
 
-class RegularWebsocketWrapper:
+class _RegularWebsocketWrapper:
     """Wrapper for regular websockets."""
 
     def __init__(self, http_client, uri: httpx.URL):
@@ -100,9 +100,11 @@ class Subscription:
         self._callbacks = set()
         self._close_event = threading.Event()
         if isinstance(context.http_client, TestClient):
-            self._websocket = TestClientWebsocketWrapper(context.http_client, self._uri)
+            self._websocket = _TestClientWebsocketWrapper(
+                context.http_client, self._uri
+            )
         else:
-            self._websocket = RegularWebsocketWrapper(context.http_client, self._uri)
+            self._websocket = _RegularWebsocketWrapper(context.http_client, self._uri)
 
     @property
     def context(self) -> Context:

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -89,9 +89,10 @@ class Subscription:
         if start is not None:
             params["start"] = start
         scheme = "wss" if context.api_uri.scheme == "https" else "ws"
-        path = "stream/single" + "/".join(f"/{segment}" for segment in segments)
+        self._node_path = "/".join(f"/{segment}" for segment in segments)
+        uri_path = "/api/v1/stream/single" + self._node_path
         self._uri = httpx.URL(
-            str(context.api_uri.copy_with(scheme=scheme)) + path,
+            str(context.api_uri.copy_with(scheme=scheme, path=uri_path)),
             params=params,
         )
         name = f"tiled-subscription-{self._uri}"
@@ -104,6 +105,9 @@ class Subscription:
             )
         else:
             self._websocket = _RegularWebsocketWrapper(context.http_client, self._uri)
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self._node_path} >"
 
     @property
     def context(self) -> Context:

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -6,7 +6,6 @@ from typing import Callable, List
 import anyio
 import httpx
 import msgpack
-from starlette.testclient import TestClient
 from websockets.sync.client import connect
 
 from tiled.client.context import Context
@@ -99,7 +98,7 @@ class Subscription:
         self._thread = threading.Thread(target=self._receive, daemon=True, name=name)
         self._callbacks = set()
         self._close_event = threading.Event()
-        if isinstance(context.http_client, TestClient):
+        if getattr(self.context.http_client, "app", None):
             self._websocket = _TestClientWebsocketWrapper(
                 context.http_client, self._uri
             )

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -136,6 +136,20 @@ class Subscription:
                 ...
 
         >>> sub.add_callback(f)
+
+        Start receiving updates, beginning with the next one.
+
+        >>> sub.start()
+
+        Or start receiving updates beginning as far back as the server has
+        available.
+
+        >>> sub.start(0)
+
+        Or start receiving updates beginning with a specific sequence number.
+
+        >>> sub.start(3)
+
         """
 
         def cleanup(ref: weakref.ref) -> None:


### PR DESCRIPTION
This documentation PR includes some "documentation-driven development":

- Fixed missing `sequence` key in array update
- Added convenience method `x.subscribe()` for creating `Subscription` from client object
- Added a nice repr to `Subscription`
- Changed API of `Subscription` to specify where to start when calling `start()` instead of at `Subscription` instantiation time.
- Handled write-initiated close gracefully (no exception printed in the client) and exposed `sub.closed` so clients can check if the stream is over. (We might actually want a callback registry for that, so clients can subscribe to be _notified_ when the stream is over, but that's more than a tweak so I'll leave it for a future PR.)

We need "explanation" docs but I don't want to hold v0.1.0 over it.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
