### PR TITLE
TST: Additional Tests for WS Endpoints with Tabular Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Writing chunked (dask) arrays with single chunk along all dimensions
 - OIDC authenticator was not quite compliant and was incompatible with
   at least some providers including Azure and ORCID.
+- Ensure that JSON payloads in streaming endpoints is properly decoded.
 
 ### Changed
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -4,6 +4,8 @@ import urllib.parse
 import dask.array
 import msgpack
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
 from starlette.testclient import WebSocketDenialResponse
 
@@ -517,6 +519,186 @@ def test_close_stream_wrong_api_key(tiled_websocket_context):
     assert response.status_code == 401
 
 
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_table_write_websocket(tiled_websocket_context, envelope_format):
+    """Test that writing a full table triggers a WS event with the correct payload."""
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    df = pd.DataFrame({"label": ["a", "b"], "value": [1.0, 2.0]})
+    table_node = client.write_table(df, key="test_table_write")
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_table_write?envelope_format={envelope_format}",
+        headers={"Authorization": "Apikey secret"},
+    ) as websocket:
+        # Overwrite with new data
+        df2 = pd.DataFrame({"label": ["c", "d"], "value": [3.0, 4.0]})
+        table_node.write_partition(0, df2)
+
+        # Receive schema + 1 data message
+        if envelope_format == "json":
+            schema_msg = websocket.receive_json()
+        else:
+            schema_msg = msgpack.unpackb(websocket.receive_bytes())
+
+        assert schema_msg["type"] == "table-schema"
+        assert "version" in schema_msg
+        # For JSON format, arrow_schema should have been converted to str
+        if envelope_format == "json":
+            assert isinstance(schema_msg["arrow_schema"], str)
+
+        if envelope_format == "json":
+            data_msg = websocket.receive_json()
+        else:
+            data_msg = msgpack.unpackb(websocket.receive_bytes())
+
+        assert data_msg["type"] == "table-data"
+        assert "timestamp" in data_msg
+        assert data_msg["append"] is False
+
+        if envelope_format == "json":
+            # stream_json transcodes Arrow IPC to dict-of-lists
+            payload = data_msg["payload"]
+            assert isinstance(payload, dict)
+            assert payload["label"] == ["c", "d"]
+            assert payload["value"] == [3.0, 4.0]
+        else:
+            # msgpack keeps the raw Arrow IPC bytes
+            assert isinstance(data_msg["payload"], bytes)
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_table_append_websocket(tiled_websocket_context, envelope_format):
+    """Test that appending rows to a table triggers a WS event."""
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    schema = pa.schema([("path", pa.string()), ("label", pa.string())])
+    table_node = client.create_appendable_table(schema, key="test_table_append")
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_table_append?envelope_format={envelope_format}",
+        headers={"Authorization": "Apikey secret"},
+    ) as websocket:
+        # Append some rows (reset_index=False avoids __index_level_0__ mismatch)
+        df1 = pa.table({"path": ["/a/b"], "label": ["cat"]})
+        table_node.append_partition(0, df1)
+
+        df2 = pa.table({"path": ["/c/d", "/e/f"], "label": ["dog", "bird"]})
+        table_node.append_partition(0, df2)
+
+        # Receive schema + 2 data messages
+        if envelope_format == "json":
+            schema_msg = websocket.receive_json()
+        else:
+            schema_msg = msgpack.unpackb(websocket.receive_bytes())
+        assert schema_msg["type"] == "table-schema"
+
+        for expected_tbl in [df1, df2]:
+            if envelope_format == "json":
+                msg = websocket.receive_json()
+            else:
+                msg = msgpack.unpackb(websocket.receive_bytes())
+
+            assert msg["type"] == "table-data"
+            assert msg["append"] is True
+
+            if envelope_format == "json":
+                payload = msg["payload"]
+                assert payload["path"] == expected_tbl.column("path").to_pylist()
+                assert payload["label"] == expected_tbl.column("label").to_pylist()
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_table_multiple_appends_with_late_subscriber(
+    tiled_websocket_context, envelope_format
+):
+    """Late subscriber sees only new appends, not historical ones."""
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    schema = pa.schema([("x", pa.float64())])
+    table_node = client.create_appendable_table(schema, key="test_table_late_sub")
+
+    # Append before subscribing
+    table_node.append_partition(0, pa.table({"x": [1.0, 2.0]}))
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_table_late_sub?envelope_format={envelope_format}",
+        headers={"Authorization": "Apikey secret"},
+    ) as websocket:
+        # Append after subscribing
+        table_node.append_partition(0, pa.table({"x": [3.0, 4.0]}))
+
+        # Receive schema
+        if envelope_format == "json":
+            schema_msg = websocket.receive_json()
+        else:
+            schema_msg = msgpack.unpackb(websocket.receive_bytes())
+        assert schema_msg["type"] == "table-schema"
+
+        # Receive the one new append
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:
+            msg = msgpack.unpackb(websocket.receive_bytes())
+        assert msg["type"] == "table-data"
+        assert msg["append"] is True
+
+        if envelope_format == "json":
+            assert msg["payload"]["x"] == [3.0, 4.0]
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_table_append_from_beginning(tiled_websocket_context, envelope_format):
+    """Subscriber with start=0 replays historical table appends."""
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    schema = pa.schema([("val", pa.int64())])
+    table_node = client.create_appendable_table(schema, key="test_table_from_beginning")
+
+    # Append before subscribing
+    table_node.append_partition(0, pa.table({"val": [10, 20]}))
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_table_from_beginning?envelope_format={envelope_format}&start=0",
+        headers={"Authorization": "Apikey secret"},
+    ) as websocket:
+        # Schema
+        if envelope_format == "json":
+            schema_msg = websocket.receive_json()
+        else:
+            schema_msg = msgpack.unpackb(websocket.receive_bytes())
+        assert schema_msg["type"] == "table-schema"
+
+        # Should receive the historical append
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:
+            msg = msgpack.unpackb(websocket.receive_bytes())
+        assert msg["type"] == "table-data"
+
+        if envelope_format == "json":
+            assert msg["payload"]["val"] == [10, 20]
+
+        # Now append more and receive it
+        table_node.append_partition(0, pa.table({"val": [30]}))
+
+        if envelope_format == "json":
+            msg2 = websocket.receive_json()
+        else:
+            msg2 = msgpack.unpackb(websocket.receive_bytes())
+        assert msg2["type"] == "table-data"
+        if envelope_format == "json":
+            assert msg2["payload"]["val"] == [30]
+
+
 def test_streaming_cache_config(tmp_path, redis_uri):
     "Test streaming_cache config parsing"
     config_path = tmp_path / "config.yml"
@@ -529,8 +711,8 @@ trees:
    args:
      uri: "sqlite:///:memory:"
      writable_storage:
-        - "file://localhost{str(tmp_path / 'data')}"
-        - "duckdb:///{tmp_path / 'data.duckdb'}"
+        - "file://localhost{str(tmp_path / "data")}"
+        - "duckdb:///{tmp_path / "data.duckdb"}"
      init_if_not_exists: true
 streaming_cache:
   uri: "{redis_uri}"

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,4 +1,5 @@
 import sys
+import urllib.parse
 
 import dask.array
 import msgpack
@@ -46,10 +47,16 @@ def append_array(client, new_arr, seq_num, persist=None):
 def receive_ws_updates(websocket, count=1):
     """Helper to receive updates in websocket tests."""
     # Receive all updates
+    envelope_format = urllib.parse.parse_qs(websocket.scope["query_string"].decode())[
+        "envelope_format"
+    ][0]
     received = []
     for _ in range(count + 1):  # +1 for schema
-        msg_bytes = websocket.receive_bytes()
-        msg = msgpack.unpackb(msg_bytes)
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:  # default to msgpack
+            msg_bytes = websocket.receive_bytes()
+            msg = msgpack.unpackb(msg_bytes)
         received.append(msg)
 
     # Verify all messages received (schema + n updates)
@@ -74,12 +81,20 @@ def verify_ws_updates(received, start=1, chunked=False):
                 assert msg["shape"] == [10]
 
             # Verify payload contains the expected array data
-            payload_array = np.frombuffer(msg["payload"], dtype=np.int64)
-            expected_array = np.arange(10) + (start - 1) + i
-            np.testing.assert_array_equal(payload_array, expected_array)
+            if isinstance(msg["payload"], bytes):
+                payload_array = np.frombuffer(msg["payload"], dtype=np.int64)
+            else:
+                payload_array = np.array(msg["payload"], dtype=np.int64)
+            expected_array = (np.arange(10) + (start - 1) + i).reshape(msg["shape"])
+            np.testing.assert_array_equal(
+                payload_array.reshape(msg["shape"]), expected_array
+            )
 
 
-def test_subscribe_immediately_after_creation_websockets(tiled_websocket_context):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_subscribe_immediately_after_creation_websockets(
+    tiled_websocket_context, envelope_format
+):
     context = tiled_websocket_context
     client = from_context(context)
     test_client = context.http_client
@@ -88,9 +103,9 @@ def test_subscribe_immediately_after_creation_websockets(tiled_websocket_context
     arr = np.arange(10)
     streaming_node = client.write_array(arr, key="test_stream_immediate")
 
-    # Connect WebSocket using TestClient with msgpack format and authorization
+    # Connect WebSocket using TestClient with specified envelope format and authorization
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_immediate?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_stream_immediate?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Send 3 updates using Tiled client that overwrite the array
@@ -101,7 +116,10 @@ def test_subscribe_immediately_after_creation_websockets(tiled_websocket_context
         verify_ws_updates(received)
 
 
-def test_websocket_connection_to_non_existent_node(tiled_websocket_context):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_connection_to_non_existent_node(
+    tiled_websocket_context, envelope_format
+):
     """Test websocket connection to non-existent node returns 404."""
     context = tiled_websocket_context
     test_client = context.http_client
@@ -111,13 +129,16 @@ def test_websocket_connection_to_non_existent_node(tiled_websocket_context):
     # Try to connect to websocket for non-existent node
     # This should result in an HTTP 404 response during the handshake
     response = test_client.get(
-        f"/api/v1/stream/single/{non_existent_node_id}",
+        f"/api/v1/stream/single/{non_existent_node_id}?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     )
     assert response.status_code == 404
 
 
-def test_subscribe_after_first_update_websockets(tiled_websocket_context):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_subscribe_after_first_update_websockets(
+    tiled_websocket_context, envelope_format
+):
     """Client that subscribes after first update sees only subsequent updates."""
     context = tiled_websocket_context
     client = from_context(context)
@@ -133,7 +154,7 @@ def test_subscribe_after_first_update_websockets(tiled_websocket_context):
 
     # Connect WebSocket after first update
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_after_update?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_stream_after_update?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Send 2 more updates that overwrite the array
@@ -145,8 +166,9 @@ def test_subscribe_after_first_update_websockets(tiled_websocket_context):
         verify_ws_updates(received, start=2)
 
 
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_subscribe_after_first_update_from_beginning_websockets(
-    tiled_websocket_context,
+    tiled_websocket_context, envelope_format
 ):
     """Client that subscribes after first update but requests from seq_num=0 sees all updates.
 
@@ -167,33 +189,48 @@ def test_subscribe_after_first_update_from_beginning_websockets(
 
     # Connect WebSocket requesting from beginning
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_from_beginning?envelope_format=msgpack&start=0",
+        f"/api/v1/stream/single/test_stream_from_beginning?envelope_format={envelope_format}&start=0",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Schema
-        schema_msg_bytes = websocket.receive_bytes()
-        schema_msg = msgpack.unpackb(schema_msg_bytes)
+        if envelope_format == "json":
+            schema_msg = websocket.receive_json()
+        else:
+            schema_msg_bytes = websocket.receive_bytes()
+            schema_msg = msgpack.unpackb(schema_msg_bytes)
         assert "type" in schema_msg
         assert "version" in schema_msg
 
         # First, should receive the initial array creation
-        historical_msg_bytes = websocket.receive_bytes()
-        historical_msg = msgpack.unpackb(historical_msg_bytes)
+        if envelope_format == "json":
+            historical_msg = websocket.receive_json()
+        else:
+            historical_msg_bytes = websocket.receive_bytes()
+            historical_msg = msgpack.unpackb(historical_msg_bytes)
         assert "timestamp" in historical_msg
         assert "payload" in historical_msg
         assert historical_msg["shape"] == [10]
 
         # Verify historical payload (initial array creation - sequence 0)
-        historical_payload = np.frombuffer(historical_msg["payload"], dtype=np.int64)
+        if envelope_format == "json":
+            historical_payload = np.array(historical_msg["payload"], dtype=np.int64)
+        else:
+            historical_payload = np.frombuffer(
+                historical_msg["payload"], dtype=np.int64
+            )
         expected_historical = np.arange(10)  # Initial array
         np.testing.assert_array_equal(historical_payload, expected_historical)
 
         # Next, should receive the first update (sequence 1)
-        first_update_bytes = websocket.receive_bytes()
-        first_update_msg = msgpack.unpackb(first_update_bytes)
-        first_update_payload = np.frombuffer(
-            first_update_msg["payload"], dtype=np.int64
-        )
+        if envelope_format == "json":
+            first_update_msg = websocket.receive_json()
+            first_update_payload = np.array(first_update_msg["payload"], dtype=np.int64)
+        else:
+            first_update_bytes = websocket.receive_bytes()
+            first_update_msg = msgpack.unpackb(first_update_bytes)
+            first_update_payload = np.frombuffer(
+                first_update_msg["payload"], dtype=np.int64
+            )
         expected_first_update = np.arange(10) + 1
         np.testing.assert_array_equal(first_update_payload, expected_first_update)
 
@@ -204,21 +241,30 @@ def test_subscribe_after_first_update_from_beginning_websockets(
 
         # Receive the new updates
         for i in range(2, 4):
-            msg_bytes = websocket.receive_bytes()
-            msg = msgpack.unpackb(msg_bytes)
+            if envelope_format == "json":
+                msg = websocket.receive_json()
+            else:
+                msg_bytes = websocket.receive_bytes()
+                msg = msgpack.unpackb(msg_bytes)
             assert "timestamp" in msg
             assert "payload" in msg
             assert msg["shape"] == [10]
 
             # Verify payload contains the expected array data
-            payload_array = np.frombuffer(msg["payload"], dtype=np.int64)
+            if envelope_format == "json":
+                payload_array = np.array(msg["payload"], dtype=np.int64)
+            else:
+                payload_array = np.frombuffer(msg["payload"], dtype=np.int64)
             expected_array = np.arange(10) + i
             np.testing.assert_array_equal(payload_array, expected_array)
 
 
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 @pytest.mark.parametrize("write_op", (overwrite_array, patch_array))
 @pytest.mark.parametrize("persist", (None, True, False))
-def test_updates_persist_write(tiled_websocket_context, write_op, persist):
+def test_updates_persist_write(
+    tiled_websocket_context, envelope_format, write_op, persist
+):
     context = tiled_websocket_context
     client = from_context(context)
     test_client = context.http_client
@@ -229,7 +275,7 @@ def test_updates_persist_write(tiled_websocket_context, write_op, persist):
 
     # Connect WebSocket using TestClient with msgpack format and authorization
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_immediate?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_stream_immediate?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Send 3 updates using Tiled client that write values into the array
@@ -248,8 +294,9 @@ def test_updates_persist_write(tiled_websocket_context, write_op, persist):
     np.testing.assert_array_equal(persisted_data, expected_persisted)
 
 
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 @pytest.mark.parametrize("persist", (None, True, False))
-def test_updates_persist_write_block(tiled_websocket_context, persist):
+def test_updates_persist_write_block(tiled_websocket_context, envelope_format, persist):
     context = tiled_websocket_context
     client = from_context(context)
     test_client = context.http_client
@@ -261,7 +308,7 @@ def test_updates_persist_write_block(tiled_websocket_context, persist):
 
     # Connect WebSocket using TestClient with msgpack format and authorization
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_immediate?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_stream_immediate?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Send 3 updates using Tiled client that write values into the array
@@ -283,8 +330,9 @@ def test_updates_persist_write_block(tiled_websocket_context, persist):
 
 
 # Extending an array with persist=False is not yet supported
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 @pytest.mark.parametrize("persist", (None, True))
-def test_updates_persist_append(tiled_websocket_context, persist):
+def test_updates_persist_append(tiled_websocket_context, envelope_format, persist):
     context = tiled_websocket_context
     client = from_context(context)
     test_client = context.http_client
@@ -295,7 +343,7 @@ def test_updates_persist_append(tiled_websocket_context, persist):
 
     # Connect WebSocket using TestClient with msgpack format and authorization
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_stream_immediate?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_stream_immediate?envelope_format={envelope_format}",
         headers={"Authorization": "Apikey secret"},
     ) as websocket:
         # Send 3 updates using Tiled client that append to the array
@@ -380,7 +428,8 @@ def test_close_stream_not_found(tiled_websocket_context):
     assert response.status_code == 404
 
 
-def test_websocket_connection_wrong_api_key(tiled_websocket_context):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_connection_wrong_api_key(tiled_websocket_context, envelope_format):
     """Test websocket connection with wrong API key fails with 401."""
 
     context = tiled_websocket_context
@@ -394,7 +443,7 @@ def test_websocket_connection_wrong_api_key(tiled_websocket_context):
     # Try to connect to websocket with wrong API key
     with pytest.raises(WebSocketDenialResponse) as exc_info:
         with test_client.websocket_connect(
-            "/api/v1/stream/single/test_auth_websocket?envelope_format=msgpack",
+            f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
             headers={"Authorization": "Apikey wrong_key"},
         ):
             pass
@@ -402,7 +451,8 @@ def test_websocket_connection_wrong_api_key(tiled_websocket_context):
     assert exc_info.value.status_code == 401
 
 
-def test_websocket_connection_no_api_key(tiled_websocket_context):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_connection_no_api_key(tiled_websocket_context, envelope_format):
     """Test websocket connection with no API key fails with 401."""
 
     context = tiled_websocket_context
@@ -419,14 +469,17 @@ def test_websocket_connection_no_api_key(tiled_websocket_context):
     # Try to connect to websocket with no API key
     with pytest.raises(WebSocketDenialResponse) as exc_info:
         with test_client.websocket_connect(
-            "/api/v1/stream/single/test_auth_websocket?envelope_format=msgpack",
+            f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
         ):
             pass
 
     assert exc_info.value.status_code == 401
 
 
-def test_websocket_connection_public_no_api_key(tiled_websocket_context_public):
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_connection_public_no_api_key(
+    tiled_websocket_context_public, envelope_format
+):
     """Test websocket connection to a public server with no API key works."""
     context = tiled_websocket_context_public
     client = from_context(context)
@@ -441,7 +494,7 @@ def test_websocket_connection_public_no_api_key(tiled_websocket_context_public):
 
     # Try to connect to (public) websocket with no API key
     with test_client.websocket_connect(
-        "/api/v1/stream/single/test_auth_websocket?envelope_format=msgpack",
+        f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
     ):
         pass
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -142,13 +142,13 @@ def pagination_links(base_url, route, path_parts, offset, limit, length_hint):
             }
         )
     if offset + limit < length_hint:
-        links["next"] = (
-            f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
-        )
+        links[
+            "next"
+        ] = f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
     if offset > 0:
-        links["prev"] = (
-            f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
-        )
+        links[
+            "prev"
+        ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
     return links
 
 
@@ -773,9 +773,10 @@ def get_websocket_envelope_formatter(
                     "content-type", "application/octet-stream"
                 )
                 if media_type == "application/json":
+                    # Nothing to do, the payload is already JSON
                     payload_decoded = payload_bytes
                 else:
-                    metadata["content-type"] = "application/json"
+                    # Transcode the payload to JSON.
                     msg_type = metadata.get("type", "")
                     if msg_type == "table-data":
                         deserializer = deserialization_registry.dispatch(
@@ -793,6 +794,7 @@ def get_websocket_envelope_formatter(
                             structure.data_type.to_numpy_dtype(),
                             metadata.get("shape"),
                         )
+                metadata["content-type"] = "application/json"
                 metadata["payload"] = payload_decoded
             # Convert non-serializable schema objects (e.g. pyarrow.Schema)
             # to their string representation for JSON transport.

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -777,6 +777,7 @@ def get_websocket_envelope_formatter(
                     payload_decoded = payload_bytes
                 else:
                     # Transcode the payload to JSON.
+                    metadata["content-type"] = "application/json"
                     msg_type = metadata.get("type", "")
                     if msg_type == "table-data":
                         deserializer = deserialization_registry.dispatch(
@@ -794,7 +795,6 @@ def get_websocket_envelope_formatter(
                             structure.data_type.to_numpy_dtype(),
                             metadata.get("shape"),
                         )
-                metadata["content-type"] = "application/json"
                 metadata["payload"] = payload_decoded
             # Convert non-serializable schema objects (e.g. pyarrow.Schema)
             # to their string representation for JSON transport.

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -142,13 +142,13 @@ def pagination_links(base_url, route, path_parts, offset, limit, length_hint):
             }
         )
     if offset + limit < length_hint:
-        links[
-            "next"
-        ] = f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
+        links["next"] = (
+            f"{base_url}{route}/{path_str}?page[offset]={offset + limit}&page[limit]={limit}"
+        )
     if offset > 0:
-        links[
-            "prev"
-        ] = f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
+        links["prev"] = (
+            f"{base_url}{route}/{path_str}?page[offset]={max(0, offset - limit)}&page[limit]={limit}"
+        )
     return links
 
 
@@ -769,28 +769,37 @@ def get_websocket_envelope_formatter(
             payload_bytes: Optional[bytes],
         ):
             if payload_bytes is not None:
-                media_type = metadata.get("content-type", "application/octet-stream")
+                media_type = metadata.get("mimetype") or metadata.get(
+                    "content-type", "application/octet-stream"
+                )
                 if media_type == "application/json":
-                    # nothing to do, the payload is already JSON
                     payload_decoded = payload_bytes
                 else:
-                    # Transcode to payload to JSON.
                     metadata["content-type"] = "application/json"
-                    structure_family = (
-                        StructureFamily.array
-                    )  # TODO: generalize beyond array
-                    structure = entry.structure()
-                    deserializer = deserialization_registry.dispatch(
-                        structure_family, media_type
-                    )
-                    payload_decoded = deserializer(
-                        payload_bytes,
-                        structure.data_type.to_numpy_dtype(),
-                        metadata.get("shape"),
-                    )
+                    msg_type = metadata.get("type", "")
+                    if msg_type == "table-data":
+                        deserializer = deserialization_registry.dispatch(
+                            StructureFamily.table, media_type
+                        )
+                        df = deserializer(payload_bytes)
+                        payload_decoded = {col: df[col].tolist() for col in df}
+                    else:
+                        structure = entry.structure()
+                        deserializer = deserialization_registry.dispatch(
+                            StructureFamily.array, media_type
+                        )
+                        payload_decoded = deserializer(
+                            payload_bytes,
+                            structure.data_type.to_numpy_dtype(),
+                            metadata.get("shape"),
+                        )
                 metadata["payload"] = payload_decoded
+            # Convert non-serializable schema objects (e.g. pyarrow.Schema)
+            # to their string representation for JSON transport.
+            if "arrow_schema" in metadata:
+                metadata["arrow_schema"] = str(metadata["arrow_schema"])
             data = safe_json_dump(metadata)
-            await websocket.send_text(data)
+            await websocket.send_text(data.decode())
 
         return stream_json
 


### PR DESCRIPTION
This PR adds a few more tests for the WebSocket endpoints, specifically for streaming tabular data, similar to the existing ones that use array data.

Related: #1339 

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
