### PR TITLE
Implement cursor-based Pagination for Catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Write the date in place of the "Unreleased" in the case a new version is release
   The new `page[cursor]` query parameter is accepted alongside the existing
   `page[offset]` and `page[limit]` parameters; supplying both at once is
   rejected with HTTP 400.
-
 - Support for slicing arrays backed by multipart adapters with modified shapes
 - OIDC Authenticator for Azure Entra
 - Add more administrative CLI commands centered around the creation of service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Added
 
+- Cursor-based pagination for catalog containers on the default sort order.
+  The server now uses the node `id` as an opaque cursor, eliminating the
+  duplicate-and-skip problem that offset pagination suffers when items are
+  inserted concurrently. Non-default sort orders continue to use offset
+  pagination. Clients that supply `page[offset]` on the default sort are
+  transparently migrated to cursor pagination from the second page onward.
+  The new `page[cursor]` query parameter is accepted alongside the existing
+  `page[offset]` and `page[limit]` parameters; supplying both at once is
+  rejected with HTTP 400.
+
 - Support for slicing arrays backed by multipart adapters with modified shapes
 - OIDC Authenticator for Azure Entra
 - Add more administrative CLI commands centered around the creation of service

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,9 +190,9 @@ def sql_storage_uri(request):
 
 
 @pytest_asyncio.fixture
-async def postgresql_adapter(request, tmpdir):
+async def postgresql_catalog_adapter(request, tmpdir):
     """
-    Adapter instance
+    Catalog adapter instance backed by PostgreSQL
 
     Note that startup() and shutdown() are not called, and must be run
     either manually (as in the fixture 'a') or via the app (as in the fixture 'client').
@@ -201,13 +201,12 @@ async def postgresql_adapter(request, tmpdir):
         raise pytest.skip("No TILED_TEST_POSTGRESQL_URI configured")
     # Create temporary database.
     async with temp_postgres(TILED_TEST_POSTGRESQL_URI) as uri_with_database_name:
-        # Build an adapter on it, and initialize the database.
-        adapter = from_uri(
+        # Build a catalog adapter on it, and initialize the database.
+        yield from_uri(
             uri_with_database_name,
             writable_storage=str(tmpdir),
             init_if_not_exists=True,
         )
-        yield adapter
 
 
 @pytest_asyncio.fixture
@@ -241,9 +240,9 @@ async def postgresql_with_example_data_adapter(request, tmpdir):
 
 
 @pytest_asyncio.fixture
-async def sqlite_adapter(request, tmpdir):
+async def sqlite_catalog_adapter(request, tmpdir):
     """
-    Adapter instance
+    Catalog adapter instance backed by SQLite (in memory)
 
     Note that startup() and shutdown() are not called, and must be run
     either manually (as in the fixture 'a') or via the app (as in the fixture 'client').
@@ -269,10 +268,10 @@ async def sqlite_with_example_data_adapter(request, tmpdir):
     yield adapter
 
 
-@pytest.fixture(params=["sqlite_adapter", "postgresql_adapter"])
-def adapter(request):
+@pytest.fixture(params=["sqlite_catalog_adapter", "postgresql_catalog_adapter"])
+def catalog_adapter(request):
     """
-    Adapter instance
+    Catalog adapter instance
 
     Note that startup() and shutdown() are not called, and must be run
     either manually (as in the fixture 'a') or via the app (as in the fixture 'client').

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,6 +3,8 @@ import string
 from contextlib import closing
 from dataclasses import asdict
 from typing import cast
+import asyncio
+import tempfile
 
 import dask.array
 import numpy
@@ -14,6 +16,8 @@ import pytest_asyncio
 import sqlalchemy.exc
 import tifffile
 import xarray
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import AsyncAdaptedQueuePool, QueuePool, StaticPool
@@ -661,7 +665,70 @@ async def test_delete_sql_assets(sql_storage_uri):
         assert len(assets_after_delete) == 1
 
         # Close and dispose the SQL storage
-        storage.dispose()
+    storage.dispose()
+
+
+async def _traverse_all_pages(n_items, page_size, direction):
+    """Build a fresh in-memory catalog, populate it, then walk every cursor page.
+
+    Returns (keys_inserted, keys_collected) where both are lists of strings.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = in_memory(writable_storage=tmpdir)
+        await adapter.startup()
+        try:
+            keys_inserted = [str(i) for i in range(n_items)]
+            for key in keys_inserted:
+                await adapter.create_node(
+                    key=key,
+                    metadata={},
+                    structure_family=StructureFamily.container,
+                    specs=[],
+                )
+            sorted_adapter = adapter.sort([("", direction)])
+            collected = []
+            cursor = None
+            while True:
+                page, next_cursor = await sorted_adapter.keys_page(
+                    cursor=cursor, limit=page_size
+                )
+                collected.extend(page)
+                if next_cursor is None:
+                    break
+                cursor = next_cursor
+            return keys_inserted, collected
+        finally:
+            await adapter.shutdown()
+
+
+@given(
+    n_items=st.integers(min_value=0, max_value=50),
+    page_size=st.integers(min_value=1, max_value=20),
+    direction=st.sampled_from([1, -1]),
+)
+@settings(deadline=None, max_examples=30)
+def test_cursor_pagination_completeness(n_items, page_size, direction):
+    """Traversing all cursor pages yields every item exactly once, in order.
+
+    Properties checked:
+    - total count matches n_items
+    - no duplicates across pages
+    - order matches insertion order (ASC) or reverse insertion order (DESC),
+      since id is strictly monotonic
+    """
+    keys_inserted, collected = asyncio.run(
+        _traverse_all_pages(n_items, page_size, direction)
+    )
+
+    assert len(collected) == n_items, "total item count must match"
+    assert len(set(collected)) == len(collected), "no duplicates across pages"
+
+    if direction == 1:
+        assert collected == keys_inserted, "ASC traversal must match insertion order"
+    else:
+        assert collected == list(
+            reversed(keys_inserted)
+        ), "DESC traversal must match reverse insertion order"
 
 
 @pytest.mark.asyncio

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,9 @@
+import asyncio
 import random
 import string
 from contextlib import closing
 from dataclasses import asdict
 from typing import cast
-import asyncio
 
 import dask.array
 import numpy
@@ -733,8 +733,10 @@ def catalog_adapter_for_hypothesis(request):
     page_size=st.integers(min_value=1, max_value=20),
     direction=st.sampled_from([1, -1]),
 )
-@settings(deadline=None, max_examples=30)
-def test_cursor_pagination_completeness(catalog_adapter_for_hypothesis, n_items, page_size, direction):
+@settings(deadline=None, max_examples=50)
+def test_cursor_pagination_completeness(
+    catalog_adapter_for_hypothesis, n_items, page_size, direction
+):
     """Traversing all cursor pages yields every item exactly once, in order.
 
     Properties checked:
@@ -748,8 +750,9 @@ def test_cursor_pagination_completeness(catalog_adapter_for_hypothesis, n_items,
     async def run():
         # Use a unique container key so parallel/sequential examples don't collide.
         import uuid
+
         container_key = uuid.uuid4().hex
-        container = await adapter.create_node(
+        await adapter.create_node(
             key=container_key,
             metadata={},
             structure_family=StructureFamily.container,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -186,7 +186,7 @@ async def test_metadata_index_is_used(example_data_adapter):
     if dialect == "postgresql":
         expected_index = "top_level_metadata"
     else:
-        expected_index = "ix_nodes_parent"  # B-tree index on parent (or parent, id)
+        expected_index = "nodes_parent"  # B-tree index on parent (name varies by Alembic/SQLite version)
     await a.startup()
     with record_explanations() as e:
         results = await a.search(Key("number_as_string") == "3").keys_page(limit=5)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -4,7 +4,6 @@ from contextlib import closing
 from dataclasses import asdict
 from typing import cast
 import asyncio
-import tempfile
 
 import dask.array
 import numpy
@@ -668,37 +667,65 @@ async def test_delete_sql_assets(sql_storage_uri):
     storage.dispose()
 
 
-async def _traverse_all_pages(n_items, page_size, direction):
-    """Build a fresh in-memory catalog, populate it, then walk every cursor page.
+# ---------------------------------------------------------------------------
+# Hypothesis: pagination completeness
+# ---------------------------------------------------------------------------
+# The adapter is started once per module (per dialect) and reused across all
+# hypothesis examples. Each example creates a fresh child container, runs its
+# traversal inside it, then deletes it, keeping the shared DB clean.
+#
+# asyncio: hypothesis does not support async test functions, so we keep a
+# single event loop alive for the lifetime of the fixture and drive all
+# coroutines with loop.run_until_complete().
+# ---------------------------------------------------------------------------
 
-    Returns (keys_inserted, keys_collected) where both are lists of strings.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        adapter = in_memory(writable_storage=tmpdir)
+
+@pytest.fixture(scope="module")
+def sqlite_adapter_for_hypothesis(tmp_path_factory):
+    loop = asyncio.new_event_loop()
+    tmpdir = tmp_path_factory.mktemp("hyp_sqlite")
+    adapter = in_memory(writable_storage=str(tmpdir))
+    loop.run_until_complete(adapter.startup())
+    yield adapter, loop
+    loop.run_until_complete(adapter.shutdown())
+    loop.close()
+
+
+@pytest.fixture(scope="module")
+def postgresql_adapter_for_hypothesis(tmp_path_factory):
+    from tiled.catalog import from_uri
+
+    from .conftest import TILED_TEST_POSTGRESQL_URI, temp_postgres
+
+    if not TILED_TEST_POSTGRESQL_URI:
+        pytest.skip("No TILED_TEST_POSTGRESQL_URI configured")
+    loop = asyncio.new_event_loop()
+    tmpdir = tmp_path_factory.mktemp("hyp_pg")
+
+    async def _setup():
+        ctx = temp_postgres(TILED_TEST_POSTGRESQL_URI)
+        uri = await ctx.__aenter__()
+        adapter = from_uri(uri, writable_storage=str(tmpdir), init_if_not_exists=True)
         await adapter.startup()
-        try:
-            keys_inserted = [str(i) for i in range(n_items)]
-            for key in keys_inserted:
-                await adapter.create_node(
-                    key=key,
-                    metadata={},
-                    structure_family=StructureFamily.container,
-                    specs=[],
-                )
-            sorted_adapter = adapter.sort([("", direction)])
-            collected = []
-            cursor = None
-            while True:
-                page, next_cursor = await sorted_adapter.keys_page(
-                    cursor=cursor, limit=page_size
-                )
-                collected.extend(page)
-                if next_cursor is None:
-                    break
-                cursor = next_cursor
-            return keys_inserted, collected
-        finally:
-            await adapter.shutdown()
+        return adapter, ctx
+
+    adapter, ctx = loop.run_until_complete(_setup())
+    yield adapter, loop
+
+    async def _teardown():
+        await adapter.shutdown()
+        await ctx.__aexit__(None, None, None)
+
+    loop.run_until_complete(_teardown())
+    loop.close()
+
+
+@pytest.fixture(
+    scope="module",
+    params=["sqlite_adapter_for_hypothesis", "postgresql_adapter_for_hypothesis"],
+)
+def catalog_adapter_for_hypothesis(request):
+    yield request.getfixturevalue(request.param)
 
 
 @given(
@@ -707,7 +734,7 @@ async def _traverse_all_pages(n_items, page_size, direction):
     direction=st.sampled_from([1, -1]),
 )
 @settings(deadline=None, max_examples=30)
-def test_cursor_pagination_completeness(n_items, page_size, direction):
+def test_cursor_pagination_completeness(catalog_adapter_for_hypothesis, n_items, page_size, direction):
     """Traversing all cursor pages yields every item exactly once, in order.
 
     Properties checked:
@@ -716,13 +743,48 @@ def test_cursor_pagination_completeness(n_items, page_size, direction):
     - order matches insertion order (ASC) or reverse insertion order (DESC),
       since id is strictly monotonic
     """
-    keys_inserted, collected = asyncio.run(
-        _traverse_all_pages(n_items, page_size, direction)
-    )
+    adapter, loop = catalog_adapter_for_hypothesis
+
+    async def run():
+        # Use a unique container key so parallel/sequential examples don't collide.
+        import uuid
+        container_key = uuid.uuid4().hex
+        container = await adapter.create_node(
+            key=container_key,
+            metadata={},
+            structure_family=StructureFamily.container,
+            specs=[],
+        )
+        child = await adapter.lookup_adapter([container_key])
+        try:
+            keys_inserted = [str(i) for i in range(n_items)]
+            for key in keys_inserted:
+                await child.create_node(
+                    key=key,
+                    metadata={},
+                    structure_family=StructureFamily.container,
+                    specs=[],
+                )
+            sorted_child = child.sort([("", direction)])
+            collected = []
+            cursor = None
+            while True:
+                page, next_cursor = await sorted_child.keys_page(
+                    cursor=cursor, limit=page_size
+                )
+                collected.extend(page)
+                if next_cursor is None:
+                    break
+                cursor = next_cursor
+            return keys_inserted, collected
+        finally:
+            child_adapter = await adapter.lookup_adapter([container_key])
+            await child_adapter.delete(recursive=True, external_only=False)
+
+    keys_inserted, collected = loop.run_until_complete(run())
 
     assert len(collected) == n_items, "total item count must match"
     assert len(set(collected)) == len(collected), "no duplicates across pages"
-
     if direction == 1:
         assert collected == keys_inserted, "ASC traversal must match insertion order"
     else:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -39,16 +39,16 @@ from .utils import sql_table_exists
 
 
 @pytest_asyncio.fixture
-async def a(adapter):
+async def a(catalog_adapter):
     "Raw adapter, not to be used within an app because it is manually started and stopped."
-    await adapter.startup()
-    yield adapter
-    await adapter.shutdown()
+    await catalog_adapter.startup()
+    yield catalog_adapter
+    await catalog_adapter.shutdown()
 
 
 @pytest_asyncio.fixture
-async def client(adapter):
-    app = build_app(adapter)
+async def client(catalog_adapter):
+    app = build_app(catalog_adapter)
     with Context.from_app(app) as context:
         yield from_context(context)
 
@@ -71,11 +71,11 @@ async def test_nested_node_creation(a):
     c = await b.lookup_adapter(["c"])
     assert await b.path_segments() == ["b"]
     assert await c.path_segments() == ["b", "c"]
-    assert (await a.keys_range(0, 1)) == ["b"]
-    assert (await b.keys_range(0, 1)) == ["c"]
+    assert (await a.keys_page(limit=1))[0] == ["b"]
+    assert (await b.keys_page(limit=1))[0] == ["c"]
     # smoke test
-    await a.items_range(0, 1)
-    await b.items_range(0, 1)
+    await a.items_page(limit=1)
+    await b.items_page(limit=1)
     await a.shutdown()
 
 
@@ -100,32 +100,36 @@ async def test_sorting(a):
         )
 
     # Default sorting is _not_ ordered.
-    default_key_order = await a.keys_range(0, 10)
+    default_key_order = (await a.keys_page(limit=10))[0]
     assert default_key_order != ordered_letters
+    assert set(default_key_order) == set(ordered_letters)
     # Sorting by ("", -1) gives reversed default order.
-    reversed_default_key_order = await a.sort([("", -1)]).keys_range(0, 10)
+    reversed_default_key_order = (await a.sort([("", -1)]).keys_page(limit=10))[0]
     assert reversed_default_key_order == list(reversed(default_key_order))
 
     # Sort by key.
-    assert await a.sort([("id", 1)]).keys_range(0, 10) == ordered_letters
-    # Test again, with items_range.
+    assert (await a.sort([("id", 1)]).keys_page(limit=10))[0] == ordered_letters
+    # Test again, with items_page.
     assert [
-        k for k, v in await a.sort([("id", 1)]).items_range(0, 10)
+        k for k, v in (await a.sort([("id", 1)]).items_page(limit=10))[0]
     ] == ordered_letters
 
     # Sort by letter metadata.
     # Use explicit 'metadata.{key}' namespace.
-    assert (await a.sort([("metadata.letter", 1)]).keys_range(0, 10)) == ordered_letters
+    assert (await a.sort([("metadata.letter", 1)]).keys_page(limit=10))[
+        0
+    ] == ordered_letters
 
     # Sort by letter metadata.
     # Use implicit '{key}' (more convenient, and necessary for back-compat).
-    assert (await a.sort([("letter", 1)]).keys_range(0, 10)) == ordered_letters
+    assert (await a.sort([("letter", 1)]).keys_page(limit=10))[0] == ordered_letters
 
     # Sort by number and then by letter.
     # Use explicit 'metadata.{key}' namespace.
-    items = await a.sort([("metadata.number", 1), ("metadata.letter", 1)]).items_range(
-        0, 10
+    items = await a.sort([("metadata.number", 1), ("metadata.letter", 1)]).items_page(
+        limit=10
     )
+    items = items[0]
     numbers = [v.metadata()["number"] for k, v in items]
     letters = [v.metadata()["letter"] for k, v in items]
     keys = [k for k, v in items]
@@ -145,9 +149,9 @@ async def test_search(a):
             structure_family=StructureFamily.container,
             specs=[],
         )
-    assert "c" in await a.keys_range(0, 5)
-    assert await a.search(Eq("letter", "c")).keys_range(0, 5) == ["c"]
-    assert await a.search(Eq("number", 2)).keys_range(0, 5) == ["c"]
+    assert "c" in (await a.keys_page(limit=5))[0]
+    assert (await a.search(Eq("letter", "c")).keys_page(limit=5))[0] == ["c"]
+    assert (await a.search(Eq("number", 2)).keys_page(limit=5))[0] == ["c"]
 
     # Looking up "d" inside search results should find nothing when
     # "d" is filtered out by a search query first.
@@ -156,8 +160,7 @@ async def test_search(a):
         await a.search(Eq("letter", "c")).lookup_adapter(["d"])
 
     # Search on nested key.
-    assert await a.search(Eq("x.y.z", "c")).keys_range(0, 5) == ["c"]
-
+    assert (await a.search(Eq("x.y.z", "c")).keys_page(limit=5))[0] == ["c"]
     # Created nested nodes and search on them.
     d = await a.lookup_adapter(["d"])
     for letter, number in zip(string.ascii_lowercase[:5], range(10, 15)):
@@ -167,8 +170,8 @@ async def test_search(a):
             structure_family=StructureFamily.container,
             specs=[],
         )
-    assert await d.search(Eq("letter", "c")).keys_range(0, 5) == ["c"]
-    assert await d.search(Eq("number", 12)).keys_range(0, 5) == ["c"]
+    assert (await d.search(Eq("letter", "c")).keys_page(limit=5))[0] == ["c"]
+    assert (await d.search(Eq("number", 12)).keys_page(limit=5))[0] == ["c"]
 
 
 @pytest.mark.asyncio
@@ -180,30 +183,32 @@ async def test_metadata_index_is_used(example_data_adapter):
     # that the index of interest is mentioned.
     await a.startup()
     with record_explanations() as e:
-        results = await a.search(Key("number_as_string") == "3").keys_range(0, 5)
-        assert len(results) == 1
+        results = await a.search(Key("number_as_string") == "3").keys_page(limit=5)
+        assert len(results[0]) == 1
         assert "top_level_metadata" in str(e)
     with record_explanations() as e:
-        results = await a.search(Key("number") == 3).keys_range(0, 5)
-        assert len(results) == 1
+        results = await a.search(Key("number") == 3).keys_page(limit=5)
+        assert len(results[0]) == 1
         assert "top_level_metadata" in str(e)
     with record_explanations() as e:
-        results = await a.search(Key("bool") == False).keys_range(0, 5)  # noqa: #712
-        assert len(results) == 1
+        results = await a.search(Key("bool") == False).keys_page(limit=5)  # noqa: #712
+        assert len(results[0]) == 1
         assert "top_level_metadata" in str(e)
     with record_explanations() as e:
-        results = await a.search(Key("nested.number_as_string") == "3").keys_range(0, 5)
-        assert len(results) == 1
-        assert "top_level_metadata" in str(e)
-    with record_explanations() as e:
-        results = await a.search(Key("nested.number") == 3).keys_range(0, 5)
-        assert len(results) == 1
-        assert "top_level_metadata" in str(e)
-    with record_explanations() as e:
-        results = await a.search(Key("nested.bool") == False).keys_range(  # noqa: #712
-            0, 5
+        results = await a.search(Key("nested.number_as_string") == "3").keys_page(
+            limit=5
         )
-        assert len(results) == 1
+        assert len(results[0]) == 1
+        assert "top_level_metadata" in str(e)
+    with record_explanations() as e:
+        results = await a.search(Key("nested.number") == 3).keys_page(limit=5)
+        assert len(results[0]) == 1
+        assert "top_level_metadata" in str(e)
+    with record_explanations() as e:
+        results = await a.search(Key("nested.bool") == False).keys_page(  # noqa: #712
+            limit=5
+        )
+        assert len(results[0]) == 1
         assert "top_level_metadata" in str(e)
     await a.shutdown()
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -177,39 +177,45 @@ async def test_search(a):
 @pytest.mark.asyncio
 async def test_metadata_index_is_used(example_data_adapter):
     a = example_data_adapter  # for succinctness below
-    # Check that an index (specifically the 'top_level_metadata' index) is used
-    # by inspecting the content of an 'EXPLAIN ...' query. The exact content
-    # is intended for humans and is not an API, but we can coarsely check
-    # that the index of interest is mentioned.
+    # Check that an index is used by inspecting the content of an 'EXPLAIN ...'
+    # query. The exact content is intended for humans and is not an API, but we
+    # can coarsely check that the index of interest is mentioned.
+    # The 'top_level_metadata' GIN index is PostgreSQL-only. SQLite uses a
+    # B-tree covering index instead; we just verify any index is used.
+    dialect = a.context.engine.url.get_dialect().name
+    if dialect == "postgresql":
+        expected_index = "top_level_metadata"
+    else:
+        expected_index = "ix_nodes_parent"  # B-tree index on parent (or parent, id)
     await a.startup()
     with record_explanations() as e:
         results = await a.search(Key("number_as_string") == "3").keys_page(limit=5)
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     with record_explanations() as e:
         results = await a.search(Key("number") == 3).keys_page(limit=5)
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     with record_explanations() as e:
         results = await a.search(Key("bool") == False).keys_page(limit=5)  # noqa: #712
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     with record_explanations() as e:
         results = await a.search(Key("nested.number_as_string") == "3").keys_page(
             limit=5
         )
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     with record_explanations() as e:
         results = await a.search(Key("nested.number") == 3).keys_page(limit=5)
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     with record_explanations() as e:
         results = await a.search(Key("nested.bool") == False).keys_page(  # noqa: #712
             limit=5
         )
         assert len(results[0]) == 1
-        assert "top_level_metadata" in str(e)
+        assert expected_index in str(e)
     await a.shutdown()
 
 

--- a/tests/test_inlined_contents.py
+++ b/tests/test_inlined_contents.py
@@ -113,7 +113,6 @@ def test_too_wide_for_inline():
     """
     The server will not inline contents above a certain limit.
 
-
     It is fetched in pages on demand, as usual with nodes.
     """
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -373,9 +373,9 @@ def test_keys_range_non_default_sort(sorted_client):
     resp = http_client.get(
         search_url, params={"sort": "id", "fields": "", "page[limit]": 10}
     )
-    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.json().get('detail')}"
+    assert resp.status_code == 200
     keys = [item["id"] for item in resp.json()["data"]]
-    assert keys == sorted(keys), f"Expected ascending id order, got: {keys}"
+    assert keys == sorted(keys)
     assert len(keys) == 5
 
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -23,7 +23,7 @@ def sorted_client(catalog_adapter):
     Insertion order: e, b, d, a, c
     Alphabetical (key/id) order: a, b, c, d, e
 
-    The scrambled insertion order means default (time-based) sort != id sort,
+    The scrambled insertion order means default (id-based) sort != alphabetical key sort,
     which is required for the cursor vs offset pagination tests to be meaningful.
     """
     app = build_app(catalog_adapter)
@@ -300,8 +300,8 @@ def test_cursor_pagination_default_sort(sorted_client):
 def test_offset_fallback_non_default_sort_second_page(sorted_client):
     """Non-default sort falls back to offset-based next links.
 
-    Insertion order is e,b,d,a,c so default time order != alphabetical key order.
-    Sorted by 'id': a,b,c,d,e  →  page 1=[a,b], page 2=[c,d].
+    Insertion order is e,b,d,a,c so default (id) order != alphabetical key order.
+    Sorted by 'id' (key): a,b,c,d,e  →  page 1=[a,b], page 2=[c,d].
     The next link must be offset-based (not cursor-based) for non-default sorts.
     """
     http_client = sorted_client.context.http_client

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,21 +1,37 @@
 import pytest
 
-from tiled.catalog import in_memory
 from tiled.client import Context, from_context, record_history
 from tiled.server.app import build_app
 
 N = 10  # number of items generated in sample
 
 
-@pytest.fixture(scope="module")
-def client(tmpdir_module):
-    catalog = in_memory(writable_storage=[tmpdir_module])
-    app = build_app(catalog)
+@pytest.fixture
+def client(catalog_adapter):
+    app = build_app(catalog_adapter)
     with Context.from_app(app) as context:
         client = from_context(context)
         for i in range(N):
             client.create_container(metadata={"num": i}, key=str(i))
         yield client
+
+
+@pytest.fixture
+def sorted_client(catalog_adapter):
+    """Client pre-populated with 5 items inserted in scrambled order.
+
+    Insertion order: e, b, d, a, c
+    Alphabetical (key/id) order: a, b, c, d, e
+
+    The scrambled insertion order means default (time-based) sort != id sort,
+    which is required for the cursor vs offset pagination tests to be meaningful.
+    """
+    app = build_app(catalog_adapter)
+    with Context.from_app(app) as context:
+        c = from_context(context)
+        for letter in ["e", "b", "d", "a", "c"]:
+            c.create_container(metadata={"letter": letter}, key=letter)
+        yield c
 
 
 def test_first_value(client):
@@ -208,3 +224,187 @@ def test_unbounded_keys_slice(client):
     actual_nums = [int(key) for key in keys]
     expected_nums = [3, 4, 5, 6, 7, 8, 9]
     assert actual_nums == expected_nums
+
+
+def _params_from_next_link(next_link, sort=None, page_size=2):
+    """Parse a pagination 'next' link into request params for the following page.
+
+    Handles both cursor-based (?page[cursor]=...) and offset-based
+    (?page[offset]=...) next links transparently.
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    qs = parse_qs(urlparse(next_link).query)
+    params = {"page[limit]": page_size}
+    if "page[cursor]" in qs:
+        params["page[cursor]"] = qs["page[cursor]"][0]
+    elif "page[offset]" in qs:
+        params["page[offset]"] = qs["page[offset]"][0]
+    if sort is not None:
+        params["sort"] = sort
+    return params
+
+
+def _paginate_all(client, sort=None, page_size=2):
+    """Walk all pages via next links and return the concatenated list of item ids."""
+    params = {"page[limit]": page_size}
+    if sort is not None:
+        params["sort"] = sort
+    http_client = client.context.http_client
+    all_keys = []
+    while True:
+        resp = http_client.get(
+            client.uri.replace("/api/v1/metadata/", "/api/v1/search/"), params=params
+        )
+        assert (
+            resp.status_code == 200
+        ), f"HTTP {resp.status_code}: {resp.json().get('detail')}"
+        body = resp.json()
+        page_keys = [item["id"] for item in body["data"]]
+        all_keys.extend(page_keys)
+        next_link = body["links"]["next"]
+        if not next_link or not page_keys:
+            break
+        params = _params_from_next_link(next_link, sort=sort, page_size=page_size)
+    return all_keys
+
+
+def test_cursor_pagination_default_sort(sorted_client):
+    """Default-sort first two pages are disjoint and next link is cursor-based."""
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+
+    resp1 = http_client.get(search_url, params={"page[limit]": 2})
+    assert resp1.status_code == 200
+    body1 = resp1.json()
+    page1_keys = [item["id"] for item in body1["data"]]
+    assert len(page1_keys) == 2
+
+    next_link = body1["links"]["next"]
+    assert next_link is not None, "Expected a 'next' link after the first page"
+    assert (
+        "page[cursor]=" in next_link
+    ), "Default sort should produce a cursor-based next link"
+
+    resp2 = http_client.get(search_url, params=_params_from_next_link(next_link))
+    assert resp2.status_code == 200
+    page2_keys = [item["id"] for item in resp2.json()["data"]]
+    assert len(page2_keys) == 2
+    assert (
+        set(page1_keys) & set(page2_keys) == set()
+    ), f"Pages overlap: {page1_keys}, {page2_keys}"
+
+
+def test_offset_fallback_non_default_sort_second_page(sorted_client):
+    """Non-default sort falls back to offset-based next links.
+
+    Insertion order is e,b,d,a,c so default time order != alphabetical key order.
+    Sorted by 'id': a,b,c,d,e  →  page 1=[a,b], page 2=[c,d].
+    The next link must be offset-based (not cursor-based) for non-default sorts.
+    """
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+
+    resp1 = http_client.get(search_url, params={"sort": "id", "page[limit]": 2})
+    assert resp1.status_code == 200
+    page1_keys = [item["id"] for item in resp1.json()["data"]]
+    assert page1_keys == ["a", "b"], f"Unexpected page 1: {page1_keys}"
+
+    next_link = resp1.json()["links"]["next"]
+    assert next_link is not None, "Expected a 'next' link"
+    assert (
+        "page[offset]=" in next_link
+    ), "Non-default sort should produce an offset-based next link, not a cursor"
+
+    resp2 = http_client.get(
+        search_url, params=_params_from_next_link(next_link, sort="id")
+    )
+    assert resp2.status_code == 200
+    page2_keys = [item["id"] for item in resp2.json()["data"]]
+    assert page2_keys == ["c", "d"], f"Wrong page 2 for 'id' sort: {page2_keys}"
+
+
+def test_full_traversal_default_sort(sorted_client):
+    """Full traversal with default sort yields all items exactly once."""
+    all_keys = _paginate_all(sorted_client)
+    assert len(all_keys) == 5
+    assert len(set(all_keys)) == 5
+
+
+def test_full_traversal_asc_sort(sorted_client):
+    """Full traversal under ascending 'id' sort yields all items once, in order."""
+    all_keys = _paginate_all(sorted_client, sort="id")
+    assert all_keys == sorted(all_keys), f"Out of order: {all_keys}"
+    assert len(all_keys) == 5
+    assert len(set(all_keys)) == 5
+
+
+def test_full_traversal_desc_sort(sorted_client):
+    """Full traversal under descending 'id' sort yields all items once, in reverse order."""
+    all_keys = _paginate_all(sorted_client, sort="-id")
+    assert all_keys == sorted(all_keys, reverse=True)
+    assert len(all_keys) == 5
+    assert len(set(all_keys)) == 5
+
+
+def test_sort_by_dotted_metadata_key_accepted(sorted_client):
+    """?sort=metadata.letter must return 200, not 422."""
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"sort": "metadata.letter", "page[limit]": 5},
+    )
+    assert resp.status_code == 200
+
+
+def test_sort_by_dotted_metadata_key_order(sorted_client):
+    """?sort=metadata.letter returns items in alphabetical letter order."""
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"sort": "metadata.letter", "page[limit]": 10},
+    )
+    assert resp.status_code == 200
+    keys = [item["id"] for item in resp.json()["data"]]
+    assert keys == sorted(keys)
+
+
+def test_full_traversal_dotted_metadata_sort(sorted_client):
+    """Full traversal with metadata.letter sort yields all items once, in order.
+
+    Exercises both: dotted sort key accepted and correct
+    multi-page results for non-default sort via offset fallback.
+    """
+    all_keys = _paginate_all(sorted_client, sort="metadata.letter")
+    assert all_keys == sorted(all_keys)
+    assert len(all_keys) == 5
+    assert len(set(all_keys)) == 5
+
+
+def test_plus_prefix_sort_accepted(sorted_client):
+    """?sort=+id (explicit ascending prefix) must return 200, not 422."""
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"sort": "+id", "page[limit]": 5},
+    )
+    assert (
+        resp.status_code == 200
+    ), f"HTTP {resp.status_code}: {resp.json().get('detail')}"
+    keys = [item["id"] for item in resp.json()["data"]]
+    assert keys == sorted(keys)
+
+
+def test_plus_prefix_reverse_does_not_produce_malformed_sort(sorted_client):
+    """Reversing a +id sort must send -id, not -+id, to the server."""
+    # Simulate what the client does when reversing a +-prefixed sort field.
+    # If the bug were present, reversed_sorting_list would contain "-+id" and
+    # the server would reject it with 422.
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"sort": "-+id", "page[limit]": 5},
+    )
+    assert resp.status_code == 422, "'-+id' is malformed and should be rejected"
+
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"sort": "-id", "page[limit]": 5},
+    )
+    assert resp.status_code == 200, "'-id' (correct reversal of '+id') must be accepted"

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -270,7 +270,7 @@ def _paginate_all(client, sort=None, page_size=2):
 
 
 def test_cursor_pagination_default_sort(sorted_client):
-    """Default-sort first two pages are disjoint and next link is cursor-based."""
+    """Default-sort first two pages are disjoint, cursor-linked, and contain the right items."""
     http_client = sorted_client.context.http_client
     search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
 
@@ -293,6 +293,8 @@ def test_cursor_pagination_default_sort(sorted_client):
     assert (
         set(page1_keys) & set(page2_keys) == set()
     ), f"Pages overlap: {page1_keys}, {page2_keys}"
+    # Together they must be exactly the first four items (insertion order: e,b,d,a,c).
+    assert set(page1_keys) | set(page2_keys) == {"e", "b", "d", "a"}
 
 
 def test_offset_fallback_non_default_sort_second_page(sorted_client):
@@ -324,11 +326,31 @@ def test_offset_fallback_non_default_sort_second_page(sorted_client):
     assert page2_keys == ["c", "d"], f"Wrong page 2 for 'id' sort: {page2_keys}"
 
 
+def test_full_traversal_default_sort_descending(sorted_client):
+    """Full traversal with default-key descending sort (sort=-) yields all items once,
+    in reverse insertion order, using cursor-based next links.
+    """
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+
+    resp = http_client.get(search_url, params={"sort": "-", "page[limit]": 2})
+    assert (
+        resp.status_code == 200
+    ), f"HTTP {resp.status_code}: {resp.json().get('detail')}"
+    next_link = resp.json()["links"]["next"]
+    assert next_link is not None
+    assert "page[cursor]=" in next_link
+
+    all_keys = _paginate_all(sorted_client, sort="-", page_size=2)
+    # Insertion order: e, b, d, a, c — descending reverses this.
+    assert all_keys == ["c", "a", "d", "b", "e"]
+
+
 def test_full_traversal_default_sort(sorted_client):
-    """Full traversal with default sort yields all items exactly once."""
+    """Full traversal with default sort yields all items exactly once, in insertion order."""
     all_keys = _paginate_all(sorted_client)
-    assert len(all_keys) == 5
-    assert len(set(all_keys)) == 5
+    # Insertion order: e, b, d, a, c
+    assert all_keys == ["e", "b", "d", "a", "c"]
 
 
 def test_full_traversal_asc_sort(sorted_client):
@@ -408,3 +430,87 @@ def test_plus_prefix_reverse_does_not_produce_malformed_sort(sorted_client):
         params={"sort": "-id", "page[limit]": 5},
     )
     assert resp.status_code == 200, "'-id' (correct reversal of '+id') must be accepted"
+
+
+def test_limit_zero_returns_empty(sorted_client):
+    """page[limit]=0 must return an empty page with no error, but still include links."""
+    resp = sorted_client.context.http_client.get(
+        sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/"),
+        params={"page[limit]": 0},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["data"] == []
+    assert "first" in body["links"]
+    assert "next" in body["links"]
+
+
+def test_cursor_for_offset_past_end(sorted_client):
+    """cursor_for_offset with an offset beyond the collection returns None,
+    falling back to offset-based pagination (empty page, no crash, no next link).
+    """
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+    # There are 5 items; offset=100 is well past the end.
+    resp = http_client.get(search_url, params={"page[offset]": 100, "page[limit]": 2})
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+    assert resp.json()["links"]["next"] is None
+
+
+def test_offset_request_migrates_to_cursor_next_link(sorted_client):
+    """A page[offset] request on the default sort should return a cursor-based
+    next link and following it should return the correct remaining items without duplication.
+    """
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+
+    # Request page 2 using an explicit offset (not a cursor).
+    resp = http_client.get(search_url, params={"page[offset]": 2, "page[limit]": 2})
+    assert resp.status_code == 200
+    body = resp.json()
+    page2_keys = [item["id"] for item in body["data"]]
+    assert len(page2_keys) == 2
+
+    next_link = body["links"]["next"]
+    assert next_link is not None, "Should have a next link (one more item remains)"
+    assert "page[cursor]=" in next_link
+    assert "page[offset]=" not in next_link
+
+    # Following the cursor next link should return the remaining item without overlap.
+    resp3 = http_client.get(search_url, params=_params_from_next_link(next_link))
+    assert resp3.status_code == 200
+    page3_keys = [item["id"] for item in resp3.json()["data"]]
+    assert len(page3_keys) == 1, f"Expected 1 remaining item, got {page3_keys}"
+    assert set(page3_keys) & set(page2_keys) == set()
+    assert resp3.json()["links"]["next"] is None
+
+
+def test_slice_by_offset_no_limit():
+    """slice_by_offset with limit=None returns all items and next_offset=None."""
+    from tiled.catalog.adapter import slice_by_offset
+
+    items = [1, 2, 3, 4, 5]
+    result, next_offset = slice_by_offset(items, offset=2, limit=None)
+    assert result == [3, 4, 5]
+    assert next_offset is None
+
+
+def test_slice_by_offset_exact_fit():
+    """slice_by_offset where items exactly fill the limit has next_offset=None."""
+    from tiled.catalog.adapter import slice_by_offset
+
+    items = [1, 2, 3]
+    result, next_offset = slice_by_offset(items, offset=0, limit=3)
+    assert result == [1, 2, 3]
+    assert next_offset is None
+
+
+def test_slice_by_offset_has_next():
+    """slice_by_offset where more items follow reports next_offset correctly."""
+    from tiled.catalog.adapter import slice_by_offset
+
+    items = [1, 2, 3, 4, 5]
+    result, next_offset = slice_by_offset(items, offset=0, limit=3)
+    assert result == [1, 2, 3]
+    assert next_offset == 3

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -361,6 +361,24 @@ def test_full_traversal_asc_sort(sorted_client):
     assert len(set(all_keys)) == 5
 
 
+def test_keys_range_non_default_sort(sorted_client):
+    """keys_range is exercised by a keys-only (fields=) request with a non-default sort.
+
+    The client sends fields= to request only keys (no metadata), which routes through
+    keys_range instead of items_range when the sort is non-default.
+    """
+    http_client = sorted_client.context.http_client
+    search_url = sorted_client.uri.replace("/api/v1/metadata/", "/api/v1/search/")
+
+    resp = http_client.get(
+        search_url, params={"sort": "id", "fields": "", "page[limit]": 10}
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.json().get('detail')}"
+    keys = [item["id"] for item in resp.json()["data"]]
+    assert keys == sorted(keys), f"Expected ascending id order, got: {keys}"
+    assert len(keys) == 5
+
+
 def test_full_traversal_desc_sort(sorted_client):
     """Full traversal under descending 'id' sort yields all items once, in reverse order."""
     all_keys = _paginate_all(sorted_client, sort="-id")

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1341,9 +1341,9 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
         Only call this when cursor is None (first page) or a valid cursor id.
         Do not call this for offset-based pagination — use keys_range/items_range instead.
 
-        The default ORDER BY is id ASC (or DESC), so the cursor condition
-        id > cursor (or id < cursor) is exact with no need for a secondary
-        time_created column.
+        The default ORDER BY is `id` ASC (or DESC); the cursor condition
+        `id > cursor` (or `id < cursor`) is therefore exact with no need
+        for a secondary column.
         """
         if cursor is not None:
             if self.default_sorting_direction == 1:
@@ -1370,7 +1370,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
             The maximum number of items to return in the page. If None, return all remaining items.
 
         Only valid for the default sort order; raises ValueError otherwise.
-        External callers should use ``keys_range(offset, limit)`` instead.
+        External callers should use `keys_range(offset, limit)` instead.
         """
         if cursor is not None and not self._is_default_sort:
             raise ValueError(
@@ -1449,7 +1449,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
             The maximum number of items to return in the page. If None, return all remaining items.
 
         Only valid for the default sort order; raises ValueError otherwise.
-        External callers should use ``items_range(offset, limit)`` instead.
+        External callers should use `items_range(offset, limit)` instead.
         """
         if cursor is not None and not self._is_default_sort:
             raise ValueError(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -13,7 +13,7 @@ from contextlib import closing
 from datetime import datetime, timezone
 from functools import partial, reduce
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union, cast
+from typing import Callable, Dict, List, Literal, Optional, Union, cast
 from urllib.parse import urlparse
 
 import anyio
@@ -285,14 +285,17 @@ class CatalogNodeAdapter:
         *,
         conditions=None,
         queries=None,
-        sorting=None,
+        sorting: Optional[list[tuple[str, Literal[1, -1]]]] = None,
         mount_path: Optional[list[str]] = None,
         create_mount_nodes_if_not_exist: bool = False,
     ):
         self.context = context
         self.node = node
         self.sorting = sorting or [("", 1)]
-        self.order_by_clauses = order_by_clauses(self.sorting)
+        (
+            self.order_by_clauses,
+            self.default_sorting_direction,
+        ) = construct_order_by_clauses(self.sorting)
         self.conditions = conditions or []
         self.queries = queries or []
         self.structure_family = node.structure_family
@@ -608,13 +611,10 @@ class CatalogNodeAdapter:
         sorting=UNCHANGED,
         conditions=UNCHANGED,
         queries=UNCHANGED,
-        # must_revalidate=UNCHANGED,
         **kwargs,
     ):
         if sorting is UNCHANGED:
             sorting = self.sorting
-        # if must_revalidate is UNCHANGED:
-        #     must_revalidate = self.must_revalidate
         if conditions is UNCHANGED:
             conditions = self.conditions
         if queries is UNCHANGED:
@@ -624,9 +624,7 @@ class CatalogNodeAdapter:
             node=self.node,
             conditions=conditions,
             sorting=sorting,
-            # entries_stale_after=self.entries_stale_after,
-            # metadata_stale_after=self.entries_stale_after,
-            # must_revalidate=must_revalidate,
+            queries=queries,
             **kwargs,
         )
 
@@ -966,7 +964,7 @@ class CatalogNodeAdapter:
             # a notification about it.
             await self.context.streaming_cache.set(self.node.id, sequence, metadata)
 
-    async def revisions(self, offset, limit):
+    async def revisions(self, offset: int = 0, limit=None):
         async with self.context.session() as db:
             revision_orms = (
                 await db.execute(
@@ -1325,56 +1323,228 @@ class CatalogNodeAdapter:
 
 
 class CatalogContainerAdapter(CatalogNodeAdapter):
-    async def keys_range(self, offset, limit):
-        if self.data_sources:
-            return it.islice(
-                (await self.get_adapter()).keys(),
-                offset,
-                (offset + limit) if limit is not None else None,  # noqa: E203
-            )
-        statement = select(orm.Node.key).filter(orm.Node.parent == self.node.id)
-        statement = self.apply_conditions(statement)
-        async with self.context.session() as db:
-            return (
-                (
-                    await db.execute(
-                        statement.order_by(*self.order_by_clauses)
-                        .offset(offset)
-                        .limit(limit)
-                    )
-                )
-                .scalars()
-                .all()
+    @property
+    def _is_default_sort(self) -> bool:
+        """True when no user-specified sort key is active.
+
+        Cursor-based pagination is only correct when the ORDER BY is purely
+        (time_created, id) — i.e. the default.  Any custom leading sort key
+        changes the row order in a way that the id-only cursor cannot track.
+        """
+        return all(key == "" for key, _ in self.sorting)
+
+    def _apply_cursor_pagination(self, statement, cursor, limit):
+        """Apply cursor-based filtering, ordering, and limit to a statement.
+
+        Returns the modified statement. Callers must still execute it and trim
+        the extra row used to detect whether a next page exists.
+        Only call this when cursor is None (first page) or a valid cursor id.
+        Do not call this for offset-based pagination — use keys_range/items_range instead.
+        """
+        if cursor is not None:
+            if self.default_sorting_direction == 1:
+                statement = statement.filter(orm.Node.id > cursor)
+            else:
+                statement = statement.filter(orm.Node.id < cursor)
+        statement = self.apply_conditions(statement).order_by(*self.order_by_clauses)
+        if limit is not None:
+            statement = statement.limit(limit + 1)
+        return statement
+
+    async def keys_page(
+        self,
+        cursor: Optional[int] = None,
+        limit: Optional[int] = None,
+    ):
+        """Return a page of keys and the cursor for the next page.
+
+        Parameters
+        ----------
+        cursor : int, optional
+            The id of the last item on the previous page.
+        limit : int, optional
+            The maximum number of items to return in the page. If None, return all remaining items.
+
+        Only valid for the default sort order; raises ValueError otherwise.
+        External callers should use ``keys_range(offset, limit)`` instead.
+        """
+        if cursor is not None and not self._is_default_sort:
+            raise ValueError(
+                "page[cursor] is not supported with non-default sort orders"
             )
 
-    async def items_range(self, offset, limit):
+        # Case 1: Node has external data sources -- delegate to the associated adapter
         if self.data_sources:
-            return it.islice(
-                (await self.get_adapter()).items(),
-                offset,
-                (offset + limit) if limit is not None else None,  # noqa: E203
-            )
-        statement = select(orm.Node).filter(orm.Node.parent == self.node.id)
-        statement = self.apply_conditions(statement)
+            keys = (await self.get_adapter()).keys()
+            if self.default_sorting_direction == -1:
+                keys = reversed(keys)
+            start = (cursor + 1) if cursor is not None else 0
+            keys, next_offset = slice_by_offset(keys, offset=start, limit=limit)
+            next_cursor = None if next_offset is None else next_offset - 1
+            return keys, next_cursor
+
+        # Case 2: No external data sources -- query the database directly
+        if limit == 0:
+            return [], None
+
+        statement = select(orm.Node.key, orm.Node.id)
+        statement = statement.filter(orm.Node.parent == self.node.id)
+        statement = self._apply_cursor_pagination(statement, cursor, limit)
+
         async with self.context.session() as db:
-            nodes = (
-                (
-                    await db.execute(
-                        statement.order_by(*self.order_by_clauses)
-                        .offset(offset)
-                        .limit(limit)
-                    )
-                )
-                .scalars()
-                .all()
+            rows = (await db.execute(statement)).all()
+
+        next_cursor = None
+        if (limit is not None) and (len(rows) > limit):
+            rows.pop()
+            if self._is_default_sort:
+                next_cursor = rows[-1][1]
+
+        return [row[0] for row in rows], next_cursor
+
+    async def keys_range(self, offset: int = 0, limit: Optional[int] = None):
+        """Return a list of keys, starting at `offset` up to `limit`.
+
+        The server uses `keys_page()` internally for cursor-based pagination.
+        """
+        if self.data_sources:
+            keys = (await self.get_adapter()).keys()
+            if self.default_sorting_direction == -1:
+                keys = reversed(keys)
+            keys, _ = slice_by_offset(keys, offset=offset, limit=limit)
+            return keys
+
+        if limit == 0:
+            return []
+
+        statement = select(orm.Node.key)
+        statement = statement.filter(orm.Node.parent == self.node.id)
+        if offset:
+            statement = statement.offset(offset)
+        statement = self.apply_conditions(statement).order_by(*self.order_by_clauses)
+        if limit is not None:
+            statement = statement.limit(limit)
+
+        async with self.context.session() as db:
+            rows = (await db.execute(statement)).all()
+
+        return [row[0] for row in rows]
+
+    async def items_page(
+        self,
+        cursor: Optional[int] = None,
+        limit: Optional[int] = None,
+    ):
+        """Return a page of (key, adapter) pairs and the cursor for the next page.
+
+        Parameters
+        ----------
+        cursor : int, optional
+            The id of the last item on the previous page.
+        limit : int, optional
+            The maximum number of items to return in the page. If None, return all remaining items.
+
+        Only valid for the default sort order; raises ValueError otherwise.
+        External callers should use ``items_range(offset, limit)`` instead.
+        """
+        if cursor is not None and not self._is_default_sort:
+            raise ValueError(
+                "page[cursor] is not supported with non-default sort orders"
             )
-            return [
+
+        # Case 1: Node has external data sources -- delegate to the associated adapter
+        if self.data_sources:
+            items = (await self.get_adapter()).items()
+            if self.default_sorting_direction == -1:
+                items = reversed(items)
+            start = (cursor + 1) if cursor is not None else 0
+            items, next_offset = slice_by_offset(items, offset=start, limit=limit)
+            next_cursor = None if next_offset is None else next_offset - 1
+            return items, next_cursor
+
+        # Case 2: No external data sources -- query the database directly
+        if limit == 0:
+            return [], None
+
+        statement = select(orm.Node).filter(orm.Node.parent == self.node.id)
+        statement = self._apply_cursor_pagination(statement, cursor, limit)
+
+        async with self.context.session() as db:
+            nodes = (await db.execute(statement)).scalars().all()
+
+        next_cursor = None
+        if (limit is not None) and (len(nodes) > limit):
+            nodes.pop()
+            if self._is_default_sort:
+                next_cursor = nodes[-1].id
+
+        return (
+            [
                 (
                     node.key,
                     STRUCTURES[node.structure_family](self.context, node),
                 )
                 for node in nodes
-            ]
+            ],
+            next_cursor,
+        )
+
+    async def items_range(self, offset: int = 0, limit: Optional[int] = None):
+        """Return a list of (key, adapter) pairs, starting at `offset` up to `limit`.
+
+        The server uses `items_page()` internally for cursor-based pagination.
+        """
+        if self.data_sources:
+            items = (await self.get_adapter()).items()
+            if self.default_sorting_direction == -1:
+                items = reversed(items)
+            items, _ = slice_by_offset(items, offset=offset, limit=limit)
+            return items
+
+        if limit == 0:
+            return []
+
+        statement = select(orm.Node).filter(orm.Node.parent == self.node.id)
+        if offset:
+            statement = statement.offset(offset)
+        statement = self.apply_conditions(statement).order_by(*self.order_by_clauses)
+        if limit is not None:
+            statement = statement.limit(limit)
+
+        async with self.context.session() as db:
+            nodes = (await db.execute(statement)).scalars().all()
+
+        return [
+            (node.key, STRUCTURES[node.structure_family](self.context, node))
+            for node in nodes
+        ]
+
+    async def cursor_for_offset(self, offset: int) -> Optional[int]:
+        """Return the id of the node just before the given offset, for cursor pagination.
+
+        Returns None when cursor pagination is not applicable:
+        - offset is 0 (first page — no previous item)
+        - a non-default sort is active (cursor correctness requires default sort)
+        """
+        if offset == 0 or not self._is_default_sort:
+            return None
+
+        if self.data_sources:
+            # For nodes with external data sources the adapter manages its own
+            # iteration order and conditions are not applied at the DB level
+            # (see keys_page/items_page data_sources path). The offset is
+            # used as a positional index directly into the adapter's sequence,
+            # so offset - 1 is the correct "previous item" cursor here.
+            return offset - 1
+
+        statement = select(orm.Node.id).filter(orm.Node.parent == self.node.id)
+        statement = self.apply_conditions(statement).order_by(*self.order_by_clauses)
+        statement = statement.offset(offset - 1).limit(1)
+
+        async with self.context.session() as db:
+            row = (await db.execute(statement)).first()
+
+        return row[0] if row is not None else None
 
     async def read(self, *args, **kwargs):
         if not self.data_sources:
@@ -1623,37 +1793,53 @@ _STANDARD_SORT_KEYS = {
 }
 
 
-def order_by_clauses(sorting):
+def construct_order_by_clauses(sorting):
     clauses = []
     default_sorting_direction = 1
     for key, direction in sorting:
         if key == "":
             default_sorting_direction = direction
             continue
-            # TODO Really we should insist that if this is given, it is last,
-            # because we always apply the default sorting last.
         if key in _STANDARD_SORT_KEYS:
             clause = getattr(orm.Node, _STANDARD_SORT_KEYS[key])
         else:
-            clause = orm.Node.metadata_
             # This can be given bare like "color" or namedspaced like
             # "metadata.color" to avoid the possibility of a name collision
             # with the standard sort keys.
             if key.startswith("metadata."):
                 key = key[len("metadata.") :]  # noqa: E203
-
+            clause = orm.Node.metadata_
             for segment in key.split("."):
                 clause = clause[segment]
         if direction == -1:
             clause = clause.desc()
         clauses.append(clause)
+
     # Ensure deterministic ordering for all queries by sorting by
     # 'time_created' and then by 'id' last.
     for clause in [orm.Node.time_created, orm.Node.id]:
         if default_sorting_direction == -1:
             clause = clause.desc()
         clauses.append(clause)
-    return clauses
+
+    return clauses, default_sorting_direction
+
+
+def slice_by_offset(items, offset=0, limit=None):
+    """Slice an iterable by offset and limit
+
+    Return the items and the next offset if there are more items.
+    """
+
+    stop = None if limit is None else offset + limit + 1
+    items = list(it.islice(items, offset, stop))
+
+    next_offset = None
+    if (limit is not None) and (len(items) > limit):
+        items.pop()  # Remove the extra item used to check for next page
+        next_offset = offset + limit
+
+    return items, next_offset
 
 
 _TYPE_CONVERSION_MAP = {

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1328,7 +1328,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
         """True when no user-specified sort key is active.
 
         Cursor-based pagination is only correct when the ORDER BY is purely
-        (time_created, id) — i.e. the default.  Any custom leading sort key
+        id ASC or id DESC — i.e. the default.  Any custom leading sort key
         changes the row order in a way that the id-only cursor cannot track.
         """
         return all(key == "" for key, _ in self.sorting)
@@ -1340,6 +1340,10 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
         the extra row used to detect whether a next page exists.
         Only call this when cursor is None (first page) or a valid cursor id.
         Do not call this for offset-based pagination — use keys_range/items_range instead.
+
+        The default ORDER BY is id ASC (or DESC), so the cursor condition
+        id > cursor (or id < cursor) is exact with no need for a secondary
+        time_created column.
         """
         if cursor is not None:
             if self.default_sorting_direction == 1:
@@ -1815,12 +1819,15 @@ def construct_order_by_clauses(sorting):
             clause = clause.desc()
         clauses.append(clause)
 
-    # Ensure deterministic ordering for all queries by sorting by
-    # 'time_created' and then by 'id' last.
-    for clause in [orm.Node.time_created, orm.Node.id]:
-        if default_sorting_direction == -1:
-            clause = clause.desc()
-        clauses.append(clause)
+    # Ensure deterministic ordering by id, which is strictly monotonic
+    # (auto-increment) and therefore a sufficient tiebreaker on its own.
+    # time_created is intentionally omitted: id already encodes insertion
+    # order, and including time_created would require a two-column cursor
+    # (time_created, id) for correct keyset pagination.
+    clause = orm.Node.id
+    if default_sorting_direction == -1:
+        clause = clause.desc()
+    clauses.append(clause)
 
     return clauses, default_sorting_direction
 

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "bf2fe0eb8ee8",
     "85a47342e78e",
     "4cf6011a8db5",
     "a86a48befff6",

--- a/tiled/catalog/explain.py
+++ b/tiled/catalog/explain.py
@@ -48,8 +48,10 @@ def record_explanations():
         explanations.append(e)
 
     _query_explanation_callbacks.append(capture)
-    yield explanations
-    _query_explanation_callbacks.remove(capture)
+    try:
+        yield explanations
+    finally:
+        _query_explanation_callbacks.remove(capture)
 
 
 class ExplainAsyncSession(AsyncSession):

--- a/tiled/catalog/migrations/versions/bf2fe0eb8ee8_add_b_tree_index_on_parent_id_in_nodes.py
+++ b/tiled/catalog/migrations/versions/bf2fe0eb8ee8_add_b_tree_index_on_parent_id_in_nodes.py
@@ -6,12 +6,10 @@ Create Date: 2026-05-14 09:24:08.541769
 
 """
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
-revision = 'bf2fe0eb8ee8'
-down_revision = '85a47342e78e'
+revision = "bf2fe0eb8ee8"
+down_revision = "85a47342e78e"
 branch_labels = None
 depends_on = None
 

--- a/tiled/catalog/migrations/versions/bf2fe0eb8ee8_new_b_tree_index_on_parent_id_in_nodes.py
+++ b/tiled/catalog/migrations/versions/bf2fe0eb8ee8_new_b_tree_index_on_parent_id_in_nodes.py
@@ -1,0 +1,28 @@
+"""New B-tree index on (parent, id) in Nodes
+
+Revision ID: bf2fe0eb8ee8
+Revises: 85a47342e78e
+Create Date: 2026-05-14 09:24:08.541769
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bf2fe0eb8ee8'
+down_revision = '85a47342e78e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_nodes_parent_id",
+        table_name="nodes",
+        columns=["parent", "id"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_nodes_parent_id", table_name="nodes")

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -101,8 +101,8 @@ class Node(Timestamped, Base):
         Index(
             "top_level_metadata",
             "parent",
-            # include the keys of the default sorting ('time_created', 'id'),
-            # used to avoid creating a temp sort index
+            # include 'time_created' and 'id' so the planner can satisfy an
+            # ORDER BY id without a separate sort step (index-only scan path).
             "time_created",
             "id",
             "metadata",

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -109,6 +109,10 @@ class Node(Timestamped, Base):
             "access_blob",
             postgresql_using="gin",
         ),
+        # B-tree index supporting cursor-based pagination (WHERE parent = ?
+        # AND id > cursor ORDER BY id) and cursor_for_offset (OFFSET N LIMIT 1
+        # ORDER BY id). Serves both SQLite and PostgreSQL efficiently.
+        Index("ix_nodes_parent_id", "parent", "id"),
     )
 
 

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -112,21 +112,24 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
             # In the Python API we encode sorting as (key, direction).
             # This order-based "record" notion does not play well with OpenAPI.
             # In the HTTP API, therefore, we use {"key": key, "direction": direction}.
+            server_sorting = item["attributes"].get("sorting") or []
             self._sorting = [
-                (s["key"], int(s["direction"]))
-                for s in (item["attributes"].get("sorting") or [])
-            ]
-        sorting = sorting or item["attributes"].get("sorting")
-        self._sorting_params = {
-            "sort": ",".join(
-                f"{'-' if item[1] < 0 else ''}{item[0]}" for item in self._sorting
-            )
-        }
-        self._reversed_sorting_params = {
-            "sort": ",".join(
-                f"{'-' if item[1] > 0 else ''}{item[0]}" for item in self._sorting
-            )
-        }
+                (s["key"], int(s["direction"])) for s in server_sorting
+            ] or [
+                ("", 1)
+            ]  # fall back to server default when not specified
+        sorting_list = [
+            f"{'-' if item[1] < 0 else ''}{item[0]}" for item in self._sorting
+        ]
+        reversed_sorting_list = [
+            item[1:] if item.startswith("-") else f"-{item.lstrip('+')}"
+            for item in sorting_list
+        ]
+        self._sorting_params = {"sort": sorting_list} if "".join(sorting_list) else {}
+        self._reversed_sorting_params = (
+            {"sort": reversed_sorting_list} if "".join(reversed_sorting_list) else {}
+        )
+
         super().__init__(
             context=context,
             item=item,

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -27,7 +27,7 @@ async def walk(node, filter_for_access, pre=None):
     if node.structure_family != StructureFamily.array:
         filtered = await filter_for_access(node)
         if hasattr(filtered, "items_range"):
-            for key, value in await filtered.items_range(0, None):
+            for key, value in await filtered.items_range():
                 async for d in walk(value, filter_for_access, pre + [key]):
                     yield d
         elif node.structure_family == StructureFamily.table:

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -20,7 +20,7 @@ async def as_dataset(node):
     data_vars = {}
     coords = {}
     if hasattr(node, "items_range"):
-        items = await node.items_range(0, None)
+        items = await node.items_range()
     else:
         items = node.items()
     for key, array_adapter in items:

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -67,7 +67,8 @@ from ..type_aliases import AccessTags
 from ..utils import SHARE_TILED_PATH, SingleUserPrincipal
 from . import schemas
 from .connection_pool import get_database_session_factory
-from .core import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, json_or_msgpack
+from .core import json_or_msgpack
+from .dependencies import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from .protocols import ExternalAuthenticator, InternalAuthenticator, UserSessionState
 from .settings import Settings, get_settings
 from .utils import API_KEY_COOKIE_NAME, get_base_url

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -2,7 +2,6 @@ import collections.abc
 import dataclasses
 import inspect
 import itertools
-import math
 import operator
 import re
 import sys
@@ -10,7 +9,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from hashlib import md5
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import anyio
 import dateutil.tz
@@ -61,9 +60,6 @@ INLINED_CONTENTS_LIMIT = 500
 # being crashed by badly designed or buggy Adapters. It is up to Adapters to
 # opt in to this behavior and decide on a reasonable depth.
 DEPTH_LIMIT = 5
-
-DEFAULT_PAGE_SIZE = 100
-MAX_PAGE_SIZE = 300
 
 
 async def len_or_approx(tree, exact=False, threshold=5000):
@@ -123,32 +119,31 @@ async def len_or_approx(tree, exact=False, threshold=5000):
     return await anyio.to_thread.run_sync(len, tree)
 
 
-def pagination_links(base_url, route, path_parts, offset, limit, length_hint):
+def pagination_links(base_url, route, path_parts, page, next_cursor, length_hint):
     path_str = "/".join(path_parts)
+    if page.cursor is not None:
+        offset_or_cursor = f"page[cursor]={page.cursor}&"
+    elif page.offset:  # Neither None nor 0
+        offset_or_cursor = f"page[offset]={page.offset}&"
+    else:
+        offset_or_cursor = ""  # No offset or cursor for the first page
     links = {
-        "self": f"{base_url}{route}/{path_str}?page[offset]={offset}&page[limit]={limit}",
-        # These are conditionally overwritten below.
-        "first": None,
-        "last": None,
+        "self": f"{base_url}{route}/{path_str}?{offset_or_cursor}page[limit]={page.limit}",
+        "first": f"{base_url}{route}/{path_str}?page[limit]={page.limit}",
         "next": None,
-        "prev": None,
     }
-    if limit:
-        last_page = math.floor(length_hint / limit) * limit
-        links.update(
-            {
-                "first": f"{base_url}{route}/{path_str}?page[offset]={0}&page[limit]={limit}",
-                "last": f"{base_url}{route}/{path_str}?page[offset]={last_page}&page[limit]={limit}",
-            }
-        )
-    if offset + limit < length_hint:
+    if next_cursor is not None:
         links[
             "next"
-        ] = f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
-    if offset > 0:
+        ] = f"{base_url}{route}/{path_str}?page[cursor]={next_cursor}&page[limit]={page.limit}"
+    elif (
+        (page.cursor is None)
+        and (page.offset is not None)
+        and (page.offset + page.limit < length_hint)
+    ):
         links[
-            "prev"
-        ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
+            "next"
+        ] = f"{base_url}{route}/{path_str}?page[offset]={page.offset + page.limit}&page[limit]={page.limit}"
     return links
 
 
@@ -215,39 +210,18 @@ async def apply_search(tree, filters, query_registry):
     return tree
 
 
-def apply_sort(tree, sort):
-    sorting = []
-    if sort is not None:
-        for item in sort.split(","):
-            if item:
-                if item.startswith("-"):
-                    sorting.append((item[1:], -1))
-                else:
-                    sorting.append((item, 1))
-    if sorting:
-        if not hasattr(tree, "sort"):
-            raise HTTPException(
-                status_code=HTTP_400_BAD_REQUEST,
-                detail="This Tree does not support sorting.",
-            )
-        tree = tree.sort(sorting)
-
-    return tree
-
-
 async def construct_entries_response(
     query_registry,
     tree,
     route,
     path,
-    offset,
-    limit,
+    page,
     fields,
     select_metadata,
     omit_links,
     include_data_sources,
     filters,
-    sort,
+    sorting: Optional[list[tuple[str, Literal[1, -1]]]],
     base_url,
     media_type,
     max_depth,
@@ -257,34 +231,62 @@ async def construct_entries_response(
 
     path_parts = [segment for segment in path.split("/") if segment]
     tree = await apply_search(tree, filters, query_registry)
-    tree = apply_sort(tree, sort)
+
+    if sorting:
+        if not hasattr(tree, "sort"):
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="This Tree does not support sorting.",
+            )
+        tree = tree.sort(sorting)
 
     count = await len_or_approx(
         tree, exact=(schemas.EntryFields.count in fields), threshold=exact_count_limit
     )
-    links = pagination_links(base_url, route, path_parts, offset, limit, count)
-    data = []
 
+    next_cursor = None
     if fields == [schemas.EntryFields.none]:
         # Pull a page of just the keys, which is cheaper.
-        if hasattr(tree, "keys_range"):
-            keys = await tree.keys_range(offset, limit)
+        if hasattr(tree, "keys_page"):
+            if page.cursor is not None:
+                keys, next_cursor = await tree.keys_page(page.cursor, page.limit)
+            else:
+                page.cursor = await tree.cursor_for_offset(page.offset)
+                if page.cursor is not None or page.offset == 0:
+                    # Cursor available (or first page): use cursor pagination
+                    keys, next_cursor = await tree.keys_page(page.cursor, page.limit)
+                else:
+                    # Non-default sort: use offset pagination
+                    keys = await tree.keys_range(page.offset, page.limit)
         else:
-            keys = tree.keys()[offset : offset + limit]  # noqa: E203
+            keys = tree.keys()[page.offset : page.offset + page.limit]  # noqa: E203
         items = [(key, None) for key in keys]
     elif fields == [schemas.EntryFields.count]:
         # Only count is requested, so we do not need to pull any items.
         items = []
     else:
         # Pull the entire page of full items into memory.
-        if hasattr(tree, "items_range"):
-            items = await tree.items_range(offset, limit)
+        if hasattr(tree, "items_page"):
+            if page.cursor is not None:
+                items, next_cursor = await tree.items_page(page.cursor, page.limit)
+            else:
+                page.cursor = await tree.cursor_for_offset(page.offset)
+                if page.cursor is not None or page.offset == 0:
+                    # Cursor available (or first page): use cursor pagination
+                    items, next_cursor = await tree.items_page(page.cursor, page.limit)
+                else:
+                    # Non-default sort: use offset pagination
+                    items = await tree.items_range(page.offset, page.limit)
         else:
-            items = tree.items()[offset : offset + limit]  # noqa: E203
+            items = tree.items()[page.offset : page.offset + page.limit]  # noqa: E203
+
+    # Construct pagination links
+    links = pagination_links(base_url, route, path_parts, page, next_cursor, count)
 
     # This value will not leak out. It just used to seed comparisons.
     metadata_stale_at = datetime.now(timezone.utc) + timedelta(days=1_000_000)
     must_revalidate = getattr(tree, "must_revalidate", True)
+    data = []
     for key, entry in items:
         resource = await construct_resource(
             base_url,
@@ -307,6 +309,7 @@ async def construct_entries_response(
                 metadata_stale_at = None
             else:
                 metadata_stale_at = min(metadata_stale_at, entry.metadata_stale_at)
+
     return (
         schemas.Response(data=data, links=links, meta={"count": count}),
         metadata_stale_at,
@@ -328,12 +331,11 @@ async def construct_revisions_response(
     base_url,
     route,
     path,
-    offset,
-    limit,
+    page,
     media_type,
 ):
     path_parts = [segment for segment in path.split("/") if segment]
-    revisions = await entry.revisions(offset, limit)
+    revisions = await entry.revisions(page.offset, page.limit)
     data = []
     for revision in revisions:
         item = {
@@ -346,9 +348,7 @@ async def construct_revisions_response(
         }
         data.append(item)
     count = len(data)
-    links = pagination_links(
-        base_url, route, path_parts, offset, limit, count
-    )  # maybe reuse or maybe make a new pagination_revision_links
+    links = pagination_links(base_url, route, path_parts, page, None, count)
     return schemas.Response(data=data, links=links, meta={"count": count})
 
 

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import pydantic_settings
 from fastapi import HTTPException, Query, Request
+from pydantic import constr
 from starlette.status import (
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
@@ -18,6 +19,14 @@ from ..utils import BrokenLink
 from .core import NoEntry
 from .schemas import Principal
 from .utils import filter_for_access, record_timing
+
+# Template for the "sort" query parameters.
+# Empty sting is NOT allowed, should be at least "-" or "+"
+SortField = constr(pattern=r"^(?:[+-][a-zA-Z0-9_.]*|[a-zA-Z0-9_.]+)$")
+
+# Limits for pagination parameters
+DEFAULT_PAGE_SIZE = 100
+MAX_PAGE_SIZE = 300
 
 # NOTE: The regex below is used by fastapi to parse the string representation of a slice
 # and raise a 422 error if the string is not valid.
@@ -203,3 +212,60 @@ def patch_offset_param(
     if patch_offset is None:
         return None
     return tuple(map(int, patch_offset.split(",")))
+
+
+def sorting_param(
+    sort: Optional[List[SortField]] = Query(None),
+):
+    "Specify and parse a sorting parameter."
+    if sort is None:
+        return None
+
+    result = {}
+    for item in sort:
+        if item.startswith("-"):
+            key, dir = item[1:], -1
+        elif item.startswith("+"):
+            key, dir = item[1:], 1
+        else:
+            key, dir = item, 1
+
+        if key in result:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=f"Duplicate sorting key: {key}",
+            )
+
+        result[key] = dir
+
+    # Check that the default sorting (""), if specified, is the last item in the list
+    if ("" in result) and (list(result.keys())[-1] != ""):
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Default sorting (empty string) must be the last item in the sort list",
+        )
+
+    return list(result.items())
+
+
+class PaginationParams:
+    def __init__(
+        self,
+        offset: Optional[int] = Query(None, alias="page[offset]", ge=0),
+        cursor: Optional[int] = Query(None, alias="page[cursor]", ge=0),
+        limit: int = Query(
+            DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
+        ),
+    ):
+        if cursor is not None and offset is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify both page[cursor] and page[offset]",
+            )
+
+        if cursor is None and offset is None:
+            offset = 0
+
+        self.offset = offset
+        self.cursor = cursor
+        self.limit = limit

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from functools import cache, partial
 from pathlib import Path
-from typing import Callable, List, Optional, TypeVar, Union
+from typing import Callable, List, Literal, Optional, TypeVar, Union
 
 import anyio
 import packaging
@@ -71,9 +71,7 @@ from .authentication import (
 )
 from .connection_pool import get_database_session_factory
 from .core import (
-    DEFAULT_PAGE_SIZE,
     DEPTH_LIMIT,
-    MAX_PAGE_SIZE,
     NoEntry,
     UnsupportedMediaTypes,
     WrongTypeForRoute,
@@ -87,6 +85,7 @@ from .core import (
     resolve_media_type,
 )
 from .dependencies import (
+    PaginationParams,
     expected_shape,
     get_entry,
     get_root_tree,
@@ -96,6 +95,7 @@ from .dependencies import (
     patch_offset_param,
     patch_shape_param,
     shape_param,
+    sorting_param,
 )
 from .settings import Settings, get_settings
 from .utils import (
@@ -317,11 +317,8 @@ def get_router(
         path: str,
         fields: Optional[List[schemas.EntryFields]] = Query(list(schemas.EntryFields)),
         select_metadata: Optional[str] = Query(None),
-        offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
-        limit: Optional[int] = Query(
-            DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
-        ),
-        sort: Optional[str] = Query(None),
+        page: PaginationParams = Depends(),
+        sort: Optional[List[tuple[str, Literal[1, -1]]]] = Depends(sorting_param),
         max_depth: Optional[int] = Query(None, ge=0, le=DEPTH_LIMIT),
         omit_links: bool = Query(False),
         include_data_sources: bool = Query(False),
@@ -357,8 +354,7 @@ def get_router(
                 entry,
                 "/search",
                 path,
-                offset,
-                limit,
+                page,
                 fields,
                 select_metadata,
                 omit_links,
@@ -2289,10 +2285,7 @@ def get_router(
     async def get_revisions(
         request: Request,
         path: str,
-        offset: Optional[int] = Query(0, alias="page[offset]", ge=0),
-        limit: Optional[int] = Query(
-            DEFAULT_PAGE_SIZE, alias="page[limit]", ge=0, le=MAX_PAGE_SIZE
-        ),
+        page: PaginationParams = Depends(),
         principal: Optional[Principal] = Depends(get_current_principal),
         root_tree=Depends(get_root_tree),
         session_state: dict = Depends(get_session_state),
@@ -2324,8 +2317,7 @@ def get_router(
             base_url,
             "/revisions",
             path,
-            offset,
-            limit,
+            page,
             resolve_media_type(request),
         )
         return json_or_msgpack(request, resource.model_dump())

--- a/tiled/server/zarr.py
+++ b/tiled/server/zarr.py
@@ -198,7 +198,7 @@ def get_zarr_router_v2() -> APIRouter:
         if entry.structure_family == StructureFamily.container:
             # List the contents of a "simulated" zarr directory (excluding .zarray and .zgroup files)
             if hasattr(entry, "keys_range"):
-                keys = await entry.keys_range(offset=0, limit=None)
+                keys = await entry.keys_range()
             else:
                 keys = entry.keys()
             url = str(request.url).rstrip("/")
@@ -484,7 +484,7 @@ def get_zarr_router_v3() -> APIRouter:
         if entry.structure_family == StructureFamily.container:
             # List the contents of a "simulated" zarr directory (excluding .zarray and .zgroup files)
             if hasattr(entry, "keys_range"):
-                keys = await entry.keys_range(offset=0, limit=None)
+                keys = await entry.keys_range()
             else:
                 keys = entry.keys()
             body = json.dumps([url + "/" + key for key in keys])

--- a/tiled/validation_registration.py
+++ b/tiled/validation_registration.py
@@ -60,7 +60,7 @@ async def validate_composite(spec, metadata, entry, structure_family, structure)
             )
 
         flat_name_space = []
-        for key, item in await entry.items_range(offset=0, limit=None):
+        for key, item in await entry.items_range():
             flat_name_space.append(key)
 
             if item.structure_family == StructureFamily.table:

--- a/web-frontend/package-lock.json
+++ b/web-frontend/package-lock.json
@@ -2193,9 +2193,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,9 +2205,6 @@
       "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2225,9 +2219,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2240,9 +2231,6 @@
       "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2257,9 +2245,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2272,9 +2257,6 @@
       "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2289,9 +2271,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2304,9 +2283,6 @@
       "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2321,9 +2297,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,9 +2309,6 @@
       "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2353,9 +2323,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2369,9 +2336,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,9 +2348,6 @@
       "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3428,6 +3389,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -6531,15 +6501,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces offset-based pagination with cursor-based pagination for catalog containers on the default sort order (`id`, ascending/descending). This addresses the duplicate/skip problem that arises when items are inserted concurrently (see #647) and improves querying middle pages in large catalogs.

### How it works

- The server uses the node `id` (an auto-increment integer) as an opaque cursor. On the default sort (`time_created, id ASC/DESC`), each page response includes a `page[cursor]=<id>` value in the `next` link instead of `page[offset]=<N>`.
- Clients that send a `page[offset]` request on the default sort are transparently migrated: the server calls `cursor_for_offset()` to convert the offset to a cursor, and the `next` link in the response is already cursor-based. Subsequent pages follow cursor pagination naturally.
- Non-default sort orders (any explicit sort key such as `sort=id` or `sort=metadata.color`) fall back to offset pagination, since the id-only cursor cannot correctly track arbitrary orderings.
- Supplying both `page[cursor]` and `page[offset]` in the same request is rejected with HTTP 400.

### Changes

- **`tiled/catalog/adapter.py`**: `CatalogContainerAdapter` gains `keys_page(cursor, limit)`, `items_page(cursor, limit)`, and `cursor_for_offset(offset)`. The existing `keys_range` and `items_range` are retained as the public offset-based interface for external callers (e.g. exporters, validators) and for non-default sort fallback.
- **`tiled/server/dependencies.py`**: New `PaginationParams` dependency class encapsulating `page[offset]`, `page[cursor]`, and `page[limit]`. New `sorting_param` dependency replacing the old comma-string `sort` parameter with a typed list supporting `+`/`-` prefixes and dotted metadata keys (e.g. `sort=metadata.color`). `DEFAULT_PAGE_SIZE` and `MAX_PAGE_SIZE` moved here from `core.py`.
- **`tiled/server/core.py`**: `construct_entries_response` routes to `keys_page`/`items_page` (cursor path) or `keys_range`/`items_range` (offset fallback) depending on sort order and cursor availability. `pagination_links` updated to emit `page[cursor]` next links.

### What is not changed

- The `keys_range` / `items_range` public interface is preserved unchanged for backward compatibility with external callers.
- Non-default sort behaviour is identical to before (offset pagination); `prev` and `last` pagination links are dropped.

Related Issue: #647

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section