### PR TITLE
Fix entra auth

### DIFF
--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -140,6 +140,7 @@ def test_about_endpoint(
     assert response.status_code == httpx.codes.OK
     assert response.json()["authentication"]["providers"][0]["links"] == {
         "auth_endpoint": well_known_response["device_authorization_endpoint"],
+        "authorize_endpoint": f"{context.http_client.base_url}/api/v1/auth/provider/keycloak_oidc/authorize",
         "client_id": oidc_config["authentication"]["providers"][0]["args"][
             "device_flow_client_id"
         ],

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -319,6 +319,8 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
         extra_scopes: Optional[List[str]] = None,
         confirmation_message: str = "",
         scopes_map: Optional[Dict[str, list[str]]] = None,
+        client_secret: str = "",
+        redirect_on_success: Optional[str] = None,
     ):
         self.scopes_map = scopes_map if scopes_map is not None else {}
         self.extra_scopes = extra_scopes or []
@@ -330,6 +332,10 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
             scopes=None,  # not used by Entra; enforcement is via scopes_map
             confirmation_message=confirmation_message,
         )
+        # Override the empty secret from ProxiedOIDCAuthenticator if provided.
+        if client_secret:
+            self._client_secret = Secret(client_secret)
+        self.redirect_on_success = redirect_on_success
 
         @property
         def scopes(self):

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -379,15 +379,24 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
                 user = user.split("@", 1)[0]
         claims["user"] = user
 
-        # Translate Entra scopes to tiled scopes
-        entra_scopes = claims["scp"].split(" ")
+        # Translate Entra scopes to tiled scopes.
+        # The "scp" claim is present in access tokens but may be absent from
+        # id_tokens (e.g. during the authorization code flow).  When absent,
+        # assume all mapped scopes were granted (Entra would not have issued
+        # the tokens if the user lacked the requested scopes).
+        scp_raw = claims.get("scp", "")
         tiled_scope_set = set()
-        for scope in entra_scopes:
-            mapped_scopes = self.scopes_map.get(scope)
-            if mapped_scopes is None:
-                logger.warning("Unmapped Entra scope in 'scp': %s", scope)
-                continue
-            tiled_scope_set.update(mapped_scopes)
+        if scp_raw:
+            for scope in scp_raw.split(" "):
+                mapped_scopes = self.scopes_map.get(scope)
+                if mapped_scopes is None:
+                    logger.warning("Unmapped Entra scope in 'scp': %s", scope)
+                    continue
+                tiled_scope_set.update(mapped_scopes)
+        else:
+            # No scp claim — grant all tiled scopes from the map.
+            for mapped_scopes in self.scopes_map.values():
+                tiled_scope_set.update(mapped_scopes)
         claims["scope"] = " ".join(tiled_scope_set)
 
         return claims

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -401,6 +401,39 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
 
         return claims
 
+    async def authenticate(self, request: Request) -> Optional[UserSessionState]:
+        code = request.query_params.get("code")
+        if not code:
+            logger.warning(
+                "Authentication failed: No authorization code parameter provided."
+            )
+            return None
+        redirect_uri = f"{get_root_url(request)}{request.url.path}"
+        response = await exchange_code(
+            self.token_endpoint,
+            code,
+            self._client_id,
+            self._client_secret.get_secret_value(),
+            redirect_uri,
+        )
+        response_body = response.json()
+        if response.is_error:
+            logger.error("Authentication error: %r", response_body)
+            return None
+        id_token = response_body["id_token"]
+        access_token = response_body.get("access_token")
+        try:
+            verified_body = self.decode_token(id_token, access_token)
+        except JWTError:
+            logger.exception(
+                "Authentication error. Unverified token: %r",
+                jwt.get_unverified_claims(id_token),
+            )
+            return None
+        # Use the human-readable username (e.g. "dallan") instead of the
+        # opaque UUID-based "sub" that OIDCAuthenticator would use.
+        return UserSessionState(verified_body["user"], {})
+
 
 async def exchange_code(
     token_uri: str,

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -432,7 +432,8 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
             return None
         # Use the human-readable username (e.g. "dallan") instead of the
         # opaque UUID-based "sub" that OIDCAuthenticator would use.
-        return UserSessionState(verified_body["user"], {})
+        username = verified_body.get("user") or verified_body["sub"]
+        return UserSessionState(username, {})
 
 
 async def exchange_code(

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -511,7 +511,7 @@ async def authenticate_websocket_first_message(
                     for identity in decoded["ids"]
                 ],
             )
-            scopes = decoded["scp"]
+            scopes = set(decoded["scp"])
         return True, principal, None, scopes
     else:
         return False, None, None, NO_SCOPES
@@ -644,6 +644,7 @@ async def get_current_principal_websocket(
                     type=schemas.PrincipalType.user,
                     identities=[schemas.Identity(id=identity_id, provider=provider)],
                 )
+            return principal
         else:
             return schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -379,6 +379,24 @@ async def get_scopes_from_api_key(
         return scopes
 
 
+def _extract_scopes(
+    decoded_access_token: dict[str, Any],
+    authenticator: Optional[ProxiedOIDCAuthenticator],
+) -> set[str]:
+    """Extract scopes from a decoded access token.
+
+    Tiled-minted tokens (auth code flow) store scopes as a list under "scp".
+    OIDC-provider tokens (device code flow) store them as a space-separated
+    string under "scope".  Handle both.
+    """
+    if "scp" in decoded_access_token:
+        scp = decoded_access_token["scp"]
+        return set(scp) if isinstance(scp, list) else set(scp.split(" "))
+    if "scope" in decoded_access_token:
+        return set(decoded_access_token["scope"].split(" "))
+    return set()
+
+
 async def get_current_scopes(
     request: Request,
     decoded_access_token: Optional[dict[str, Any]] = Depends(get_decoded_access_token),
@@ -394,10 +412,7 @@ async def get_current_scopes(
                 api_key, settings, request.app.state.authenticated, db
             )
     elif decoded_access_token is not None:
-        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            return set(decoded_access_token["scope"].split(" "))
-        else:
-            return decoded_access_token["scp"]
+        return _extract_scopes(decoded_access_token, settings.authenticator)
     else:
         return PUBLIC_SCOPES if settings.allow_anonymous_access else NO_SCOPES
 
@@ -417,10 +432,7 @@ async def get_current_scopes_websocket(
                 api_key, settings, websocket.app.state.authenticated, db
             )
     elif decoded_access_token is not None:
-        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            return set(decoded_access_token["scope"].split(" "))
-        else:
-            return decoded_access_token["scp"]
+        return _extract_scopes(decoded_access_token, settings.authenticator)
     else:
         return PUBLIC_SCOPES if settings.allow_anonymous_access else NO_SCOPES
 
@@ -472,12 +484,24 @@ async def authenticate_websocket_first_message(
         except Exception:
             return False, None, None, NO_SCOPES
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            principal = schemas.Principal(
-                uuid=uuid_module.UUID(hex=decoded["sub"]),
-                type=schemas.PrincipalType.user,
-                identities=[],
-            )
-            scopes = set(decoded["scope"].split(" "))
+            # Tiled-minted tokens (auth code flow) include "sub_typ" and "ids";
+            # Entra-minted tokens (device code flow) do not.
+            if "sub_typ" in decoded:
+                principal = schemas.Principal(
+                    uuid=uuid_module.UUID(hex=decoded["sub"]),
+                    type=decoded["sub_typ"],
+                    identities=[
+                        schemas.Identity(id=identity["id"], provider=identity["idp"])
+                        for identity in decoded["ids"]
+                    ],
+                )
+            else:
+                principal = schemas.Principal(
+                    uuid=uuid_module.UUID(hex=decoded["sub"]),
+                    type=schemas.PrincipalType.user,
+                    identities=[],
+                )
+            scopes = _extract_scopes(decoded, settings.authenticator)
         else:
             principal = schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded["sub"]),
@@ -592,22 +616,34 @@ async def get_current_principal_websocket(
         return principal
     elif decoded_access_token is not None:
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            identity_id = (
-                decoded_access_token.get("user") or decoded_access_token["sub"]
-            )
-            provider = websocket.app.state.provider
-            async with db_factory() as db:
-                session = await create_session(
-                    settings,
-                    db,
-                    provider,
-                    identity_id,
+            if "sub_typ" in decoded_access_token:
+                # Tiled-minted token (auth code flow).
+                principal = schemas.Principal(
+                    uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
+                    type=decoded_access_token["sub_typ"],
+                    identities=[
+                        schemas.Identity(id=identity["id"], provider=identity["idp"])
+                        for identity in decoded_access_token["ids"]
+                    ],
                 )
-            principal = schemas.Principal(
-                uuid=session.principal.uuid,
-                type=schemas.PrincipalType.user,
-                identities=[schemas.Identity(id=identity_id, provider=provider)],
-            )
+            else:
+                # Entra-minted token (device code flow).
+                identity_id = (
+                    decoded_access_token.get("user") or decoded_access_token["sub"]
+                )
+                provider = websocket.app.state.provider
+                async with db_factory() as db:
+                    session = await create_session(
+                        settings,
+                        db,
+                        provider,
+                        identity_id,
+                    )
+                principal = schemas.Principal(
+                    uuid=session.principal.uuid,
+                    type=schemas.PrincipalType.user,
+                    identities=[schemas.Identity(id=identity_id, provider=provider)],
+                )
         else:
             return schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
@@ -666,22 +702,34 @@ async def get_current_principal(
             )
     elif decoded_access_token is not None:
         if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            identity_id = (
-                decoded_access_token.get("user") or decoded_access_token["sub"]
-            )
-            provider = request.app.state.provider
-            async with db_factory() as db:
-                session = await create_session(
-                    settings,
-                    db,
-                    provider,
-                    identity_id,
+            if "sub_typ" in decoded_access_token:
+                # Tiled-minted token (auth code flow): use the full claims.
+                principal = schemas.Principal(
+                    uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
+                    type=decoded_access_token["sub_typ"],
+                    identities=[
+                        schemas.Identity(id=identity["id"], provider=identity["idp"])
+                        for identity in decoded_access_token["ids"]
+                    ],
                 )
-            principal = schemas.Principal(
-                uuid=session.principal.uuid,
-                type=schemas.PrincipalType.user,
-                identities=[schemas.Identity(id=identity_id, provider=provider)],
-            )
+            else:
+                # Entra-minted token (device code flow): look up / create session.
+                identity_id = (
+                    decoded_access_token.get("user") or decoded_access_token["sub"]
+                )
+                provider = request.app.state.provider
+                async with db_factory() as db:
+                    session = await create_session(
+                        settings,
+                        db,
+                        provider,
+                        identity_id,
+                    )
+                principal = schemas.Principal(
+                    uuid=session.principal.uuid,
+                    type=schemas.PrincipalType.user,
+                    identities=[schemas.Identity(id=identity_id, provider=provider)],
+                )
         else:
             principal = schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -158,25 +158,21 @@ def decode_token(
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
+    # Try tiled-issued keys first (covers both normal auth and auth-code flow
+    # tokens issued via create_tokens_from_session).
+    for secret_key in secret_keys:
+        try:
+            payload = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
+            return payload
+        except ExpiredSignatureError:
+            raise
+        except JWTError:
+            continue
+    # If none of the tiled keys worked, try the proxied authenticator
+    # (e.g. tokens issued directly by an OIDC provider in the device code flow).
     if proxied_authenticator:
         return proxied_authenticator.decode_token(token)
-    else:
-        # The first key in settings.secret_keys is used for *encoding*.
-        # All keys are tried for *decoding* until one works or they all
-        # fail. They supports key rotation.
-        for secret_key in secret_keys:
-            try:
-                payload = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
-                break
-            except ExpiredSignatureError:
-                # Do not let this be caught below with the other JWTError types.
-                raise
-            except JWTError:
-                # Try the next key in the key rotation.
-                continue
-        else:
-            raise credentials_exception
-    return payload
+    raise credentials_exception
 
 
 async def get_api_key(
@@ -912,10 +908,12 @@ def add_external_routes(
 
         redirect_uri = f"{get_base_url(request)}/auth/provider/{provider}/code"
 
+        scopes = {"openid", "offline_access"}
+        scopes.update(getattr(authenticator, "extra_scopes", []))
         params = {
             "client_id": authenticator.client_id,
             "response_type": "code",
-            "scope": "openid",
+            "scope": " ".join(sorted(scopes)),
             "redirect_uri": redirect_uri,
             "prompt": "login",
         }

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -233,6 +233,7 @@ def get_router(
                     "mode": "external",
                     "links": {
                         "auth_endpoint": authenticator.device_authorization_endpoint,
+                        "authorize_endpoint": f"{base_url}/auth/provider/{provider}/authorize",
                         "client_id": authenticator.device_flow_client_id,
                         "token_endpoint": authenticator.token_endpoint,
                     },

--- a/web-frontend/src/routes/login.tsx
+++ b/web-frontend/src/routes/login.tsx
@@ -104,7 +104,10 @@ function PasswordLogin({
 function ExternalLogin({ provider }: { provider: Provider }) {
   const handleClick = () => {
     const state = encodeURIComponent(window.location.href);
-    window.location.href = `${provider.links.auth_endpoint}?state=${state}`;
+    // Prefer authorize_endpoint (browser auth code flow) over auth_endpoint
+    // (device code flow, for CLI clients).
+    const endpoint = provider.links.authorize_endpoint ?? provider.links.auth_endpoint;
+    window.location.href = `${endpoint}?state=${state}`;
   };
 
   return (


### PR DESCRIPTION
## Introduced Changes

### `tiled/authenticators.py` — EntraAuthenticator enhancements

1. **`__init__`**: accepts optional `client_secret` and `redirect_on_success`. Overrides the empty string from `ProxiedOIDCAuthenticator` when `client_secret` is provided. *Needed for: auth code flow requires a secret to exchange the code for tokens.*

2. **`decode_token`**: `scp` claim handled defensively with `.get("scp", "")`. When absent (id_token in auth code flow), all `scopes_map` values are granted. *Needed for: id_tokens from Entra don't contain `scp`, only access tokens do.*

3. **`authenticate`** (new override): Full implementation instead of delegating to `super()`. Returns `UserSessionState(username, {})` where `username` is `verified_body["user"]` (human-readable) with fallback to `verified_body["sub"]` (UUID). *Needed for: (a) `OIDCAuthenticator.authenticate` uses `sub` which is an opaque UUID, (b) calling `super()` then re-exchanging the code fails because Entra codes are single-use.*

### `tiled/server/authentication.py` — dual token format support

4. **`decode_token`**: tries tiled secret keys (HS256) first, falls back to `proxied_authenticator.decode_token` (RS256). *Needed for: auth code flow mints tiled JWTs (HS256 via `create_tokens_from_session`), but the old code sent them to Entra's decoder which only accepts RS256.*

5. **`_extract_scopes` helper** (new): handles both `scp` (list, tiled-minted) and `scope` (space-separated string, Entra-minted). *Needed for: tiled tokens use `"scp": [...]`, Entra tokens use `"scope": "..."`. The old code hardcoded `decoded["scope"].split(" ")`.*

6. **`get_current_scopes` + websocket variant**: use `_extract_scopes` instead of the hardcoded `decoded["scope"]` pattern. *Needed for: prevented `KeyError: 'scope'` on tiled-minted tokens.*

7. **`get_current_principal` + websocket variant**: when token has `sub_typ` (tiled-minted), construct principal directly from token claims. Otherwise (Entra-minted), look up/create session as before. *Needed for: tiled-minted tokens have `sub` = principal UUID, not identity ID. Using it as `identity_id` in `create_session` would create broken identity records.*

8. **`authenticate_websocket_first_message`**: same tiled-vs-Entra branching for principal construction + uses `_extract_scopes`. *Needed for: same reasons as #7 and #6.*

9. **`authorize_redirect_route`**: includes `extra_scopes` and `offline_access` in the OAuth scope request to Entra. *Needed for: without requesting `api://{client_id}/access_as_user`, Entra issues a Graph API token instead of an app token.*

### `tiled/server/router.py`

10. **Provider spec**: adds `authorize_endpoint` link to `ProxiedOIDCAuthenticator` providers. *Needed for: browser needs the auth code flow URL (`/auth/provider/{name}/authorize`), not the device code URL.*

### `web-frontend/src/routes/login.tsx`

11. **`ExternalLogin`**: prefers `authorize_endpoint` (browser flow) over `auth_endpoint` (CLI device code flow). *Needed for: without this, clicking "Login" redirects to the device code endpoint which returns `{"detail":"Not Found"}`.*

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
