### PR TITLE
FIX: Allow Empty `sort` Parameters

### DIFF
--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -104,3 +104,21 @@ def test_sort_missing():
         client = from_context(context)
         client_sorted = client.sort(("stuff", 1))
         list(client_sorted)  # Just check for no errors.
+
+
+def test_empty_sort_param_ignored(client):
+    """An empty sort= query parameter (sent by old clients) is silently ignored.
+
+    Old tiled client versions serialised the default sort as sort= (empty string).
+    The server should treat this identically to the parameter being absent rather
+    than returning a 422.
+    """
+    app = build_app(tree)
+    with Context.from_app(app) as context:
+        http_client = context.http_client
+        # Simulate old client behaviour: send sort= explicitly.
+        response = http_client.get(
+            str(context.api_uri) + "search/",
+            params={"sort": ""},
+        )
+        assert response.status_code == 200, response.text

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -21,8 +21,9 @@ from .schemas import Principal
 from .utils import filter_for_access, record_timing
 
 # Template for the "sort" query parameters.
-# Empty sting is NOT allowed, should be at least "-" or "+"
-SortField = constr(pattern=r"^(?:[+-][a-zA-Z0-9_.]*|[a-zA-Z0-9_.]+)$")
+# An empty string is allowed here for back-compatibility with old clients
+# that send sort= when no sort is specified. Non-empty values must be a valid sort field.
+SortField = constr(pattern=r"^(?:[+-][a-zA-Z0-9_.]*|[a-zA-Z0-9_.]+)?$")
 
 # Limits for pagination parameters
 DEFAULT_PAGE_SIZE = 100
@@ -219,6 +220,12 @@ def sorting_param(
 ):
     "Specify and parse a sorting parameter."
     if sort is None:
+        return None
+
+    # Backcompatibility: Old clients send sort= (empty string) when no sort is
+    # specified. Filter these out to avoid a spurious error.
+    sort = [s for s in sort if s]
+    if not sort:
         return None
 
     result = {}


### PR DESCRIPTION
Fix a backcompatibility issue to allow empty `sort=` query parameters send by older clients.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
