### PR TITLE
Fix refresh flow for Entra by providing scopes.

### DIFF
--- a/tiled/client/auth.py
+++ b/tiled/client/auth.py
@@ -13,7 +13,12 @@ class CannotRefreshAuthentication(Exception):
 
 class TiledAuth(httpx.Auth):
     def __init__(
-        self, refresh_url, csrf_token, token_directory, client_id: Optional[str] = None
+        self,
+        refresh_url,
+        csrf_token,
+        token_directory,
+        client_id: Optional[str] = None,
+        scopes: Optional[str] = None,
     ):
         self.refresh_url = refresh_url
         self.csrf_token = csrf_token
@@ -26,6 +31,7 @@ class TiledAuth(httpx.Auth):
         # self._async_lock = asyncio.Lock()
         self.tokens = {}
         self.client_id = client_id
+        self.scopes = scopes
 
     @staticmethod
     def _check_writable_token_directory(token_directory):
@@ -117,7 +123,11 @@ class TiledAuth(httpx.Auth):
                     "For a given client c, use c.context.authenticate()."
                 )
             token_request = build_refresh_request(
-                self.refresh_url, refresh_token, self.csrf_token, self.client_id
+                self.refresh_url,
+                refresh_token,
+                self.csrf_token,
+                self.client_id,
+                self.scopes,
             )
             token_response = yield token_request
             if token_response.status_code == httpx.codes.UNAUTHORIZED:
@@ -158,7 +168,11 @@ class TiledAuth(httpx.Auth):
 
 
 def build_refresh_request(
-    refresh_url, refresh_token, csrf_token, client_id: Optional[str] = None
+    refresh_url,
+    refresh_token,
+    csrf_token,
+    client_id: Optional[str] = None,
+    scopes: Optional[str] = None,
 ):
     if client_id:
         return httpx.Request(
@@ -168,6 +182,7 @@ def build_refresh_request(
                 "client_id": client_id,
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
+                **({"scope": scopes} if scopes else {}),
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -297,6 +297,17 @@ class Context:
             if len(self.server_info.authentication.providers) == 1
             else None
         )
+        provider = (
+            self.server_info.authentication.providers[0]
+            if len(self.server_info.authentication.providers) == 1
+            else None
+        )
+        extra_scopes = getattr(provider, "extra_scopes", None) or []
+        self.scopes = (
+            " ".join(sorted({"openid", "offline_access"} | set(extra_scopes)))
+            if extra_scopes
+            else None
+        )
         # To determine httpx.Auth used by Tiled client is TiledAuth(internal) or external Auth
         self.has_external_auth = False
 
@@ -716,7 +727,9 @@ class Context:
             temp_auth.sync_clear_token("refresh_token")
             # Store tokens in memory only, with no syncing to disk.
             token_directory = None
-        auth = TiledAuth(refresh_url, csrf_token, token_directory)
+        auth = TiledAuth(
+            refresh_url, csrf_token, token_directory, self.client_id, self.scopes
+        )
         auth.sync_tokens(tokens)
         self.http_client.auth = auth
 
@@ -777,7 +790,11 @@ class Context:
         # We have to make an HTTP request to let the server validate whether we
         # have a valid session.
         self.http_client.auth = TiledAuth(
-            refresh_url, csrf_token, token_directory, self.client_id
+            refresh_url,
+            csrf_token,
+            token_directory,
+            self.client_id,
+            self.scopes,
         )
         # This will either:
         # * Use an access_token and succeed.
@@ -816,6 +833,7 @@ class Context:
             refresh_token,
             csrf_token,
             self.http_client.auth.client_id,
+            self.http_client.auth.scopes,
         )
         for attempt in retry_context():
             with attempt:


### PR DESCRIPTION
Follow-up to #1381. Entra auth worked but refresh failed. Reproduce bug with:

```python
from tiled.client import from_uri, show_logs
c = from_uri('https://tiled-staging.nsls2.bnl.gov')
c.context.force_auth_refresh()
```

Current `main` gets this response on refresh:

```
ipdb> p token_response.json()
{'error': 'invalid_request', 'error_description': "AADSTS90009: Application '362d7249-4150-40eb-8040-2d8f0934943d'(362d7249-4150-40eb-8040-2d8f0934943d) is requesting a token for itself. This scenario is supported only if resource is specified using the GUID based App Identifier. Trace ID: 373480da-37b2-4f4d-a0ea-b97eb0065e00 Correlation ID: 3940d4ab-2b7b-4602-a3c9-cf7cc8d2f649 Timestamp: 2026-05-12 17:13:19Z", 'error_codes': [90009], 'timestamp': '2026-05-12 17:13:19Z', 'trace_id': '373480da-37b2-4f4d-a0ea-b97eb0065e00', 'correlation_id': '3940d4ab-2b7b-4602-a3c9-cf7cc8d2f649'}
```

but now it works as expected by provided the required scopes.