### PR TITLE
Fix using TILED_API_KEY to authenticate CLI

### DIFF
--- a/tiled/commandline/_utils.py
+++ b/tiled/commandline/_utils.py
@@ -79,7 +79,7 @@ def get_context(profile):
     context, _ = Context.from_any_uri(
         profile_content["uri"], verify=profile_content.get("verify", True)
     )
-    if not context.use_cached_tokens():
+    if not context.authenticated and not context.use_cached_tokens():
         if context.server_info.authentication.required:
             context.authenticate()
     return context


### PR DESCRIPTION
w.r.t. the discussion in the dev call on Monday, it turns out the CLI already does support the use of `TILED_API_KEY`, but it was being ignored.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
