### PR TITLE
Warn if `redirect_on_success` config is missing

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -206,6 +206,15 @@ authentication:
   #       client_id: YOUR_CLIENT_ID_HERE
   #       client_secret: ${OIDC_CLIENT_SECRET}
   #       well_known_uri: https://accounts.google.com/.well-known/openid-configuration
+  #
+  #       # REQUIRED for browser-based login (Web UI). After the OIDC provider
+  #       # authenticates the user, Tiled redirects to this URL with tokens in
+  #       # the query string. Point it at your UI's auth-callback route:
+  #       #   https://<BASE_URL>/ui/auth-callback
+  #       # Without this, the browser will see raw JSON tokens instead of being
+  #       # redirected back to the UI.
+  #       # Not needed for CLI-only (device flow) deployments.
+  #       redirect_on_success: https://<BASE_URL>/ui/auth-callback
 
 
   # OPTION 3 — Development / demo only: dictionary of hardcoded passwords

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -567,6 +567,21 @@ def build_app(
                     + API_KEY_MSG
                 )
 
+        # Warn if any external authenticator lacks redirect_on_success.
+        # Without it, browser-based OIDC login will show raw JSON tokens
+        # instead of redirecting back to the web UI.
+        for provider, authenticator in authenticators.items():
+            if isinstance(authenticator, ExternalAuthenticator):
+                if not getattr(authenticator, "redirect_on_success", None):
+                    logger.warning(
+                        f"External authenticator '{provider}' has no "
+                        f"'redirect_on_success' configured. Browser-based login "
+                        f"will return raw JSON tokens instead of redirecting to "
+                        f"the web UI. Set redirect_on_success to your UI's "
+                        f"auth-callback URL (e.g. "
+                        f"'https://example.com/ui/auth-callback')."
+                    )
+
         # Inject webhook_secret_keys into catalog contexts before startup tasks
         # run. When a 'webhooks:' config section is present, pass its
         # secret_keys (not the JWT auth keys). A non-None value enables the


### PR DESCRIPTION
Issues a startup warning when WebUI is enabled, but `redirerct_on_success` is not configured with an external authenticator.