### PR TITLE
Fix color image display in WebUI array viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Display of color images in the web UI array viewer.
 - JSON serialization of tables now correctly handles numpy scalar types
   (e.g. `float32`, `int64`), pandas nullable types (`pd.NA`), `NaT`, and
   `Timestamp` when using the `orjson` backend.

--- a/web-frontend/src/components/array-nd/array-nd.test.tsx
+++ b/web-frontend/src/components/array-nd/array-nd.test.tsx
@@ -114,4 +114,56 @@ describe("ArrayND", () => {
       expect.objectContaining({ responseType: "blob" }),
     );
   });
+
+  it("renders 3D RGB color image (H, W, 3) without any sliders", async () => {
+    const props = {
+      ...baseProps,
+      structure: { shape: [300, 451, 3] }, // color image: H=300, W=451, C=3
+    };
+    render(<ArrayND {...props} />);
+    await waitFor(() =>
+      screen.getByRole("img", { name: /Data rendered/i }),
+    );
+    // No cuts needed — last dim is the color channel
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/array?format=image/png",
+      expect.objectContaining({ responseType: "blob" }),
+    );
+    // No sliders for a single color image
+    expect(screen.queryAllByRole("slider")).toHaveLength(0);
+  });
+
+  it("renders 4D stack of RGB color images (N, H, W, 3) with one slider", async () => {
+    const props = {
+      ...baseProps,
+      structure: { shape: [10, 300, 451, 3] }, // stack of 10 color images
+    };
+    render(<ArrayND {...props} />);
+    await waitFor(() =>
+      screen.getByRole("img", { name: /Data rendered/i }),
+    );
+    // Cut at middle of stack dim (floor(10/2) = 5)
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/array?format=image/png&slice=5",
+      expect.objectContaining({ responseType: "blob" }),
+    );
+    // One slider for the N dimension
+    expect(screen.queryAllByRole("slider")).toHaveLength(1);
+  });
+
+  it("includes color channel in stride slice for large color images", async () => {
+    const props = {
+      ...baseProps,
+      structure: { shape: [3000, 3000, 3] }, // large RGB image, stride=3
+    };
+    render(<ArrayND {...props} />);
+    await waitFor(() =>
+      screen.getByRole("img", { name: /Data rendered/i }),
+    );
+    // Stride applied to H and W, color channel kept whole
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/array?format=image/png&slice=::3,::3,:",
+      expect.objectContaining({ responseType: "blob" }),
+    );
+  });
 });

--- a/web-frontend/src/components/array-nd/array-nd.tsx
+++ b/web-frontend/src/components/array-nd/array-nd.tsx
@@ -18,13 +18,32 @@ interface IProps {
   structure: components["schemas"]["Structure"];
 }
 
+/**
+ * Returns true if the last dimension of the shape looks like a color channel
+ * (RGB = 3, RGBA = 4). This lets us treat (H, W, 3) and (H, W, 4) arrays as
+ * color images rather than stacks of 2-D planes.
+ */
+function isColorImage(shape: number[]): boolean {
+  return shape.length >= 3 && (shape[shape.length - 1] === 3 || shape[shape.length - 1] === 4);
+}
+
 const ArrayND: React.FunctionComponent<IProps> = (props) => {
   const shape = props.structure!.shape as number[];
   const ndim = shape.length;
-  // Find the middle slice in all dimensions except the last two.
+
+  // Determine how many trailing dimensions belong to the image plane.
+  // For color images (last dim == 3 or 4) the image plane is (H, W, C) → 3 dims.
+  // For grayscale the image plane is (H, W) → 2 dims.
+  const imageDims = isColorImage(shape) ? 3 : 2;
+
+  // The number of "stack" dimensions that get sliders.
+  const stackDims = ndim - imageDims;
+
+  // Find the middle slice index for each stack dimension.
   const middles = shape
-    .slice(0, ndim - 2)
+    .slice(0, stackDims)
     .map((size: number) => Math.floor(size / 2));
+
   // Request an image from the server that is downsampled to be at most
   // 2X as big as it will be displayed.
   const theme = useTheme();
@@ -38,16 +57,22 @@ const ArrayND: React.FunctionComponent<IProps> = (props) => {
   } else {
     maxImageSize = theme.breakpoints.values.lg;
   }
-  // Compute a downsampling stride based on the largest dimension
-  // among the last two.
-  const stride = Math.ceil(
-    Math.max(...shape.slice(ndim - 2, ndim)) / maxImageSize,
-  );
+
+  // Compute a downsampling stride based on the largest spatial dimension
+  // (H and W, i.e. the two dimensions just before the optional color channel).
+  const spatialDims = shape.slice(stackDims, stackDims + 2);
+  const stride = Math.ceil(Math.max(...spatialDims) / maxImageSize);
+
   const [cuts, setCuts] = useState<number[]>(middles);
   return (
     <Box>
-      <ImageDisplay link={props.link} cuts={cuts} stride={stride} />
-      {shape.length > 2 ? (
+      <ImageDisplay
+        link={props.link}
+        cuts={cuts}
+        stride={stride}
+        isColor={isColorImage(shape)}
+      />
+      {stackDims > 0 ? (
         <Typography id="input-slider" gutterBottom>
           Choose a planar cut through this {shape.length}-dimensional array.
         </Typography>
@@ -63,7 +88,7 @@ const ArrayND: React.FunctionComponent<IProps> = (props) => {
       ) : (
         ""
       )}
-      {shape.slice(0, ndim - 2).map((size: number, index: number) => {
+      {shape.slice(0, stackDims).map((size: number, index: number) => {
         if (size > 1) {
           return (
             <CutSlider
@@ -95,13 +120,23 @@ interface ImageDisplayProps {
   link: string;
   cuts: number[];
   stride: number;
+  isColor: boolean;
 }
 
 const ImageDisplay: React.FunctionComponent<ImageDisplayProps> = (props) => {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  // Build the slice string:
+  //   - One integer per stack dimension (the "cut" value)
+  //   - ::stride for H (height)
+  //   - ::stride for W (width)
+  //   - For color images, no striding on the color channel (just ":" to select all)
   const sliceParts = props.cuts.map(c => c.toString());
   if (props.stride !== 1) {
     sliceParts.push(`::${props.stride}`, `::${props.stride}`);
+    if (props.isColor) {
+      sliceParts.push(`:`);
+    }
   }
   const url = sliceParts.length > 0
     ? `${props.link}?format=image/png&slice=${sliceParts.join(",")}`


### PR DESCRIPTION
ArrayND component was treating the last two dimensions as (H, W) for all arrays, which broke color images shaped (H, W, 3) or (H, W, 4) — the color channel was incorrectly used as the width axis.

Introduce isColorImage() heuristic: if the last dimension is 3 or 4, treat the last three dims as the image plane (H, W, C) and build sliders only over the remaining stack dimensions. The stride-based downsampling slice is also updated to stride only H and W, leaving the color channel whole (e.g. ::3,::3,:).

Add tests for RGB (H,W,3), stacked RGB (N,H,W,3), and large color image striding.

<img width="532" height="618" alt="image" src="https://github.com/user-attachments/assets/6bd077f6-951d-447d-96f1-15aaba9600c0" />

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
