### PR TITLE
Use Adapter[Any] as type of root_tree

### DIFF
--- a/tiled/_tests/test_config.py
+++ b/tiled/_tests/test_config.py
@@ -305,7 +305,8 @@ def test_empty_api_key():
 class Dummy:
     "Referenced below in test_tree_given_as_method"
 
-    def constructor():
+    @classmethod
+    def constructor(cls):
         return tree
 
 
@@ -318,7 +319,8 @@ def test_tree_given_as_method():
             },
         ]
     }
-    Config.model_validate(config)
+    conf = Config.model_validate(config)
+    assert conf.merged_trees == tree
 
 
 tree.include_routers = [APIRouter()]

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -36,6 +36,8 @@ from starlette.status import (
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
+from tiled.adapters.core import Adapter
+
 from ..access_control.protocols import AccessPolicy
 from ..authenticators import ProxiedOIDCAuthenticator
 from ..catalog.adapter import WouldDeleteData
@@ -115,7 +117,7 @@ def custom_openapi(app):
 
 
 def build_app(
-    tree,
+    tree: Adapter[Any],
     authentication: Optional[Authentication] = None,
     server_settings=None,
     query_registry: Optional[QueryRegistry] = None,
@@ -132,7 +134,7 @@ def build_app(
 
     Parameters
     ----------
-    tree : Tree
+    tree : Adapter[Any]
     authentication: dict, optional
         Dict of authentication configuration.
     server_settings: dict, optional

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -1,11 +1,10 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
-import pydantic_settings
 from fastapi import HTTPException, Query, Request
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND, HTTP_410_GONE
 
 from ..access_control.protocols import AccessPolicy
-from ..adapters.protocols import AnyAdapter
+from ..adapters.core import Adapter
 from ..structures.core import StructureFamily
 from ..type_aliases import AccessTags, Scopes
 from ..utils import BrokenLink
@@ -14,7 +13,7 @@ from .schemas import Principal
 from .utils import filter_for_access, record_timing
 
 
-def get_root_tree(request: Request):
+def get_root_tree(request: Request) -> Adapter[Any]:
     return request.app.state.root_tree
 
 
@@ -24,12 +23,12 @@ async def get_entry(
     principal: Optional[Principal],
     authn_access_tags: Optional[AccessTags],
     authn_scopes: Scopes,
-    root_tree: pydantic_settings.BaseSettings,
+    root_tree: Adapter[Any],
     session_state: dict,
     metrics: dict,
     structure_families: Optional[set[StructureFamily]] = None,
     access_policy: Optional[AccessPolicy] = None,
-) -> AnyAdapter:
+) -> Adapter[Any]:
     """
     Obtain a node in the tree from its path.
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -8,11 +8,10 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from functools import cache, partial
 from pathlib import Path
-from typing import Callable, List, Optional, TypeVar, Union
+from typing import Any, Callable, List, Optional, TypeVar, Union
 
 import anyio
 import packaging
-import pydantic_settings
 from fastapi import (
     APIRouter,
     Body,
@@ -41,7 +40,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_CONTENT,
 )
 
-from tiled.adapters.protocols import AnyAdapter
+from tiled.adapters.core import Adapter
 from tiled.authenticators import ProxiedOIDCAuthenticator
 from tiled.media_type_registration import SerializationRegistry
 from tiled.query_registration import QueryRegistry
@@ -683,7 +682,7 @@ def get_router(
         request: Request,
         path: str,
         principal: Optional[schemas.Principal] = Depends(get_current_principal),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
@@ -862,7 +861,7 @@ def get_router(
     async def table_partition(
         request: Request,
         partition: int,
-        entry: AnyAdapter,
+        entry: Adapter[Any],
         column: Optional[List[str]],
         format: Optional[str],
         filename: Optional[str],
@@ -998,7 +997,7 @@ def get_router(
 
     async def table_full(
         request: Request,
-        entry: AnyAdapter,
+        entry: Adapter[Any],
         column: Optional[List[str]],
         format: Optional[str],
         filename: Optional[str],
@@ -2461,7 +2460,7 @@ def get_router(
     async def validate_specs(
         specs: List[Spec],
         metadata: dict,
-        entry: Optional[AnyAdapter] = None,
+        entry: Optional[Adapter[Any]] = None,
         structure_family: Optional[StructureFamily] = None,
         structure: Optional[dict] = None,
         settings: Settings = Depends(get_settings),

--- a/tiled/server/zarr.py
+++ b/tiled/server/zarr.py
@@ -1,13 +1,14 @@
 import json
 import re
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import numcodecs
 import orjson
-import pydantic_settings
 from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import Response
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+
+from tiled.adapters.core import Adapter
 
 from ..structures.core import StructureFamily
 from ..type_aliases import AccessTags, Scopes
@@ -58,7 +59,7 @@ def get_zarr_router_v2() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         "Return entry.metadata as Zarr attributes metadata (.zattrs)"
@@ -94,7 +95,7 @@ def get_zarr_router_v2() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         await get_entry(
@@ -122,7 +123,7 @@ def get_zarr_router_v2() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         entry = await get_entry(
@@ -166,7 +167,7 @@ def get_zarr_router_v2() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         # If a zarr block is requested, e.g. http://localhost:8000/zarr/v2/array/0.1.2.3,
@@ -285,7 +286,7 @@ def get_zarr_router_v3() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         from zarr.dtype import parse_data_type
@@ -377,7 +378,7 @@ def get_zarr_router_v3() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         entry = await get_entry(
@@ -458,7 +459,7 @@ def get_zarr_router_v3() -> APIRouter:
         principal: Union[Principal] = Depends(get_current_principal),
         authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
         authn_scopes: Scopes = Depends(get_current_scopes),
-        root_tree: pydantic_settings.BaseSettings = Depends(get_root_tree),
+        root_tree: Adapter[Any] = Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
     ):
         entry = await get_entry(

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -1,13 +1,12 @@
 import sys
 
-from pydantic import AfterValidator
-
 if sys.version_info < (3, 10):
     EllipsisType = type(Ellipsis)
 else:
     from types import EllipsisType
 
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Callable,
@@ -17,6 +16,7 @@ from typing import (
     Sequence,
     Set,
     TypedDict,
+    TypeVar,
     Union,
 )
 
@@ -43,10 +43,48 @@ class TaskMap(TypedDict):
     shutdown: list[AppTask]
 
 
-EntryPointString = Annotated[
-    str,
-    AfterValidator(import_object),
-]
+if TYPE_CHECKING:
+    # Let type checking treat this as just the underlying type
+    T = TypeVar("T")
+    EntryPointString = Annotated[T, ...]
+else:
+    from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+    from pydantic.json_schema import JsonSchemaValue
+    from pydantic.types import AnyType
+    from pydantic_core import CoreSchema, core_schema
+
+    class EntryPointString:
+        """
+        Version of Pydantic's ImportString that supports importing fields of
+        imported items, not just top level attributes
+
+        A string such as `path.to.module:Type.field` is equivalent to
+
+        ```
+        from path.to.module import type
+        return type.field
+        ```
+
+        """
+
+        @classmethod
+        def __class_getitem__(cls, item: AnyType):
+            return Annotated[item, cls()]
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
+            return core_schema.no_info_plain_validator_function(function=import_object)
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, cs: CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return handler(core_schema.str_schema())
+
+        def __repr__(self) -> str:
+            return "EntryPointString"
 
 
 __all__ = [


### PR DESCRIPTION
The `root_tree` is never going to be an instance of `BaseSettings`.

I'm not clear on the difference between `AnyAdapter` and `Adapter[Any]`
but the `MapAdapter` returned from the config tree merging is not an
instance of `AnyAdapter` so I've used `Adapter[Any]` for everything for
now.

The `EntryPointString` has been expanded using the same approach as
pydantic's ImportString so that it satisfies the type checker when it's
used in the config loading instead of appearing as a str.

