### PR TITLE
fix: The built UI app was placed in the wrong location.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -108,7 +108,7 @@ ENV TILED_CONFIG=/deploy/config
 # Copy the pre-built `/app` directory to the runtime container
 # and change the ownership to user app and group app in one step.
 COPY --from=app_build --chown=app:app /app /app
-COPY --from=web_frontend_build --chown=app:app /src/dist /src/share/tiled/ui
+COPY --from=web_frontend_build --chown=app:app /src/dist /app/share/tiled/ui
 
 USER app
 WORKDIR /app


### PR DESCRIPTION
Closes #1139 

The app loads, but now I'm seeing issues with the single-user auth. It may be that this may not be operating as expected; it was recently refactored slightly as part of enabling the WebSockets work. I tested it at the time, but could have been mistaken.

https://github.com/bluesky/tiled/blob/6b47006419c1bf88cb952b9c843cc5ed7114f52a/tiled/server/authentication.py#L300-L313

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
