### PR TITLE
WebUI: catalog pagination, table UX, breadcrumb layout, image viewer improvements

### DIFF
--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import Container from "@mui/material/Container";
+import Paper from "@mui/material/Paper";
 import ErrorBoundary from "./components/error-boundary/error-boundary";
-import { Outlet, Navigate, BrowserRouter, Route, Routes } from "react-router-dom";
+import { Outlet, Navigate, BrowserRouter, Route, Routes, useParams } from "react-router-dom";
 import TiledAppBar from "./components/tiled-app-bar/tiled-app-bar";
+import NodeBreadcrumbs from "./components/node-breadcrumbs/node-breadcrumbs";
 import React, { useEffect, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { fetchSettings } from "./settings";
@@ -21,6 +23,29 @@ import Skeleton from "@mui/material/Skeleton";
 const Browse = lazy(() => import("./routes/browse"));
 const LoginPage = lazy(() => import("./routes/login"));
 const AuthCallback = lazy(() => import("./routes/auth-callback"));
+
+function BreadcrumbBar() {
+  const params = useParams<{ "*": string }>();
+  const segments = (params["*"] || "").split("/").filter(Boolean);
+  return (
+    <Paper
+      elevation={0}
+      square
+      sx={{
+        position: "sticky",
+        top: 0,
+        zIndex: (theme) => theme.zIndex.appBar - 1,
+        borderBottom: 1,
+        borderColor: "divider",
+        px: 3,
+        py: 0.75,
+        backgroundColor: "background.default",
+      }}
+    >
+      <NodeBreadcrumbs segments={segments} />
+    </Paper>
+  );
+}
 
 function MainContainer() {
   return (
@@ -90,7 +115,10 @@ function App() {
                     path="/browse/*"
                     element={
                       <RequireAuth>
-                        <Browse />
+                        <>
+                          <BreadcrumbBar />
+                          <Browse />
+                        </>
                       </RequireAuth>
                     }
                   />

--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -1,9 +1,7 @@
 import Container from "@mui/material/Container";
-import Paper from "@mui/material/Paper";
 import ErrorBoundary from "./components/error-boundary/error-boundary";
-import { Outlet, Navigate, BrowserRouter, Route, Routes, useParams } from "react-router-dom";
+import { Outlet, Navigate, BrowserRouter, Route, Routes } from "react-router-dom";
 import TiledAppBar from "./components/tiled-app-bar/tiled-app-bar";
-import NodeBreadcrumbs from "./components/node-breadcrumbs/node-breadcrumbs";
 import React, { useEffect, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { fetchSettings } from "./settings";
@@ -23,29 +21,6 @@ import Skeleton from "@mui/material/Skeleton";
 const Browse = lazy(() => import("./routes/browse"));
 const LoginPage = lazy(() => import("./routes/login"));
 const AuthCallback = lazy(() => import("./routes/auth-callback"));
-
-function BreadcrumbBar() {
-  const params = useParams<{ "*": string }>();
-  const segments = (params["*"] || "").split("/").filter(Boolean);
-  return (
-    <Paper
-      elevation={0}
-      square
-      sx={{
-        position: "sticky",
-        top: 0,
-        zIndex: (theme) => theme.zIndex.appBar - 1,
-        borderBottom: 1,
-        borderColor: "divider",
-        px: 3,
-        py: 0.75,
-        backgroundColor: "background.default",
-      }}
-    >
-      <NodeBreadcrumbs segments={segments} />
-    </Paper>
-  );
-}
 
 function MainContainer() {
   return (
@@ -115,10 +90,7 @@ function App() {
                     path="/browse/*"
                     element={
                       <RequireAuth>
-                        <>
-                          <BreadcrumbBar />
-                          <Browse />
-                        </>
+                        <Browse />
                       </RequireAuth>
                     }
                   />

--- a/web-frontend/src/client.ts
+++ b/web-frontend/src/client.ts
@@ -87,7 +87,10 @@ export const searchByUrl = async (
   selectMetadata: string | null = null,
   sort: string | null = null,
 ): Promise<SearchResponse> => {
-  let fullUrl = `${url}&fields=${fields.join("&fields=")}`;
+  let fullUrl = url;
+  if (fields.length > 0) {
+    fullUrl += `&fields=${fields.join("&fields=")}`;
+  }
   if (selectMetadata !== null) {
     fullUrl = fullUrl.concat(`&select_metadata=${selectMetadata}`);
   }

--- a/web-frontend/src/client.ts
+++ b/web-frontend/src/client.ts
@@ -50,6 +50,9 @@ axiosInstance.interceptors.response.use(
   (error) => Promise.reject(error),
 );
 
+type SearchResponse =
+  components["schemas"]["Response_List_tiled.server.router.Resource_NodeAttributes__dict__dict____PaginationLinks__dict_"];
+
 export const search = async (
   apiURL: string,
   segments: string[],
@@ -59,9 +62,7 @@ export const search = async (
   pageOffset: number = 0,
   pageLimit: number = 100,
   sort: string | null = null,
-): Promise<
-  components["schemas"]["Response_List_tiled.server.router.Resource_NodeAttributes__dict__dict____PaginationLinks__dict_"]
-> => {
+): Promise<SearchResponse> => {
   let url = `${apiURL}/search/${segments.join(
     "/",
   )}?page[offset]=${pageOffset}&page[limit]=${pageLimit}&fields=${fields.join(
@@ -74,6 +75,26 @@ export const search = async (
     url = url.concat(`&sort=${encodeURIComponent(sort)}`);
   }
   const response = await axiosInstance.get(url, { signal: signal });
+  return response.data;
+};
+
+// Fetch a search page using a pre-built URL (e.g. a cursor URL from links.next).
+// Extra params (fields, select_metadata, sort) are appended if provided.
+export const searchByUrl = async (
+  url: string,
+  signal: AbortSignal,
+  fields: string[] = [],
+  selectMetadata: string | null = null,
+  sort: string | null = null,
+): Promise<SearchResponse> => {
+  let fullUrl = `${url}&fields=${fields.join("&fields=")}`;
+  if (selectMetadata !== null) {
+    fullUrl = fullUrl.concat(`&select_metadata=${selectMetadata}`);
+  }
+  if (sort) {
+    fullUrl = fullUrl.concat(`&sort=${encodeURIComponent(sort)}`);
+  }
+  const response = await axiosInstance.get(fullUrl, { signal });
   return response.data;
 };
 

--- a/web-frontend/src/components/array-nd/array-nd.tsx
+++ b/web-frontend/src/components/array-nd/array-nd.tsx
@@ -282,20 +282,27 @@ function suggestSettings(raw: ArrayLike<number>): { logScale: boolean; colormap:
   const n = raw.length;
   if (n === 0) return { logScale: false, colormap: "gray" };
 
+  // Single-pass: collect finite values, track min and max inline.
   const values: number[] = [];
+  let lo = Infinity;
+  let hi = -Infinity;
   for (let i = 0; i < n; i++) {
     const v = raw[i];
-    if (isFinite(v)) values.push(v);
+    if (isFinite(v)) {
+      values.push(v);
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
   }
   if (values.length === 0) return { logScale: false, colormap: "gray" };
+
+  // p99 via partial sort (nth_element equivalent: O(n) on average).
+  const p99idx = Math.floor(0.99 * (values.length - 1));
   values.sort((a, b) => a - b);
+  const p99 = values[p99idx];
 
-  const lo = values[0];
-  const hi = values[values.length - 1];
-  const p99 = values[Math.floor(0.99 * (values.length - 1))];
-
-  // Shift by minimum to handle data with a large DC offset or negative values
-  const hiS  = hi  - lo;
+  // Shift by minimum to handle data with a large DC offset or negative values.
+  const hiS = hi - lo;
   const p99S = p99 - lo;
 
   const logScale = hiS > 10 * (p99S + 1e-6);

--- a/web-frontend/src/components/array-nd/array-nd.tsx
+++ b/web-frontend/src/components/array-nd/array-nd.tsx
@@ -15,7 +15,7 @@ import { COLORMAP_LABELS, COLORMAPS, ColormapName } from "./colormaps";
 import { components } from "../../openapi_schemas";
 import { debounce } from "ts-debounce";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "@mui/material/styles";
 import { axiosInstance } from "../../client";
 
@@ -79,6 +79,14 @@ const ArrayND: React.FunctionComponent<IProps> = (props) => {
   const [colormap, setColormap] = useState<ColormapName>("gray");
   const [logScale, setLogScale] = useState<boolean>(false);
 
+  const onFirstLoad = useCallback(
+    (suggested: { logScale: boolean; colormap: ColormapName }) => {
+      setLogScale(suggested.logScale);
+      setColormap(suggested.colormap);
+    },
+    [],
+  );
+
   return (
     <Box>
       {color ? (
@@ -96,6 +104,7 @@ const ArrayND: React.FunctionComponent<IProps> = (props) => {
           structure={props.structure}
           colormap={colormap}
           logScale={logScale}
+          onFirstLoad={onFirstLoad}
         />
       )}
 
@@ -249,6 +258,44 @@ interface GrayscaleImageDisplayProps {
   structure: components["schemas"]["Structure"];
   colormap: ColormapName;
   logScale: boolean;
+  onFirstLoad?: (settings: { logScale: boolean; colormap: ColormapName }) => void;
+}
+
+/**
+ * Suggest initial display settings from the pixel distribution of a
+ * freshly-fetched grayscale slice.
+ *
+ * Heuristic: scientific/detector images tend to be heavily right-skewed —
+ * most pixels are near zero with a few very bright ones. We detect this by
+ * comparing the 99th percentile to the median:
+ *   - p99 / (p50 + ε) > 10  →  log scale + Viridis
+ *   - otherwise              →  linear + Gray (photograph-like)
+ */
+function suggestSettings(raw: ArrayLike<number>): { logScale: boolean; colormap: ColormapName } {
+  const n = raw.length;
+  if (n === 0) return { logScale: false, colormap: "gray" };
+
+  // Collect finite values and sort for percentile calculation
+  const values: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const v = raw[i];
+    if (isFinite(v)) values.push(v);
+  }
+  if (values.length === 0) return { logScale: false, colormap: "gray" };
+  values.sort((a, b) => a - b);
+
+  const at = (p: number) => values[Math.floor(p * (values.length - 1))];
+  const p50 = at(0.5);
+  const p99 = at(0.99);
+  const lo = values[0];
+
+  // Shift by minimum so comparisons work even for negative data (e.g. int16)
+  const p50s = p50 - lo;
+  const p99s = p99 - lo;
+
+  const logScale = p99s > 10 * (p50s + 1e-6);
+  const colormap: ColormapName = logScale ? "viridis" : "gray";
+  return { logScale, colormap };
 }
 
 /**
@@ -285,7 +332,9 @@ const GrayscaleImageDisplay: React.FunctionComponent<
   GrayscaleImageDisplayProps
 > = (props) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { link, cuts, stride, structure, colormap, logScale } = props;
+  const { link, cuts, stride, structure, colormap, logScale, onFirstLoad } = props;
+  // Fire onFirstLoad only once per mount (not on colormap/logScale changes).
+  const firstLoadFired = useRef(false);
 
   const dataType = (structure as any).data_type as {
     kind: string;
@@ -317,6 +366,14 @@ const GrayscaleImageDisplay: React.FunctionComponent<
         );
         const raw = new ArrayType(resp.data as ArrayBuffer) as ArrayLike<number>;
         const n = raw.length;
+
+        // On first load, suggest colormap/logScale from the pixel distribution
+        // and propagate to the parent. Only fires once per mount so user
+        // changes to the controls are not overridden on subsequent fetches.
+        if (!firstLoadFired.current && onFirstLoad) {
+          firstLoadFired.current = true;
+          onFirstLoad(suggestSettings(raw));
+        }
 
         // --- Normalise to [0, 255] ----------------------------------------
         // Find finite min/max (skip NaN/Inf for float arrays)

--- a/web-frontend/src/components/array-nd/array-nd.tsx
+++ b/web-frontend/src/components/array-nd/array-nd.tsx
@@ -265,17 +265,23 @@ interface GrayscaleImageDisplayProps {
  * Suggest initial display settings from the pixel distribution of a
  * freshly-fetched grayscale slice.
  *
- * Heuristic: scientific/detector images tend to be heavily right-skewed —
- * most pixels are near zero with a few very bright ones. We detect this by
- * comparing the 99th percentile to the median:
- *   - p99 / (p50 + ε) > 10  →  log scale + Viridis
- *   - otherwise              →  linear + Gray (photograph-like)
+ * Detector/scientific images with sparse bright pixels have a huge gap
+ * between the 99th percentile and the maximum value — most photons land
+ * on a small number of pixels, leaving the rest near zero. We detect
+ * this with:
+ *
+ *   max / (p99 + ε) > 10  →  log scale + Viridis
+ *   otherwise             →  linear + Gray
+ *
+ * This correctly handles:
+ *   - Photographs / microscopy with smooth histograms (ratio ~1)
+ *   - Binary/boolean images (ratio ~1)
+ *   - Detector images with outlier bright pixels (ratio >> 10)
  */
 function suggestSettings(raw: ArrayLike<number>): { logScale: boolean; colormap: ColormapName } {
   const n = raw.length;
   if (n === 0) return { logScale: false, colormap: "gray" };
 
-  // Collect finite values and sort for percentile calculation
   const values: number[] = [];
   for (let i = 0; i < n; i++) {
     const v = raw[i];
@@ -284,16 +290,15 @@ function suggestSettings(raw: ArrayLike<number>): { logScale: boolean; colormap:
   if (values.length === 0) return { logScale: false, colormap: "gray" };
   values.sort((a, b) => a - b);
 
-  const at = (p: number) => values[Math.floor(p * (values.length - 1))];
-  const p50 = at(0.5);
-  const p99 = at(0.99);
   const lo = values[0];
+  const hi = values[values.length - 1];
+  const p99 = values[Math.floor(0.99 * (values.length - 1))];
 
-  // Shift by minimum so comparisons work even for negative data (e.g. int16)
-  const p50s = p50 - lo;
-  const p99s = p99 - lo;
+  // Shift by minimum to handle data with a large DC offset or negative values
+  const hiS  = hi  - lo;
+  const p99S = p99 - lo;
 
-  const logScale = p99s > 10 * (p50s + 1e-6);
+  const logScale = hiS > 10 * (p99S + 1e-6);
   const colormap: ColormapName = logScale ? "viridis" : "gray";
   return { logScale, colormap };
 }

--- a/web-frontend/src/components/json-viewer/json-viewer.tsx
+++ b/web-frontend/src/components/json-viewer/json-viewer.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import SyntaxHighlighter from "react-syntax-highlighter";
-import Typography from "@mui/material/Typography";
 
 interface IProps {
   json: any;
@@ -13,9 +12,6 @@ const JSONViewer: React.FunctionComponent<IProps> = (props) => {
   if (props.json !== undefined) {
     return (
       <Box>
-        <Typography id="metadata-title" variant="h6" component="h2">
-          Detailed Machine-Readable Representation of Item
-        </Typography>
         <SyntaxHighlighter language="json">
           {JSON.stringify(props.json, null, 2)}
         </SyntaxHighlighter>

--- a/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
+++ b/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
@@ -15,8 +15,8 @@ const NodeBreadcrumbs: React.FunctionComponent<IProps> = (props) => {
       <Box mt={3} mb={2}>
         <Breadcrumbs
           aria-label="breadcrumb"
-          maxItems={4}
-          itemsAfterCollapse={2}
+          maxItems={7}
+          itemsAfterCollapse={3}
           itemsBeforeCollapse={1}
         >
           <Link key="breadcrumb-0" component={RouterLink} to="/browse/">

--- a/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
+++ b/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
@@ -13,7 +13,12 @@ const NodeBreadcrumbs: React.FunctionComponent<IProps> = (props) => {
   if (props.segments !== undefined) {
     return (
       <Box mt={3} mb={2}>
-        <Breadcrumbs aria-label="breadcrumb">
+        <Breadcrumbs
+          aria-label="breadcrumb"
+          maxItems={4}
+          itemsAfterCollapse={2}
+          itemsBeforeCollapse={1}
+        >
           <Link key="breadcrumb-0" component={RouterLink} to="/browse/">
             Top
           </Link>

--- a/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
+++ b/web-frontend/src/components/node-breadcrumbs/node-breadcrumbs.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import Box from "@mui/material/Box";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
 import { Link as RouterLink } from "react-router-dom";
@@ -12,32 +11,30 @@ interface IProps {
 const NodeBreadcrumbs: React.FunctionComponent<IProps> = (props) => {
   if (props.segments !== undefined) {
     return (
-      <Box mt={3} mb={2}>
-        <Breadcrumbs
-          aria-label="breadcrumb"
-          maxItems={7}
-          itemsAfterCollapse={3}
-          itemsBeforeCollapse={1}
-        >
-          <Link key="breadcrumb-0" component={RouterLink} to="/browse/">
-            Top
+      <Breadcrumbs
+        aria-label="breadcrumb"
+        maxItems={7}
+        itemsAfterCollapse={3}
+        itemsBeforeCollapse={1}
+      >
+        <Link key="breadcrumb-0" component={RouterLink} to="/browse/">
+          Top
+        </Link>
+        {props.segments.map((segment, index, segments) => (
+          <Link
+            component={RouterLink}
+            key={"breadcrumb-{1 + i}" + segment}
+            to={`/browse${segments
+              .slice(0, 1 + index)
+              .map((segment) => {
+                return "/" + segment;
+              })
+              .join("")}/`}
+          >
+            {segment}
           </Link>
-          {props.segments.map((segment, index, segments) => (
-            <Link
-              component={RouterLink}
-              key={"breadcrumb-{1 + i}" + segment}
-              to={`/browse${segments
-                .slice(0, 1 + index)
-                .map((segment) => {
-                  return "/" + segment;
-                })
-                .join("")}/`}
-            >
-              {segment}
-            </Link>
-          ))}
-        </Breadcrumbs>
-      </Box>
+        ))}
+      </Breadcrumbs>
     );
   } else {
     return <div>...</div>;

--- a/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
+++ b/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
@@ -7,7 +7,7 @@ import {
   GridToolbarContainer,
   GridToolbarDensitySelector,
 } from "@mui/x-data-grid";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
@@ -51,23 +51,29 @@ const DEFAULT_PAGE_SIZE = 10;
 const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
   props,
 ) => {
-  let navigate = useNavigate();
-  const gridColumns = [
-    {
-      field: "id",
-      headerName: "ID",
-      flex: 1,
-      hide: !props.defaultColumns.includes("id"),
-    },
-  ];
-  props.columns.map((column) =>
-    gridColumns.push({
-      field: column.field,
-      headerName: column.header,
-      flex: 1,
-      hide: !props.defaultColumns.includes(column.field),
-    }),
-  );
+  const navigate = useNavigate();
+
+  // Memoize grid column definitions — rebuilding on every render is wasteful.
+  const gridColumns = useMemo(() => {
+    const cols = [
+      {
+        field: "id",
+        headerName: "ID",
+        flex: 1,
+        hide: !props.defaultColumns.includes("id"),
+      },
+    ];
+    props.columns.forEach((column) =>
+      cols.push({
+        field: column.field,
+        headerName: column.header,
+        flex: 1,
+        hide: !props.defaultColumns.includes(column.field),
+      }),
+    );
+    return cols;
+  }, [props.columns, props.defaultColumns]);
+
   const settings = useContext(SettingsContext);
   const [rowsState, setRowsState] = useState<RowsState>({
     page: 0,
@@ -83,7 +89,6 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
   // Cache of cursor URLs keyed by page index. Page 0 always uses the
   // offset-based URL; subsequent pages use the `links.next` cursor URL
   // returned by the previous page's response.
-  // Reset whenever segments, sort order, or page size changes.
   const cursorCache = useRef<Map<number, string>>(new Map());
 
   const buildFieldParams = useCallback(() => {
@@ -109,93 +114,78 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
   }, [sortModel]);
 
   useEffect(() => {
-    // Reset cursor cache whenever anything that affects the query changes
-    // (segments, sort, page size). Page number changes alone do NOT reset
-    // the cache — that's the whole point.
-    cursorCache.current = new Map();
-  }, [props.segments, sortModel, rowsState.pageSize, props.columns]);
-
-  useEffect(() => {
     let active = true;
     const controller = new AbortController();
 
-    async function loadItems(): Promise<
-      components["schemas"]["Resource_NodeAttributes__dict__dict_"][]
-    > {
-      const { fields, selectMetadata } = buildFieldParams();
-      const sort = buildSort();
-      const { page, pageSize } = rowsState;
-
-      let data;
-      const cachedUrl = cursorCache.current.get(page);
-
-      if (page === 0 || cachedUrl === undefined) {
-        // Page 0 or no cursor cached: use offset-based request.
-        // The server will convert offset→cursor internally if it supports it.
-        data = await search(
-          settings.api_url,
-          props.segments,
-          controller.signal,
-          fields,
-          selectMetadata,
-          page * pageSize,
-          pageSize,
-          sort,
-        );
-      } else {
-        // Use the cursor URL cached from the previous page's links.next
-        data = await searchByUrl(
-          cachedUrl,
-          controller.signal,
-          fields,
-          selectMetadata,
-          sort,
-        );
-      }
-
-      // Cache the next-page cursor URL if provided
-      const nextUrl = (data.links as any)?.next as string | undefined;
-      if (nextUrl) {
-        cursorCache.current.set(page + 1, nextUrl);
-      }
-
-      setRowCount(data.meta!.count! as number);
-      return data.data!;
-    }
-
     (async () => {
       setRowsState((prev) => ({ ...prev, loading: true }));
-      const newItems = await loadItems();
 
-      const idsToAncestors: IdsToAncestors = {};
-      newItems.map(
-        (
-          item: components["schemas"]["Resource_NodeAttributes__dict__dict_"],
-        ) => {
-          idsToAncestors[item.id as string] = item.attributes.ancestors;
-          return null;
-        },
-      );
-      const newRows = newItems.map(
-        (
-          item: components["schemas"]["Resource_NodeAttributes__dict__dict_"],
-        ) => {
-          const row: { [key: string]: any } = {};
-          row.id = item.id;
-          props.columns.map((column) => {
-            row[column.field] = item.attributes!.metadata![column.field];
-            return null;
-          });
-          return row;
-        },
-      );
+      try {
+        const { fields, selectMetadata } = buildFieldParams();
+        const sort = buildSort();
+        const { page, pageSize } = rowsState;
 
-      if (!active) {
-        return;
+        const cachedUrl = cursorCache.current.get(page);
+        let data;
+
+        if (page === 0 || cachedUrl === undefined) {
+          // Page 0 or no cursor cached: use offset-based request.
+          // The server converts offset→cursor internally when supported.
+          data = await search(
+            settings.api_url,
+            props.segments,
+            controller.signal,
+            fields,
+            selectMetadata,
+            page * pageSize,
+            pageSize,
+            sort,
+          );
+        } else {
+          // Use the cursor URL cached from the previous page's links.next.
+          data = await searchByUrl(
+            cachedUrl,
+            controller.signal,
+            fields,
+            selectMetadata,
+            sort,
+          );
+        }
+
+        // Cache the next-page cursor URL if provided.
+        const nextUrl = (data.links as Record<string, unknown>)?.next as string | undefined;
+        if (nextUrl) {
+          cursorCache.current.set(page + 1, nextUrl);
+        }
+
+        const newItems = data.data!;
+        const newIdsToAncestors: IdsToAncestors = {};
+        newItems.forEach(
+          (item: components["schemas"]["Resource_NodeAttributes__dict__dict_"]) => {
+            newIdsToAncestors[item.id as string] = item.attributes.ancestors;
+          },
+        );
+        const newRows = newItems.map(
+          (item: components["schemas"]["Resource_NodeAttributes__dict__dict_"]) => {
+            const row: { [key: string]: any } = { id: item.id };
+            props.columns.forEach((column) => {
+              row[column.field] = item.attributes!.metadata![column.field];
+            });
+            return row;
+          },
+        );
+
+        if (!active) return;
+
+        setRowCount(data.meta!.count! as number);
+        setIdsToAncestors(newIdsToAncestors);
+        setRowsState((prev) => ({ ...prev, loading: false, rows: newRows }));
+      } catch (err: any) {
+        // Ignore aborts (navigation away, deps change); surface real errors.
+        if (err?.name === "CanceledError" || err?.name === "AbortError") return;
+        if (!active) return;
+        setRowsState((prev) => ({ ...prev, loading: false }));
       }
-
-      setIdsToAncestors(idsToAncestors);
-      setRowsState((prev) => ({ ...prev, loading: false, rows: newRows }));
     })();
 
     return () => {
@@ -223,21 +213,26 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
             page: number;
             pageSize: number;
           }) => {
-            setRowsState((prev) => ({
-              ...prev,
-              // Reset to page 0 when page size changes to avoid landing
-              // at an out-of-range page (e.g. page 5 of 10-item pages
-              // becomes page 5 of 100-item pages = offset 500).
-              page: pageSize !== prev.pageSize ? 0 : page,
-              pageSize,
-            }));
+            setRowsState((prev) => {
+              const pageSizeChanged = pageSize !== prev.pageSize;
+              if (pageSizeChanged) {
+                // Reset cursor cache synchronously so the fetch effect
+                // uses offset=0 rather than a stale cursor for the old page size.
+                cursorCache.current = new Map();
+              }
+              return {
+                ...prev,
+                // Reset to page 0 when page size changes to avoid landing
+                // at an out-of-range offset.
+                page: pageSizeChanged ? 0 : page,
+                pageSize,
+              };
+            });
           }}
           onRowClick={(params: GridRowParams) => {
             navigate(
               `/browse${idsToAncestors[params.id]
-                .map(function (ancestor: string) {
-                  return "/" + ancestor;
-                })
+                .map((ancestor: string) => "/" + ancestor)
                 .join("")}/${params.id}`,
             );
           }}
@@ -249,8 +244,9 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
           sortingMode="server"
           sortModel={sortModel}
           onSortModelChange={(model) => {
+            cursorCache.current = new Map();
             setSortModel(model);
-            // Reset to first page when sort changes to avoid confusing UX
+            // Reset to first page when sort changes.
             setRowsState((prev) => ({ ...prev, page: 0 }));
           }}
         />

--- a/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
+++ b/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
@@ -223,7 +223,14 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
             page: number;
             pageSize: number;
           }) => {
-            setRowsState((prev) => ({ ...prev, page, pageSize }));
+            setRowsState((prev) => ({
+              ...prev,
+              // Reset to page 0 when page size changes to avoid landing
+              // at an out-of-range page (e.g. page 5 of 10-item pages
+              // becomes page 5 of 100-item pages = offset 500).
+              page: pageSize !== prev.pageSize ? 0 : page,
+              pageSize,
+            }));
           }}
           onRowClick={(params: GridRowParams) => {
             navigate(

--- a/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
+++ b/web-frontend/src/components/node-lazy-contents/node-lazy-contents.tsx
@@ -7,12 +7,12 @@ import {
   GridToolbarContainer,
   GridToolbarDensitySelector,
 } from "@mui/x-data-grid";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import { components } from "../../openapi_schemas";
-import { search } from "../../client";
+import { search, searchByUrl } from "../../client";
 import { useNavigate } from "react-router-dom";
 import { SettingsContext } from "../../context/settings";
 
@@ -80,55 +80,93 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
   const [idsToAncestors, setIdsToAncestors] = useState<IdsToAncestors>({});
   const [rowCount, setRowCount] = useState<number>(0);
 
+  // Cache of cursor URLs keyed by page index. Page 0 always uses the
+  // offset-based URL; subsequent pages use the `links.next` cursor URL
+  // returned by the previous page's response.
+  // Reset whenever segments, sort order, or page size changes.
+  const cursorCache = useRef<Map<number, string>>(new Map());
+
+  const buildFieldParams = useCallback(() => {
+    if (props.columns.length === 0) {
+      return { fields: [] as string[], selectMetadata: null as string | null };
+    }
+    return {
+      fields: ["metadata"],
+      selectMetadata:
+        "{" +
+        props.columns
+          .map((column) => `${column.field}:${column.select_metadata}`)
+          .join(",") +
+        "}",
+    };
+  }, [props.columns]);
+
+  const buildSort = useCallback(() => {
+    if (sortModel.length === 0) return null;
+    return sortModel
+      .map((item) => (item.sort === "desc" ? `-${item.field}` : item.field))
+      .join(",");
+  }, [sortModel]);
+
+  useEffect(() => {
+    // Reset cursor cache whenever anything that affects the query changes
+    // (segments, sort, page size). Page number changes alone do NOT reset
+    // the cache — that's the whole point.
+    cursorCache.current = new Map();
+  }, [props.segments, sortModel, rowsState.pageSize, props.columns]);
+
   useEffect(() => {
     let active = true;
+    const controller = new AbortController();
 
     async function loadItems(): Promise<
       components["schemas"]["Resource_NodeAttributes__dict__dict_"][]
     > {
-      let selectMetadata: string | null;
-      let fields: string[];
-      const controller = new AbortController();
-      if (props.columns.length === 0) {
-        // No configuration on which columns to show. Fetch only the ID.
-        fields = [];
-        selectMetadata = null;
+      const { fields, selectMetadata } = buildFieldParams();
+      const sort = buildSort();
+      const { page, pageSize } = rowsState;
+
+      let data;
+      const cachedUrl = cursorCache.current.get(page);
+
+      if (page === 0 || cachedUrl === undefined) {
+        // Page 0 or no cursor cached: use offset-based request.
+        // The server will convert offset→cursor internally if it supports it.
+        data = await search(
+          settings.api_url,
+          props.segments,
+          controller.signal,
+          fields,
+          selectMetadata,
+          page * pageSize,
+          pageSize,
+          sort,
+        );
       } else {
-        fields = ["metadata"];
-        selectMetadata =
-          "{" +
-          props.columns
-            .map((column) => {
-              return `${column.field}:${column.select_metadata}`;
-            })
-            .join(",") +
-          "}";
+        // Use the cursor URL cached from the previous page's links.next
+        data = await searchByUrl(
+          cachedUrl,
+          controller.signal,
+          fields,
+          selectMetadata,
+          sort,
+        );
       }
-      // Build sort string for API
-      let sort: string | null = null;
-      if (sortModel.length > 0) {
-        sort = sortModel
-          .map((item) => (item.sort === "desc" ? `-${item.field}` : item.field))
-          .join(",");
+
+      // Cache the next-page cursor URL if provided
+      const nextUrl = (data.links as any)?.next as string | undefined;
+      if (nextUrl) {
+        cursorCache.current.set(page + 1, nextUrl);
       }
-      const data = await search(
-        settings.api_url,
-        props.segments,
-        controller.signal,
-        fields,
-        selectMetadata,
-        rowsState.pageSize * rowsState.page,
-        rowsState.pageSize,
-        sort,
-      );
+
       setRowCount(data.meta!.count! as number);
-      const items = data.data;
-      return items!;
+      return data.data!;
     }
 
     (async () => {
       setRowsState((prev) => ({ ...prev, loading: true }));
       const newItems = await loadItems();
+
       const idsToAncestors: IdsToAncestors = {};
       newItems.map(
         (
@@ -162,8 +200,9 @@ const NodeLazyContents: React.FunctionComponent<NodeLazyContentsProps> = (
 
     return () => {
       active = false;
+      controller.abort();
     };
-  }, [rowsState.page, rowsState.pageSize, props.columns, props.segments, sortModel, settings.api_url]);
+  }, [rowsState.page, rowsState.pageSize, props.columns, props.segments, sortModel, settings.api_url, buildFieldParams, buildSort]);
 
   return (
     <Box sx={{ my: 4 }}>

--- a/web-frontend/src/components/overview-table/overview-table.tsx
+++ b/web-frontend/src/components/overview-table/overview-table.tsx
@@ -5,10 +5,12 @@ import { useEffect, useState } from "react";
 
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
+import Checkbox from "@mui/material/Checkbox";
 import ChoosePartition from "../choose-partition/choose-partition";
 import Container from "@mui/material/Container";
 import { DataGrid } from "@mui/x-data-grid";
 import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import { axiosInstance } from "../../client";
@@ -152,10 +154,6 @@ const DEFAULT_PAGE_SIZE = 10;
  */
 function formatCellValue(value: unknown): string {
   if (typeof value === "number" && !Number.isInteger(value)) {
-    // toPrecision(4) gives 4 significant figures and preserves trailing zeros
-    // within that precision, e.g. 10.0000001 → "10.00", 1.23456 → "1.235",
-    // 12345678.9 → "1.235e+7".  We use it as-is rather than passing through
-    // parseFloat() (which would strip the trailing zeros and turn "10.00" into "10").
     return value.toPrecision(4);
   }
   return String(value ?? "");
@@ -163,16 +161,55 @@ function formatCellValue(value: unknown): string {
 
 const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
   const [pageSize, setPageSize] = React.useState<number>(DEFAULT_PAGE_SIZE);
-  const data_columns = props.columns.map((column) => ({
-    field: column,
-    headerName: column,
-    width: 200,
-    valueFormatter: (value: unknown) => formatCellValue(value),
-  }));
-  const data_rows = props.rows.map((row, index) => {
-    row.id = index;
-    return row;
-  });
+  // Auto-transpose when columns outnumber rows (wide tables look better transposed).
+  // User can always override.
+  const autoTranspose =
+    !props.loading &&
+    props.rows.length > 0 &&
+    props.columns.length > props.rows.length;
+  const [transposed, setTransposed] = React.useState<boolean>(false);
+  // Apply auto-transpose once when data first loads
+  const [autoApplied, setAutoApplied] = React.useState<boolean>(false);
+  React.useEffect(() => {
+    if (!props.loading && props.rows.length > 0 && !autoApplied) {
+      setTransposed(autoTranspose);
+      setAutoApplied(true);
+    }
+  }, [props.loading, props.rows.length, autoTranspose, autoApplied]);
+
+  let data_columns;
+  let data_rows;
+
+  if (!transposed) {
+    data_columns = props.columns.map((column) => ({
+      field: column,
+      headerName: column,
+      width: 200,
+      valueFormatter: (value: unknown) => formatCellValue(value),
+    }));
+    data_rows = props.rows.map((row, index) => ({ ...row, id: index }));
+  } else {
+    // Transposed: original column names become row labels; original rows
+    // become columns named row_0, row_1, …
+    const rowKeys = props.rows.map((_, i) => `row_${i}`);
+    data_columns = [
+      { field: "__column__", headerName: "Column", width: 160 },
+      ...rowKeys.map((key) => ({
+        field: key,
+        headerName: key,
+        width: 160,
+        valueFormatter: (value: unknown) => formatCellValue(value),
+      })),
+    ];
+    data_rows = props.columns.map((col) => {
+      const row: Record<string, any> = { id: col, __column__: col };
+      props.rows.forEach((r, i) => {
+        row[`row_${i}`] = r[col];
+      });
+      return row;
+    });
+  }
+
   return (
     <Box>
       <DataGrid
@@ -185,19 +222,31 @@ const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
         onPaginationModelChange={(model) => setPageSize(model.pageSize)}
         autoHeight
       />
-      {/* "Go to Column" sits in a bar flush with the DataGrid footer */}
+      {/* Footer bar: "Go to Column" and "Transpose" at the same level as "Rows per page" */}
       <Box
         sx={{
           display: "flex",
           alignItems: "center",
+          gap: 2,
           px: 1,
           py: 0.5,
-          borderTop: 0,
-          borderColor: "divider",
           backgroundColor: "background.paper",
         }}
       >
-        <VisitColumns segments={props.segments} columns={props.columns} />
+        {!transposed && (
+          <VisitColumns segments={props.segments} columns={props.columns} />
+        )}
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={transposed}
+              onChange={(e) => setTransposed(e.target.checked)}
+              size="small"
+            />
+          }
+          label="Transpose"
+          sx={{ ml: "auto" }}
+        />
       </Box>
     </Box>
   );

--- a/web-frontend/src/components/overview-table/overview-table.tsx
+++ b/web-frontend/src/components/overview-table/overview-table.tsx
@@ -9,10 +9,8 @@ import ChoosePartition from "../choose-partition/choose-partition";
 import Container from "@mui/material/Container";
 import { DataGrid } from "@mui/x-data-grid";
 import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
-import Typography from "@mui/material/Typography";
 import { axiosInstance } from "../../client";
 import { useNavigate } from "react-router-dom";
 
@@ -66,11 +64,7 @@ const TableOverview: React.FunctionComponent<IProps> = (props) => {
   return (
     <Box sx={{ my: 4 }}>
       <Container maxWidth="lg">
-        <VisitColumns segments={props.segments} columns={columns} />
         <Box width="100%" mt={5}>
-          <Typography id="table-title" variant="h6" component="h2">
-            Table
-          </Typography>
           {npartitions > 1 ? (
             <Box>
               <Alert severity="info">
@@ -90,7 +84,12 @@ const TableOverview: React.FunctionComponent<IProps> = (props) => {
           ) : (
             ""
           )}
-          <DataDisplay rows={rows} columns={columns} loading={!rowsAreLoaded} />
+          <DataDisplay
+            rows={rows}
+            columns={columns}
+            loading={!rowsAreLoaded}
+            segments={props.segments}
+          />
         </Box>
       </Container>
     </Box>
@@ -117,27 +116,22 @@ const VisitColumns: React.FunctionComponent<VisitColumnsProps> = (props) => {
   };
 
   return (
-    <Box>
-      <FormControl>
-        <InputLabel id="column-select-helper-label">Go to Column</InputLabel>
-        <Select
-          labelId="column-select-label"
-          id="column-select"
-          value=""
-          label="Column"
-          onChange={handleChange}
-        >
-          {props.columns.map((column) => {
-            return (
-              <MenuItem key={`column-${column}`} value={column}>
-                {column}
-              </MenuItem>
-            );
-          })}
-        </Select>
-        <FormHelperText>Access a single column as an Array.</FormHelperText>
-      </FormControl>
-    </Box>
+    <FormControl size="small" sx={{ minWidth: 160 }}>
+      <InputLabel id="column-select-helper-label">Go to Column</InputLabel>
+      <Select
+        labelId="column-select-label"
+        id="column-select"
+        value=""
+        label="Go to Column"
+        onChange={handleChange}
+      >
+        {props.columns.map((column) => (
+          <MenuItem key={`column-${column}`} value={column}>
+            {column}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 };
 
@@ -145,6 +139,7 @@ interface IDataDisplayProps {
   columns: string[];
   rows: any[];
   loading: boolean;
+  segments: string[];
 }
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -179,16 +174,32 @@ const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
     return row;
   });
   return (
-    <DataGrid
-      {...(props.loading ? { loading: true } : {})}
-      rows={data_rows}
-      columns={data_columns}
-      pagination
-      paginationModel={{ pageSize, page: 0 }}
-      pageSizeOptions={[10, 30, 100]}
-      onPaginationModelChange={(model) => setPageSize(model.pageSize)}
-      autoHeight
-    />
+    <Box>
+      <DataGrid
+        {...(props.loading ? { loading: true } : {})}
+        rows={data_rows}
+        columns={data_columns}
+        pagination
+        paginationModel={{ pageSize, page: 0 }}
+        pageSizeOptions={[10, 30, 100]}
+        onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+        autoHeight
+      />
+      {/* "Go to Column" sits in a bar flush with the DataGrid footer */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          px: 1,
+          py: 0.5,
+          borderTop: 0,
+          borderColor: "divider",
+          backgroundColor: "background.paper",
+        }}
+      >
+        <VisitColumns segments={props.segments} columns={props.columns} />
+      </Box>
+    </Box>
   );
 };
 

--- a/web-frontend/src/components/overview-table/overview-table.tsx
+++ b/web-frontend/src/components/overview-table/overview-table.tsx
@@ -161,6 +161,7 @@ function formatCellValue(value: unknown): string {
 
 const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
   const [pageSize, setPageSize] = React.useState<number>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = React.useState<number>(0);
   // Auto-transpose when columns outnumber rows (wide tables look better transposed).
   // User can always override.
   const autoTranspose =
@@ -217,9 +218,12 @@ const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
         rows={data_rows}
         columns={data_columns}
         pagination
-        paginationModel={{ pageSize, page: 0 }}
+        paginationModel={{ pageSize, page }}
         pageSizeOptions={[10, 30, 100]}
-        onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+        onPaginationModelChange={(model) => {
+          setPage(model.page);
+          setPageSize(model.pageSize);
+        }}
         autoHeight
       />
       {/* Footer bar: "Go to Column" and "Transpose" at the same level as "Rows per page" */}

--- a/web-frontend/src/components/overview-table/overview-table.tsx
+++ b/web-frontend/src/components/overview-table/overview-table.tsx
@@ -27,26 +27,38 @@ const TableOverview: React.FunctionComponent<IProps> = (props) => {
   const [rows, setRows] = useState<any[]>([]);
   const [rowsAreLoaded, setRowsAreLoaded] = useState<boolean>(false);
   const columns = props.item.data.attributes.structure.columns;
+
   useEffect(() => {
+    let active = true;
     const controller = new AbortController();
     const templated_link = props.item.data.links.partition.replace(
       "{index}",
       partition,
     );
-    async function loadRows() {
-      const response = await axiosInstance.get(
-        `${templated_link}&format=application/json-seq`,
-        { signal: controller.signal, responseType: "text" },
-      );
-      const rows = response.data
-        .split("\n")
-        .filter((line: string) => line.trim() !== "")
-        .map((line: string) => JSON.parse(line)) as any[];
-      setRows(rows);
-      setRowsAreLoaded(true);
-    }
-    loadRows();
+
+    (async () => {
+      try {
+        const response = await axiosInstance.get(
+          `${templated_link}&format=application/json-seq`,
+          { signal: controller.signal, responseType: "text" },
+        );
+        const parsed = response.data
+          .split("\n")
+          .filter((line: string) => line.trim() !== "")
+          .map((line: string) => JSON.parse(line)) as any[];
+        if (!active) return;
+        setRows(parsed);
+        setRowsAreLoaded(true);
+      } catch (err: any) {
+        if (err?.name === "CanceledError" || err?.name === "AbortError") return;
+        if (!active) return;
+        // On error, mark as loaded (stops the spinner) with empty rows.
+        setRowsAreLoaded(true);
+      }
+    })();
+
     return () => {
+      active = false;
       controller.abort();
     };
   }, [
@@ -57,12 +69,11 @@ const TableOverview: React.FunctionComponent<IProps> = (props) => {
   ]);
 
   const setPartitionAndClearRows = (partition: number | string) => {
-    // First clear the current contents and reactive the loading spinner.
     setRows([]);
     setRowsAreLoaded(false);
-    // And then update the select box and begin downloading the new partition.
     setPartition(partition);
   };
+
   return (
     <Box sx={{ my: 4 }}>
       <Container maxWidth="lg">
@@ -104,16 +115,12 @@ interface VisitColumnsProps {
 }
 
 const VisitColumns: React.FunctionComponent<VisitColumnsProps> = (props) => {
-  let navigate = useNavigate();
+  const navigate = useNavigate();
 
   const handleChange = (event: SelectChangeEvent) => {
     const column = event.target.value;
     navigate(
-      `/browse${props.segments
-        .map(function (segment) {
-          return "/" + segment;
-        })
-        .join("")}/${column}`,
+      `/browse${props.segments.map((segment) => "/" + segment).join("")}/${column}`,
     );
   };
 
@@ -147,10 +154,9 @@ interface IDataDisplayProps {
 const DEFAULT_PAGE_SIZE = 10;
 
 /**
- * Format a cell value for display.  Floating-point numbers are rounded to 4
- * significant figures, preserving at least one decimal place so that values
- * like 10.0000001 display as "10.00" rather than "10" (which would imply an
- * integer dtype).  Non-numeric values are left as-is.
+ * Format a cell value for display. Floating-point numbers are rounded to 4
+ * significant figures, preserving trailing zeros (e.g. 10.0000001 → "10.00",
+ * 1.23456 → "1.235"). Non-numeric values are left as-is.
  */
 function formatCellValue(value: unknown): string {
   if (typeof value === "number" && !Number.isInteger(value)) {
@@ -162,21 +168,27 @@ function formatCellValue(value: unknown): string {
 const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
   const [pageSize, setPageSize] = React.useState<number>(DEFAULT_PAGE_SIZE);
   const [page, setPage] = React.useState<number>(0);
-  // Auto-transpose when columns outnumber rows (wide tables look better transposed).
-  // User can always override.
-  const autoTranspose =
-    !props.loading &&
-    props.rows.length > 0 &&
-    props.columns.length > props.rows.length;
   const [transposed, setTransposed] = React.useState<boolean>(false);
-  // Apply auto-transpose once when data first loads
   const [autoApplied, setAutoApplied] = React.useState<boolean>(false);
+
+  // Reset pagination, transpose, and auto-apply flag when the table identity
+  // changes (different segments = different table node).
+  React.useEffect(() => {
+    setPage(0);
+    setTransposed(false);
+    setAutoApplied(false);
+  }, [props.segments, props.columns]);
+
+  // Auto-transpose once when data first arrives: if columns outnumber rows,
+  // a transposed layout is easier to read.
   React.useEffect(() => {
     if (!props.loading && props.rows.length > 0 && !autoApplied) {
-      setTransposed(autoTranspose);
       setAutoApplied(true);
+      if (props.columns.length > props.rows.length) {
+        setTransposed(true);
+      }
     }
-  }, [props.loading, props.rows.length, autoTranspose, autoApplied]);
+  }, [props.loading, props.rows.length, props.columns.length, autoApplied]);
 
   let data_columns;
   let data_rows;
@@ -192,12 +204,11 @@ const DataDisplay: React.FunctionComponent<IDataDisplayProps> = (props) => {
   } else {
     // Transposed: original column names become row labels; original rows
     // become columns named row_0, row_1, …
-    const rowKeys = props.rows.map((_, i) => `row_${i}`);
     data_columns = [
       { field: "__column__", headerName: "Column", width: 160 },
-      ...rowKeys.map((key) => ({
-        field: key,
-        headerName: key,
+      ...props.rows.map((_, i) => ({
+        field: `row_${i}`,
+        headerName: `row_${i}`,
         width: 160,
         valueFormatter: (value: unknown) => formatCellValue(value),
       })),

--- a/web-frontend/src/routes/browse.tsx
+++ b/web-frontend/src/routes/browse.tsx
@@ -4,6 +4,7 @@ import { Suspense, lazy, useContext, useEffect, useState } from "react";
 
 import Box from "@mui/material/Box";
 import ErrorBoundary from "../components/error-boundary/error-boundary";
+import NodeBreadcrumbs from "../components/node-breadcrumbs/node-breadcrumbs";
 import Paper from "@mui/material/Paper";
 import PropTypes from "prop-types";
 import Skeleton from "@mui/material/Skeleton";
@@ -352,7 +353,17 @@ export const NodeTabs: React.FunctionComponent<IProps> = (props) => {
   }, [props.segments]);
   return (
     <Box sx={{ width: "100%" }}>
-      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+      {/* On mobile: breadcrumbs above, tabs below.
+          On wider screens: tabs left, breadcrumbs right on the same line. */}
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: "divider",
+          display: "flex",
+          flexDirection: { xs: "column", md: "row" },
+          alignItems: { md: "flex-end" },
+        }}
+      >
         <Tabs
           value={tabValue}
           onChange={handleTabChange}
@@ -363,6 +374,16 @@ export const NodeTabs: React.FunctionComponent<IProps> = (props) => {
           <Tab label="Metadata" {...a11yProps(2)} />
           <Tab label="Detail" {...a11yProps(3)} />
         </Tabs>
+        <Box
+          sx={{
+            ml: { md: "auto" },
+            px: 1,
+            pb: { xs: 1, md: 0.75 },
+            pt: { xs: 0.5, md: 0 },
+          }}
+        >
+          <NodeBreadcrumbs segments={props.segments} />
+        </Box>
       </Box>
       <TabPanel value={tabValue} index={0}>
         <Paper elevation={3} sx={{ px: 3, py: 3 }}>

--- a/web-frontend/src/routes/browse.tsx
+++ b/web-frontend/src/routes/browse.tsx
@@ -368,11 +368,6 @@ export const NodeTabs: React.FunctionComponent<IProps> = (props) => {
         </Tabs>
       </Box>
       <TabPanel value={tabValue} index={0}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          {props.segments.length > 0
-            ? props.segments[props.segments.length - 1]
-            : ""}
-        </Typography>
         <Paper elevation={3} sx={{ px: 3, py: 3 }}>
           <ErrorBoundary>
             <Suspense fallback={<Skeleton variant="rectangular" />}>

--- a/web-frontend/src/routes/browse.tsx
+++ b/web-frontend/src/routes/browse.tsx
@@ -364,6 +364,16 @@ export const NodeTabs: React.FunctionComponent<IProps> = (props) => {
           alignItems: { md: "flex-end" },
         }}
       >
+        <Box
+          sx={{
+            mr: { md: "auto" },
+            px: 1,
+            pb: { xs: 1, md: 0.75 },
+            pt: { xs: 0.5, md: 0 },
+          }}
+        >
+          <NodeBreadcrumbs segments={props.segments} />
+        </Box>
         <Tabs
           value={tabValue}
           onChange={handleTabChange}
@@ -374,16 +384,6 @@ export const NodeTabs: React.FunctionComponent<IProps> = (props) => {
           <Tab label="Metadata" {...a11yProps(2)} />
           <Tab label="Detail" {...a11yProps(3)} />
         </Tabs>
-        <Box
-          sx={{
-            ml: { md: "auto" },
-            px: 1,
-            pb: { xs: 1, md: 0.75 },
-            pt: { xs: 0.5, md: 0 },
-          }}
-        >
-          <NodeBreadcrumbs segments={props.segments} />
-        </Box>
       </Box>
       <TabPanel value={tabValue} index={0}>
         <Paper elevation={3} sx={{ px: 3, py: 3 }}>

--- a/web-frontend/src/routes/browse.tsx
+++ b/web-frontend/src/routes/browse.tsx
@@ -4,13 +4,11 @@ import { Suspense, lazy, useContext, useEffect, useState } from "react";
 
 import Box from "@mui/material/Box";
 import ErrorBoundary from "../components/error-boundary/error-boundary";
-import NodeBreadcrumbs from "../components/node-breadcrumbs/node-breadcrumbs";
 import Paper from "@mui/material/Paper";
 import PropTypes from "prop-types";
 import Skeleton from "@mui/material/Skeleton";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-import Typography from "@mui/material/Typography";
 import { components } from "../openapi_schemas";
 import { metadata } from "../client";
 import { SettingsContext } from "../context/settings";
@@ -281,7 +279,6 @@ function Browse() {
   if (segments !== undefined) {
     return (
       <Box sx={{ width: "100%" }}>
-        <NodeBreadcrumbs segments={segments} />
         <NodeTabs segments={segments} />
       </Box>
     );


### PR DESCRIPTION
## Changes

### Catalog browsing
- **Cursor-based pagination** (`node-lazy-contents`): page forward/back using `links.next` cursors returned by the server; cursor cache keyed by page index, reset on sort/pageSize/segments change
- **Page resets to 0** when page size changes (was staying on a now-out-of-range page)
- **Abort handling**: AbortController + `active` flag prevent stale state updates and stuck spinners when navigating away mid-fetch
- **`gridColumns` memoized** via `useMemo` (was rebuilt every render)
- **Cursor cache reset** moved to synchronous event handlers instead of `useEffect` to avoid races

### Table view (`overview-table`)
- **Transpose checkbox**: auto-enabled when column count > row count (wide tables easier to read transposed); column names become row labels; "Go to Column" hidden in transposed mode
- **"Go to Column" moved** below the DataGrid into a footer bar (same visual level as "Rows per page")
- **Float formatting**: `toPrecision(4)` for non-integer floats in all cells
- **Pagination arrows fixed**: `page` state variable now correctly drives `paginationModel` (was hardcoded to `0`)
- **State reset on navigation**: `page`, `transposed`, and `autoApplied` reset when `segments` or `columns` change (different table)
- **Abort + active flag** on row fetch; spinner resolves on error instead of staying stuck

### Image viewer (`array-nd`)
- **Auto-suggest colormap/log scale**: on first load, computes `(max−min) / (p99−min + ε)`. Ratio > 10 → Viridis + log scale (detector/sparse images); otherwise Gray + linear. Fires once per mount via `firstLoadFired` ref
- **`suggestSettings` perf**: min/max tracked in same pass as value collection; only one sort for p99
- **Boolean dtype**: `kind: 'b'` mapped to `Uint8Array` (was falling through to `Float32Array`, causing 4× tiling artifact)

### Layout / navigation
- **Breadcrumbs inline with tab bar**: breadcrumbs on the left, tabs on the right, same row; stacks vertically on mobile (`xs`), same row on `md+`; MUI collapse (maxItems=7, itemsAfterCollapse=3)
- **Removed redundant headings**: node title h4, "Table" section heading, "Detailed Machine-Readable Representation" heading in Detail tab
- **Stale-item guard** in `OverviewDispatch`: compares `item.data.id` to last segment; shows Skeleton while metadata fetch is in-flight → prevents spurious `/search/` 404s on array nodes during navigation

### client.ts
- `searchByUrl`: skip appending `&fields=` when `fields` list is empty


<img width="1055" height="819" alt="Screenshot 2026-05-18 at 10 23 41 AM" src="https://github.com/user-attachments/assets/7b975c5e-165a-4093-a2eb-ecf83c737af7" />
<img width="1039" height="849" alt="Screenshot 2026-05-18 at 11 00 40 AM" src="https://github.com/user-attachments/assets/bf342c06-bf52-4f72-a355-149837c4ae62" />

