### PR TITLE
📵 Remove `async` from blocking function calls

### DIFF
--- a/tiled/adapters/zarr.py
+++ b/tiled/adapters/zarr.py
@@ -145,7 +145,7 @@ class ZarrArrayAdapter(Adapter[ArrayStructure]):
             raise NotImplementedError
         self._array[self._stencil()] = data
 
-    async def write_block(
+    def write_block(
         self,
         data: NDArray[Any],
         block: Tuple[int, ...],
@@ -155,7 +155,7 @@ class ZarrArrayAdapter(Adapter[ArrayStructure]):
         )
         self._array[block_slice] = data
 
-    async def patch(
+    def patch(
         self,
         data: NDArray[Any],
         offset: Tuple[int, ...],


### PR DESCRIPTION
This is a change to address some of the concerns raised in #1220 , allowing us to continue supporting Zarr 2.0 until it is EOL, at which point we can finally convert these blocking calls to natively async functions. For now this relies on the `ensure_awaitable` util to spool the workload onto a thread.
