### PR TITLE
Accept Multiple Providers in TagBasedAccessPolicy -- ON HOLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Added
 
-- Tests for the WebSocket endpoints that stream tabukar data.
+- Tests for the WebSocket endpoints that stream tabular data.
+- `TagBasedAccessPolicy` now accepts a list of providers in addition to a
+  single provider string.
 
 ## v0.2.7 (2026-02-27)
 

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -72,7 +72,7 @@ class TagBasedAccessPolicy(AccessPolicy):
         access_tags_parser,
         scopes=None,
     ):
-        self.provider = provider
+        self.providers = [provider] if isinstance(provider, str) else list(provider)
         self.scopes = scopes if (scopes is not None) else ALL_SCOPES
 
         access_tags_parser = import_object(access_tags_parser)
@@ -92,11 +92,11 @@ class TagBasedAccessPolicy(AccessPolicy):
 
     def _get_id(self, principal):
         for identity in principal.identities:
-            if identity.provider == self.provider:
+            if identity.provider in self.providers:
                 return identity.id
         else:
             raise ValueError(
-                f"Principal {principal} has no identity from provider {self.provider}."
+                f"Principal {principal} has no identity from providers {self.providers}."
                 f"The Principal's identities are: {principal.identities}"
             )
 


### PR DESCRIPTION
Allow configuring multiple identity providers in `TagBasedAccessPolicy` by accepting either a single string or a list of strings for the provider parameter.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
