### PR TITLE
Fix regression in config-parsing classmethod constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   across multiple files. (This can be useful for config.d-style configuration
   where different config files are managed by different stages of configuration
   management.)
+- A regression in v0.1.1 disallowed specifying
+  `tree: databroker.mongo_normalized:MongoAdapter.from_uri` or in fact
+  specifying any method (e.g. classmethod constructor) as a tree.
 
 
 ## v0.1.2 (2025-09-17)

--- a/tiled/_tests/test_config.py
+++ b/tiled/_tests/test_config.py
@@ -215,3 +215,22 @@ def test_empty_api_key():
         ValidationError, match=r"should match pattern '\[a-zA-Z0-9\]\+'"
     ):
         Config.model_validate({"authentication": {"single_user_api_key": ""}})
+
+
+class Dummy:
+    "Referenced below in test_tree_given_as_method"
+
+    def constructor():
+        return tree
+
+
+def test_tree_given_as_method():
+    config = {
+        "trees": [
+            {
+                "tree": f"{__name__}:Dummy.constructor",
+                "path": "/",
+            },
+        ]
+    }
+    Config.model_validate(config)

--- a/tiled/_tests/test_entrypoint_string.py
+++ b/tiled/_tests/test_entrypoint_string.py
@@ -1,0 +1,38 @@
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from ..type_aliases import EntryPointString
+
+type_adapter = TypeAdapter(EntryPointString)
+
+
+@pytest.mark.parametrize(
+    ("s", "args"),
+    [
+        # callables and valid arguments for them
+        ("json:dumps", ({"a": 1},)),  # function in package
+        ("os.path:join", ("a", "b")),  # function in submodule
+        ("datetime:datetime.now", ()),  # method
+    ],
+)
+def test_valid_input(s, args):
+    result = type_adapter.validate_python(s)
+    # Verify that we have the real method by calling it.
+    result(*args)
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        "",  # empty
+        ":",  # empty parts
+        "nonexistent:module",  # bad module
+        "os:nonexistent",  # bad attribute
+        "os.path:nonexistent.method",  # bad nested attribute
+        "os.path.join",  # dotted syntax (not allowed)
+        "datetime.datetime.now",  # dotted syntax (not allowed)
+    ],
+)
+def test_invalid_input(s):
+    with pytest.raises(ValidationError):
+        type_adapter.validate_python(s)

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Annotated, Any, Iterator, Optional, Union
 
-from pydantic import BaseModel, Field, ImportString, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from tiled.server.protocols import ExternalAuthenticator, InternalAuthenticator
 from tiled.type_aliases import AppTask, TaskMap
@@ -26,6 +26,7 @@ from .media_type_registration import (
 from .query_registration import default_query_registry
 from .server.settings import get_settings
 from .structures.core import Spec
+from .type_aliases import EntryPointString
 from .utils import parse, prepend_to_sys_path
 from .validation_registration import ValidationRegistry, default_validation_registry
 
@@ -38,7 +39,7 @@ def sub_paths(segments: tuple[str, ...]) -> Iterator[tuple[str, ...]]:
 
 
 class TreeSpec(BaseModel):
-    tree_type: Annotated[ImportString, Field(alias="tree")]
+    tree_type: Annotated[EntryPointString, Field(alias="tree")]
     path: str
     args: Optional[dict[str, Any]] = None
 
@@ -84,7 +85,7 @@ class TreeSpec(BaseModel):
 
 class AuthenticationProviderSpec(BaseModel):
     provider: str
-    authenticator: ImportString
+    authenticator: EntryPointString
     args: Optional[dict[str, Any]] = None
 
     def into_auth_entry(
@@ -138,7 +139,7 @@ class Database(BaseModel):
 
 
 class AccessControl(BaseModel):
-    access_policy: ImportString
+    access_policy: EntryPointString
     args: Optional[dict[str, Any]]
 
     def build(self):
@@ -151,7 +152,7 @@ class MetricsConfig(BaseModel):
 
 class ValidationSpec(BaseModel):
     spec: str
-    validator: Optional[ImportString] = None
+    validator: Optional[EntryPointString] = None
 
 
 class StreamingCache(BaseModel):
@@ -164,7 +165,7 @@ class StreamingCache(BaseModel):
 
 class Config(BaseModel):
     trees: list[TreeSpec]
-    media_types: dict[str, dict[str, ImportString]] = {}
+    media_types: dict[str, dict[str, EntryPointString]] = {}
     file_extensions: dict[str, str] = {}
     authentication: Authentication = Authentication()
     database: Optional[Database] = None

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -1,5 +1,7 @@
 import sys
 
+from pydantic import AfterValidator
+
 from tiled.structures.array import ArrayStructure
 from tiled.structures.awkward import AwkwardStructure
 from tiled.structures.sparse import SparseStructure
@@ -10,7 +12,19 @@ if sys.version_info < (3, 10):
 else:
     from types import EllipsisType
 
-from typing import Any, Callable, Coroutine, Dict, List, Set, TypedDict, Union
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Set,
+    TypedDict,
+    Union,
+)
+
+from .utils import import_object
 
 JSON = Dict[str, Union[str, int, float, bool, Dict[str, "JSON"], List["JSON"]]]
 
@@ -28,6 +42,12 @@ class TaskMap(TypedDict):
     background: list[AppTask]
     startup: list[AppTask]
     shutdown: list[AppTask]
+
+
+EntryPointString = Annotated[
+    str,
+    AfterValidator(import_object),
+]
 
 
 __all__ = [

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -460,8 +460,20 @@ def import_object(colon_separated_string, accept_live_object=True):
     for attr in obj_path.split("."):
         if not attr.isidentifier():
             raise ValueError(MESSAGE)
-    module = importlib.import_module(import_path)
-    return operator.attrgetter(obj_path)(module)
+    try:
+        module = importlib.import_module(import_path)
+    except ModuleNotFoundError:
+        raise ValueError(
+            f"Could not parse {colon_separated_string!r}: "
+            f"No module {import_path!r} could be found"
+        )
+    try:
+        return operator.attrgetter(obj_path)(module)
+    except AttributeError:
+        raise ValueError(
+            f"Could not parse {colon_separated_string!r}: "
+            f"No object {obj_path!r} found in module {module!r}"
+        )
 
 
 def modules_available(*module_names):


### PR DESCRIPTION
Tiled config expects entrypoint-style strings, where the module and the object within it are separated by a _colon_ not a dot, as in:

```
databroker.mongo_normalized:MongoAdapter.from_uri
```

This format avoids potential ambiguity, so we prefer it. In #1091 the pydantic config parsing treating these as pydantic `ImportString`s which use dots only and cannot be used to reference methods (such as classmethod constructors). This new unit test reproduces the error:

```
____________________________________________________________________________ test_tree_given_as_method _____________________________________________________________________________

    def test_tree_given_as_method():
        config = {
            "trees": [
                {
                    "tree": f"{__name__}:Dummy.constructor",
                    "path": "/",
                },
            ]
        }
>       Config.model_validate(config)
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for Config
E       trees.0.tree
E         Invalid python path: cannot import name 'Dummy.constructor' from 'tiled._tests.test_config' [type=import_error, input_value='tiled._tests.test_config:Dummy.constructor', input_type=str]

tiled/_tests/test_config.py:214: ValidationError
```

The PR then introduces a new `EntryPointString` type which can be used instead.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
