### PR TITLE
Adding missing frontslash in containerfile example config

### DIFF
--- a/example_configs/config_for_containerfile.yml
+++ b/example_configs/config_for_containerfile.yml
@@ -17,7 +17,7 @@ catalog:
     - "/storage/data"
 
     # Embedded tabular data storage
-    - "duckdb:///storage/data.db"
+    - "duckdb:////storage/data.db"
 
   # This creates the database if it does not exist. This is convenient, but in
   # a horizontally-scaled deployment, this can be a race condition and multiple


### PR DESCRIPTION
See title.

    # Embedded tabular data storage
    - "duckdb:////storage/data.db"
    
    four forward slashes are needed after duckdb
