### PR TITLE
Move util shared by client and adapters out of adapters subpackage.

### DIFF
--- a/tiled/adapters/utils.py
+++ b/tiled/adapters/utils.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import defaultdict
 from typing import Any, Optional
 
@@ -7,40 +6,14 @@ from tiled.adapters.core import A, S
 from ..structures.data_source import DataSource
 
 # for back-compat
+from ..utils import IndexersMixin  # noqa: F401
 from ..utils import node_repr as tree_repr  # noqa: F401
 
-_MESSAGE = (
-    "Instead of {name}_indexer[...] use {name}()[...]. "
-    "The {name}_indexer accessor is deprecated."
-)
-
-
-class IndexersMixin:
-    """
-    Provides sliceable attributes keys_indexer, items_indexer, values_indexer.
-
-    This is just for back-ward compatibility.
-    """
-
-    keys: Any
-    values: Any
-    items: Any
-    fn: Any
-
-    @property
-    def keys_indexer(self) -> Any:
-        warnings.warn(_MESSAGE.format(name="keys"), DeprecationWarning)
-        return self.keys()
-
-    @property
-    def values_indexer(self) -> Any:
-        warnings.warn(_MESSAGE.format(name="values"), DeprecationWarning)
-        return self.values()
-
-    @property
-    def items_indexer(self) -> Any:
-        warnings.warn(_MESSAGE.format(name="items"), DeprecationWarning)
-        return self.items()
+__all__ = [
+    "IndexersMixin",
+    "asset_parameters_to_adapter_kwargs",
+    "init_adapter_from_catalog",
+]
 
 
 class IndexCallable:

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -14,13 +14,19 @@ import entrypoints
 import httpx
 import orjson
 
-from ..adapters.utils import IndexersMixin
 from ..iterviews import ItemsView, KeysView, ValuesView
 from ..queries import KeyLookup
 from ..query_registration import default_query_registry
 from ..structures.core import StructureFamily
 from ..structures.data_source import DataSource
-from ..utils import UNCHANGED, OneShotCachedMap, Sentinel, node_repr, safe_json_dump
+from ..utils import (
+    UNCHANGED,
+    IndexersMixin,
+    OneShotCachedMap,
+    Sentinel,
+    node_repr,
+    safe_json_dump,
+)
 from .base import STRUCTURE_TYPES, BaseClient
 from .utils import (
     MSGPACK_MIME_TYPE,

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -901,3 +901,36 @@ def interning_constructor(loader, node):
 
 
 InterningLoader.add_constructor("tag:yaml.org,2002:str", interning_constructor)
+
+_MESSAGE = (
+    "Instead of {name}_indexer[...] use {name}()[...]. "
+    "The {name}_indexer accessor is deprecated."
+)
+
+
+class IndexersMixin:
+    """
+    Provides sliceable attributes keys_indexer, items_indexer, values_indexer.
+
+    This is just for back-ward compatibility.
+    """
+
+    keys: Any
+    values: Any
+    items: Any
+    fn: Any
+
+    @property
+    def keys_indexer(self) -> Any:
+        warnings.warn(_MESSAGE.format(name="keys"), DeprecationWarning)
+        return self.keys()
+
+    @property
+    def values_indexer(self) -> Any:
+        warnings.warn(_MESSAGE.format(name="values"), DeprecationWarning)
+        return self.values()
+
+    @property
+    def items_indexer(self) -> Any:
+        warnings.warn(_MESSAGE.format(name="items"), DeprecationWarning)
+        return self.items()


### PR DESCRIPTION
This superses #1191, fixing the issue by avoiding a sqlalchemy dependency in the client.

This is a backward-compatible minor reorganization to fix an unreleased regression, so I'll leave it off the CHANGELOG.