### PR TITLE
Bury tiled.auth imports in CLI

### DIFF
--- a/tiled/commandline/_serve.py
+++ b/tiled/commandline/_serve.py
@@ -5,8 +5,6 @@ from typing import Any, List, Optional
 
 import typer
 
-from tiled.config import Authentication, parse_configs
-
 serve_app = typer.Typer(no_args_is_help=True)
 
 SQLITE_CATALOG_FILENAME = "catalog.db"
@@ -140,6 +138,7 @@ def serve_directory(
     stamp_head(ALEMBIC_INI_TEMPLATE_PATH, ALEMBIC_DIR, database)
 
     from ..catalog import from_uri as catalog_from_uri
+    from ..config import Authentication
     from ..server.app import build_app, print_server_info
 
     if keep_ext:
@@ -377,6 +376,7 @@ def serve_catalog(
     import urllib.parse
 
     from ..catalog import from_uri
+    from ..config import Authentication
     from ..server.app import build_app, print_server_info
 
     parsed_database = urllib.parse.urlparse(database)
@@ -560,6 +560,7 @@ def serve_pyobject(
     ),
 ):
     "Serve a Tree instance from a Python module."
+    from ..config import Authentication
     from ..server.app import build_app, print_server_info
     from ..utils import import_object
 
@@ -593,6 +594,7 @@ def serve_demo(
     port: int = typer.Option(8000, help="Bind to a socket with this port."),
 ):
     "Start a public server with example data."
+    from ..config import Authentication
     from ..server.app import build_app, print_server_info
     from ..utils import import_object
 
@@ -660,6 +662,8 @@ def serve_config(
 ):
     "Serve a Tree as specified in configuration file(s)."
     import os
+
+    from ..config import parse_configs
 
     config_path = config_path or Path(os.getenv("TILED_CONFIG", "config.yml"))
     try:


### PR DESCRIPTION
When installing the client-only dependencies, the tiled CLI errors out due to the server-only dependency, `cachetools`.

This PR buries the tiled auth imports that trigger this within the CLI _serve command.

This has been tested by building a pixi env that contains the following dependency.

```
tiled = { git = "https://github.com/padraic-shafer/tiled.git", branch="cli-deps", extras = ["client"] }
```