### PR TITLE
Additional Metrics for Connection Pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## Unreleased
+
+### Added
+
+- Monitoring of pool overflow and max-out events.
+
+
 ## v0.1.4 (2025-09-24)
 
 ### Fixed


### PR DESCRIPTION
This add Prometheus metrics to monitor when the connection pool overflows and when all connections (regular + overflow are checked out).

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
