### PR TITLE
FIX: Ensure Column Names are Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 # Changelog
 
 
+## Unreleased
+
+### Fixed
+
+- Column names in `TableStructure` are explicitly converted to strings.
+
+
 ## v0.1.6 (2025-09-29)
 
 ### Fixed

--- a/tiled/structures/table.py
+++ b/tiled/structures/table.py
@@ -24,6 +24,7 @@ class TableStructure:
     resizable: Union[bool, Tuple[bool, ...]] = False
 
     def __post_init__(self):
+        self.columns = list(map(str, self.columns))  # Ensure all column names are str
         for column in self.columns:
             if column.startswith("_"):
                 raise ValueError(


### PR DESCRIPTION
This adds a type conversion for column names in `TableStructure`. Previously, if a structure would have been intialized from e.g. a DataFrame with numerical column names, these names would be kept as integers and break downstream processing that assumes they should be strings.

For example,
```python
df = pandas.DataFrame({1:['a', 'b', 'c'], 2:[10, 20, 30]})
ts = TableStructure.from_pandas(df)
```
raises `AttributeError: 'int' object has no attribute 'startswith'`.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
