### PR TITLE
Handle errors building queries from request

### DIFF
--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -632,7 +632,3 @@ class Key:
     # Note: __contains__ cannot be supported because the language coerces
     # the result of __contains__ to be a literal boolean. We are not
     # allowed to return a custom type.
-
-
-class QueryValueError(ValueError):
-    pass

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -24,7 +24,7 @@ from starlette.status import HTTP_200_OK, HTTP_304_NOT_MODIFIED, HTTP_400_BAD_RE
 from .. import queries
 from ..adapters.mapping import MapAdapter
 from ..links import links_for_node
-from ..queries import KeyLookup, QueryValueError
+from ..queries import KeyLookup
 from ..serialization import register_builtin_serializers
 from ..structures.core import Spec, StructureFamily
 from ..utils import (
@@ -184,7 +184,7 @@ async def apply_search(tree, filters, query_registry):
                     key_lookups.append(query.key)
                     continue
                 tree = tree.search(query)
-            except QueryValueError as err:
+            except TypeError as err:
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST, detail=err.args[0]
                 )


### PR DESCRIPTION
The exception being caught (QueryValueError) was never being raised and
the TypeErrors being raised instead caused 503 server errors when fields
were missing or invalid. Catching TypeError instead allows the client to
get a `400 Bad Request` error with the exception detail as intended.
