### PR TITLE
Expose command and args in helm chart

### DIFF
--- a/helm/tiled/templates/deployment.yaml
+++ b/helm/tiled/templates/deployment.yaml
@@ -36,6 +36,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/helm/tiled/values.yaml
+++ b/helm/tiled/values.yaml
@@ -24,6 +24,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Override the container command. If not set, the image's CMD is used.
+command: []
+
+# Override the container args. If not set, the image's ENTRYPOINT args are used.
+args: []
+
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.


### PR DESCRIPTION
This PR exposes `command` and `args` in the helm chart so that downstream deployments can override them.

Closes #1323 