### PR TITLE
Reconcile device code flow and API keys with ProxiedOIDCAuthenticator

### DIFF
--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -37,8 +37,8 @@ def external_policy() -> ExternalPolicyDecisionPoint:
 @pytest.fixture
 def principal() -> Principal:
     return Principal(
-        type=PrincipalType.external,
-        identities=[],
+        type=PrincipalType.user,
+        identities=[{"id": "alice", "provider": "dummy"}],
         uuid=uuid.uuid4(),
         access_token=SecretStr("token123"),
     )

--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -2,7 +2,6 @@ import textwrap
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Union
 from unittest.mock import MagicMock, patch
-from uuid import UUID
 
 import httpx
 import pytest
@@ -16,7 +15,6 @@ from tiled.client.auth import TiledAuth
 from tiled.client.constructors import from_context
 from tiled.client.context import prompt_for_credentials
 from tiled.server.app import build_app_from_config
-from tiled.server.schemas import Principal, PrincipalType
 
 tree = MapAdapter({})
 
@@ -92,7 +90,7 @@ def mock_oidc_server(
 
     respx_mock.post(
         well_known_response["device_authorization_endpoint"],
-        data={"client_id": device_flow_client_id, "scope": "openid offline_access"},
+        data={"client_id": device_flow_client_id, "scope": "offline_access openid"},
     ).mock(
         return_value=httpx.Response(
             status_code=httpx.codes.OK,
@@ -284,12 +282,7 @@ def test_whoami_endpoint(
 ):
     decode_token.return_value = decoded_token
     info = client.context.whoami()
-    assert info == Principal(
-        uuid=UUID(decoded_token["sub"]),
-        type=PrincipalType.external,
-        api_keys=[],
-        identities=[],
-    ).model_dump(mode="json")
+    assert info["identities"][0]["id"] == decoded_token["sub"]
 
 
 @patch("tiled.authenticators.OIDCAuthenticator.decode_token")

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -316,19 +316,31 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
         client_id: str,
         well_known_uri: str,
         device_flow_client_id: str,
-        scopes: Optional[List[str]] = None,
+        extra_scopes: Optional[List[str]] = None,
         confirmation_message: str = "",
         scopes_map: Optional[Dict[str, list[str]]] = None,
     ):
+        self.scopes_map = scopes_map if scopes_map is not None else {}
+        self.extra_scopes = extra_scopes or []
         super().__init__(
             audience,
             client_id,
             well_known_uri,
             device_flow_client_id,
-            scopes,
-            confirmation_message,
+            scopes=None,  # not used by Entra; enforcement is via scopes_map
+            confirmation_message=confirmation_message,
         )
-        self.scopes_map = scopes_map if scopes_map is not None else {}
+
+        @property
+        def scopes(self):
+            mapped = set()
+            for tiled_scopes in self.scopes_map.values():
+                mapped.update(tiled_scopes)
+            return list(mapped)
+
+        @scopes.setter
+        def scopes(self, value):
+            pass  # ignored; scopes are derived from scopes_map
 
     def decode_token(
         self, id_token: str, access_token: Optional[str] = None

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -138,7 +138,9 @@ def prompt_for_credentials(http_client, providers: List[AboutAuthenticationProvi
     elif mode == "external":
         # Display link and access code, and try to open web browser.
         # Block while polling the server awaiting confirmation of authorization.
-        scopes = " ".join({"openid", "offline_access"} | set(spec.extra_scopes or []))
+        scopes = " ".join(
+            sorted({"openid", "offline_access"} | set(spec.extra_scopes or []))
+        )
         tokens = device_code_grant(
             http_client,
             auth_endpoint,

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -138,8 +138,13 @@ def prompt_for_credentials(http_client, providers: List[AboutAuthenticationProvi
     elif mode == "external":
         # Display link and access code, and try to open web browser.
         # Block while polling the server awaiting confirmation of authorization.
+        scopes = " ".join({"openid", "offline_access"} | set(spec.extra_scopes or []))
         tokens = device_code_grant(
-            http_client, auth_endpoint, client_id, token_endpoint
+            http_client,
+            auth_endpoint,
+            client_id,
+            token_endpoint,
+            scopes,
         )
     else:
         raise ValueError(f"Server has unknown authentication mechanism {mode!r}")

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -1061,25 +1061,45 @@ def device_code_grant(
     for attempt in retry_context():
         with attempt:
             if client_id and token_endpoint:
+                # The device code will be given to the external OIDC provider.
                 oauth2_spec = True
-                uri = "verification_uri_complete"
                 verification_response = http_client.post(
                     auth_endpoint,
                     data={"client_id": client_id, "scope": scopes},
                 )
+                handle_error(verification_response)
+                verification = verification_response.json()
+                keys = [
+                    "verification_uri_complete",  # includes code
+                    "verification_uri",
+                    "verification_url",  # non-standard Entra
+                ]
+                for key in keys:
+                    verification_uri = verification.get(key)
+                    if verification_uri:
+                        break
+                else:
+                    raise KeyError(
+                        "Verification response is missing expected keys. "
+                        f"Expected one of {keys}. Got: {verification}"
+                    )
 
             else:
+                # The device code will be given to Tiled's own implementation
+                # of device code flow. Tiled will do authorization code from with the
+                # external providers. (This handles cases that ORCID and Globus that do
+                # not support device code flow.)
                 oauth2_spec = False
-                uri = "authorization_uri"
                 verification_response = http_client.post(auth_endpoint)
-            handle_error(verification_response)
-    verification = verification_response.json()
-    authorization_uri = verification[uri]
+                handle_error(verification_response)
+                verification = verification_response.json()
+                token_endpoint = verification["authorization_uri"]
+                verification_uri = verification["verification_uri"]
     print(
         f"""
 You have {int(verification['expires_in']) // 60} minutes to visit this URL
 
-{authorization_uri}
+{verification_uri}
 
 and enter the code:
 
@@ -1090,11 +1110,11 @@ and enter the code:
     )
     import webbrowser
 
-    webbrowser.open(authorization_uri)
-    deadline = verification["expires_in"] + time.monotonic()
+    webbrowser.open(verification_uri)
+    deadline = float(verification["expires_in"]) + time.monotonic()
     print("Waiting...", end="", flush=True)
     while True:
-        time.sleep(verification["interval"])
+        time.sleep(float(verification["interval"]))
         if time.monotonic() > deadline:
             raise Exception("Deadline expired.")
         for attempt in polling_retry_context(timeout=verification["expires_in"]):
@@ -1112,7 +1132,7 @@ and enter the code:
                     )
                 else:
                     access_response = http_client.post(
-                        verification["verification_uri"],
+                        token_endpoint,
                         json={
                             "device_code": verification["device_code"],
                             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",

--- a/tiled/schemas.py
+++ b/tiled/schemas.py
@@ -9,6 +9,7 @@ class AboutAuthenticationProvider(BaseModel):
     mode: Literal["internal", "external", "password"]
     links: Dict[str, str]
     confirmation_message: Optional[str] = None
+    extra_scopes: Optional[List[str]] = None
 
 
 class AboutAuthenticationLinks(BaseModel):

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -455,6 +455,8 @@ def build_app(
                 add_internal_routes(authentication_router, provider, authenticator)
             elif isinstance(authenticator, ExternalAuthenticator):
                 add_external_routes(authentication_router, provider, authenticator)
+                if isinstance(authenticator, ProxiedOIDCAuthenticator):
+                    app.state.provider = provider
             else:
                 raise ValueError(f"unknown authenticator type {type(authenticator)}")
             for custom_router in getattr(authenticator, "include_routers", []):

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -596,8 +596,10 @@ async def get_current_principal_websocket(
         return principal
     elif decoded_access_token is not None:
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            identity_id = decoded_access_token.get("user") or decoded_access_token["sub"]
-            provider = request.app.state.provider
+            identity_id = (
+                decoded_access_token.get("user") or decoded_access_token["sub"]
+            )
+            provider = websocket.app.state.provider
             async with db_factory() as db:
                 session = await create_session(
                     settings,
@@ -608,10 +610,7 @@ async def get_current_principal_websocket(
             principal = schemas.Principal(
                 uuid=session.principal.uuid,
                 type=schemas.PrincipalType.user,
-                identities=[
-                    schemas.Identity(id=identity_id, provider=provider)
-                ],
-                access_token=access_token,
+                identities=[schemas.Identity(id=identity_id, provider=provider)],
             )
         else:
             return schemas.Principal(
@@ -671,7 +670,9 @@ async def get_current_principal(
             )
     elif decoded_access_token is not None:
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            identity_id = decoded_access_token.get("user") or decoded_access_token["sub"]
+            identity_id = (
+                decoded_access_token.get("user") or decoded_access_token["sub"]
+            )
             provider = request.app.state.provider
             async with db_factory() as db:
                 session = await create_session(
@@ -683,10 +684,7 @@ async def get_current_principal(
             principal = schemas.Principal(
                 uuid=session.principal.uuid,
                 type=schemas.PrincipalType.user,
-                identities=[
-                    schemas.Identity(id=identity_id, provider=provider)
-                ],
-                access_token=access_token,
+                identities=[schemas.Identity(id=identity_id, provider=provider)],
             )
         else:
             principal = schemas.Principal(

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -478,7 +478,7 @@ async def authenticate_websocket_first_message(
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
             principal = schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded["sub"]),
-                type=schemas.PrincipalType.external,
+                type=schemas.PrincipalType.user,
                 identities=[],
             )
             scopes = set(decoded["scope"].split(" "))
@@ -596,10 +596,22 @@ async def get_current_principal_websocket(
         return principal
     elif decoded_access_token is not None:
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            return schemas.Principal(
-                uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
-                type=schemas.PrincipalType.external,
-                identities=[],
+            identity_id = decoded_access_token.get("user") or decoded_access_token["sub"]
+            provider = request.app.state.provider
+            async with db_factory() as db:
+                session = await create_session(
+                    settings,
+                    db,
+                    provider,
+                    identity_id,
+                )
+            principal = schemas.Principal(
+                uuid=session.principal.uuid,
+                type=schemas.PrincipalType.user,
+                identities=[
+                    schemas.Identity(id=identity_id, provider=provider)
+                ],
+                access_token=access_token,
             )
         else:
             return schemas.Principal(
@@ -657,26 +669,34 @@ async def get_current_principal(
                 detail="Invalid API key",
                 headers=headers_for_401(request, security_scopes),
             )
-    elif decoded_access_token is not None and not isinstance(
-        settings.authenticator, ProxiedOIDCAuthenticator
-    ):
-        principal = schemas.Principal(
-            uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
-            type=decoded_access_token["sub_typ"],
-            identities=[
-                schemas.Identity(id=identity["id"], provider=identity["idp"])
-                for identity in decoded_access_token["ids"]
-            ],
-        )
-    elif decoded_access_token is not None and isinstance(
-        settings.authenticator, ProxiedOIDCAuthenticator
-    ):
-        principal = schemas.Principal(
-            uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
-            type=schemas.PrincipalType.external,
-            identities=[],
-            access_token=access_token,
-        )
+    elif decoded_access_token is not None:
+        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
+            identity_id = decoded_access_token.get("user") or decoded_access_token["sub"]
+            provider = request.app.state.provider
+            async with db_factory() as db:
+                session = await create_session(
+                    settings,
+                    db,
+                    provider,
+                    identity_id,
+                )
+            principal = schemas.Principal(
+                uuid=session.principal.uuid,
+                type=schemas.PrincipalType.user,
+                identities=[
+                    schemas.Identity(id=identity_id, provider=provider)
+                ],
+                access_token=access_token,
+            )
+        else:
+            principal = schemas.Principal(
+                uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
+                type=decoded_access_token["sub_typ"],
+                identities=[
+                    schemas.Identity(id=identity["id"], provider=identity["idp"])
+                    for identity in decoded_access_token["ids"]
+                ],
+            )
     else:
         # No form of authentication is present.
         principal = None
@@ -1596,12 +1616,6 @@ def authentication_router() -> APIRouter:
         request.state.endpoint = "auth"
         if principal is None:
             return json_or_msgpack(request, None)
-
-        if principal and principal.type == schemas.PrincipalType.external:
-            return json_or_msgpack(
-                request,
-                principal.model_dump(),
-            )
 
         # The principal from get_current_principal tells us everything that the
         # access_token carries around, but the database knows more than that.

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -236,6 +236,7 @@ def get_router(
                         "client_id": authenticator.device_flow_client_id,
                         "token_endpoint": authenticator.token_endpoint,
                     },
+                    "extra_scopes": getattr(authenticator, "extra_scopes", []),
                     "confirmation_message": getattr(
                         authenticator, "confirmation_message", None
                     ),

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -300,7 +300,6 @@ class DeviceCode(pydantic.BaseModel):
 class PrincipalType(str, enum.Enum):
     user = "user"
     service = "service"
-    external = "external"
 
 
 class Identity(pydantic.BaseModel):


### PR DESCRIPTION
~~This is still not fully working with Entra. I think the remaining issues are all due to configuration on the Entra side; the code here _may_ be correct. But let's hold until we can confirm a fully working run.~~

---

Login works:

```python
In [1]: from tiled.client import from_uri, show_logs

In [2]: c = from_uri('https://tiled-demo.nsls2.bnl.gov')

In [3]: c.login()

You have 15 minutes to visit this URL

https://login.microsoft.com/device

and enter the code:

F34ED9KWN

Waiting....


In [4]: c
Out[4]: <Container {'bmm', 'csx', 'fxi', 'examples', 'amx', 'hxn'}>
```

A critical step is on the Entra side: set `accessTokenAcceptedVersion: 2` in the Entra App Manifest (JSON settings).

It remains to fixed that `ProxiedOIDCAuthenticator` does not create a Principal with Roles or Identities in Tiled, which breaks API key functionality.

```python
In [5]: c.context
Out[5]: <Context authenticated as >

In [6]: c.context.whoami()
Out[6]:
{'uuid': '023e49c0-5524-5fd2-b3af-ef36722bd090',
 'type': 'external',
 'identities': [],
 'roles': [],
 'api_keys': [],
 'sessions': [],
 'latest_activity': None}
```

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
