### PR TITLE
Fix orjson pandas serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 - JSON serialization of tables now correctly handles numpy scalar types
   (e.g. `float32`, `int64`), pandas nullable types (`pd.NA`), `NaT`, and
-  `Timestamp` when using the `orjson` backend. Previously these raised a
-  `TypeError` because orjson is stricter than the stdlib `json` module.
-  Affects both `application/json` and `application/json-seq` responses.
+  `Timestamp` when using the `orjson` backend.
 - A `mount_node` referencing a nonexistent path in the database no longer causes
   silent data corruption. The server now raises a clear error at startup if the
   mount node does not exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- JSON serialization of tables now correctly handles numpy scalar types
+  (e.g. `float32`, `int64`), pandas nullable types (`pd.NA`), `NaT`, and
+  `Timestamp` when using the `orjson` backend. Previously these raised a
+  `TypeError` because orjson is stricter than the stdlib `json` module.
+  Affects both `application/json` and `application/json-seq` responses.
 - A `mount_node` referencing a nonexistent path in the database no longer causes
   silent data corruption. The server now raises a clear error at startup if the
   mount node does not exist.

--- a/tests/test_table_json_serialization.py
+++ b/tests/test_table_json_serialization.py
@@ -1,0 +1,146 @@
+"""Tests for JSON serialization of tables containing numpy/pandas types that
+orjson cannot handle natively (numpy scalars, pd.NA, NaT, Timestamp).
+
+Regression test for the _series_to_json_safe fix in
+tiled/serialization/table.py.
+"""
+
+import io
+import json
+
+import numpy
+import pandas
+import pytest
+
+from tiled.adapters.dataframe import DataFrameAdapter
+from tiled.adapters.mapping import MapAdapter
+from tiled.client import Context, from_context
+from tiled.server.app import build_app_from_config
+
+# DataFrame with every problematic type in one place:
+#   - numpy float32 / int32 (orjson rejects non-native numpy scalars)
+#   - pandas nullable Int64 with pd.NA
+#   - pandas nullable Float64 with pd.NA
+#   - datetime column with NaT
+#   - pandas Timestamp (object dtype)
+_df = pandas.DataFrame(
+    {
+        "float32_col": numpy.array([1.5, 2.5, float("nan")], dtype=numpy.float32),
+        "int32_col": numpy.array([1, 2, 3], dtype=numpy.int32),
+        "nullable_int": pandas.array([10, pandas.NA, 30], dtype="Int64"),
+        "nullable_float": pandas.array([1.1, pandas.NA, 3.3], dtype="Float64"),
+        "datetime_col": pandas.to_datetime(["2024-01-01", "NaT", "2024-03-01"]),
+        "timestamp_obj": pandas.array(
+            [pandas.Timestamp("2024-01-01"), pandas.NaT, pandas.Timestamp("2024-03-01")],
+            dtype=object,
+        ),
+    }
+)
+
+tree = MapAdapter({"df": DataFrameAdapter.from_pandas(_df, npartitions=1)})
+
+config = {
+    "trees": [
+        {
+            "tree": f"{__name__}:tree",
+            "path": "/",
+        },
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def client():
+    app = build_app_from_config(config)
+    with Context.from_app(app) as context:
+        yield from_context(context)
+
+
+def _read_json(client):
+    """Export the df node as application/json and return the parsed dict."""
+    buf = io.BytesIO()
+    client["df"].export(buf, format="application/json")
+    return json.loads(buf.getvalue())
+
+
+def _read_jsonseq(client):
+    """Export the df node as application/json-seq and return list of row dicts."""
+    buf = io.BytesIO()
+    client["df"].export(buf, format="application/json-seq")
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_numpy_float32(client, reader):
+    """numpy float32 values must round-trip through JSON without TypeError."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["float32_col"]
+    else:
+        col = [row["float32_col"] for row in result]
+    assert abs(col[0] - 1.5) < 1e-4
+    assert abs(col[1] - 2.5) < 1e-4
+    assert col[2] is None  # NaN → None
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_numpy_int32(client, reader):
+    """numpy int32 values must be serialized as plain Python ints."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["int32_col"]
+    else:
+        col = [row["int32_col"] for row in result]
+    assert col == [1, 2, 3]
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_pandas_na_int(client, reader):
+    """pandas NA in a nullable integer column must become None in JSON."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["nullable_int"]
+    else:
+        col = [row["nullable_int"] for row in result]
+    assert col[0] == 10
+    assert col[1] is None
+    assert col[2] == 30
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_pandas_na_float(client, reader):
+    """pandas NA in a nullable float column must become None in JSON."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["nullable_float"]
+    else:
+        col = [row["nullable_float"] for row in result]
+    assert abs(col[0] - 1.1) < 1e-6
+    assert col[1] is None
+    assert abs(col[2] - 3.3) < 1e-6
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_nat_datetime(client, reader):
+    """NaT in a datetime column must become None in JSON."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["datetime_col"]
+    else:
+        col = [row["datetime_col"] for row in result]
+    assert col[0] is not None  # valid date → ISO string
+    assert col[1] is None      # NaT → None
+    assert col[2] is not None
+
+
+@pytest.mark.parametrize("reader", [_read_json, _read_jsonseq])
+def test_timestamp_object(client, reader):
+    """pandas Timestamp in object-dtype column must be serialized as ISO string."""
+    result = reader(client)
+    if isinstance(result, dict):
+        col = result["timestamp_obj"]
+    else:
+        col = [row["timestamp_obj"] for row in result]
+    assert isinstance(col[0], str)
+    assert col[1] is None  # NaT → None
+    assert isinstance(col[2], str)

--- a/tests/test_table_json_serialization.py
+++ b/tests/test_table_json_serialization.py
@@ -1,8 +1,5 @@
 """Tests for JSON serialization of tables containing numpy/pandas types that
 orjson cannot handle natively (numpy scalars, pd.NA, NaT, Timestamp).
-
-Regression test for the _series_to_json_safe fix in
-tiled/serialization/table.py.
 """
 
 import io
@@ -31,7 +28,11 @@ _df = pandas.DataFrame(
         "nullable_float": pandas.array([1.1, pandas.NA, 3.3], dtype="Float64"),
         "datetime_col": pandas.to_datetime(["2024-01-01", "NaT", "2024-03-01"]),
         "timestamp_obj": pandas.array(
-            [pandas.Timestamp("2024-01-01"), pandas.NaT, pandas.Timestamp("2024-03-01")],
+            [
+                pandas.Timestamp("2024-01-01"),
+                pandas.NaT,
+                pandas.Timestamp("2024-03-01"),
+            ],
             dtype=object,
         ),
     }
@@ -129,7 +130,7 @@ def test_nat_datetime(client, reader):
     else:
         col = [row["datetime_col"] for row in result]
     assert col[0] is not None  # valid date → ISO string
-    assert col[1] is None      # NaT → None
+    assert col[1] is None  # NaT → None
     assert col[2] is not None
 
 

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -1,6 +1,9 @@
 import io
 import mimetypes
 
+import numpy
+import pandas
+
 from ..media_type_registration import (
     default_deserialization_registry,
     default_serialization_registry,
@@ -109,11 +112,37 @@ if modules_available("openpyxl", "pandas"):
 if modules_available("orjson"):
     import orjson
 
+    def _series_to_json_safe(series):
+        """Convert a pandas Series to a list of JSON-serializable Python values.
+
+        orjson is stricter than stdlib json: it rejects numpy scalars (float32,
+        int32, ...), pandas NA, and pandas NaT. Convert all of these to their
+        Python-native equivalents, with missing values becoming None.
+        """
+        arr = series.to_numpy(dtype=object, na_value=None)
+
+        def to_native(v):
+            if v is None:
+                return None
+            if isinstance(v, float) and numpy.isnan(v):
+                return None
+            if v is pandas.NaT:
+                return None
+            if isinstance(v, numpy.integer):
+                return int(v)
+            if isinstance(v, numpy.floating):
+                return float(v)
+            if isinstance(v, pandas.Timestamp):
+                return v.isoformat()
+            return v
+
+        return [to_native(v) for v in arr]
+
     default_serialization_registry.register(
         StructureFamily.table,
         "application/json",
         lambda mimetype, df, metadata: orjson.dumps(
-            {column: df[column].tolist() for column in df},
+            {column: _series_to_json_safe(df[column]) for column in df},
         ),
     )
 
@@ -131,15 +160,17 @@ if modules_available("orjson"):
         "application/json-seq",  # official mimetype for newline-delimited JSON
     )
     def json_sequence(mimetype, df, metadata):
-        if rows := df.to_dict(orient="records"):
-            # The first row is a special case; the rest start with a newline.
-            yield orjson.dumps(rows[0])
-            # Emit the remaining rows, prepending newline.
-            for row in rows[1:]:
-                yield b"\n" + orjson.dumps(row)
-        else:
-            # No rows
+        # Build a JSON-safe version of the dataframe once, then emit row-by-row.
+        safe = {column: _series_to_json_safe(df[column]) for column in df}
+        n = len(df)
+        if n == 0:
             yield b""
+            return
+        columns = list(safe)
+        # First row has no leading newline; subsequent rows do.
+        yield orjson.dumps({col: safe[col][0] for col in columns})
+        for i in range(1, n):
+            yield b"\n" + orjson.dumps({col: safe[col][i] for col in columns})
 
 
 if modules_available("h5py"):

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -1,9 +1,6 @@
 import io
 import mimetypes
 
-import numpy
-import pandas
-
 from ..media_type_registration import (
     default_deserialization_registry,
     default_serialization_registry,
@@ -109,6 +106,7 @@ if modules_available("openpyxl", "pandas"):
         lambda mimetype, buffer: pandas.read_excel(buffer),
     )
     mimetypes.types_map.setdefault(".xlsx", XLSX_MIME_TYPE)
+
 if modules_available("orjson"):
     import orjson
 
@@ -119,6 +117,8 @@ if modules_available("orjson"):
         int32, ...), pandas NA, and pandas NaT. Convert all of these to their
         Python-native equivalents, with missing values becoming None.
         """
+        import numpy
+
         arr = series.to_numpy(dtype=object, na_value=None)
 
         def to_native(v):


### PR DESCRIPTION
Fix JSON serialization of tables to correctly handle pandas nullable types (`pd.NA`), `NaT`, and `Timestamp` when using the `orjson` backend.
Previously these raised a `TypeError` because orjson is stricter than the stdlib `json` module.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
