### PR TITLE
Fix Serving Catalogs when Mount Nodes Don't Exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - A `mount_node` referencing a nonexistent path in the database no longer causes
-  silent data corruption. Trees with missing mount nodes are excluded from the
-  served tree with a warning logged at startup.
+  silent data corruption. The server now raises a clear error at startup if the
+  mount node does not exist.
 - Writing chunked (dask) arrays with single chunk along all dimensions
 - OIDC authenticator was not quite compfixedliant and was incompatible with
   at least some providers including Azure and ORCID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- A `mount_node` referencing a nonexistent path in the database no longer causes
+  silent data corruption. Trees with missing mount nodes are excluded from the
+  served tree with a warning logged at startup.
 - Writing chunked (dask) arrays with single chunk along all dimensions
 - OIDC authenticator was not quite compfixedliant and was incompatible with
   at least some providers including Azure and ORCID.
@@ -24,6 +27,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Array client fully supports slicing when communicating with the server
   and only fetches the data needed to satisfy the slice.
 - CSVArrayAdapter supports reading heterogenous tables as structured arrays
+
+### Added
+
+- New server config option `create_mount_nodes_if_not_exist` (default `false`)
+  that auto-creates missing intermediate container nodes when a `mount_node`
+  path does not exist in the database. Also settable via the
+  `TILED_CREATE_MOUNT_NODES_IF_NOT_EXIST` environment variable.
 
 ## v0.2.7 (2026-02-27)
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -89,6 +89,14 @@
 #   storage_pool_size: 5
 #   catalog_max_overflow: 10
 #   storage_max_overflow: 10
+#
+#   # Mount a sub-tree of the catalog as if it were the root. Useful for
+#   # exposing different sections of a single catalog database at different
+#   # URL path prefixes (see the 'trees' section below). The value is a
+#   # slash-separated path (e.g. "/experiment/2024") or a list of segments
+#   # (e.g. ["experiment", "2024"]).
+#   #
+#   # mount_node: /experiment/2024
 
 
 # -----------------------------------------------------------------------------
@@ -373,6 +381,22 @@ authentication:
 
 
 # -----------------------------------------------------------------------------
+# Mount Node Auto-Creation
+# -----------------------------------------------------------------------------
+# When using 'mount_node' in a catalog/tree config, the referenced path must
+# exist in the database. By default, if the path does not exist, the tree is
+# silently excluded from the server and a warning is logged.
+#
+# Set this to true to automatically create any missing intermediate container
+# nodes at server startup. This is a global setting that applies to all
+# catalogs/trees.
+#
+# Also settable via the TILED_CREATE_MOUNT_NODES_IF_NOT_EXIST environment variable.
+#
+# create_mount_nodes_if_not_exist: false
+
+
+# -----------------------------------------------------------------------------
 # Metrics
 # -----------------------------------------------------------------------------
 # Prometheus metrics are exposed at /metrics by default.
@@ -441,6 +465,21 @@ authentication:
 #     tree: catalog
 #     args:
 #       uri: ${TILED_CATALOG_B_URI}
+#
+# Trees also support 'mount_node' to serve a sub-tree of a catalog.
+# This lets you house multiple logical catalogs in a single database:
+#
+# trees:
+#   - path: /raw
+#     tree: catalog
+#     args:
+#       uri: ${TILED_CATALOG_URI}
+#       mount_node: /experiment/raw
+#   - path: /processed
+#     tree: catalog
+#     args:
+#       uri: ${TILED_CATALOG_URI}
+#       mount_node: /experiment/processed
 #
 # It also supports custom alternatives to Tiled's catalog:
 #

--- a/config.example.yml
+++ b/config.example.yml
@@ -384,8 +384,8 @@ authentication:
 # Mount Node Auto-Creation
 # -----------------------------------------------------------------------------
 # When using 'mount_node' in a catalog/tree config, the referenced path must
-# exist in the database. By default, if the path does not exist, the tree is
-# silently excluded from the server and a warning is logged.
+# exist in the database. By default, if the path does not exist, the server
+# raises an error at startup.
 #
 # Set this to true to automatically create any missing intermediate container
 # nodes at server startup. This is a global setting that applies to all

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -107,3 +107,52 @@ def test_mount_node(sqlite_or_postgres_uri, tmpdir):
     with Context.from_app(build_app_from_config(multi_tree_config)) as context:
         client = from_context(context)
         assert list(client["some"]["nested"]["path"]) == ["i"]
+
+
+def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
+    "A tree whose mount_node does not exist in the database should be silently excluded."
+    # Initialize the catalog database with a single container "A".
+    init_config = {
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "init_if_not_exists": True,
+                    "writable_storage": [tmpdir / "data"],
+                },
+            },
+        ]
+    }
+    with Context.from_app(build_app_from_config(init_config)) as context:
+        client = from_context(context)
+        client.create_container("A")
+
+    # Mount two trees: one pointing at an existing node, one at a nonexistent node.
+    multi_tree_config = {
+        "trees": [
+            {
+                "path": "/a",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "writable_storage": [tmpdir / "data"],
+                    "mount_node": "/A",
+                },
+            },
+            {
+                "path": "/b",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "writable_storage": [tmpdir / "data"],
+                    "mount_node": "/does_not_exist",
+                },
+            },
+        ]
+    }
+    with Context.from_app(build_app_from_config(multi_tree_config)) as context:
+        client = from_context(context)
+        # Only the tree with the existing mount_node should be served.
+        assert list(client) == ["a"]

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -156,3 +156,69 @@ def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
         client = from_context(context)
         # Only the tree with the existing mount_node should be served.
         assert list(client) == ["a"]
+
+
+def test_create_mount_node_if_not_exists(sqlite_or_postgres_uri, tmpdir):
+    "Test that create_mount_node_if_not_exists auto-creates missing mount node paths."
+    # Initialize the catalog database (empty, no containers).
+    init_config = {
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "init_if_not_exists": True,
+                    "writable_storage": [tmpdir / "data"],
+                },
+            },
+        ]
+    }
+    with Context.from_app(build_app_from_config(init_config)) as context:
+        client = from_context(context)
+        # Database is empty, no containers exist.
+        assert list(client) == []
+
+    # Mount a tree at a nonexistent path with create_mount_node_if_not_exists=True.
+    # This should auto-create intermediate container nodes /X/Y/Z.
+    mount_config = {
+        "create_mount_node_if_not_exists": True,
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "writable_storage": [tmpdir / "data"],
+                    "mount_node": "/X/Y/Z",
+                },
+            },
+        ],
+    }
+    with Context.from_app(build_app_from_config(mount_config)) as context:
+        client = from_context(context)
+        # The tree should be served (mount node was auto-created).
+        # We can write into it.
+        client.create_container("child")
+        assert list(client) == ["child"]
+
+    # Verify the nodes were actually created by mounting the root.
+    root_config = {
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "writable_storage": [tmpdir / "data"],
+                },
+            },
+        ]
+    }
+    with Context.from_app(build_app_from_config(root_config)) as context:
+        client = from_context(context)
+        # The auto-created path should be visible from root.
+        assert "X" in list(client)
+        assert "Y" in list(client["X"])
+        assert "Z" in list(client["X"]["Y"])
+        assert "child" in list(client["X"]["Y"]["Z"])

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
@@ -111,7 +112,7 @@ def test_mount_node(sqlite_or_postgres_uri, tmpdir):
 
 
 def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
-    "A tree whose mount_node does not exist in the database should be silently excluded."
+    "A tree whose mount_node does not exist should raise an error at startup."
     # Initialize the catalog database with a single container "A".
     init_config = {
         "trees": [
@@ -130,18 +131,9 @@ def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
         client = from_context(context)
         client.create_container("A")
 
-    # Mount two trees: one pointing at an existing node, one at a nonexistent node.
-    multi_tree_config = {
+    # Mount a tree pointing at a nonexistent node.
+    bad_config = {
         "trees": [
-            {
-                "path": "/a",
-                "tree": "catalog",
-                "args": {
-                    "uri": sqlite_or_postgres_uri,
-                    "writable_storage": [tmpdir / "data"],
-                    "mount_node": "/A",
-                },
-            },
             {
                 "path": "/b",
                 "tree": "catalog",
@@ -153,10 +145,9 @@ def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
             },
         ]
     }
-    with Context.from_app(build_app_from_config(multi_tree_config)) as context:
-        client = from_context(context)
-        # Only the tree with the existing mount_node should be served.
-        assert list(client) == ["a"]
+    with pytest.raises(ValueError, match="was not found in the database"):
+        with Context.from_app(build_app_from_config(bad_config)) as context:
+            from_context(context)
 
 
 def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
@@ -226,8 +217,11 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         assert "Y" in list(client["X"])
         assert "Z" in list(client["X"]["Y"])
         assert "child" in list(client["X"]["Y"]["Z"])
-        # Intermediate nodes should have empty specs.
+        # Intermediate nodes should have empty specs and access_blob.
         assert client["X"].specs == []
         assert client["X"]["Y"].specs == []
+        assert not client["X"].access_blob
+        assert not client["X"]["Y"].access_blob
         # The leaf (mount node) should carry the configured specs.
         assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]
+        assert client["X"]["Y"]["Z"].access_blob.get("tags") == ["_ROOT_NODE"]

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -2,6 +2,7 @@ import numpy
 
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
+from tiled.structures.core import Spec
 
 
 def test_mount_node(sqlite_or_postgres_uri, tmpdir):
@@ -181,6 +182,7 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
 
     # Mount a tree at a nonexistent path with create_mount_nodes_if_not_exist=True.
     # This should auto-create intermediate container nodes /X/Y/Z.
+    # The leaf node should receive the configured specs and access_tags.
     mount_config = {
         "create_mount_nodes_if_not_exist": True,
         "trees": [
@@ -191,6 +193,8 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
                     "uri": sqlite_or_postgres_uri,
                     "writable_storage": [tmpdir / "data"],
                     "mount_node": "/X/Y/Z",
+                    "specs": [{"name": "MyCustomSpec", "version": "3.0"}],
+                    "top_level_access_blob": {"tags": ["_ROOT_NODE"]},
                 },
             },
         ],
@@ -222,3 +226,8 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         assert "Y" in list(client["X"])
         assert "Z" in list(client["X"]["Y"])
         assert "child" in list(client["X"]["Y"]["Z"])
+        # Intermediate nodes should have empty specs.
+        assert client["X"].specs == []
+        assert client["X"]["Y"].specs == []
+        # The leaf (mount node) should carry the configured specs.
+        assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -158,8 +158,8 @@ def test_mount_node_nonexistent(sqlite_or_postgres_uri, tmpdir):
         assert list(client) == ["a"]
 
 
-def test_create_mount_node_if_not_exists(sqlite_or_postgres_uri, tmpdir):
-    "Test that create_mount_node_if_not_exists auto-creates missing mount node paths."
+def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
+    "Test that create_mount_nodes_if_not_exist auto-creates missing mount node paths."
     # Initialize the catalog database (empty, no containers).
     init_config = {
         "trees": [
@@ -179,10 +179,10 @@ def test_create_mount_node_if_not_exists(sqlite_or_postgres_uri, tmpdir):
         # Database is empty, no containers exist.
         assert list(client) == []
 
-    # Mount a tree at a nonexistent path with create_mount_node_if_not_exists=True.
+    # Mount a tree at a nonexistent path with create_mount_nodes_if_not_exist=True.
     # This should auto-create intermediate container nodes /X/Y/Z.
     mount_config = {
-        "create_mount_node_if_not_exists": True,
+        "create_mount_nodes_if_not_exist": True,
         "trees": [
             {
                 "path": "/",

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -225,3 +225,61 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         # The leaf (mount node) should carry the configured specs.
         assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]
         assert client["X"]["Y"]["Z"].access_blob.get("tags") == ["_ROOT_NODE"]
+
+
+def test_create_mount_nodes_partial(sqlite_or_postgres_uri, tmpdir):
+    "Test auto-creation when some path segments already exist."
+    # Initialize catalog and create /A.
+    init_config = {
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "init_if_not_exists": True,
+                    "writable_storage": [tmpdir / "data"],
+                },
+            },
+        ]
+    }
+    with Context.from_app(build_app_from_config(init_config)) as context:
+        client = from_context(context)
+        client.create_container("A")
+
+    # Mount at /A/B/C with auto-create. /A exists, /A/B and /A/B/C do not.
+    mount_config = {
+        "create_mount_nodes_if_not_exist": True,
+        "trees": [
+            {
+                "path": "/",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "writable_storage": [tmpdir / "data"],
+                    "mount_node": "/A/B/C",
+                    "specs": [{"name": "PartialSpec", "version": "1.0"}],
+                    "top_level_access_blob": {"tags": ["_LEAF"]},
+                },
+            },
+        ],
+    }
+    with Context.from_app(build_app_from_config(mount_config)) as context:
+        client = from_context(context)
+        client.create_container("item")
+        assert list(client) == ["item"]
+
+    # Verify from root: /A should exist (pre-existing), /A/B and /A/B/C created.
+    with Context.from_app(build_app_from_config(init_config)) as context:
+        client = from_context(context)
+        assert "A" in list(client)
+        assert "B" in list(client["A"])
+        assert "C" in list(client["A"]["B"])
+        assert "item" in list(client["A"]["B"]["C"])
+        # Pre-existing /A should not have been modified (no specs).
+        assert client["A"].specs == []
+        # Intermediate /A/B should have empty specs.
+        assert client["A"]["B"].specs == []
+        # Leaf /A/B/C should carry the configured specs.
+        assert client["A"]["B"]["C"].specs == [Spec(name="PartialSpec", version="1.0")]
+        assert client["A"]["B"]["C"].access_blob.get("tags") == ["_LEAF"]

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -6,6 +6,7 @@ import itertools as it
 import logging
 import operator
 import os
+import re
 import shutil
 import sys
 import uuid
@@ -1866,6 +1867,28 @@ def from_uri(
         if isinstance(mount_node, str)
         else mount_node
     )
+    if mount_path:
+        # Verify that mount_node exists in the database before proceeding.
+        # Use a temporary sync engine to run the check at config-parsing time.
+        sync_uri = re.sub(r"\+[^:]+", "", uri)  # strip async driver
+        from sqlalchemy import create_engine
+
+        sync_engine = create_engine(sync_uri)
+        try:
+            statement = node_from_segments(mount_path).with_only_columns(orm.Node.id)
+            with sync_engine.connect() as conn:
+                node_id = conn.execute(statement).scalar()
+            if node_id is None:
+                path_str = "/" + "/".join(mount_path)
+                logger.warning(
+                    "mount_node %r was not found in the database. "
+                    "This catalog tree will not be served. Create the node "
+                    "first (e.g. via the admin API or tiled CLI) and restart the server.",
+                    path_str,
+                )
+                return None
+        finally:
+            sync_engine.dispose()
     adapter = CatalogContainerAdapter(context, node, mount_path=mount_path)
 
     return adapter
@@ -1877,7 +1900,7 @@ def format_distinct_result(results, counts):
             {"value": value, "count": count} for value, count in results
         ]
     else:
-        formatted_result = [{"value": value} for value, in results]
+        formatted_result = [{"value": value} for (value,) in results]
     return formatted_result
 
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1132,9 +1132,9 @@ class CatalogNodeAdapter:
                     status_code=HTTP_404_NOT_FOUND,
                     detail=f"No revision {number} for node {self.node.id}",
                 )
-            assert result.rowcount == 1, (
-                f"Deletion would affect {result.rowcount} rows; rolling back"
-            )
+            assert (
+                result.rowcount == 1
+            ), f"Deletion would affect {result.rowcount} rows; rolling back"
             await db.commit()
 
     async def replace_metadata(
@@ -1745,7 +1745,8 @@ def key_present(query, tree):
     else:
         keys = query.key.split(".")
         condition = (
-            orm.Node.metadata_.op("#>")(sql_cast(keys, ARRAY(TEXT))) != None  # noqa: E711
+            orm.Node.metadata_.op("#>")(sql_cast(keys, ARRAY(TEXT)))
+            != None  # noqa: E711
         )
     condition = condition if getattr(query, "exists", True) else not_(condition)
     return tree.new_variation(conditions=tree.conditions + [condition])
@@ -1806,17 +1807,22 @@ def in_memory(
     )
 
 
-def _create_mount_node_segments(sync_engine, mount_path):
+def _create_mount_node_segments(sync_engine, mount_path, specs=None, access_blob=None):
     """Create missing intermediate container nodes for a mount path.
 
     Walks the path segments, creating any that don't exist yet.
     DB triggers automatically maintain the nodes_closure table.
+    The leaf node (last segment) receives the given specs and access_blob;
+    intermediate nodes get empty defaults.
     """
     from sqlalchemy import insert
 
+    specs = specs or []
+    access_blob = access_blob or {}
     with sync_engine.begin() as conn:
         parent_id = 0  # root node id
-        for segment in mount_path:
+        for i, segment in enumerate(mount_path):
+            is_leaf = i == len(mount_path) - 1
             # Check if this segment exists under parent_id
             statement = (
                 select(orm.Node.id)
@@ -1832,8 +1838,8 @@ def _create_mount_node_segments(sync_engine, mount_path):
                         parent=parent_id,
                         structure_family=StructureFamily.container,
                         metadata_={},
-                        specs=[],
-                        access_blob={},
+                        specs=specs if is_leaf else [],
+                        access_blob=access_blob if is_leaf else {},
                     )
                 )
                 node_id = result.inserted_primary_key[0]
@@ -1926,7 +1932,12 @@ def from_uri(
                         "Creating intermediate container nodes.",
                         path_str,
                     )
-                    _create_mount_node_segments(sync_engine, mount_path)
+                    _create_mount_node_segments(
+                        sync_engine,
+                        mount_path,
+                        specs=specs,
+                        access_blob=top_level_access_blob,
+                    )
                 else:
                     logger.warning(
                         "mount_node %r was not found in the database. "

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1132,9 +1132,9 @@ class CatalogNodeAdapter:
                     status_code=HTTP_404_NOT_FOUND,
                     detail=f"No revision {number} for node {self.node.id}",
                 )
-            assert (
-                result.rowcount == 1
-            ), f"Deletion would affect {result.rowcount} rows; rolling back"
+            assert result.rowcount == 1, (
+                f"Deletion would affect {result.rowcount} rows; rolling back"
+            )
             await db.commit()
 
     async def replace_metadata(
@@ -1745,8 +1745,7 @@ def key_present(query, tree):
     else:
         keys = query.key.split(".")
         condition = (
-            orm.Node.metadata_.op("#>")(sql_cast(keys, ARRAY(TEXT)))
-            != None  # noqa: E711
+            orm.Node.metadata_.op("#>")(sql_cast(keys, ARRAY(TEXT))) != None  # noqa: E711
         )
     condition = condition if getattr(query, "exists", True) else not_(condition)
     return tree.new_variation(conditions=tree.conditions + [condition])
@@ -1858,7 +1857,7 @@ def from_uri(
     adapters_by_mimetype=None,
     top_level_access_blob=None,
     mount_node: Optional[Union[str, List[str]]] = None,
-    create_mount_node_if_not_exists=False,
+    create_mount_nodes_if_not_exist=False,
     cache_config=None,
     catalog_pool_size=5,
     storage_pool_size=5,
@@ -1921,7 +1920,7 @@ def from_uri(
                 node_id = conn.execute(statement).scalar()
             if node_id is None:
                 path_str = "/" + "/".join(mount_path)
-                if create_mount_node_if_not_exists:
+                if create_mount_nodes_if_not_exist:
                     logger.info(
                         "mount_node %r does not exist in the database. "
                         "Creating intermediate container nodes.",

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -6,7 +6,6 @@ import itertools as it
 import logging
 import operator
 import os
-import re
 import shutil
 import sys
 import uuid
@@ -266,6 +265,7 @@ class CatalogNodeAdapter:
         queries=None,
         sorting=None,
         mount_path: Optional[list[str]] = None,
+        create_mount_nodes_if_not_exist: bool = False,
     ):
         self.context = context
         self.node = node
@@ -277,7 +277,15 @@ class CatalogNodeAdapter:
         self.specs = [Spec(**spec) for spec in node.specs]
         self.startup_tasks = [self.startup]
         if mount_path:
-            self.startup_tasks.append(partial(self.create_mount, mount_path))
+            self.startup_tasks.append(
+                partial(
+                    self.create_mount,
+                    mount_path,
+                    create_if_not_exist=create_mount_nodes_if_not_exist,
+                    specs=node.specs,
+                    access_blob=node.access_blob,
+                )
+            )
         self.shutdown_tasks = [self.shutdown]
 
     async def path_segments(self):
@@ -302,10 +310,41 @@ class CatalogNodeAdapter:
     async def startup(self):
         await self.context.startup()
 
-    async def create_mount(self, mount_path: list[str]):
+    async def create_mount(
+        self,
+        mount_path: list[str],
+        *,
+        create_if_not_exist=False,
+        specs=None,
+        access_blob=None,
+    ):
         statement = node_from_segments(mount_path).with_only_columns(orm.Node.id)
         async with self.context.engine.connect() as conn:
             self.node.id = (await conn.execute(statement)).scalar()
+        if self.node.id is None:
+            path_str = "/" + "/".join(mount_path)
+            if create_if_not_exist:
+                logger.info(
+                    "mount_node %r does not exist in the database. "
+                    "Creating intermediate container nodes.",
+                    path_str,
+                )
+                await _create_mount_node_segments(
+                    self.context.engine,
+                    mount_path,
+                    specs=specs,
+                    access_blob=access_blob,
+                )
+                # Re-query to get the id of the newly created node.
+                async with self.context.engine.connect() as conn:
+                    self.node.id = (await conn.execute(statement)).scalar()
+            else:
+                raise ValueError(
+                    f"mount_node {path_str!r} was not found in the database. "
+                    "Create the node first (e.g. via the admin API or tiled CLI) "
+                    "and restart the server, or set "
+                    "create_mount_nodes_if_not_exist: true in the config."
+                )
         self.node.key = mount_path[-1]
 
     async def shutdown(self):
@@ -1807,7 +1846,7 @@ def in_memory(
     )
 
 
-def _create_mount_node_segments(sync_engine, mount_path, specs=None, access_blob=None):
+async def _create_mount_node_segments(engine, mount_path, specs=None, access_blob=None):
     """Create missing intermediate container nodes for a mount path.
 
     Walks the path segments, creating any that don't exist yet.
@@ -1819,7 +1858,7 @@ def _create_mount_node_segments(sync_engine, mount_path, specs=None, access_blob
 
     specs = specs or []
     access_blob = access_blob or {}
-    with sync_engine.begin() as conn:
+    async with engine.begin() as conn:
         parent_id = 0  # root node id
         for i, segment in enumerate(mount_path):
             is_leaf = i == len(mount_path) - 1
@@ -1829,10 +1868,10 @@ def _create_mount_node_segments(sync_engine, mount_path, specs=None, access_blob
                 .where(orm.Node.parent == parent_id)
                 .where(orm.Node.key == segment)
             )
-            node_id = conn.execute(statement).scalar()
+            node_id = (await conn.execute(statement)).scalar()
             if node_id is None:
                 # Create the container node
-                result = conn.execute(
+                result = await conn.execute(
                     insert(orm.Node).values(
                         key=segment,
                         parent=parent_id,
@@ -1913,42 +1952,12 @@ def from_uri(
         if isinstance(mount_node, str)
         else mount_node
     )
-    if mount_path:
-        # Verify that mount_node exists in the database before proceeding.
-        # Use a temporary sync engine to run the check at config-parsing time.
-        sync_uri = re.sub(r"\+[^:]+", "", uri)  # strip async driver
-        from sqlalchemy import create_engine
-
-        sync_engine = create_engine(sync_uri)
-        try:
-            statement = node_from_segments(mount_path).with_only_columns(orm.Node.id)
-            with sync_engine.connect() as conn:
-                node_id = conn.execute(statement).scalar()
-            if node_id is None:
-                path_str = "/" + "/".join(mount_path)
-                if create_mount_nodes_if_not_exist:
-                    logger.info(
-                        "mount_node %r does not exist in the database. "
-                        "Creating intermediate container nodes.",
-                        path_str,
-                    )
-                    _create_mount_node_segments(
-                        sync_engine,
-                        mount_path,
-                        specs=specs,
-                        access_blob=top_level_access_blob,
-                    )
-                else:
-                    logger.warning(
-                        "mount_node %r was not found in the database. "
-                        "This catalog tree will not be served. Create the node "
-                        "first (e.g. via the admin API or tiled CLI) and restart the server.",
-                        path_str,
-                    )
-                    return None
-        finally:
-            sync_engine.dispose()
-    adapter = CatalogContainerAdapter(context, node, mount_path=mount_path)
+    adapter = CatalogContainerAdapter(
+        context,
+        node,
+        mount_path=mount_path,
+        create_mount_nodes_if_not_exist=create_mount_nodes_if_not_exist,
+    )
 
     return adapter
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1807,6 +1807,46 @@ def in_memory(
     )
 
 
+def _create_mount_node_segments(sync_engine, mount_path):
+    """Create missing intermediate container nodes for a mount path.
+
+    Walks the path segments, creating any that don't exist yet.
+    DB triggers automatically maintain the nodes_closure table.
+    """
+    from sqlalchemy import insert
+
+    with sync_engine.begin() as conn:
+        parent_id = 0  # root node id
+        for segment in mount_path:
+            # Check if this segment exists under parent_id
+            statement = (
+                select(orm.Node.id)
+                .where(orm.Node.parent == parent_id)
+                .where(orm.Node.key == segment)
+            )
+            node_id = conn.execute(statement).scalar()
+            if node_id is None:
+                # Create the container node
+                result = conn.execute(
+                    insert(orm.Node).values(
+                        key=segment,
+                        parent=parent_id,
+                        structure_family=StructureFamily.container,
+                        metadata_={},
+                        specs=[],
+                        access_blob={},
+                    )
+                )
+                node_id = result.inserted_primary_key[0]
+                logger.info(
+                    "Created container node %r (id=%d) under parent_id=%d.",
+                    segment,
+                    node_id,
+                    parent_id,
+                )
+            parent_id = node_id
+
+
 def from_uri(
     uri,
     *,
@@ -1818,6 +1858,7 @@ def from_uri(
     adapters_by_mimetype=None,
     top_level_access_blob=None,
     mount_node: Optional[Union[str, List[str]]] = None,
+    create_mount_node_if_not_exists=False,
     cache_config=None,
     catalog_pool_size=5,
     storage_pool_size=5,
@@ -1880,13 +1921,21 @@ def from_uri(
                 node_id = conn.execute(statement).scalar()
             if node_id is None:
                 path_str = "/" + "/".join(mount_path)
-                logger.warning(
-                    "mount_node %r was not found in the database. "
-                    "This catalog tree will not be served. Create the node "
-                    "first (e.g. via the admin API or tiled CLI) and restart the server.",
-                    path_str,
-                )
-                return None
+                if create_mount_node_if_not_exists:
+                    logger.info(
+                        "mount_node %r does not exist in the database. "
+                        "Creating intermediate container nodes.",
+                        path_str,
+                    )
+                    _create_mount_node_segments(sync_engine, mount_path)
+                else:
+                    logger.warning(
+                        "mount_node %r was not found in the database. "
+                        "This catalog tree will not be served. Create the node "
+                        "first (e.g. via the admin API or tiled CLI) and restart the server.",
+                        path_str,
+                    )
+                    return None
         finally:
             sync_engine.dispose()
     adapter = CatalogContainerAdapter(context, node, mount_path=mount_path)

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -359,9 +359,9 @@ class Config(BaseSettings):
                     self.streaming_cache.model_dump() if self.streaming_cache else None
                 )
             if tree.tree_type is from_uri:
-                tree.args["create_mount_nodes_if_not_exist"] = (
-                    self.create_mount_nodes_if_not_exist
-                )
+                tree.args[
+                    "create_mount_nodes_if_not_exist"
+                ] = self.create_mount_nodes_if_not_exist
         return self
 
     @property

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -257,7 +257,7 @@ class Config(BaseSettings):
     expose_raw_assets: bool = True
     routers: list[EntryPointString] = []
     streaming_cache: Optional[StreamingCacheConfig] = None
-    create_mount_node_if_not_exists: bool = False
+    create_mount_nodes_if_not_exist: bool = False
 
     # If recommended 'catalog' config is used, these parameters are
     # not used; they are set inside the CatalogConfig.
@@ -359,9 +359,9 @@ class Config(BaseSettings):
                     self.streaming_cache.model_dump() if self.streaming_cache else None
                 )
             if tree.tree_type is from_uri:
-                tree.args[
-                    "create_mount_node_if_not_exists"
-                ] = self.create_mount_node_if_not_exists
+                tree.args["create_mount_nodes_if_not_exist"] = (
+                    self.create_mount_nodes_if_not_exist
+                )
         return self
 
     @property

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -373,7 +373,6 @@ class Config(BaseSettings):
         trees = {
             segments: tree
             for segments, tree in (tree_spec.tree_entry for tree_spec in self.trees)
-            if tree is not None
         }
         if list(trees) == [()]:
             # Simple case: there is one tree, served at the root path /.
@@ -403,8 +402,6 @@ class Config(BaseSettings):
         shutdown = []
         background = []
         for tree in self.trees:
-            if tree.tree is None:
-                continue
             startup.extend(tree.startup_tasks)
             shutdown.extend(tree.shutdown_tasks)
             background.extend(tree.background_tasks)

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -257,6 +257,7 @@ class Config(BaseSettings):
     expose_raw_assets: bool = True
     routers: list[EntryPointString] = []
     streaming_cache: Optional[StreamingCacheConfig] = None
+    create_mount_node_if_not_exists: bool = False
 
     # If recommended 'catalog' config is used, these parameters are
     # not used; they are set inside the CatalogConfig.
@@ -357,6 +358,10 @@ class Config(BaseSettings):
                 tree.args["cache_config"] = (
                     self.streaming_cache.model_dump() if self.streaming_cache else None
                 )
+            if tree.tree_type is from_uri:
+                tree.args[
+                    "create_mount_node_if_not_exists"
+                ] = self.create_mount_node_if_not_exists
         return self
 
     @property

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -365,7 +365,11 @@ class Config(BaseSettings):
 
     @cached_property
     def merged_trees(self) -> Any:  # TODO: update when # 1047 is merged
-        trees = dict(tree.tree_entry for tree in self.trees)
+        trees = {
+            segments: tree
+            for segments, tree in (tree_spec.tree_entry for tree_spec in self.trees)
+            if tree is not None
+        }
         if list(trees) == [()]:
             # Simple case: there is one tree, served at the root path /.
             root_tree = trees[()]
@@ -394,6 +398,8 @@ class Config(BaseSettings):
         shutdown = []
         background = []
         for tree in self.trees:
+            if tree.tree is None:
+                continue
             startup.extend(tree.startup_tasks)
             shutdown.extend(tree.shutdown_tasks)
             background.extend(tree.background_tasks)

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -239,9 +239,11 @@ def build_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         "Manage lifespan events for each event loop that the app runs in"
-        await startup_event()
-        yield
-        await shutdown_event()
+        try:
+            await startup_event()
+            yield
+        finally:
+            await shutdown_event()
 
     app = FastAPI(lifespan=lifespan, strict_content_type=False)
 
@@ -699,7 +701,7 @@ def build_app(
             from .connection_pool import close_database_connection_pool
 
             await close_database_connection_pool(settings.database_settings)
-        for task in app.state.tasks:
+        for task in getattr(app.state, "tasks", []):
             task.cancel()
 
     app.add_middleware(


### PR DESCRIPTION
This PR fixes a bug where configuring a `mount_node` that doesn't exist in the database causes silent data corruption -- the catalog appears to work but returns wrong results because `node.id` is silently set to None -- any children created in this corrupted catalog receive the root as their parent.

Changes
- Validate mount nodes at startup: `CatalogContainerAdapter.create_mount` now checks whether the mount node exists in the database. If it doesn't, it raises a clear ValueError telling the user to create the node first or enable auto-creation.
- New config option `create_mount_nodes_if_not_exist`: A global server setting (default `false`) that auto-creates missing intermediate container nodes for `mount_node` paths at startup. The leaf node receives `specs` and `top_level_access_blob` from the tree config; intermediate nodes get empty defaults. Also settable via `TILED_CREATE_MOUNT_NODES_IF_NOT_EXIST` env var.
- Robust lifespan handling: The ASGI lifespan now runs shutdown tasks in a finally block, ensuring database connections are properly disposed even when startup fails.
- Updated tests and docs.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
