### PR TITLE
Accept 'trees' and 'media_types' config in multiple files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## Unreleased
+
+### Fixed
+
+- A regression in v0.1.1 disallowed specifying `trees` and `media_types`
+  across multiple files. (This can be useful for config.d-style configuration
+  where different config files are managed by different stages of configuration
+  management.)
+
+
 ## v0.1.2 (2025-09-17)
 
 This release temporarily pins backs the version of the depedency DuckDB to

--- a/tiled/_tests/test_config.py
+++ b/tiled/_tests/test_config.py
@@ -114,16 +114,36 @@ def test_extra_files(tmpdir):
     parse_configs(str(tmpdir))
 
 
-def test_multi_file_conflict(tmpdir):
+def test_multi_file_trees(tmpdir):
+    "Test that 'trees' can be specified across more than one file, merged."
     import yaml
 
-    conf1 = {"trees": [{"path": "/", "tree": "tiled.examples.generated_minimal:tree"}]}
-    conf2 = {"trees": [{"path": "/", "tree": "tiled.examples.generated_minimal:tree"}]}
+    conf1 = {"trees": [{"path": "/a", "tree": "tiled.examples.generated_minimal:tree"}]}
+    conf2 = {"trees": [{"path": "/b", "tree": "tiled.examples.generated_minimal:tree"}]}
     with open(tmpdir / "conf1.yml", "w") as c1:
         yaml.dump(conf1, c1)
     with open(tmpdir / "conf2.yml", "w") as c2:
         yaml.dump(conf2, c2)
-    with pytest.raises(ValueError, match="Duplicate configuration for {'trees'}"):
+    parse_configs(tmpdir)
+
+
+def test_multi_file_conflict(tmpdir):
+    "Test that media_types can only be specified in a single config file."
+    import yaml
+
+    conf1 = {
+        "media_types": {},
+        "trees": [{"path": "/a", "tree": "tiled.examples.generated_minimal:tree"}],
+    }
+    conf2 = {
+        "media_types": {},
+        "trees": [{"path": "/b", "tree": "tiled.examples.generated_minimal:tree"}],
+    }
+    with open(tmpdir / "conf1.yml", "w") as c1:
+        yaml.dump(conf1, c1)
+    with open(tmpdir / "conf2.yml", "w") as c2:
+        yaml.dump(conf2, c2)
+    with pytest.raises(ValueError, match="Duplicate configuration for {'media_types'}"):
         parse_configs(tmpdir)
 
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -304,7 +304,16 @@ def parse_configs(src_file: Union[str, Path]) -> Config:
             if f.is_file() and f.suffix == ".yml":
                 new_config = parse(f)
                 if common := new_config.keys() & conf.keys():
-                    raise ValueError(f"Duplicate configuration for {common} in {f}")
+                    # These specific keys can be merged from separate files.
+                    # This can be useful for config.d-style where different
+                    # files are managed by different stages of configuration
+                    # management.
+                    mergeable_lists = {"trees", "specs"}
+                    for key in common.intersection(mergeable_lists):
+                        conf[key].extend(new_config[key])
+                        common.remove(key)
+                    if common:
+                        raise ValueError(f"Duplicate configuration for {common} in {f}")
                 conf.update(new_config)
     else:
         conf = parse(src_file)


### PR DESCRIPTION
Closes #1148

Testing the NSLS-II tiled configuration (as I should have done before merging #1091)...

On `main`:

```
❯ uv run tiled admin check-config ../tiled-site-config
Duplicate configuration for {'trees', 'specs'} in ../tiled-site-config/bluesky_prod_mongos.yml
```

On this PR branch:

```
❯ uv run tiled admin check-config ../tiled-site-config
No errors found in configuration.
```

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
