### PR TITLE
Pin back duckdb to avoid regression in 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## v0.1.2 (2025-09-17)
+
+This release temporarily pins backs the version of the depedency DuckDB to
+avoid breakage (seemingly unintended) to documented behavior.
+
+
 ## v0.1.1 (2025-09-10)
 
 ### Fixed

--- a/pixi.toml
+++ b/pixi.toml
@@ -89,7 +89,7 @@ asyncpg = "*"
 cachetools = "*"
 canonicaljson = "*"
 dask = "*"
-duckdb = "*"
+duckdb = "<1.4.0"  # https://github.com/bluesky/tiled/issues/1144
 fastapi = ">=0.115.8"
 jinja2 = "*"
 jmespath = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ all = [
     "dask",
     "dask[array]",
     "dask[dataframe]",
-    "duckdb",
+    "duckdb <1.4.0",  # https://github.com/bluesky/tiled/issues/1144
     "entrypoints",
     "fastapi >=0.115.8",
     "h5netcdf",
@@ -230,7 +230,7 @@ server = [
     "dask",
     "dask[array]",
     "dask[dataframe]",
-    "duckdb",
+    "duckdb <1.4.0",  # https://github.com/bluesky/tiled/issues/1144
     "entrypoints",
     "fastapi >=0.115.8",
     "h5netcdf",


### PR DESCRIPTION
Works around #1144 as a temporary fix while we wait for word (and hopefully a fix) from upstream.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
