### PR TITLE
Avoid printing error message when waiting for external authenticator

### DIFF
--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -173,7 +173,6 @@ def test_device_flow_success(
 
         LCWE-ROXW
 
-
         Waiting...
 
         You have logged in with Proxied OIDC as external user.
@@ -184,7 +183,6 @@ def test_device_flow_success(
     assert tokens == tokens_response
 
 
-@pytest.mark.xfail(reason="This should not fail,but needs investigation in stamina")
 @patch("tiled.client.context.time.sleep")
 def test_device_flow_polling(
     _: MagicMock,
@@ -225,8 +223,8 @@ def test_device_flow_polling(
 
         LCWE-ROXW
 
+        Waiting....
 
-        Waiting...
         You have logged in with Proxied OIDC as external user.
     """
     )

--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -175,6 +175,7 @@ def test_device_flow_success(
 
 
         Waiting...
+
         You have logged in with Proxied OIDC as external user.
     """
     )

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -1126,7 +1126,7 @@ and enter the code:
                         else access_response.json()["detail"]["error"]
                     )
                     if access_response_error == "authorization_pending":
-                        print(".", end="\n", flush=True)
+                        print(".", end="", flush=True)
                         # Don't raise -- this is expected during polling.
                         # Just break out of the retry context and let the
                         # outer while loop sleep and try again.

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -1085,7 +1085,8 @@ and enter the code:
 
 {verification['user_code']}
 
-"""
+""",
+        end="",
     )
     import webbrowser
 
@@ -1125,11 +1126,22 @@ and enter the code:
                         else access_response.json()["detail"]["error"]
                     )
                     if access_response_error == "authorization_pending":
-                        print(".", end="", flush=True)
-                        time.sleep(verification["interval"])
-                        access_response.raise_for_status()
+                        print(".", end="\n", flush=True)
+                        # Don't raise -- this is expected during polling.
+                        # Just break out of the retry context and let the
+                        # outer while loop sleep and try again.
+                        break
+                    # Other 400 errors are genuine failures.
+                    access_response.raise_for_status()
                 handle_error(access_response)
-        print("")
-        break
+        else:
+            # The for/else means we exhausted retries without break.
+            # This happens when handle_error(access_response) succeeds,
+            # meaning we got a successful response.
+            print("\n")
+            break
+        # We broke out of the for loop due to authorization_pending.
+        # Continue the outer while loop to poll again.
+        continue
     tokens = access_response.json()
     return tokens

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -130,11 +130,10 @@ def retry_context():
 
 
 def should_poll_for_tokens(exception: Exception) -> bool:
-    # If the error is an HTTP status error, only retry on 400.
-    if isinstance(exception, httpx.HTTPStatusError):
-        return exception.response.status_code == httpx.codes.BAD_REQUEST
-    else:
-        return False
+    # Retry on transient network errors during device flow polling.
+    if isinstance(exception, (httpx.ConnectError, httpx.TimeoutException)):
+        return True
+    return False
 
 
 def polling_retry_context(timeout: float):


### PR DESCRIPTION
In device flow, when waiting for the external authenticator, the expected `authorization_pending` 400 error message has not been properly caught and was being displayed in CLI during stamina retires.