### PR TITLE
Keep Extra kwargs in CompositeClient.base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## Unreleased
+
+### Fixed
+
+- Additional kwargs (`include_data_sources`, `queries`, `sorting`) propagated to
+  the instantiated container when calling `CompositeClient.base`.
+
+
 ## v0.1.4 (2025-09-24)
 
 ### Fixed

--- a/tiled/client/composite.py
+++ b/tiled/client/composite.py
@@ -59,7 +59,12 @@ class CompositeClient(Container):
     def base(self):
         "Return the base Container client instead of a CompositeClient"
         return Container(
-            self.context, item=self.item, structure_clients=self.structure_clients
+            self.context,
+            item=self.item,
+            structure_clients=self.structure_clients,
+            queries=self._queries,
+            sorting=self._sorting,
+            include_data_sources=self._include_data_sources,
         )
 
     def _keys_slice(self, start, stop, direction, _ignore_inlined_contents=False):


### PR DESCRIPTION
This fixes a regression in Bluesky TiledWriter, which caused it to send unnecessary GET requests because `include_data_sources` didn't propagate past `CompositeClient.base`.

Related: [Bluesky PR](https://github.com/bluesky/bluesky/pull/1947)

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
