### PR TITLE
Update config schema for new authdb default

### DIFF
--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -301,8 +301,8 @@ properties:
           used without authentication providers, no database is used.)
 
           If Tiled is configured with authentication providers above but a database
-          URI is not specified, `sqlite:///./tiled.sqlite` (i.e. a SQLite database in
-          the current working directory) will be used.
+          URI is not specified, `sqlite:///file:authdb?mode=memory&cache=shared&uri=true`
+          (i.e. a SQLite database in process memory) will be used.
 
           Tiled officially supports PostgreSQL and SQLite, but any database engine
           supported by SQLAlchemy *may* work.


### PR DESCRIPTION
Make configuration reference reflect [recent changes](https://github.com/bluesky/tiled/blob/b71e1d6946e3e5544ac99852c0a3bdb28000b8ce/tiled/server/app.py#L471-L478) to authN URI defaults.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
