### PR TITLE
fix(streaming): Process stream updates without parallelism by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Array client fully supports slicing when communicating with the server
   and only fetches the data needed to satisfy the slice.
 - CSVArrayAdapter supports reading heterogenous tables as structured arrays
+- Stream updates are processed using a single worker thread, by
+  default, in order to guarantee that they are processed in order.
 
 ### Added
 

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -260,7 +260,10 @@ class Subscription(abc.ABC):
         Path to node of interest, given as a list of path segments
     executor : concurrent.futures.Executor, optional
         Launches tasks asynchronously, in response to updates. By default,
-        a concurrent.futures.ThreadPoolExecutor is used.
+        a concurrent.futures.ThreadPoolExecutor is used. It is
+        configured with a single worker thread, which guarantees that
+        updates will be processed sequentially in the order they are
+        received.
     """
 
     def __init__(
@@ -273,7 +276,7 @@ class Subscription(abc.ABC):
         self._context = context
         self._segments = segments
         self._executor = executor or concurrent.futures.ThreadPoolExecutor(
-            max_workers=5
+            max_workers=1
         )
         params = {"envelope_format": "msgpack"}
         scheme = "wss" if context.api_uri.scheme == "https" else "ws"


### PR DESCRIPTION
Prompted by discussion in https://github.com/bluesky/tiled/pull/1353#issuecomment-4315168072 about a flaky test that revealed an incorrect assumption.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
