### PR TITLE
Fix call to `ProxiedOIDCAuthenticator.decode_token`.

### DIFF
--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -140,11 +140,11 @@ def test_oidc_decoding(
 
     if not expired:
         # Decode does not currently care if issued_at_time > current time
-        assert authenticator.decode_token(encrypted_access_token, "placeholder") == access_token
+        assert authenticator.decode_token(encrypted_access_token) == access_token
 
     else:
         with pytest.raises(ExpiredSignatureError):
-            authenticator.decode_token(encrypted_access_token, "placeholder")
+            authenticator.decode_token(encrypted_access_token)
 
 
 @pytest.fixture

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -207,7 +207,7 @@ properties:
         return httpx.get(self.jwks_uri).raise_for_status().json().get("keys", [])
 
     def decode_token(
-        self, id_token: str, access_token: Optional[str]
+        self, id_token: str, access_token: Optional[str] = None
     ) -> dict[str, Any]:
         return jwt.decode(
             id_token,

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -206,7 +206,9 @@ properties:
     def keys(self) -> List[str]:
         return httpx.get(self.jwks_uri).raise_for_status().json().get("keys", [])
 
-    def decode_token(self, id_token: str, access_token: str) -> dict[str, Any]:
+    def decode_token(
+        self, id_token: str, access_token: Optional[str]
+    ) -> dict[str, Any]:
         return jwt.decode(
             id_token,
             key=self.keys(),

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -159,7 +159,7 @@ def decode_token(
         headers={"WWW-Authenticate": "Bearer"},
     )
     if proxied_authenticator:
-        return proxied_authenticator.decode_token(token, None)
+        return proxied_authenticator.decode_token(token)
     else:
         # The first key in settings.secret_keys is used for *encoding*.
         # All keys are tried for *decoding* until one works or they all

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -159,7 +159,7 @@ def decode_token(
         headers={"WWW-Authenticate": "Bearer"},
     )
     if proxied_authenticator:
-        return proxied_authenticator.decode_token(token)
+        return proxied_authenticator.decode_token(token, None)
     else:
         # The first key in settings.secret_keys is used for *encoding*.
         # All keys are tried for *decoding* until one works or they all


### PR DESCRIPTION
Follow-up on #1333. Note that `jose.jwt.decode` accepts an `access_token` (in addition the the `token` to be decoded) but only requires it in certain circumstances.

```
Docstring:
Verifies a JWT string's signature and validates reserved claims.

Args:
    token (str): A signed JWS to be verified.
    key (str or iterable): A key to attempt to verify the payload with.
        This can be simple string with an individual key (e.g. "a1234"),
        a tuple or list of keys (e.g. ("a1234...", "b3579"),
        a JSON string, (e.g. '["a1234", "b3579"]'),
        a dict with the 'keys' key that gives a tuple or list of keys (e.g {'keys': [...]} ) or
        a dict or JSON string for a JWK set as defined by RFC 7517 (e.g.
            {'keys': [{'kty': 'oct', 'k': 'YTEyMzQ'}, {'kty': 'oct', 'k':'YjM1Nzk'}]} or
            '{"keys": [{"kty":"oct","k":"YTEyMzQ"},{"kty":"oct","k":"YjM1Nzk"}]}'
        ) in which case the keys must be base64 url safe encoded (with optional padding).
    algorithms (str or list): Valid algorithms that should be used to verify the JWS.
    audience (str): The intended audience of the token.  If the "aud" claim is
        included in the claim set, then the audience must be included and must equal
        the provided claim.
    issuer (str or iterable): Acceptable value(s) for the issuer of the token.
        If the "iss" claim is included in the claim set, then the issuer must be
        given and the claim in the token must be among the acceptable values.
    subject (str): The subject of the token.  If the "sub" claim is
        included in the claim set, then the subject must be included and must equal
        the provided claim.
    access_token (str): An access token string. If the "at_hash" claim is included in the
        claim set, then the access_token must be included, and it must match
        the "at_hash" claim.
```

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
