### PR TITLE
Fix: SimpleTiledServer race condition

### DIFF
--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -10,6 +10,7 @@ import time
 from typing import Optional, Union, cast
 from urllib.parse import quote_plus, urlparse
 
+import httpx
 import uvicorn
 
 from ..storage import SQLStorage, get_storage
@@ -145,19 +146,12 @@ class SimpleTiledServer:
         ).run_in_thread()
         base_url = self._cm.__enter__()
 
-        # Wait for the FastAPI lifespan startup to complete.
         # ThreadedServer.started is True as soon as uvicorn opens the
-        # socket, but the app's startup_event() may still be running.
-        # Poll the metadata endpoint until it returns 200.
-        import httpx
-
+        # socket, but FastAPI does not serve requests until the lifespan
+        # startup_event() completes. Poll /healthz to wait for that.
         for _ in range(200):
             try:
-                r = httpx.get(
-                    f"{base_url}/api/v1/?api_key={quote_plus(api_key)}",
-                    timeout=1.0,
-                    follow_redirects=True,
-                )
+                r = httpx.get(f"{base_url}/healthz", timeout=1.0)
                 if r.status_code == 200:
                     break
             except (httpx.ConnectError, httpx.ReadTimeout):

--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -149,19 +149,31 @@ class SimpleTiledServer:
         # ThreadedServer.started is True as soon as uvicorn opens the
         # socket, but FastAPI does not serve requests until the lifespan
         # startup_event() completes. Poll /healthz to wait for that.
-        for _ in range(200):
-            try:
-                r = httpx.get(f"{base_url}/healthz", timeout=1.0)
-                if r.status_code == 200:
-                    break
-            except (httpx.ConnectError, httpx.ReadTimeout):
-                pass
-            time.sleep(0.1)
-        else:
-            raise TimeoutError(
-                "Tiled server started listening but the application "
-                "did not become ready within 20 seconds."
-            )
+        # Ensure the background server thread is shut down if anything
+        # in the readiness probe fails; otherwise it would leak.
+        try:
+            deadline = time.monotonic() + 20.0
+            with httpx.Client() as client:
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            "Tiled server started listening but the application "
+                            "did not become ready within 20 seconds."
+                        )
+                    try:
+                        r = client.get(
+                            f"{base_url}/healthz",
+                            timeout=min(1.0, remaining),
+                        )
+                        if r.status_code == 200:
+                            break
+                    except httpx.RequestError:
+                        pass
+                    time.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+        except BaseException:
+            self._cm.__exit__(None, None, None)
+            raise
 
         # Extract port from base_url.
         actual_port = urlparse(base_url).port

--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -25,8 +25,8 @@ class ThreadedServer(uvicorn.Server):
 
     @contextlib.contextmanager
     def run_in_thread(self):
-        self._thread = threading.Thread(target=self.run)
-        self._thread.start()
+        self.thread = threading.Thread(target=self.run)
+        self.thread.start()
         try:
             # Wait for server to start up, or raise TimeoutError.
             for _ in range(int(_STARTUP_TIMEOUT / 0.1)):
@@ -41,7 +41,7 @@ class ThreadedServer(uvicorn.Server):
             yield f"http://{host}:{port}"
         finally:
             self.should_exit = True
-            self._thread.join()
+            self.thread.join()
 
 
 class SimpleTiledServer:
@@ -160,7 +160,7 @@ class SimpleTiledServer:
             deadline = time.monotonic() + _STARTUP_TIMEOUT
             with httpx.Client(trust_env=False) as client:
                 while True:
-                    if not self._server._thread.is_alive():
+                    if not self._server.thread.is_alive():
                         raise RuntimeError(
                             "Tiled server thread exited before the application "
                             "became ready. Check the log files in the server's "

--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -145,6 +145,30 @@ class SimpleTiledServer:
         ).run_in_thread()
         base_url = self._cm.__enter__()
 
+        # Wait for the FastAPI lifespan startup to complete.
+        # ThreadedServer.started is True as soon as uvicorn opens the
+        # socket, but the app's startup_event() may still be running.
+        # Poll the metadata endpoint until it returns 200.
+        import httpx
+
+        for _ in range(200):
+            try:
+                r = httpx.get(
+                    f"{base_url}/api/v1/?api_key={quote_plus(api_key)}",
+                    timeout=1.0,
+                    follow_redirects=True,
+                )
+                if r.status_code == 200:
+                    break
+            except (httpx.ConnectError, httpx.ReadTimeout):
+                pass
+            time.sleep(0.1)
+        else:
+            raise TimeoutError(
+                "Tiled server started listening but the application "
+                "did not become ready within 20 seconds."
+            )
+
         # Extract port from base_url.
         actual_port = urlparse(base_url).port
 

--- a/tiled/server/simple.py
+++ b/tiled/server/simple.py
@@ -16,6 +16,8 @@ import uvicorn
 from ..storage import SQLStorage, get_storage
 from ..utils import ensure_uri
 
+_STARTUP_TIMEOUT = 20  # seconds; used for both socket listen and readiness checks
+
 
 class ThreadedServer(uvicorn.Server):
     def install_signal_handlers(self):
@@ -23,21 +25,23 @@ class ThreadedServer(uvicorn.Server):
 
     @contextlib.contextmanager
     def run_in_thread(self):
-        thread = threading.Thread(target=self.run)
-        thread.start()
+        self._thread = threading.Thread(target=self.run)
+        self._thread.start()
         try:
             # Wait for server to start up, or raise TimeoutError.
-            for _ in range(200):
+            for _ in range(int(_STARTUP_TIMEOUT / 0.1)):
                 time.sleep(0.1)
                 if self.started:
                     break
             else:
-                raise TimeoutError("Server did not start in 20 seconds.")
+                raise TimeoutError(
+                    f"Server did not start in {_STARTUP_TIMEOUT} seconds."
+                )
             host, port = self.servers[0].sockets[0].getsockname()
             yield f"http://{host}:{port}"
         finally:
             self.should_exit = True
-            thread.join()
+            self._thread.join()
 
 
 class SimpleTiledServer:
@@ -141,9 +145,10 @@ class SimpleTiledServer:
         self.app = build_app(
             self.catalog, authentication=Authentication(single_user_api_key=api_key)
         )
-        self._cm = ThreadedServer(
+        self._server = ThreadedServer(
             uvicorn.Config(self.app, port=port, loop="asyncio", log_config=log_config)
-        ).run_in_thread()
+        )
+        self._cm = self._server.run_in_thread()
         base_url = self._cm.__enter__()
 
         # ThreadedServer.started is True as soon as uvicorn opens the
@@ -152,14 +157,20 @@ class SimpleTiledServer:
         # Ensure the background server thread is shut down if anything
         # in the readiness probe fails; otherwise it would leak.
         try:
-            deadline = time.monotonic() + 20.0
-            with httpx.Client() as client:
+            deadline = time.monotonic() + _STARTUP_TIMEOUT
+            with httpx.Client(trust_env=False) as client:
                 while True:
+                    if not self._server._thread.is_alive():
+                        raise RuntimeError(
+                            "Tiled server thread exited before the application "
+                            "became ready. Check the log files in the server's "
+                            f"directory for details: {directory}"
+                        )
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         raise TimeoutError(
                             "Tiled server started listening but the application "
-                            "did not become ready within 20 seconds."
+                            f"did not become ready within {_STARTUP_TIMEOUT} seconds."
                         )
                     try:
                         r = client.get(


### PR DESCRIPTION
This resolves the race condition where ThreadedServer.started becomes True when uvicorn opens the socket, but the app's startup_event() might still be running. The code now waits for a successful 200 response from the API before continuing.

Tested using: /tests/test_simple_server.py to verify that check for startup_event() completes does not cause issues.
