### PR TITLE
Bug: De-dupe profile editor artifacts

### DIFF
--- a/tiled/profiles.py
+++ b/tiled/profiles.py
@@ -85,10 +85,10 @@ def gather_profiles(paths, strict=True):
             for filename in path.iterdir():
                 filepath = path / filename
                 # Only parse files in the YAML format.
-                if (
-                    filename.name.startswith(".")
-                    or filename.suffix not in {".yml", ".yaml"}
-                ):
+                if filename.name.startswith(".") or filename.suffix not in {
+                    ".yml",
+                    ".yaml",
+                }:
                     continue
                 try:
                     content = parse(filepath)


### PR DESCRIPTION
Resolves #1157 by blocking file suffixes identified as editor artifacts. I didn't think to go so far as exclude certain valid alphanumeric filetypes such as `.bak` that might benefit from the creation of an explicit file extension blacklist.