### PR TITLE
Add custom auth for tiled client

### DIFF
--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -290,6 +290,8 @@ class Context:
             if len(self.server_info.authentication.providers) == 1
             else None
         )
+        # To determine httpx.Auth used by Tiled client is TiledAuth(internal) or external Auth
+        self.has_external_auth = False
 
     def __repr__(self):
         auth_info = []


### PR DESCRIPTION
The tiled client currently supports non-interactive authentication exclusively through API keys. With this PR, users can authenticate using service accounts (i.e., obtain access tokens non-interactively for machine users) or take full control of the tiled-client authentication flow themselves.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
