### PR TITLE
WebSocket First-message Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Added
 
-- Tests for the WebSocket endpoints that stream tabukar data.
+- WebSocket "first message" authentication: clients can now authenticate
+  WebSocket connections by sending credentials in the first message instead
+  of exposing tokens in query parameters (#1138).
 
 ## v0.2.7 (2026-02-27)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,9 +427,8 @@ def tiled_websocket_context_public(tmpdir, redis_uri):
 def tiled_websocket_context_multiuser(tmpdir, redis_uri, enter_username_password):
     """Fixture that provides a multi-user Tiled context with JWT auth and websocket support.
 
-    Returns (context, client, access_token) where access_token is a valid JWT for 'alice'.
-    Uses build_app_from_config (like the other websocket fixtures) so that Redis
-    connections are created in the correct event loop.
+    Logs in as 'alice' during setup so that context.tokens and from_context()
+    work without additional login steps in the test.
     """
     from tiled.server.app import build_app_from_config
 
@@ -459,9 +458,8 @@ def tiled_websocket_context_multiuser(tmpdir, redis_uri, enter_username_password
     app = build_app_from_config(config)
     with Context.from_app(app) as context:
         with enter_username_password("alice", "secret1"):
-            client = from_context(context)
-        access_token = context.tokens["access_token"]
-        yield context, client, access_token
+            from_context(context)  # triggers login, caches tokens
+        yield context
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from tiled import profiles
 from tiled.catalog import from_uri, in_memory
-from tiled.client import Context
-from tiled.client import from_context
-from tiled.client.context import Context
+from tiled.client import Context, from_context
 from tiled.client.base import BaseClient
 from tiled.config import Authentication
 from tiled.server.app import build_app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from tiled import profiles
 from tiled.catalog import from_uri, in_memory
 from tiled.client import Context
+from tiled.client import from_context
+from tiled.client.context import Context
 from tiled.client.base import BaseClient
 from tiled.config import Authentication
 from tiled.server.app import build_app
@@ -351,6 +353,35 @@ def minio_uri():
         raise pytest.skip("No TILED_TEST_BUCKET configured")
 
 
+# Shared authentication config for tests that need multi-user JWT auth.
+# Uses the toy DictionaryAuthenticator with alice/bob users.
+TOY_AUTHENTICATION = {
+    "secret_keys": ["SECRET"],
+    "providers": [
+        {
+            "provider": "toy",
+            "authenticator": "tiled.authenticators:DictionaryAuthenticator",
+            "args": {
+                "users_to_passwords": {"alice": "secret1", "bob": "secret2"},
+            },
+        }
+    ],
+}
+
+
+def init_auth_database(tmpdir):
+    """Initialize an auth database and return its URI."""
+    import subprocess
+
+    database_uri = f"sqlite:///{tmpdir / 'auth.db'}"
+    subprocess.run(
+        [sys.executable, "-m", "tiled", "admin", "initialize-database", database_uri],
+        check=True,
+        capture_output=True,
+    )
+    return database_uri
+
+
 def build_test_app(tmpdir, redis_uri, public=False):
     tree = from_uri(
         "sqlite:///:memory:",
@@ -392,6 +423,47 @@ def tiled_websocket_context_public(tmpdir, redis_uri):
     """Fixture that provides a Tiled context with websocket support."""
     with Context.from_app(build_test_app(tmpdir, redis_uri, public=True)) as context:
         yield context
+
+
+@pytest.fixture(scope="function")
+def tiled_websocket_context_multiuser(tmpdir, redis_uri, enter_username_password):
+    """Fixture that provides a multi-user Tiled context with JWT auth and websocket support.
+
+    Returns (context, client, access_token) where access_token is a valid JWT for 'alice'.
+    Uses build_app_from_config (like the other websocket fixtures) so that Redis
+    connections are created in the correct event loop.
+    """
+    from tiled.server.app import build_app_from_config
+
+    database_uri = init_auth_database(tmpdir)
+    config = {
+        "authentication": TOY_AUTHENTICATION,
+        "database": {"uri": database_uri},
+        "trees": [
+            {
+                "tree": "catalog",
+                "path": "/",
+                "args": {
+                    "uri": "sqlite:///:memory:",
+                    "writable_storage": [str(tmpdir / "data")],
+                    "init_if_not_exists": True,
+                },
+            },
+        ],
+        "streaming_cache": {
+            "uri": redis_uri,
+            "data_ttl": 600,
+            "seq_ttl": 600,
+            "socket_timeout": 600,
+            "socket_connect_timeout": 10,
+        },
+    }
+    app = build_app_from_config(config)
+    with Context.from_app(app) as context:
+        with enter_username_password("alice", "secret1"):
+            client = from_context(context)
+        access_token = context.tokens["access_token"]
+        yield context, client, access_token
 
 
 @pytest.fixture

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,3 +1,5 @@
+import copy
+
 import io
 import os
 import shutil
@@ -21,6 +23,7 @@ from tiled.client.context import PasswordRejected
 from tiled.server import authentication
 from tiled.server.app import build_app_from_config
 
+from .conftest import TOY_AUTHENTICATION
 from .utils import fail_with_status_code
 
 arr = ArrayAdapter.from_array(numpy.ones((5, 5)))
@@ -44,18 +47,7 @@ def config(sqlite_or_postgres_uri):
         capture_output=True,
     )
     return {
-        "authentication": {
-            "secret_keys": ["SECRET"],
-            "providers": [
-                {
-                    "provider": "toy",
-                    "authenticator": "tiled.authenticators:DictionaryAuthenticator",
-                    "args": {
-                        "users_to_passwords": {"alice": "secret1", "bob": "secret2"}
-                    },
-                }
-            ],
-        },
+        "authentication": copy.deepcopy(TOY_AUTHENTICATION),
         "database": {
             "uri": database_uri,
         },

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,5 +1,4 @@
 import copy
-
 import io
 import os
 import shutil

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -5,19 +5,12 @@ from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context
 from tiled.server.app import build_app_from_config
 
+from .conftest import TOY_AUTHENTICATION
+
 # Basic authenticated server config
 tree = MapAdapter({})
 config = {
-    "authentication": {
-        "secret_keys": ["SECRET"],
-        "providers": [
-            {
-                "provider": "toy",
-                "authenticator": "tiled.authenticators:DictionaryAuthenticator",
-                "args": {"users_to_passwords": {"alice": "secret1", "bob": "secret2"}},
-            }
-        ],
-    },
+    "authentication": TOY_AUTHENTICATION,
     "trees": [
         {
             "tree": f"{__name__}:tree",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from tiled.config import Authentication
 from tiled.server.app import build_app, build_app_from_config
 from tiled.server.logging_config import LOGGING_CONFIG
 
+from .conftest import TOY_AUTHENTICATION, init_auth_database
 from .utils import Server
 
 router = APIRouter()
@@ -54,25 +55,9 @@ tree = MapAdapter({"A1": arr, "A2": arr})
 
 @pytest.fixture
 def multiuser_server(tmpdir):
-    database_uri = f"sqlite:///{tmpdir}/tiled.sqlite"
-    subprocess.run(
-        [sys.executable, "-m", "tiled", "admin", "initialize-database", database_uri],
-        check=True,
-        capture_output=True,
-    )
+    database_uri = init_auth_database(tmpdir)
     config = {
-        "authentication": {
-            "secret_keys": ["SECRET"],
-            "providers": [
-                {
-                    "provider": "toy",
-                    "authenticator": "tiled.authenticators:DictionaryAuthenticator",
-                    "args": {
-                        "users_to_passwords": {"alice": "secret1", "bob": "secret2"}
-                    },
-                }
-            ],
-        },
+        "authentication": TOY_AUTHENTICATION,
         "database": {
             "uri": database_uri,
         },

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,3 @@
-import subprocess
-import sys
-
 import httpx
 import numpy
 import pytest

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -707,29 +707,31 @@ def test_subscription_auto_reconnect_on_network_failure(
 
 
 def test_subscribe_no_api_key_rejected(tiled_websocket_context):
-    "Private server does not allow anonymous user to subscribe."
+    "Private server rejects unauthenticated first-message auth."
     context = tiled_websocket_context
     client = from_context(context)
 
     arr = np.arange(10)
-    streaming_node = client.write_array(
-        arr, key=f"test_stream_immediate_{uuid.uuid4().hex[:8]}"
-    )
+    node = client.write_array(arr, key=f"test_stream_immediate_{uuid.uuid4().hex[:8]}")
 
-    received_event = threading.Event()
+    # Build the websocket URL for this node's stream endpoint.
+    segments = node.uri.rsplit("/metadata/", 1)[-1]
+    ws_path = f"/api/v1/stream/single/{segments}"
+    ws_url = f"{ws_path}?envelope_format=msgpack&start=0"
 
-    def callback(update):
-        "Set event once any update has been received."
-        received_event.set()
+    # Connect without credentials — server accepts for first-message auth,
+    # then we send an invalid auth message and expect the server to close.
+    # We must NOT use context.http_client because it carries the API key header.
+    from starlette.testclient import TestClient
 
-    # Any further requests will be unauthenticated.
-    context.api_key = None
-
-    subscription = streaming_node.subscribe()
-    subscription.new_data.add_callback(callback)
-
-    with pytest.raises(WebSocketDenialResponse):
-        subscription.start(0)
+    unauthenticated_client = TestClient(context.http_client.app)
+    with unauthenticated_client.websocket_connect(ws_url) as ws:
+        # Send a first message with a bogus API key.
+        ws.send_json({"type": "auth", "api_key": "bad-key"})
+        # Server should close with code 4003.
+        response = ws.receive()
+        assert response["type"] == "websocket.close"
+        assert response.get("code") == 4003
 
 
 def test_subscribe_no_api_key_public(tiled_websocket_context_public):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -803,7 +803,9 @@ def test_first_message_auth_with_access_token(
     tiled_websocket_context_multiuser, envelope_format
 ):
     """Test websocket first-message authentication with a valid JWT access token."""
-    context, client, access_token = tiled_websocket_context_multiuser
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
+    access_token = context.tokens["access_token"]
 
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_first_msg")
@@ -819,7 +821,9 @@ def test_first_message_auth_with_access_token(
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_query_param_access_token(tiled_websocket_context_multiuser, envelope_format):
     """Test websocket connection with JWT access token as query parameter."""
-    context, client, access_token = tiled_websocket_context_multiuser
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
+    access_token = context.tokens["access_token"]
 
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_query_param")
@@ -838,7 +842,8 @@ def test_expired_access_token_query_param(
     tiled_websocket_context_multiuser, envelope_format
 ):
     """Test that an expired JWT in the query parameter is rejected with 401."""
-    context, client, access_token = tiled_websocket_context_multiuser
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
 
     arr = np.arange(10)
     client.write_array(arr, key="test_expired_jwt")
@@ -880,7 +885,8 @@ def test_first_message_jwt_auth_rejected(
     tiled_websocket_context_multiuser, envelope_format, auth_message
 ):
     """First-message auth with missing or invalid JWT is rejected with close code 4003."""
-    context, client, _ = tiled_websocket_context_multiuser
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
 
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_rejected")

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -12,7 +12,6 @@ import pytest
 from starlette.testclient import TestClient, WebSocketDenialResponse
 
 from tiled.client import from_context
-from tiled.client.context import Context
 from tiled.config import parse_configs
 
 pytestmark = pytest.mark.skipif(
@@ -773,74 +772,68 @@ streaming_cache:
     assert config.streaming_cache.socket_connect_timeout == 12
 
 
-@pytest.fixture(scope="function")
-def authenticated_websocket_context(tmpdir, redis_uri, enter_username_password):
-    """Fixture that provides a multi-user Tiled context with JWT auth and websocket support.
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_first_message_auth_with_access_token(
+    tiled_websocket_context_multiuser, envelope_format
+):
+    """Test websocket first-message authentication with a valid JWT access token."""
+    context, client, access_token = tiled_websocket_context_multiuser
 
-    Returns (context, client, access_token) where access_token is a valid JWT for 'alice'.
-    Uses build_app_from_config (like the other websocket fixtures) so that Redis
-    connections are created in the correct event loop.
-    """
-    import subprocess
-    import sys
+    arr = np.arange(10)
+    client.write_array(arr, key="test_jwt_first_msg")
 
-    from tiled.server.app import build_app_from_config
+    # Connect without any credentials — server accepts for first-message auth.
+    unauthenticated = TestClient(context.http_client.app)
+    with unauthenticated.websocket_connect(
+        f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send first-message auth with valid access token
+        websocket.send_json({"type": "auth", "access_token": access_token})
+        # Should receive schema message (auth succeeded)
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:
+            msg = msgpack.unpackb(websocket.receive_bytes())
+        assert msg["type"] in ("array-schema", "table-schema")
 
-    database_uri = f"sqlite:///{tmpdir / 'auth.db'}"
-    subprocess.run(
-        [sys.executable, "-m", "tiled", "admin", "initialize-database", database_uri],
-        check=True,
-        capture_output=True,
-    )
-    config = {
-        "authentication": {
-            "secret_keys": ["SECRET"],
-            "providers": [
-                {
-                    "provider": "toy",
-                    "authenticator": "tiled.authenticators:DictionaryAuthenticator",
-                    "args": {
-                        "users_to_passwords": {"alice": "secret1", "bob": "secret2"},
-                    },
-                }
-            ],
-        },
-        "database": {
-            "uri": database_uri,
-        },
-        "trees": [
-            {
-                "tree": "catalog",
-                "path": "/",
-                "args": {
-                    "uri": "sqlite:///:memory:",
-                    "writable_storage": [str(tmpdir / "data")],
-                    "init_if_not_exists": True,
-                },
-            },
-        ],
-        "streaming_cache": {
-            "uri": redis_uri,
-            "data_ttl": 600,
-            "seq_ttl": 600,
-            "socket_timeout": 600,
-            "socket_connect_timeout": 10,
-        },
-    }
-    app = build_app_from_config(config)
-    with Context.from_app(app) as context:
-        with enter_username_password("alice", "secret1"):
-            client = from_context(context)
-        access_token = context.tokens["access_token"]
-        yield context, client, access_token
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_query_param_access_token(tiled_websocket_context_multiuser, envelope_format):
+    """Test websocket connection with JWT access token as query parameter."""
+    context, client, access_token = tiled_websocket_context_multiuser
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_jwt_query_param")
+
+    # Connect with access_token as query parameter — no first-message auth needed.
+    unauthenticated = TestClient(context.http_client.app)
+    token_param = urllib.parse.quote(access_token, safe="")
+    try:
+        with unauthenticated.websocket_connect(
+            f"/api/v1/stream/single/test_jwt_query_param"
+            f"?envelope_format={envelope_format}&access_token={token_param}",
+        ) as websocket:
+            # Should receive schema message directly (auth via query param succeeded).
+            if envelope_format == "json":
+                msg = websocket.receive_json()
+            else:
+                msg = msgpack.unpackb(websocket.receive_bytes())
+            assert msg["type"] in ("array-schema", "table-schema")
+    except RuntimeError as exc:
+        # The multi-user tiled_websocket_context_multiuser fixture creates Redis
+        # connections bound to a different event loop than the WebSocket handler's
+        # buffer_live_events task. This causes a harmless RuntimeError during
+        # cleanup. The schema receipt above already proves auth succeeded.
+        if "attached to a different loop" not in str(exc):
+            raise
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_expired_access_token_query_param(
-    authenticated_websocket_context, envelope_format
+    tiled_websocket_context_multiuser, envelope_format
 ):
     """Test that an expired JWT in the query parameter is rejected with 401."""
-    context, client, access_token = authenticated_websocket_context
+    context, client, access_token = tiled_websocket_context_multiuser
 
     arr = np.arange(10)
     client.write_array(arr, key="test_expired_jwt")
@@ -879,10 +872,10 @@ def test_expired_access_token_query_param(
     ],
 )
 def test_first_message_jwt_auth_rejected(
-    authenticated_websocket_context, envelope_format, auth_message
+    tiled_websocket_context_multiuser, envelope_format, auth_message
 ):
     """First-message auth with missing or invalid JWT is rejected with close code 4003."""
-    context, client, _ = authenticated_websocket_context
+    context, client, _ = tiled_websocket_context_multiuser
 
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_rejected")

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -11,7 +11,6 @@ import pyarrow as pa
 import pytest
 from starlette.testclient import TestClient, WebSocketDenialResponse
 
-from tiled.catalog import from_uri
 from tiled.client import from_context
 from tiled.client.context import Context
 from tiled.config import parse_configs
@@ -834,62 +833,6 @@ def authenticated_websocket_context(tmpdir, redis_uri, enter_username_password):
             client = from_context(context)
         access_token = context.tokens["access_token"]
         yield context, client, access_token
-
-
-@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_first_message_auth_with_access_token(
-    authenticated_websocket_context, envelope_format
-):
-    """Test websocket first-message authentication with a valid JWT access token."""
-    context, client, access_token = authenticated_websocket_context
-
-    arr = np.arange(10)
-    client.write_array(arr, key="test_jwt_first_msg")
-
-    # Connect without any credentials — server accepts for first-message auth.
-    unauthenticated = TestClient(context.http_client.app)
-    with unauthenticated.websocket_connect(
-        f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
-    ) as websocket:
-        # Send first-message auth with valid access token
-        websocket.send_json({"type": "auth", "access_token": access_token})
-        # Should receive schema message (auth succeeded)
-        if envelope_format == "json":
-            msg = websocket.receive_json()
-        else:
-            msg = msgpack.unpackb(websocket.receive_bytes())
-        assert msg["type"] in ("array-schema", "table-schema")
-
-
-@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_query_param_access_token(authenticated_websocket_context, envelope_format):
-    """Test websocket connection with JWT access token as query parameter."""
-    context, client, access_token = authenticated_websocket_context
-
-    arr = np.arange(10)
-    client.write_array(arr, key="test_jwt_query_param")
-
-    # Connect with access_token as query parameter — no first-message auth needed.
-    unauthenticated = TestClient(context.http_client.app)
-    token_param = urllib.parse.quote(access_token, safe="")
-    try:
-        with unauthenticated.websocket_connect(
-            f"/api/v1/stream/single/test_jwt_query_param"
-            f"?envelope_format={envelope_format}&access_token={token_param}",
-        ) as websocket:
-            # Should receive schema message directly (auth via query param succeeded).
-            if envelope_format == "json":
-                msg = websocket.receive_json()
-            else:
-                msg = msgpack.unpackb(websocket.receive_bytes())
-            assert msg["type"] in ("array-schema", "table-schema")
-    except RuntimeError as exc:
-        # The multi-user authenticated_websocket_context fixture creates Redis
-        # connections bound to a different event loop than the WebSocket handler's
-        # buffer_live_events task. This causes a harmless RuntimeError during
-        # cleanup. The schema receipt above already proves auth succeeded.
-        if "attached to a different loop" not in str(exc):
-            raise
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,5 +1,5 @@
+import contextlib
 import datetime
-import logging
 import sys
 import urllib.parse
 
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from starlette.testclient import TestClient, WebSocketDenialResponse
+from starlette.testclient import WebSocketDenialResponse
 
 from tiled.client import from_context
 from tiled.config import parse_configs
@@ -783,26 +783,19 @@ def _receive_schema(websocket, envelope_format):
     return msg
 
 
-def _ws_connect_ignore_streaming_error(test_client, url, body=None):
-    """Connect to a websocket, optionally send a first message, receive schema,
-    and tolerate the Redis event-loop RuntimeError that occurs in multi-user
-    test fixtures (buffer_live_events background task).
+@contextlib.contextmanager
+def _unauthenticated(context):
+    """Temporarily strip auth from context.http_client for unauthenticated requests.
+
+    Reuses the same TestClient (and its event loop) to avoid creating a second
+    event loop that would conflict with Redis connections created at startup.
     """
-    # Suppress noisy ERROR log from buffer_live_events crashing.
-    streaming_logger = logging.getLogger("tiled.server.streaming")
-    prev_level = streaming_logger.level
-    streaming_logger.setLevel(logging.CRITICAL)
+    saved_auth = context.http_client.auth
+    context.http_client.auth = None
     try:
-        envelope_format = "json" if "json" in url else "msgpack"
-        with test_client.websocket_connect(url) as websocket:
-            if body is not None:
-                websocket.send_json(body)
-            _receive_schema(websocket, envelope_format)
-    except RuntimeError as exc:
-        if "attached to a different loop" not in str(exc):
-            raise
+        yield context.http_client
     finally:
-        streaming_logger.setLevel(prev_level)
+        context.http_client.auth = saved_auth
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
@@ -815,12 +808,12 @@ def test_first_message_auth_with_access_token(
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_first_msg")
 
-    unauthenticated = TestClient(context.http_client.app)
-    _ws_connect_ignore_streaming_error(
-        unauthenticated,
-        f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
-        body={"type": "auth", "access_token": access_token},
-    )
+    with _unauthenticated(context) as test_client:
+        with test_client.websocket_connect(
+            f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
+        ) as websocket:
+            websocket.send_json({"type": "auth", "access_token": access_token})
+            _receive_schema(websocket, envelope_format)
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
@@ -831,13 +824,13 @@ def test_query_param_access_token(tiled_websocket_context_multiuser, envelope_fo
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_query_param")
 
-    unauthenticated = TestClient(context.http_client.app)
     token_param = urllib.parse.quote(access_token, safe="")
-    _ws_connect_ignore_streaming_error(
-        unauthenticated,
-        f"/api/v1/stream/single/test_jwt_query_param"
-        f"?envelope_format={envelope_format}&access_token={token_param}",
-    )
+    with _unauthenticated(context) as test_client:
+        with test_client.websocket_connect(
+            f"/api/v1/stream/single/test_jwt_query_param"
+            f"?envelope_format={envelope_format}&access_token={token_param}",
+        ) as websocket:
+            _receive_schema(websocket, envelope_format)
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
@@ -862,14 +855,14 @@ def test_expired_access_token_query_param(
         algorithm="HS256",
     )
     token_param = urllib.parse.quote(expired_token, safe="")
-    unauthenticated = TestClient(context.http_client.app)
-    with pytest.raises(WebSocketDenialResponse) as exc_info:
-        with unauthenticated.websocket_connect(
-            f"/api/v1/stream/single/test_expired_jwt"
-            f"?envelope_format={envelope_format}&access_token={token_param}",
-        ):
-            pass
-    assert exc_info.value.status_code == 401
+    with _unauthenticated(context) as test_client:
+        with pytest.raises(WebSocketDenialResponse) as exc_info:
+            with test_client.websocket_connect(
+                f"/api/v1/stream/single/test_expired_jwt"
+                f"?envelope_format={envelope_format}&access_token={token_param}",
+            ):
+                pass
+        assert exc_info.value.status_code == 401
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
@@ -892,11 +885,11 @@ def test_first_message_jwt_auth_rejected(
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_rejected")
 
-    unauthenticated = TestClient(context.http_client.app)
-    with unauthenticated.websocket_connect(
-        f"/api/v1/stream/single/test_jwt_rejected?envelope_format={envelope_format}",
-    ) as websocket:
-        websocket.send_json(auth_message)
-        msg = websocket.receive()
-        assert msg["type"] == "websocket.close"
-        assert msg.get("code") == 4003
+    with _unauthenticated(context) as test_client:
+        with test_client.websocket_connect(
+            f"/api/v1/stream/single/test_jwt_rejected?envelope_format={envelope_format}",
+        ) as websocket:
+            websocket.send_json(auth_message)
+            msg = websocket.receive()
+            assert msg["type"] == "websocket.close"
+            assert msg.get("code") == 4003

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -123,9 +123,7 @@ def test_subscribe_immediately_after_creation_websockets(
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_connection_to_non_existent_node(
-    tiled_websocket_context, envelope_format
-):
+def test_connection_to_non_existent_node(tiled_websocket_context, envelope_format):
     """Test websocket connection to non-existent node returns 404."""
     context = tiled_websocket_context
     test_client = context.http_client
@@ -435,7 +433,7 @@ def test_close_stream_not_found(tiled_websocket_context):
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_connection_wrong_api_key(tiled_websocket_context, envelope_format):
+def test_connection_wrong_api_key(tiled_websocket_context, envelope_format):
     """Test websocket connection with wrong API key fails with 401."""
 
     context = tiled_websocket_context
@@ -458,82 +456,50 @@ def test_websocket_connection_wrong_api_key(tiled_websocket_context, envelope_fo
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_connection_no_api_key(tiled_websocket_context, envelope_format):
-    """Test websocket connection with no credentials is accepted but expects first-message auth."""
-
-    context = tiled_websocket_context
-    client = from_context(context)
-    test_client = context.http_client
-
-    # Create streaming array node using correct key
-    arr = np.arange(10)
-    client.write_array(arr, key="test_auth_websocket")
-
-    # Strip API key so requests below are unauthenticated.
-    context.api_key = None
-
-    # Connection is accepted (for first-message auth), but sending invalid
-    # auth should cause the server to close the connection.
-    with test_client.websocket_connect(
-        f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
-    ) as websocket:
-        # Send an invalid auth message
-        websocket.send_json({"type": "auth", "access_token": "invalid_token"})
-        # Server should close the connection
-        msg = websocket.receive()
-        assert msg["type"] == "websocket.close"
-
-
-@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_auth_wrong_api_key(
-    tiled_websocket_context, envelope_format
+@pytest.mark.parametrize(
+    "auth_message,expected_close_code",
+    [
+        pytest.param(
+            {"type": "auth", "api_key": "wrong_secret"},
+            4003,
+            id="wrong-api-key",
+        ),
+        pytest.param(
+            {"type": "auth", "access_token": "invalid_token"},
+            4003,
+            id="invalid-access-token",
+        ),
+        pytest.param(
+            {"type": "subscribe", "path": "foo"},
+            4001,
+            id="non-auth-message-type",
+        ),
+    ],
+)
+def test_first_message_auth_rejected(
+    tiled_websocket_context, envelope_format, auth_message, expected_close_code
 ):
-    """Test websocket first-message authentication with a wrong API key."""
-
+    """First-message auth with bad credentials or wrong message type is rejected."""
     context = tiled_websocket_context
     client = from_context(context)
     test_client = context.http_client
 
     arr = np.arange(10)
-    client.write_array(arr, key="test_wrong_key_auth")
+    client.write_array(arr, key="test_first_msg_rejected")
 
     context.api_key = None
 
     with test_client.websocket_connect(
-        f"/api/v1/stream/single/test_wrong_key_auth?envelope_format={envelope_format}",
+        f"/api/v1/stream/single/test_first_msg_rejected?envelope_format={envelope_format}",
     ) as websocket:
-        websocket.send_json({"type": "auth", "api_key": "wrong_secret"})
+        websocket.send_json(auth_message)
         msg = websocket.receive()
         assert msg["type"] == "websocket.close"
+        assert msg.get("code") == expected_close_code
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_auth_invalid_message(
-    tiled_websocket_context, envelope_format
-):
-    """Test websocket first-message with non-auth message type is rejected."""
-
-    context = tiled_websocket_context
-    client = from_context(context)
-    test_client = context.http_client
-
-    arr = np.arange(10)
-    client.write_array(arr, key="test_invalid_msg_auth")
-
-    context.api_key = None
-
-    with test_client.websocket_connect(
-        f"/api/v1/stream/single/test_invalid_msg_auth?envelope_format={envelope_format}",
-    ) as websocket:
-        websocket.send_json({"type": "subscribe", "path": "foo"})
-        msg = websocket.receive()
-        assert msg["type"] == "websocket.close"
-
-
-@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_auth_with_api_key(
-    tiled_websocket_context, envelope_format
-):
+def test_first_message_auth_with_api_key(tiled_websocket_context, envelope_format):
     """Test websocket first-message authentication with a valid API key."""
 
     context = tiled_websocket_context
@@ -558,9 +524,7 @@ def test_websocket_first_message_auth_with_api_key(
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_connection_public_no_api_key(
-    tiled_websocket_context_public, envelope_format
-):
+def test_connection_public_no_api_key(tiled_websocket_context_public, envelope_format):
     """Test websocket connection to a public server with no API key works."""
     context = tiled_websocket_context_public
     client = from_context(context)
@@ -815,35 +779,56 @@ def authenticated_websocket_context(tmpdir, redis_uri, enter_username_password):
     """Fixture that provides a multi-user Tiled context with JWT auth and websocket support.
 
     Returns (context, client, access_token) where access_token is a valid JWT for 'alice'.
+    Uses build_app_from_config (like the other websocket fixtures) so that Redis
+    connections are created in the correct event loop.
     """
-    from tiled.config import Authentication, AuthenticationProviderSpec
-    from tiled.server.app import build_app
+    import subprocess
+    import sys
 
-    tree = from_uri(
-        "sqlite:///:memory:",
-        writable_storage=[str(tmpdir / "data")],
-        init_if_not_exists=True,
-        cache_config={
+    from tiled.server.app import build_app_from_config
+
+    database_uri = f"sqlite:///{tmpdir / 'auth.db'}"
+    subprocess.run(
+        [sys.executable, "-m", "tiled", "admin", "initialize-database", database_uri],
+        check=True,
+        capture_output=True,
+    )
+    config = {
+        "authentication": {
+            "secret_keys": ["SECRET"],
+            "providers": [
+                {
+                    "provider": "toy",
+                    "authenticator": "tiled.authenticators:DictionaryAuthenticator",
+                    "args": {
+                        "users_to_passwords": {"alice": "secret1", "bob": "secret2"},
+                    },
+                }
+            ],
+        },
+        "database": {
+            "uri": database_uri,
+        },
+        "trees": [
+            {
+                "tree": "catalog",
+                "path": "/",
+                "args": {
+                    "uri": "sqlite:///:memory:",
+                    "writable_storage": [str(tmpdir / "data")],
+                    "init_if_not_exists": True,
+                },
+            },
+        ],
+        "streaming_cache": {
             "uri": redis_uri,
             "data_ttl": 600,
             "seq_ttl": 600,
             "socket_timeout": 600,
             "socket_connect_timeout": 10,
         },
-    )
-    app = build_app(
-        tree,
-        authentication=Authentication(
-            secret_keys=["SECRET"],
-            providers=[
-                AuthenticationProviderSpec(
-                    provider="toy",
-                    authenticator="tiled.authenticators:DictionaryAuthenticator",
-                    args={"users_to_passwords": {"alice": "secret1", "bob": "secret2"}},
-                )
-            ],
-        ),
-    )
+    }
+    app = build_app_from_config(config)
     with Context.from_app(app) as context:
         with enter_username_password("alice", "secret1"):
             client = from_context(context)
@@ -852,7 +837,7 @@ def authenticated_websocket_context(tmpdir, redis_uri, enter_username_password):
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_auth_with_access_token(
+def test_first_message_auth_with_access_token(
     authenticated_websocket_context, envelope_format
 ):
     """Test websocket first-message authentication with a valid JWT access token."""
@@ -877,9 +862,7 @@ def test_websocket_first_message_auth_with_access_token(
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_query_param_access_token(
-    authenticated_websocket_context, envelope_format
-):
+def test_query_param_access_token(authenticated_websocket_context, envelope_format):
     """Test websocket connection with JWT access token as query parameter."""
     context, client, access_token = authenticated_websocket_context
 
@@ -889,41 +872,28 @@ def test_websocket_query_param_access_token(
     # Connect with access_token as query parameter — no first-message auth needed.
     unauthenticated = TestClient(context.http_client.app)
     token_param = urllib.parse.quote(access_token, safe="")
-    with unauthenticated.websocket_connect(
-        f"/api/v1/stream/single/test_jwt_query_param"
-        f"?envelope_format={envelope_format}&access_token={token_param}",
-    ) as websocket:
-        # Should receive schema message directly (auth via query param succeeded).
-        if envelope_format == "json":
-            msg = websocket.receive_json()
-        else:
-            msg = msgpack.unpackb(websocket.receive_bytes())
-        assert msg["type"] in ("array-schema", "table-schema")
+    try:
+        with unauthenticated.websocket_connect(
+            f"/api/v1/stream/single/test_jwt_query_param"
+            f"?envelope_format={envelope_format}&access_token={token_param}",
+        ) as websocket:
+            # Should receive schema message directly (auth via query param succeeded).
+            if envelope_format == "json":
+                msg = websocket.receive_json()
+            else:
+                msg = msgpack.unpackb(websocket.receive_bytes())
+            assert msg["type"] in ("array-schema", "table-schema")
+    except RuntimeError as exc:
+        # The multi-user authenticated_websocket_context fixture creates Redis
+        # connections bound to a different event loop than the WebSocket handler's
+        # buffer_live_events task. This causes a harmless RuntimeError during
+        # cleanup. The schema receipt above already proves auth succeeded.
+        if "attached to a different loop" not in str(exc):
+            raise
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_no_credentials(
-    authenticated_websocket_context, envelope_format
-):
-    """Test websocket first-message with neither api_key nor access_token is rejected."""
-    context, client, _ = authenticated_websocket_context
-
-    arr = np.arange(10)
-    client.write_array(arr, key="test_no_creds")
-
-    unauthenticated = TestClient(context.http_client.app)
-    with unauthenticated.websocket_connect(
-        f"/api/v1/stream/single/test_no_creds?envelope_format={envelope_format}",
-    ) as websocket:
-        # Send auth message with no credentials
-        websocket.send_json({"type": "auth"})
-        msg = websocket.receive()
-        assert msg["type"] == "websocket.close"
-        assert msg.get("code") == 4003
-
-
-@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_expired_access_token_query_param(
+def test_expired_access_token_query_param(
     authenticated_websocket_context, envelope_format
 ):
     """Test that an expired JWT in the query parameter is rejected with 401."""
@@ -955,21 +925,30 @@ def test_websocket_expired_access_token_query_param(
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
-def test_websocket_first_message_auth_invalid_token(
-    authenticated_websocket_context, envelope_format
+@pytest.mark.parametrize(
+    "auth_message",
+    [
+        pytest.param({"type": "auth"}, id="no-credentials"),
+        pytest.param(
+            {"type": "auth", "access_token": "not.a.valid.jwt"},
+            id="invalid-jwt",
+        ),
+    ],
+)
+def test_first_message_jwt_auth_rejected(
+    authenticated_websocket_context, envelope_format, auth_message
 ):
-    """Test that a malformed JWT in first-message auth is rejected with close code 4003."""
+    """First-message auth with missing or invalid JWT is rejected with close code 4003."""
     context, client, _ = authenticated_websocket_context
 
     arr = np.arange(10)
-    client.write_array(arr, key="test_invalid_jwt")
+    client.write_array(arr, key="test_jwt_rejected")
 
     unauthenticated = TestClient(context.http_client.app)
     with unauthenticated.websocket_connect(
-        f"/api/v1/stream/single/test_invalid_jwt?envelope_format={envelope_format}",
+        f"/api/v1/stream/single/test_jwt_rejected?envelope_format={envelope_format}",
     ) as websocket:
-        # Send first-message auth with a garbage token
-        websocket.send_json({"type": "auth", "access_token": "not.a.valid.jwt"})
+        websocket.send_json(auth_message)
         msg = websocket.receive()
         assert msg["type"] == "websocket.close"
         assert msg.get("code") == 4003

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -455,7 +455,7 @@ def test_websocket_connection_wrong_api_key(tiled_websocket_context, envelope_fo
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_websocket_connection_no_api_key(tiled_websocket_context, envelope_format):
-    """Test websocket connection with no API key fails with 401."""
+    """Test websocket connection with no credentials is accepted but expects first-message auth."""
 
     context = tiled_websocket_context
     client = from_context(context)
@@ -468,14 +468,89 @@ def test_websocket_connection_no_api_key(tiled_websocket_context, envelope_forma
     # Strip API key so requests below are unauthenticated.
     context.api_key = None
 
-    # Try to connect to websocket with no API key
-    with pytest.raises(WebSocketDenialResponse) as exc_info:
-        with test_client.websocket_connect(
-            f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
-        ):
-            pass
+    # Connection is accepted (for first-message auth), but sending invalid
+    # auth should cause the server to close the connection.
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_auth_websocket?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send an invalid auth message
+        websocket.send_json({"type": "auth", "access_token": "invalid_token"})
+        # Server should close the connection
+        msg = websocket.receive()
+        assert msg["type"] == "websocket.close"
 
-    assert exc_info.value.status_code == 401
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_auth_wrong_api_key(
+    tiled_websocket_context, envelope_format
+):
+    """Test websocket first-message authentication with a wrong API key."""
+
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_wrong_key_auth")
+
+    context.api_key = None
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_wrong_key_auth?envelope_format={envelope_format}",
+    ) as websocket:
+        websocket.send_json({"type": "auth", "api_key": "wrong_secret"})
+        msg = websocket.receive()
+        assert msg["type"] == "websocket.close"
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_auth_invalid_message(
+    tiled_websocket_context, envelope_format
+):
+    """Test websocket first-message with non-auth message type is rejected."""
+
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_invalid_msg_auth")
+
+    context.api_key = None
+
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_invalid_msg_auth?envelope_format={envelope_format}",
+    ) as websocket:
+        websocket.send_json({"type": "subscribe", "path": "foo"})
+        msg = websocket.receive()
+        assert msg["type"] == "websocket.close"
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_auth_with_api_key(
+    tiled_websocket_context, envelope_format
+):
+    """Test websocket first-message authentication with a valid API key."""
+
+    context = tiled_websocket_context
+    client = from_context(context)
+    test_client = context.http_client
+
+    # Create streaming array node
+    arr = np.arange(10)
+    streaming_node = client.write_array(arr, key="test_first_msg_auth")
+
+    # Connect WITHOUT API key in headers — server will accept and wait for
+    # first-message auth.
+    with test_client.websocket_connect(
+        f"/api/v1/stream/single/test_first_msg_auth?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send first-message auth with valid API key
+        websocket.send_json({"type": "auth", "api_key": "secret"})
+        # Send an update and receive it, proving auth worked
+        send_ws_updates(streaming_node, overwrite_array, count=1)
+        received = receive_ws_updates(websocket, count=1)
+        verify_ws_updates(received)
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -807,8 +807,7 @@ def test_first_message_auth_with_access_token(
     client = from_context(context)
     access_token = context.tokens["access_token"]
 
-    arr = np.arange(10)
-    client.write_array(arr, key="test_jwt_first_msg")
+    client.write_array(np.arange(10), key="test_jwt_first_msg")
 
     with _unauthenticated(context) as test_client:
         with test_client.websocket_connect(
@@ -825,8 +824,7 @@ def test_query_param_access_token(tiled_websocket_context_multiuser, envelope_fo
     client = from_context(context)
     access_token = context.tokens["access_token"]
 
-    arr = np.arange(10)
-    client.write_array(arr, key="test_jwt_query_param")
+    client.write_array(np.arange(10), key="test_jwt_query_param")
 
     token_param = urllib.parse.quote(access_token, safe="")
     with _unauthenticated(context) as test_client:
@@ -845,8 +843,7 @@ def test_expired_access_token_query_param(
     context = tiled_websocket_context_multiuser
     client = from_context(context)
 
-    arr = np.arange(10)
-    client.write_array(arr, key="test_expired_jwt")
+    client.write_array(np.arange(10), key="test_expired_jwt")
 
     # Create an expired token using the same secret key.
     expired_token = jose.jwt.encode(
@@ -888,8 +885,7 @@ def test_first_message_jwt_auth_rejected(
     context = tiled_websocket_context_multiuser
     client = from_context(context)
 
-    arr = np.arange(10)
-    client.write_array(arr, key="test_jwt_rejected")
+    client.write_array(np.arange(10), key="test_jwt_rejected")
 
     with _unauthenticated(context) as test_client:
         with test_client.websocket_connect(

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -799,6 +799,45 @@ def _unauthenticated(context):
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_first_message_auth_with_api_key_multiuser(
+    tiled_websocket_context_multiuser, envelope_format
+):
+    """Test first-message auth with a valid API key in multi-user mode."""
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
+
+    key_info = context.create_api_key()
+    client.write_array(np.arange(10), key="test_apikey_multiuser")
+
+    with _unauthenticated(context) as test_client:
+        with test_client.websocket_connect(
+            f"/api/v1/stream/single/test_apikey_multiuser?envelope_format={envelope_format}",
+        ) as websocket:
+            websocket.send_json({"type": "auth", "api_key": key_info["secret"]})
+            _receive_schema(websocket, envelope_format)
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_first_message_auth_wrong_api_key_multiuser(
+    tiled_websocket_context_multiuser, envelope_format
+):
+    """Test first-message auth with a wrong API key in multi-user mode is rejected."""
+    context = tiled_websocket_context_multiuser
+    client = from_context(context)
+
+    client.write_array(np.arange(10), key="test_bad_apikey_multiuser")
+
+    with _unauthenticated(context) as test_client:
+        with test_client.websocket_connect(
+            f"/api/v1/stream/single/test_bad_apikey_multiuser?envelope_format={envelope_format}",
+        ) as websocket:
+            websocket.send_json({"type": "auth", "api_key": "wrong-key"})
+            msg = websocket.receive()
+            assert msg["type"] == "websocket.close"
+            assert msg.get("code") == 4003
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_first_message_auth_with_access_token(
     tiled_websocket_context_multiuser, envelope_format
 ):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import sys
 import urllib.parse
 
@@ -772,6 +773,38 @@ streaming_cache:
     assert config.streaming_cache.socket_connect_timeout == 12
 
 
+def _receive_schema(websocket, envelope_format):
+    """Receive and return the schema message from a websocket."""
+    if envelope_format == "json":
+        msg = websocket.receive_json()
+    else:
+        msg = msgpack.unpackb(websocket.receive_bytes())
+    assert msg["type"] in ("array-schema", "table-schema")
+    return msg
+
+
+def _ws_connect_ignore_streaming_error(test_client, url, body=None):
+    """Connect to a websocket, optionally send a first message, receive schema,
+    and tolerate the Redis event-loop RuntimeError that occurs in multi-user
+    test fixtures (buffer_live_events background task).
+    """
+    # Suppress noisy ERROR log from buffer_live_events crashing.
+    streaming_logger = logging.getLogger("tiled.server.streaming")
+    prev_level = streaming_logger.level
+    streaming_logger.setLevel(logging.CRITICAL)
+    try:
+        envelope_format = "json" if "json" in url else "msgpack"
+        with test_client.websocket_connect(url) as websocket:
+            if body is not None:
+                websocket.send_json(body)
+            _receive_schema(websocket, envelope_format)
+    except RuntimeError as exc:
+        if "attached to a different loop" not in str(exc):
+            raise
+    finally:
+        streaming_logger.setLevel(prev_level)
+
+
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
 def test_first_message_auth_with_access_token(
     tiled_websocket_context_multiuser, envelope_format
@@ -782,19 +815,12 @@ def test_first_message_auth_with_access_token(
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_first_msg")
 
-    # Connect without any credentials — server accepts for first-message auth.
     unauthenticated = TestClient(context.http_client.app)
-    with unauthenticated.websocket_connect(
+    _ws_connect_ignore_streaming_error(
+        unauthenticated,
         f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
-    ) as websocket:
-        # Send first-message auth with valid access token
-        websocket.send_json({"type": "auth", "access_token": access_token})
-        # Should receive schema message (auth succeeded)
-        if envelope_format == "json":
-            msg = websocket.receive_json()
-        else:
-            msg = msgpack.unpackb(websocket.receive_bytes())
-        assert msg["type"] in ("array-schema", "table-schema")
+        body={"type": "auth", "access_token": access_token},
+    )
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
@@ -805,27 +831,13 @@ def test_query_param_access_token(tiled_websocket_context_multiuser, envelope_fo
     arr = np.arange(10)
     client.write_array(arr, key="test_jwt_query_param")
 
-    # Connect with access_token as query parameter — no first-message auth needed.
     unauthenticated = TestClient(context.http_client.app)
     token_param = urllib.parse.quote(access_token, safe="")
-    try:
-        with unauthenticated.websocket_connect(
-            f"/api/v1/stream/single/test_jwt_query_param"
-            f"?envelope_format={envelope_format}&access_token={token_param}",
-        ) as websocket:
-            # Should receive schema message directly (auth via query param succeeded).
-            if envelope_format == "json":
-                msg = websocket.receive_json()
-            else:
-                msg = msgpack.unpackb(websocket.receive_bytes())
-            assert msg["type"] in ("array-schema", "table-schema")
-    except RuntimeError as exc:
-        # The multi-user tiled_websocket_context_multiuser fixture creates Redis
-        # connections bound to a different event loop than the WebSocket handler's
-        # buffer_live_events task. This causes a harmless RuntimeError during
-        # cleanup. The schema receipt above already proves auth succeeded.
-        if "attached to a different loop" not in str(exc):
-            raise
+    _ws_connect_ignore_streaming_error(
+        unauthenticated,
+        f"/api/v1/stream/single/test_jwt_query_param"
+        f"?envelope_format={envelope_format}&access_token={token_param}",
+    )
 
 
 @pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,15 +1,19 @@
+import datetime
 import sys
 import urllib.parse
 
 import dask.array
+import jose.jwt
 import msgpack
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from starlette.testclient import WebSocketDenialResponse
+from starlette.testclient import TestClient, WebSocketDenialResponse
 
+from tiled.catalog import from_uri
 from tiled.client import from_context
+from tiled.client.context import Context
 from tiled.config import parse_configs
 
 pytestmark = pytest.mark.skipif(
@@ -804,3 +808,168 @@ streaming_cache:
     assert config.streaming_cache.seq_ttl == 60
     assert config.streaming_cache.socket_timeout == 11
     assert config.streaming_cache.socket_connect_timeout == 12
+
+
+@pytest.fixture(scope="function")
+def authenticated_websocket_context(tmpdir, redis_uri, enter_username_password):
+    """Fixture that provides a multi-user Tiled context with JWT auth and websocket support.
+
+    Returns (context, client, access_token) where access_token is a valid JWT for 'alice'.
+    """
+    from tiled.config import Authentication, AuthenticationProviderSpec
+    from tiled.server.app import build_app
+
+    tree = from_uri(
+        "sqlite:///:memory:",
+        writable_storage=[str(tmpdir / "data")],
+        init_if_not_exists=True,
+        cache_config={
+            "uri": redis_uri,
+            "data_ttl": 600,
+            "seq_ttl": 600,
+            "socket_timeout": 600,
+            "socket_connect_timeout": 10,
+        },
+    )
+    app = build_app(
+        tree,
+        authentication=Authentication(
+            secret_keys=["SECRET"],
+            providers=[
+                AuthenticationProviderSpec(
+                    provider="toy",
+                    authenticator="tiled.authenticators:DictionaryAuthenticator",
+                    args={"users_to_passwords": {"alice": "secret1", "bob": "secret2"}},
+                )
+            ],
+        ),
+    )
+    with Context.from_app(app) as context:
+        with enter_username_password("alice", "secret1"):
+            client = from_context(context)
+        access_token = context.tokens["access_token"]
+        yield context, client, access_token
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_auth_with_access_token(
+    authenticated_websocket_context, envelope_format
+):
+    """Test websocket first-message authentication with a valid JWT access token."""
+    context, client, access_token = authenticated_websocket_context
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_jwt_first_msg")
+
+    # Connect without any credentials — server accepts for first-message auth.
+    unauthenticated = TestClient(context.http_client.app)
+    with unauthenticated.websocket_connect(
+        f"/api/v1/stream/single/test_jwt_first_msg?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send first-message auth with valid access token
+        websocket.send_json({"type": "auth", "access_token": access_token})
+        # Should receive schema message (auth succeeded)
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:
+            msg = msgpack.unpackb(websocket.receive_bytes())
+        assert msg["type"] in ("array-schema", "table-schema")
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_query_param_access_token(
+    authenticated_websocket_context, envelope_format
+):
+    """Test websocket connection with JWT access token as query parameter."""
+    context, client, access_token = authenticated_websocket_context
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_jwt_query_param")
+
+    # Connect with access_token as query parameter — no first-message auth needed.
+    unauthenticated = TestClient(context.http_client.app)
+    token_param = urllib.parse.quote(access_token, safe="")
+    with unauthenticated.websocket_connect(
+        f"/api/v1/stream/single/test_jwt_query_param"
+        f"?envelope_format={envelope_format}&access_token={token_param}",
+    ) as websocket:
+        # Should receive schema message directly (auth via query param succeeded).
+        if envelope_format == "json":
+            msg = websocket.receive_json()
+        else:
+            msg = msgpack.unpackb(websocket.receive_bytes())
+        assert msg["type"] in ("array-schema", "table-schema")
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_no_credentials(
+    authenticated_websocket_context, envelope_format
+):
+    """Test websocket first-message with neither api_key nor access_token is rejected."""
+    context, client, _ = authenticated_websocket_context
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_no_creds")
+
+    unauthenticated = TestClient(context.http_client.app)
+    with unauthenticated.websocket_connect(
+        f"/api/v1/stream/single/test_no_creds?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send auth message with no credentials
+        websocket.send_json({"type": "auth"})
+        msg = websocket.receive()
+        assert msg["type"] == "websocket.close"
+        assert msg.get("code") == 4003
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_expired_access_token_query_param(
+    authenticated_websocket_context, envelope_format
+):
+    """Test that an expired JWT in the query parameter is rejected with 401."""
+    context, client, access_token = authenticated_websocket_context
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_expired_jwt")
+
+    # Create an expired token using the same secret key.
+    expired_token = jose.jwt.encode(
+        {
+            "sub": "fake",
+            "type": "access",
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=60),
+        },
+        "SECRET",
+        algorithm="HS256",
+    )
+    token_param = urllib.parse.quote(expired_token, safe="")
+    unauthenticated = TestClient(context.http_client.app)
+    with pytest.raises(WebSocketDenialResponse) as exc_info:
+        with unauthenticated.websocket_connect(
+            f"/api/v1/stream/single/test_expired_jwt"
+            f"?envelope_format={envelope_format}&access_token={token_param}",
+        ):
+            pass
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.parametrize("envelope_format", (["msgpack", "json"]))
+def test_websocket_first_message_auth_invalid_token(
+    authenticated_websocket_context, envelope_format
+):
+    """Test that a malformed JWT in first-message auth is rejected with close code 4003."""
+    context, client, _ = authenticated_websocket_context
+
+    arr = np.arange(10)
+    client.write_array(arr, key="test_invalid_jwt")
+
+    unauthenticated = TestClient(context.http_client.app)
+    with unauthenticated.websocket_connect(
+        f"/api/v1/stream/single/test_invalid_jwt?envelope_format={envelope_format}",
+    ) as websocket:
+        # Send first-message auth with a garbage token
+        websocket.send_json({"type": "auth", "access_token": "not.a.valid.jwt"})
+        msg = websocket.receive()
+        assert msg["type"] == "websocket.close"
+        assert msg.get("code") == 4003

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -296,6 +296,23 @@ def get_api_key_websocket(
     return api_key
 
 
+def get_decoded_access_token_websocket(
+    websocket: WebSocket,
+    access_token: Optional[str] = Query(None),
+    settings: Settings = Depends(get_settings),
+) -> Optional[dict]:
+    """Decode a JWT access token passed as a query parameter on WebSocket connections."""
+    if not access_token:
+        return None
+    try:
+        return decode_token(access_token, settings.secret_keys, settings.authenticator)
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Access token has expired. Refresh token.",
+        )
+
+
 async def get_current_access_tags_websocket(
     websocket: WebSocket,
     api_key: Optional[str] = Depends(get_api_key_websocket),
@@ -392,6 +409,7 @@ async def get_current_scopes(
 async def get_current_scopes_websocket(
     websocket: WebSocket,
     api_key: Optional[str] = Depends(get_api_key_websocket),
+    decoded_access_token: Optional[dict] = Depends(get_decoded_access_token_websocket),
     settings: Settings = Depends(get_settings),
     db_factory: Callable[[], Optional[AsyncSession]] = Depends(
         get_database_session_factory
@@ -402,8 +420,81 @@ async def get_current_scopes_websocket(
             return await get_scopes_from_api_key(
                 api_key, settings, websocket.app.state.authenticated, db
             )
+    elif decoded_access_token is not None:
+        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
+            return set(decoded_access_token["scope"].split(" "))
+        else:
+            return decoded_access_token["scp"]
     else:
         return PUBLIC_SCOPES if settings.allow_anonymous_access else NO_SCOPES
+
+
+async def authenticate_websocket_first_message(
+    websocket: WebSocket,
+    message: dict,
+    settings: Settings,
+    db_factory: Callable,
+) -> tuple[bool, Optional[schemas.Principal], Optional[set], set]:
+    """Authenticate a WebSocket connection from a 'first message' payload.
+
+    Supports two credential types:
+      {"type": "auth", "access_token": "..."}
+      {"type": "auth", "api_key": "..."}
+
+    Returns (success, principal, access_tags, scopes). ``success`` is True if
+    credentials were valid, False otherwise.  ``principal`` may legitimately
+    be None in single-user API-key mode even when auth succeeds.
+    """
+    api_key = message.get("api_key")
+    access_token = message.get("access_token")
+
+    if api_key is not None:
+        try:
+            async with db_factory() as db:
+                principal = await get_current_principal_from_api_key(
+                    api_key, websocket.app.state.authenticated, db, settings
+                )
+        except HTTPException:
+            return False, None, None, NO_SCOPES
+        if (principal is None) and websocket.app.state.authenticated:
+            # In multi-user mode, None principal means key not found.
+            return False, None, None, NO_SCOPES
+        async with db_factory() as db:
+            access_tags = await get_access_tags_from_api_key(
+                api_key, websocket.app.state.authenticated, db
+            )
+        async with db_factory() as db:
+            scopes = await get_scopes_from_api_key(
+                api_key, settings, websocket.app.state.authenticated, db
+            )
+        return True, principal, access_tags, scopes
+    elif access_token is not None:
+        try:
+            decoded = decode_token(
+                access_token, settings.secret_keys, settings.authenticator
+            )
+        except Exception:
+            return False, None, None, NO_SCOPES
+        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
+            principal = schemas.Principal(
+                uuid=uuid_module.UUID(hex=decoded["sub"]),
+                type=schemas.PrincipalType.external,
+                identities=[],
+            )
+            scopes = set(decoded["scope"].split(" "))
+        else:
+            principal = schemas.Principal(
+                uuid=uuid_module.UUID(hex=decoded["sub"]),
+                type=decoded["sub_typ"],
+                identities=[
+                    schemas.Identity(id=identity["id"], provider=identity["idp"])
+                    for identity in decoded["ids"]
+                ],
+            )
+            scopes = decoded["scp"]
+        return True, principal, None, scopes
+    else:
+        return False, None, None, NO_SCOPES
 
 
 async def check_scopes(
@@ -487,6 +578,7 @@ async def get_current_principal_from_api_key(
 async def get_current_principal_websocket(
     websocket: WebSocket,
     api_key: Optional[str] = Depends(get_api_key_websocket),
+    decoded_access_token: Optional[dict] = Depends(get_decoded_access_token_websocket),
     settings: Settings = Depends(get_settings),
     db_factory: Callable[[], Optional[AsyncSession]] = Depends(
         get_database_session_factory
@@ -502,14 +594,29 @@ async def get_current_principal_websocket(
                 status_code=HTTP_401_UNAUTHORIZED, detail="Invalid API key"
             )
         return principal
+    elif decoded_access_token is not None:
+        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
+            return schemas.Principal(
+                uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
+                type=schemas.PrincipalType.external,
+                identities=[],
+            )
+        else:
+            return schemas.Principal(
+                uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
+                type=decoded_access_token["sub_typ"],
+                identities=[
+                    schemas.Identity(id=identity["id"], provider=identity["idp"])
+                    for identity in decoded_access_token["ids"]
+                ],
+            )
     else:
         if settings.allow_anonymous_access:
             return None
         else:
-            raise HTTPException(
-                status_code=HTTP_401_UNAUTHORIZED,
-                detail="No API key was provided with this request.",
-            )
+            # No credentials provided. Return None to allow the WebSocket
+            # endpoint to attempt "first message" authentication. See Issue #1138.
+            return None
 
 
 async def get_current_principal(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -57,15 +57,19 @@ from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
 from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from .authentication import (
+    authenticate_websocket_first_message,
     check_scopes,
+    get_api_key_websocket,
     get_current_access_tags,
     get_current_access_tags_websocket,
     get_current_principal,
     get_current_principal_websocket,
     get_current_scopes,
     get_current_scopes_websocket,
+    get_decoded_access_token_websocket,
     get_session_state,
 )
+from .connection_pool import get_database_session_factory
 from .core import (
     DEFAULT_PAGE_SIZE,
     DEPTH_LIMIT,
@@ -758,11 +762,51 @@ def get_router(
             get_current_access_tags_websocket
         ),
         authn_scopes: Scopes = Depends(get_current_scopes_websocket),
+        settings: Settings = Depends(get_settings),
+        db_factory: Callable = Depends(get_database_session_factory),
+        api_key: Optional[str] = Depends(get_api_key_websocket),
+        decoded_access_token: Optional[dict] = Depends(
+            get_decoded_access_token_websocket
+        ),
     ):
         root_tree = websocket.app.state.root_tree
         websocket.state.metrics = collections.defaultdict(
             lambda: collections.defaultdict(lambda: 0)
         )
+
+        # If no auth was provided via headers or query params on a server that
+        # requires authentication, accept the connection and wait for a "first
+        # message" carrying credentials. See Issue #1138.
+        # In single-user (API-key-only) mode, principal is legitimately None
+        # for valid keys, so we check whether any credentials were provided.
+        has_credentials = api_key is not None or decoded_access_token is not None
+        needs_first_message_auth = (
+            not has_credentials and not settings.allow_anonymous_access
+        )
+        if needs_first_message_auth:
+            await websocket.accept()
+            try:
+                message = await websocket.receive_json()
+            except Exception:
+                await websocket.close(code=4001, reason="Expected JSON auth message")
+                return
+            if not isinstance(message, dict) or message.get("type") != "auth":
+                await websocket.close(
+                    code=4001, reason='Expected {"type": "auth", ...}'
+                )
+                return
+            (
+                success,
+                principal,
+                authn_access_tags,
+                authn_scopes,
+            ) = await authenticate_websocket_first_message(
+                websocket, message, settings, db_factory
+            )
+            if not success:
+                await websocket.close(code=4003, reason="Authentication failed")
+                return
+
         entry = await get_entry(
             path,
             ["read:data", "read:metadata"],
@@ -789,7 +833,7 @@ def get_router(
         path_str = "/".join(path_parts)
         uri = f"{base_websocket_url.replace(scheme=scheme)}/array/full/{path_str}"
         handler = entry.make_ws_handler(websocket, formatter, uri)
-        await handler(start)
+        await handler(start, already_accepted=needs_first_message_auth)
 
     @router.get(
         "/table/partition/{path:path}",

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -224,8 +224,9 @@ def _make_ws_handler_common(
     - Ensures cleanup of resources (e.g., live stream subscriptions) on exit.
     """
 
-    async def handler(sequence: Optional[int] = None):
-        await websocket.accept()
+    async def handler(sequence: Optional[int] = None, already_accepted: bool = False):
+        if not already_accepted:
+            await websocket.accept()
         end_stream = asyncio.Event()
 
         # Send schema to provide client context to interpret what follows.
@@ -247,7 +248,7 @@ def _make_ws_handler_common(
             if metadata.get("type") == "array-ref":
                 if metadata.get("patch"):
                     s = ",".join(
-                        f"{offset}:{offset+shape}"
+                        f"{offset}:{offset + shape}"
                         for offset, shape in zip(
                             metadata["patch"]["offset"], metadata["patch"]["shape"]
                         )


### PR DESCRIPTION
Support authenticating WebSocket connections by sending credentials in the first JSON message instead of exposing tokens in query parameters.

Issue: #1138 
Related: #1350 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
