### PR TITLE
Fix tiled auth sync bug when `token_directory is None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Writing chunked (dask) arrays with single chunk along all dimensions
 - OIDC authenticator was not quite compliant and was incompatible with
   at least some providers including Azure and ORCID.
+- A bug in `TiledAuth` when `token_directory` is `None` caused an
+  error during token refresh.
 
 ### Changed
 

--- a/tests/test_tiled_auth.py
+++ b/tests/test_tiled_auth.py
@@ -1,0 +1,17 @@
+from tiled.client.auth import TiledAuth
+
+
+def test_no_token_directory():
+    auth = TiledAuth(
+        refresh_url="https://example.com/refresh",
+        csrf_token="placeholder_csrf_token",
+        token_directory=None,
+    )
+    assert auth.sync_get_token("access_token") is None
+    assert auth.sync_get_token("refresh_token") is None
+    assert auth.sync_get_token("access_token", reload_from_disk=True) is None
+    assert auth.sync_get_token("refresh_token", reload_from_disk=True) is None
+    auth.sync_set_token("access_token", "placeholder_access_token")
+    auth.sync_set_token("refresh_token", "placeholder_refresh_token")
+    assert auth.sync_get_token("access_token") == "placeholder_access_token"
+    assert auth.sync_get_token("refresh_token") == "placeholder_refresh_token"

--- a/tiled/client/auth.py
+++ b/tiled/client/auth.py
@@ -56,12 +56,15 @@ class TiledAuth(httpx.Auth):
 
     def sync_get_token(self, key, reload_from_disk=False):
         if not reload_from_disk:
-            # Use in-memory cached copy.
+            # Try in-memory cached copy first.
             try:
                 return self.tokens[key]
-            except Exception:
-                if self.token_directory is None:
-                    return None
+            except KeyError:
+                # Continue on to try to read token form disk.
+                pass
+        if self.token_directory is None:
+            # No token directory was configured. Give up.
+            return None
         with self._sync_lock:
             filepath = self.token_directory / key
             try:


### PR DESCRIPTION
We observed this issue at QAS. The unit test reproduces the bug:

```
_____________________________________________________________________________ test_no_token_directory _____________________________________________________________________________

    def test_no_token_directory():
        auth = TiledAuth(
            refresh_url="https://example.com/refresh",
            csrf_token="placeholder_csrf_token",
            token_directory=None
        )
        assert auth.sync_get_token("access_token") is None
        assert auth.sync_get_token("refresh_token") is None
>       assert auth.sync_get_token("access_token", reload_from_disk=True) is None
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_tiled_auth.py:12:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tiled.client.auth.TiledAuth object at 0x76e39f910ad0>, key = 'access_token', reload_from_disk = True

    def sync_get_token(self, key, reload_from_disk=False):
        if not reload_from_disk:
            # Use in-memory cached copy.
            try:
                return self.tokens[key]
            except Exception:
                if self.token_directory is None:
                    return None
        with self._sync_lock:
>           filepath = self.token_directory / key
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: unsupported operand type(s) for /: 'NoneType' and 'str'

tiled/client/auth.py:66: TypeError
```

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
