### PR TITLE
Add client dependency on sqlalchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ client = [
     "pyarrow >=14.0.1",  # includes fix to CVE 2023-47248
     "rich",
     "sparse >=0.15.5",
+    "sqlalchemy[asyncio] >=2",
     "stamina",
     "websockets",
     "watchfiles",


### PR DESCRIPTION
Recent changes to add typing to adapters have introduced a runtime
dependency on sqlalchemy in the client. The dependency is already
present in the 'all' group but not if only the client group is enabled.

Not sure if this is the right approach or whether effort should be made
to remove the dependency as (I don't think) sqlalchemy is actually used
at runtime from the client.