### PR TITLE
Avoid circular import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## Unreleased
+
+### Fixed
+
+- Resolved circular dependency in `tiled.storage`.
+
+
 ## v0.1.5 (2025-09-26)
 
 ### Added

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -8,8 +8,6 @@ from urllib.parse import urlparse, urlunparse
 
 import sqlalchemy.pool
 
-from .server.metrics import monitor_db_pool
-
 if TYPE_CHECKING:
     import adbc_driver_manager.dbapi
 
@@ -99,6 +97,8 @@ class SQLStorage(Storage):
 
     @functools.cached_property
     def _connection_pool(self) -> "sqlalchemy.pool.QueuePool":
+        from .server.metrics import monitor_db_pool
+
         creator = self._adbc_connection.adbc_clone
         if (self.dialect == "duckdb") or (":memory:" in self.uri):
             pool = sqlalchemy.pool.StaticPool(creator)


### PR DESCRIPTION
There is a circular dependency issue that can be tripped like this:

```sh
❯ python -c "import tiled.storage"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import tiled.storage
  File "/home/dallan/Repos/bnl/tiled/tiled/storage.py", line 11, in <module>
    from .server.metrics import monitor_db_pool
  File "/home/dallan/Repos/bnl/tiled/tiled/server/__init__.py", line 1, in <module>
    from .simple import SimpleTiledServer
  File "/home/dallan/Repos/bnl/tiled/tiled/server/simple.py", line 15, in <module>
    from ..storage import SQLStorage, get_storage
ImportError: cannot import name 'SQLStorage' from partially initialized module 'tiled.storage' (most likely due to a circular import) (/home/dallan/Repos/bnl/tiled/tiled/storage.py)
```

Normal usage happens to step around this issue by import things in the right order, but we should fix it. This came up in https://github.com/conda-forge/tiled-suite-feedstock.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
