### PR TITLE
Bumped py39 env to python 3.13 after reaching end of life

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -120,7 +120,7 @@ pyarrow-all = ">=14.0.1"  # includes fix to CVE 2023-47248
 xarray = "*"
 
 [feature.py39.dependencies]
-python = "3.13.*" # python 3.9 reached end of life in October 2025
+python = "3.13.*"
 # python-blosc2 is not available for Python 3.9
 
 [feature.py310.dependencies]


### PR DESCRIPTION
### Checklist
- [x] Add a Changelog entry

This PR updates the `pixi.toml` file to stop using python 3.9 as it reached End of Life back in October 2025