### PR TITLE
ENH: configure recycle and pre_ping for storage ADBC connections

### DIFF
--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -102,7 +102,11 @@ class SQLStorage(Storage):
             return sqlalchemy.pool.StaticPool(creator)
         else:
             return sqlalchemy.pool.QueuePool(
-                creator, pool_size=self.pool_size, max_overflow=self.max_overflow
+                creator,
+                pool_size=self.pool_size,
+                max_overflow=self.max_overflow,
+                recycle=1800,  # Recycle connections after 30 minutes
+                pre_ping=False,  # Default -- don't test connections before using them
             )
 
     def connect(self) -> "adbc_driver_manager.dbapi.Connection":


### PR DESCRIPTION
Fine-tuning DB Connection Pooling:
1. Allow recycling in Storage connection Pool;
2. Explicitly configure `pre_ping` (False by default) in Storage connection pool;
3. ...

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
