### PR TITLE
More OIDC follow-up

### DIFF
--- a/example_configs/keycloak_oidc/tiled_policy/example_pdp.py
+++ b/example_configs/keycloak_oidc/tiled_policy/example_pdp.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import HttpUrl
 
 from tiled.access_control.access_policies import ExternalPolicyDecisionPoint
-from tiled.server.schemas import Principal, PrincipalType
+from tiled.server.schemas import Principal
 from tiled.type_aliases import AccessBlob, AccessTags, Scopes
 
 
@@ -42,10 +42,7 @@ class ExampleAuthorizationPolicy(ExternalPolicyDecisionPoint):
     ) -> str:
         _input = {"audience": self._token_audience}
 
-        if (
-            principal.type is PrincipalType.external
-            and principal.access_token is not None
-        ):
+        if principal.access_token is not None:
             _input["token"] = principal.access_token.get_secret_value()
 
         if access_blob is not None:

--- a/tiled/authn_database/core.py
+++ b/tiled/authn_database/core.py
@@ -331,3 +331,30 @@ async def latest_principal_activity(
     if all([t is None for t in all_activity]):
         return None
     return max(t for t in all_activity if t is not None)
+
+
+async def get_or_create_principal(
+    db: AsyncSession, identity_provider: str, id: str
+) -> Principal:
+    """
+    Look up a Principal by identity, creating one if it does not exist.
+    Does not create a Session -- intended for proxied OIDC where session
+    management is handled externally.
+    """
+    identity = (
+        await db.execute(
+            select(Identity)
+            .options(
+                selectinload(Identity.principal).selectinload(Principal.roles),
+                selectinload(Identity.principal).selectinload(Principal.identities),
+            )
+            .filter(Identity.id == id)
+            .filter(Identity.provider == identity_provider)
+        )
+    ).scalar()
+    if identity is not None:
+        now = datetime.now(timezone.utc)
+        identity.latest_login = now
+        await db.commit()
+        return identity.principal
+    return await create_user(db, identity_provider, id)

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -57,6 +57,7 @@ from ..authn_database import orm
 from ..authn_database.core import (
     create_service,
     create_user,
+    get_or_create_principal,
     latest_principal_activity,
     lookup_valid_api_key,
     lookup_valid_pending_session_by_device_code,
@@ -512,12 +513,14 @@ async def authenticate_websocket_first_message(
                         schemas.Identity(id=identity["id"], provider=identity["idp"])
                         for identity in decoded["ids"]
                     ],
+                    access_token=decoded,
                 )
             else:
                 principal = schemas.Principal(
                     uuid=uuid_module.UUID(hex=decoded["sub"]),
                     type=schemas.PrincipalType.user,
                     identities=[],
+                    access_token=decoded,
                 )
             scopes = _extract_scopes(decoded, settings.authenticator)
         else:
@@ -528,6 +531,7 @@ async def authenticate_websocket_first_message(
                     schemas.Identity(id=identity["id"], provider=identity["idp"])
                     for identity in decoded["ids"]
                 ],
+                access_token=decoded,
             )
             scopes = set(decoded["scp"])
         return True, principal, None, scopes
@@ -633,45 +637,36 @@ async def get_current_principal_websocket(
             )
         return principal
     elif decoded_access_token is not None:
-        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            if "sub_typ" in decoded_access_token:
-                # Tiled-minted token (auth code flow).
-                principal = schemas.Principal(
-                    uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
-                    type=decoded_access_token["sub_typ"],
-                    identities=[
-                        schemas.Identity(id=identity["id"], provider=identity["idp"])
-                        for identity in decoded_access_token["ids"]
-                    ],
-                )
-            else:
-                # Entra-minted token (device code flow).
-                identity_id = (
-                    decoded_access_token.get("user") or decoded_access_token["sub"]
-                )
-                provider = websocket.app.state.provider
-                async with db_factory() as db:
-                    session = await create_session(
-                        settings,
-                        db,
-                        provider,
-                        identity_id,
-                    )
-                principal = schemas.Principal(
-                    uuid=session.principal.uuid,
-                    type=schemas.PrincipalType.user,
-                    identities=[schemas.Identity(id=identity_id, provider=provider)],
-                )
-            return principal
-        else:
-            return schemas.Principal(
+        if "sub_typ" in decoded_access_token:
+            # Token minted by Tiled's OAuth2 implementation
+            principal = schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
                 type=decoded_access_token["sub_typ"],
                 identities=[
                     schemas.Identity(id=identity["id"], provider=identity["idp"])
                     for identity in decoded_access_token["ids"]
                 ],
+                access_token=decoded_access_token,
             )
+        else:
+            # Token minted by external OIDC provider
+            identity_id = (
+                decoded_access_token.get("user") or decoded_access_token["sub"]
+            )
+            provider = websocket.app.state.provider
+            async with db_factory() as db:
+                session = await get_or_create_principal(
+                    db,
+                    provider,
+                    identity_id,
+                )
+            principal = schemas.Principal(
+                uuid=session.principal.uuid,
+                type=schemas.PrincipalType.user,
+                identities=[schemas.Identity(id=identity_id, provider=provider)],
+                access_token=decoded_access_token,
+            )
+        return principal
     else:
         if settings.allow_anonymous_access:
             return None
@@ -720,36 +715,8 @@ async def get_current_principal(
                 headers=headers_for_401(request, security_scopes),
             )
     elif decoded_access_token is not None:
-        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-            if "sub_typ" in decoded_access_token:
-                # Tiled-minted token (auth code flow): use the full claims.
-                principal = schemas.Principal(
-                    uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
-                    type=decoded_access_token["sub_typ"],
-                    identities=[
-                        schemas.Identity(id=identity["id"], provider=identity["idp"])
-                        for identity in decoded_access_token["ids"]
-                    ],
-                )
-            else:
-                # Entra-minted token (device code flow): look up / create session.
-                identity_id = (
-                    decoded_access_token.get("user") or decoded_access_token["sub"]
-                )
-                provider = request.app.state.provider
-                async with db_factory() as db:
-                    session = await create_session(
-                        settings,
-                        db,
-                        provider,
-                        identity_id,
-                    )
-                principal = schemas.Principal(
-                    uuid=session.principal.uuid,
-                    type=schemas.PrincipalType.user,
-                    identities=[schemas.Identity(id=identity_id, provider=provider)],
-                )
-        else:
+        if "sub_typ" in decoded_access_token:
+            # Token minted by Tiled's OAuth2 implementation
             principal = schemas.Principal(
                 uuid=uuid_module.UUID(hex=decoded_access_token["sub"]),
                 type=decoded_access_token["sub_typ"],
@@ -757,6 +724,23 @@ async def get_current_principal(
                     schemas.Identity(id=identity["id"], provider=identity["idp"])
                     for identity in decoded_access_token["ids"]
                 ],
+            )
+        else:
+            # Token minted by external OIDC provider
+            identity_id = (
+                decoded_access_token.get("user") or decoded_access_token["sub"]
+            )
+            provider = request.app.state.provider
+            async with db_factory() as db:
+                principal = await get_or_create_principal(
+                    db,
+                    provider,
+                    identity_id,
+                )
+            principal = schemas.Principal(
+                uuid=principal.uuid,
+                type=schemas.PrincipalType.user,
+                identities=[schemas.Identity(id=identity_id, provider=provider)],
             )
     else:
         # No form of authentication is present.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -513,14 +513,13 @@ async def authenticate_websocket_first_message(
                         schemas.Identity(id=identity["id"], provider=identity["idp"])
                         for identity in decoded["ids"]
                     ],
-                    access_token=decoded,
                 )
             else:
                 principal = schemas.Principal(
                     uuid=uuid_module.UUID(hex=decoded["sub"]),
                     type=schemas.PrincipalType.user,
                     identities=[],
-                    access_token=decoded,
+                    access_token=access_token,
                 )
             scopes = _extract_scopes(decoded, settings.authenticator)
         else:
@@ -531,7 +530,7 @@ async def authenticate_websocket_first_message(
                     schemas.Identity(id=identity["id"], provider=identity["idp"])
                     for identity in decoded["ids"]
                 ],
-                access_token=decoded,
+                access_token=access_token,
             )
             scopes = set(decoded["scp"])
         return True, principal, None, scopes
@@ -620,6 +619,7 @@ async def get_current_principal_from_api_key(
 async def get_current_principal_websocket(
     websocket: WebSocket,
     api_key: Optional[str] = Depends(get_api_key_websocket),
+    access_token: Optional[str] = Query(None),
     decoded_access_token: Optional[dict] = Depends(get_decoded_access_token_websocket),
     settings: Settings = Depends(get_settings),
     db_factory: Callable[[], Optional[AsyncSession]] = Depends(
@@ -646,7 +646,6 @@ async def get_current_principal_websocket(
                     schemas.Identity(id=identity["id"], provider=identity["idp"])
                     for identity in decoded_access_token["ids"]
                 ],
-                access_token=decoded_access_token,
             )
         else:
             # Token minted by external OIDC provider
@@ -664,7 +663,7 @@ async def get_current_principal_websocket(
                 uuid=session.principal.uuid,
                 type=schemas.PrincipalType.user,
                 identities=[schemas.Identity(id=identity_id, provider=provider)],
-                access_token=decoded_access_token,
+                access_token=access_token,
             )
         return principal
     else:
@@ -741,6 +740,7 @@ async def get_current_principal(
                 uuid=principal.uuid,
                 type=schemas.PrincipalType.user,
                 identities=[schemas.Identity(id=identity_id, provider=provider)],
+                access_token=access_token,
             )
     else:
         # No form of authentication is present.

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -412,7 +412,25 @@ async def get_current_scopes(
                 api_key, settings, request.app.state.authenticated, db
             )
     elif decoded_access_token is not None:
-        return _extract_scopes(decoded_access_token, settings.authenticator)
+        token_scopes = _extract_scopes(decoded_access_token, settings.authenticator)
+        if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
+            async with db_factory() as db:
+                principal_orm = (
+                    await db.execute(
+                        select(orm.Principal)
+                        .options(selectinload(orm.Principal.roles))
+                        .filter(
+                            orm.Principal.uuid
+                            == uuid_module.UUID(hex=decoded_access_token["sub"])
+                        )
+                    )
+                ).scalar()
+            if principal_orm:
+                role_scopes = set().union(
+                    *[role.scopes for role in principal_orm.roles]
+                )
+                return token_scopes | role_scopes
+        return token_scopes
     else:
         return PUBLIC_SCOPES if settings.allow_anonymous_access else NO_SCOPES
 


### PR DESCRIPTION
More follow up to #1381.

- In `main`, everyone is treated as a `Role.user`. This merges in `Role.admin` scopes when appropriate.
- Carry the access token in the Principal model (needed for DLS' authorization code and may be useful in general).
- Do not track sessions in Tiled's AuthN database when the sessions are generated externally.