### PR TITLE
Utility Methods for Slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Added
 
+- Utility methods for fetching chunked arrays for a given slice.
+
+
+## v0.2.10 (2026-05-22)
+
+### Added
+
 - Cursor-based pagination for catalog containers on the default sort order.
   The server now uses the node `id` as an opaque cursor, eliminating the
   duplicate-and-skip problem that offset pagination suffers when items are

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -495,3 +495,38 @@ def test_block_for_slice_basic():
     # Slice indexing out of bounds
     with pytest.raises(IndexError):
         block_for_slice(chunks, (50, 10))
+
+
+def test_ndblock_chunk_indices():
+    """Test NDBlock.chunk_indices method."""
+    chunks = ((10, 10, 10), (20, 20))
+
+    # Mix of int and slice
+    block = NDBlock(builtins.slice(0, 2), 1)
+    assert block.chunk_indices(chunks) == [(0, 1), (1, 1)]
+
+    # Opposite - int then slice
+    block = NDBlock(0, builtins.slice(0, 2))
+    assert block.chunk_indices(chunks) == [(0, 0), (0, 1)]
+
+    # All slices (2D grid)
+    block = NDBlock(builtins.slice(0, 2), builtins.slice(0, 2))
+    assert block.chunk_indices(chunks) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    # Single chunk (all integers)
+    block = NDBlock(1, 0)
+    assert block.chunk_indices(chunks) == [(1, 0)]
+
+    # 1D case
+    chunks_1d = ((10, 10, 10),)
+    block = NDBlock(builtins.slice(1, 3))
+    assert block.chunk_indices(chunks_1d) == [(1,), (2,)]
+
+    # 3D case
+    chunks_3d = ((5, 5), (10, 10), (20, 20))
+    block = NDBlock(0, builtins.slice(0, 2), 1)
+    assert block.chunk_indices(chunks_3d) == [(0, 0, 1), (0, 1, 1)]
+
+    # Larger slice range
+    block = NDBlock(builtins.slice(0, 3), 0)
+    assert block.chunk_indices(chunks) == [(0, 0), (1, 0), (2, 0)]

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -10,7 +10,13 @@ from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 from tiled.catalog import in_memory
 from tiled.client import Context, from_context
-from tiled.ndslice import NDBlock, NDSlice, block_for_slice, compose_slices
+from tiled.ndslice import (
+    NDBlock,
+    NDSlice,
+    block_for_slice,
+    build_nested_grid,
+    compose_slices,
+)
 from tiled.server.app import build_app
 
 
@@ -367,72 +373,19 @@ def test_block_for_slice_correctness(shape, data):
     test_slice = data.draw(ndslice_strategy(shape))
     expected = arr[test_slice] if test_slice else arr
 
-    # Get block and slice from block_for_slice
+    # Get block and slice from block_for_slice, list indices of all touched chunks
     block, slice_in_block = block_for_slice(chunks, test_slice)
+    chunk_indices = block.chunk_indices(chunks)
 
-    # Extract the selected blocks
-    num_chunks_per_dim = tuple(len(dim_chunks) for dim_chunks in chunks)
-    block_expanded = block.expand_for_shape(num_chunks_per_dim)
+    # Extract each chunk, organize them into a grid, and concatenate them together
+    if not chunk_indices:
+        assume(False)  # No blocks selected
 
-    # Collect blocks
-    selected_blocks = []
-    for idx in np.ndindex(num_chunks_per_dim):
-        if all(
-            (isinstance(sel, int) and idx[i] == sel)
-            or (isinstance(sel, builtins.slice) and sel.start <= idx[i] < sel.stop)
-            for i, sel in enumerate(block_expanded)
-        ):
-            # Get this block from array
-            block_slices = tuple(
-                builtins.slice(
-                    sum(chunks[dim][: idx[dim]]), sum(chunks[dim][: idx[dim] + 1])
-                )
-                for dim in range(len(shape))
-            )
-            selected_blocks.append((idx, arr[block_slices]))
-
-    # Concatenate blocks if multiple, otherwise use single block
-    if len(selected_blocks) == 1:
-        concatenated = selected_blocks[0][1]
-    elif len(selected_blocks) > 1:
-        # Organize into grid for concatenation
-        grid_shape = tuple(
-            sel.stop - sel.start if isinstance(sel, builtins.slice) else 1
-            for sel in block_expanded
+    concatenated = np.block(
+        build_nested_grid(
+            chunk_indices, lambda idx: arr[NDBlock(*idx).slice_from_chunks(chunks)]
         )
-        grid = {
-            tuple(
-                idx[i] - (sel.start if isinstance(sel, builtins.slice) else sel)
-                for i, sel in enumerate(block_expanded)
-            ): block_data
-            for idx, block_data in selected_blocks
-        }
-
-        # Concatenate based on dimensionality
-        if len(grid_shape) == 1:
-            concatenated = np.concatenate(
-                [grid[tuple([i])] for i in range(grid_shape[0])], axis=0
-            )
-        elif len(grid_shape) == 2:
-            rows = [
-                np.concatenate([grid[(i, j)] for j in range(grid_shape[1])], axis=1)
-                for i in range(grid_shape[0])
-            ]
-            concatenated = np.concatenate(rows, axis=0)
-        else:  # 3D
-            planes = []
-            for i in range(grid_shape[0]):
-                rows = [
-                    np.concatenate(
-                        [grid[(i, j, k)] for k in range(grid_shape[2])], axis=2
-                    )
-                    for j in range(grid_shape[1])
-                ]
-                planes.append(np.concatenate(rows, axis=1))
-            concatenated = np.concatenate(planes, axis=0)
-    else:
-        # No blocks selected - shouldn't happen with valid slices
-        assume(False)
+    )
 
     # Apply slice_in_block and verify correctness
     result = concatenated[slice_in_block] if slice_in_block else concatenated
@@ -498,7 +451,6 @@ def test_block_for_slice_basic():
 
 
 def test_ndblock_chunk_indices():
-    """Test NDBlock.chunk_indices method."""
     chunks = ((10, 10, 10), (20, 20))
 
     # Mix of int and slice
@@ -530,3 +482,101 @@ def test_ndblock_chunk_indices():
     # Larger slice range
     block = NDBlock(builtins.slice(0, 3), 0)
     assert block.chunk_indices(chunks) == [(0, 0), (1, 0), (2, 0)]
+
+
+def test_build_nested_grid():
+    """Test build_nested_grid function for organizing multi-dimensional indices."""
+
+    # 1D case
+    indices_1d = [(0,), (1,), (2,)]
+    result_1d = build_nested_grid(indices_1d)
+    assert result_1d == [(0,), (1,), (2,)]
+
+    # 2D case - 2x3 grid
+    indices_2d = [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]
+    result_2d = build_nested_grid(indices_2d)
+    assert result_2d == [[(0, 0), (0, 1), (0, 2)], [(1, 0), (1, 1), (1, 2)]]
+
+    # 2D case - single row
+    indices_2d_row = [(0, 0), (0, 1), (0, 2)]
+    result_2d_row = build_nested_grid(indices_2d_row)
+    assert result_2d_row == [[(0, 0), (0, 1), (0, 2)]]
+
+    # 2D case - single column
+    indices_2d_col = [(0, 0), (1, 0), (2, 0)]
+    result_2d_col = build_nested_grid(indices_2d_col)
+    assert result_2d_col == [[(0, 0)], [(1, 0)], [(2, 0)]]
+
+    # 3D case - 2x2x2 cube
+    indices_3d = [
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1),
+    ]
+    result_3d = build_nested_grid(indices_3d)
+    assert len(result_3d) == 2  # 2 groups along first dimension
+    assert len(result_3d[0]) == 2  # 2 groups along second dimension
+    assert len(result_3d[0][0]) == 2  # 2 elements along third dimension
+    assert result_3d[0][0][0] == (0, 0, 0)
+    assert result_3d[0][0][1] == (0, 0, 1)
+    assert result_3d[1][1][1] == (1, 1, 1)
+
+    # 3D case - irregular shape (2x1x3)
+    indices_3d_irregular = [
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 0, 2),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 0, 2),
+    ]
+    result_3d_irregular = build_nested_grid(indices_3d_irregular)
+    assert len(result_3d_irregular) == 2
+    assert len(result_3d_irregular[0]) == 1
+    assert len(result_3d_irregular[0][0]) == 3
+
+    # With callable - simple transform
+    indices_with_callable = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    result_with_callable = build_nested_grid(
+        indices_with_callable, lambda idx: sum(idx)
+    )
+    assert result_with_callable == [[0, 1], [1, 2]]
+
+    # With callable - dictionary lookup
+    array_dict = {
+        (0, 0): np.array([[1, 2]]),
+        (0, 1): np.array([[3, 4]]),
+        (1, 0): np.array([[5, 6]]),
+        (1, 1): np.array([[7, 8]]),
+    }
+    indices_dict = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    result_dict = build_nested_grid(indices_dict, lambda idx: array_dict[idx])
+    # Verify structure by concatenating with np.block
+    concatenated = np.block(result_dict)
+    expected = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+    np.testing.assert_array_equal(concatenated, expected)
+
+    # Single element
+    indices_single = [(5, 3, 2)]
+    result_single = build_nested_grid(indices_single)
+    # Single element still gets nested structure matching dimensionality
+    assert result_single == [[[(5, 3, 2)]]]
+
+    # Single element with callable
+    result_single_callable = build_nested_grid(indices_single, lambda idx: idx[0] * 10)
+    assert result_single_callable == [[[50]]]
+
+    # Single element 1D
+    indices_single_1d = [(3,)]
+    result_single_1d = build_nested_grid(indices_single_1d)
+    assert result_single_1d == [(3,)]
+
+    # Single element 2D
+    indices_single_2d = [(2, 1)]
+    result_single_2d = build_nested_grid(indices_single_2d)
+    assert result_single_2d == [[(2, 1)]]

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -10,7 +10,7 @@ from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 from tiled.catalog import in_memory
 from tiled.client import Context, from_context
-from tiled.ndslice import NDSlice, compose_slices
+from tiled.ndslice import NDBlock, NDSlice, block_for_slice, compose_slices
 from tiled.server.app import build_app
 
 
@@ -321,3 +321,177 @@ def test_compose_slices(shape, data):
 
     # Test the composition via __getitem__
     np.testing.assert_array_equal(arr[slc1][slc2], arr[slc1[slc2]])
+
+
+def chunks_strategy(shape):
+    """Generate valid chunking schemes for a given shape."""
+
+    def gen_chunks_for_dim(dim_size):
+        # Generate a list of chunk sizes that sum to dim_size
+        if dim_size == 0:
+            return st.just(())
+        # Generate between 1 and min(dim_size, 5) chunks
+        num_chunks = st.integers(1, min(dim_size, 5))
+        return num_chunks.flatmap(lambda n: _partition_into_chunks(dim_size, n))
+
+    def _partition_into_chunks(total, n_chunks):
+        """Partition total into n_chunks positive integers."""
+        if n_chunks == 1:
+            return st.just((total,))
+        # Generate n_chunks-1 split points
+        splits = st.lists(
+            st.integers(1, total - 1),
+            min_size=n_chunks - 1,
+            max_size=n_chunks - 1,
+            unique=True,
+        ).map(sorted)
+
+        def make_chunks(split_points):
+            points = [0] + split_points + [total]
+            return tuple(points[i + 1] - points[i] for i in range(len(points) - 1))
+
+        return splits.map(make_chunks)
+
+    return st.tuples(*(gen_chunks_for_dim(dim) for dim in shape))
+
+
+@given(
+    shape=st.lists(st.integers(5, 20), min_size=1, max_size=3),
+    data=st.data(),
+)
+def test_block_for_slice_correctness(shape, data):
+    """Test that block_for_slice produces correct results when applied to real arrays."""
+    # Create test array, valid slice, and chunking scheme
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    chunks = data.draw(chunks_strategy(shape))
+    test_slice = data.draw(ndslice_strategy(shape))
+    expected = arr[test_slice] if test_slice else arr
+
+    # Get block and slice from block_for_slice
+    block, slice_in_block = block_for_slice(chunks, test_slice)
+
+    # Extract the selected blocks
+    num_chunks_per_dim = tuple(len(dim_chunks) for dim_chunks in chunks)
+    block_expanded = block.expand_for_shape(num_chunks_per_dim)
+
+    # Collect blocks
+    selected_blocks = []
+    for idx in np.ndindex(num_chunks_per_dim):
+        if all(
+            (isinstance(sel, int) and idx[i] == sel)
+            or (isinstance(sel, builtins.slice) and sel.start <= idx[i] < sel.stop)
+            for i, sel in enumerate(block_expanded)
+        ):
+            # Get this block from array
+            block_slices = tuple(
+                builtins.slice(
+                    sum(chunks[dim][: idx[dim]]), sum(chunks[dim][: idx[dim] + 1])
+                )
+                for dim in range(len(shape))
+            )
+            selected_blocks.append((idx, arr[block_slices]))
+
+    # Concatenate blocks if multiple, otherwise use single block
+    if len(selected_blocks) == 1:
+        concatenated = selected_blocks[0][1]
+    elif len(selected_blocks) > 1:
+        # Organize into grid for concatenation
+        grid_shape = tuple(
+            sel.stop - sel.start if isinstance(sel, builtins.slice) else 1
+            for sel in block_expanded
+        )
+        grid = {
+            tuple(
+                idx[i] - (sel.start if isinstance(sel, builtins.slice) else sel)
+                for i, sel in enumerate(block_expanded)
+            ): block_data
+            for idx, block_data in selected_blocks
+        }
+
+        # Concatenate based on dimensionality
+        if len(grid_shape) == 1:
+            concatenated = np.concatenate(
+                [grid[tuple([i])] for i in range(grid_shape[0])], axis=0
+            )
+        elif len(grid_shape) == 2:
+            rows = [
+                np.concatenate([grid[(i, j)] for j in range(grid_shape[1])], axis=1)
+                for i in range(grid_shape[0])
+            ]
+            concatenated = np.concatenate(rows, axis=0)
+        else:  # 3D
+            planes = []
+            for i in range(grid_shape[0]):
+                rows = [
+                    np.concatenate(
+                        [grid[(i, j, k)] for k in range(grid_shape[2])], axis=2
+                    )
+                    for j in range(grid_shape[1])
+                ]
+                planes.append(np.concatenate(rows, axis=1))
+            concatenated = np.concatenate(planes, axis=0)
+    else:
+        # No blocks selected - shouldn't happen with valid slices
+        assume(False)
+
+    # Apply slice_in_block and verify correctness
+    result = concatenated[slice_in_block] if slice_in_block else concatenated
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_block_for_slice_basic():
+    """Test basic block_for_slice functionality."""
+    # Full array
+    chunks = ((10, 10), (20, 20))
+    block, slice_in_block = block_for_slice(chunks, None)
+    assert block == NDBlock(builtins.slice(0, 2), builtins.slice(0, 2))
+    assert slice_in_block == NDSlice()
+
+    # Single block
+    block, slice_in_block = block_for_slice(
+        chunks, (builtins.slice(2, 8), builtins.slice(5, 15))
+    )
+    assert block == NDBlock(0, 0)
+
+    # Multiple blocks
+    block, slice_in_block = block_for_slice(
+        chunks, (builtins.slice(5, 15), builtins.slice(15, 35))
+    )
+    assert block == NDBlock(builtins.slice(0, 2), builtins.slice(0, 2))
+    assert isinstance(block, NDBlock)
+    assert isinstance(slice_in_block, NDSlice)
+    for item in block:
+        if isinstance(item, builtins.slice):
+            assert item.step in (None, 1)
+
+    # Integer index
+    block, slice_in_block = block_for_slice(chunks, (15, 25))
+    assert block == NDBlock(1, 1)
+    assert slice_in_block == NDSlice(5, 5)
+
+    # Slice with step
+    block, slice_in_block = block_for_slice(
+        chunks, (builtins.slice(5, 25, 2), builtins.slice(10, 30))
+    )
+    assert slice_in_block[0].step == 2
+    assert slice_in_block[0].start == 5
+
+    # Negative step
+    block, slice_in_block = block_for_slice(
+        chunks, (builtins.slice(15, 5, -1), builtins.slice(10, 30))
+    )
+    assert block == NDBlock(builtins.slice(0, 2), builtins.slice(0, 2))
+    assert slice_in_block[0].step == -1
+    assert isinstance(block, NDBlock)
+
+    # Negative step to beginning (None)
+    block, slice_in_block = block_for_slice(
+        chunks, (builtins.slice(None, None, -1), builtins.slice(10, 30))
+    )
+    assert block == NDBlock(builtins.slice(0, 2), builtins.slice(0, 2))
+    assert slice_in_block[0].step == -1
+    assert slice_in_block[0].stop is None  # Should be None, not negative
+
+    # Slice indexing out of bounds
+    with pytest.raises(IndexError):
+        block_for_slice(chunks, (50, 10))

--- a/tiled/ndslice.py
+++ b/tiled/ndslice.py
@@ -608,6 +608,40 @@ class NDBlock(NDSlice):
 
         return NDSlice(*slice_)
 
+    def chunk_indices(self, chunks: Chunks) -> list[tuple[int, ...]]:
+        """Return a list of all n-dimensional chunk indices in this block.
+
+        Expands any slice dimensions into individual indices while keeping
+        integer dimensions as-is. The result is a list of tuples where each
+        tuple represents the chunk index for one block.
+
+        Parameters
+        ----------
+        chunks : Chunks
+            The chunking scheme to determine the valid range of chunk indices.
+
+        Returns
+        -------
+        list[tuple[int, ...]]
+            List of n-dimensional chunk index tuples.
+        """
+        # Expand to get actual indices for each dimension
+        expanded = self.expand_for_shape(tuple(len(ch) for ch in chunks))
+
+        # Convert each dimension to a list of indices
+        dim_indices = []
+        for item in expanded:
+            if isinstance(item, int):
+                dim_indices.append([item])
+            elif isinstance(item, builtins.slice):
+                # Extract start, stop from the slice (step is guaranteed to be 1 or None)
+                start = item.start if item.start is not None else 0
+                stop = item.stop
+                dim_indices.append(list(range(start, stop)))
+
+        # Generate all combinations (Cartesian product)
+        return sorted(itertools.product(*dim_indices))
+
 
 def block_for_slice(
     chunks: Chunks, slice: Optional[Union[tuple, "NDSlice"]] = None

--- a/tiled/ndslice.py
+++ b/tiled/ndslice.py
@@ -1,3 +1,4 @@
+import bisect
 import builtins
 import itertools
 import math
@@ -660,45 +661,17 @@ def block_for_slice(
     ----------
     chunks : Chunks
         The chunking scheme as a tuple of tuples, where chunks[i] gives the sizes
-        of chunks along dimension i. For example: ((10, 10, 10), (50, 50))
-        represents an array chunked into 3 chunks of size 10 along axis 0 and
-        2 chunks of size 50 along axis 1.
+        of chunks along dimension i.
     slice : tuple or NDSlice, optional
-        The slice to apply to the full array. Can be:
-        - None: returns all blocks and identity slice
-        - tuple: e.g., (slice(10, 50), slice(20, 30))
-        - NDSlice: instance of NDSlice class
-        If the slice contains Ellipsis or unresolved dimensions, it will be
-        expanded using the shape derived from chunks.
+        The slice to apply to the full array.
 
     Returns
     -------
     block : NDBlock
-        The contiguous block indices touched by the slice. This is an NDBlock
-        (subclass of NDSlice) representing which chunks to read. Each dimension
-        contains either an integer (single chunk) or a slice with step=1
-        (contiguous range of chunks).
+        The contiguous block indices touched by the slice.
     slice_within_blocks : NDSlice
         The slice to apply to the array formed by concatenating the selected blocks
-        to produce the final result. This accounts for:
-        - Offsets within the first touched chunk
-        - Trimming of the last touched chunk
-        - Step sizes in the original slice
-
-    Examples
-    --------
-    >>> # Array with shape (100, 200), chunks ((10, 10, 10, ...), (50, 50, ...))
-    >>> chunks = ((10, 10, 10, 10, 10, 10, 10, 10, 10, 10), (50, 50, 50, 50))
-    >>>
-    >>> # Want to read arr[15:35, 40:110]
-    >>> block, slice_in_block = block_for_slice(chunks, (slice(15, 35), slice(40, 110)))
-    >>> # block = NDBlock(slice(1, 4), slice(0, 3))  # chunks [1:4, 0:3]
-    >>> # slice_in_block = NDSlice(slice(5, 25), slice(40, 60))  # within concatenated blocks
-    >>>
-    >>> # With step
-    >>> block, slice_in_block = block_for_slice(chunks, (slice(15, 35, 2), slice(40, 110)))
-    >>> # block = NDBlock(slice(1, 4), slice(0, 3))  # same blocks
-    >>> # slice_in_block = NDSlice(slice(5, 25, 2), slice(40, 60))  # step preserved
+        to produce the final result.
     """
 
     # If empty slice, return all blocks and identity slice
@@ -713,24 +686,21 @@ def block_for_slice(
     shape = tuple(sum(dim_chunks) for dim_chunks in chunks)
     slice = slice.expand_for_shape(shape)
 
-    # For each dimension, determine which chunks are touched and the adjusted slice
+    # For each dimension, determine which chunks are touched and how to slice concatenated blocks
     block_slices, adjusted_slices = [], []
-
     for dim_idx, (slc, dim_chunks) in enumerate(zip(slice, chunks)):
         # Compute chunk boundaries: [0, chunks[0], chunks[0]+chunks[1], ...]
         chunk_bounds = [0, *itertools.accumulate(dim_chunks)]
 
         if isinstance(slc, int):
-            # Single index - find which chunk it falls in and adjust
-            for chunk_idx in range(len(dim_chunks)):
-                if chunk_bounds[chunk_idx] <= slc < chunk_bounds[chunk_idx + 1]:
-                    block_slices.append(chunk_idx)
-                    adjusted_slices.append(slc - chunk_bounds[chunk_idx])
-                    break
-            else:
+            # Single index - find which chunk it falls in using binary search
+            chunk_idx = bisect.bisect_right(chunk_bounds, slc) - 1
+            if chunk_idx < 0 or chunk_idx >= len(dim_chunks):
                 raise IndexError(
                     f"Index {slc} out of bounds for dimension {dim_idx} with shape {shape[dim_idx]}"
                 )
+            block_slices.append(chunk_idx)
+            adjusted_slices.append(slc - chunk_bounds[chunk_idx])
 
         elif isinstance(slc, builtins.slice):
             # Normalize slice indices for this dimension
@@ -739,45 +709,27 @@ def block_for_slice(
             if step == 0:
                 raise ValueError("slice step cannot be zero")
 
-            # Find all chunks touched by this slice
-            touched_chunks = []
-
-            for chunk_idx in range(len(dim_chunks)):
-                chunk_start = chunk_bounds[chunk_idx]
-                chunk_end = chunk_bounds[chunk_idx + 1]
-
-                # Check if any element from range(start, stop, step) falls in [chunk_start, chunk_end)
-                if step > 0:
-                    # Forward iteration: find smallest k where start + k*step >= chunk_start
-                    k_min = (
-                        0
-                        if start >= chunk_start
-                        else (chunk_start - start + step - 1) // step
-                    )
-                    first_in_chunk = start + k_min * step
-
-                    # Check if this element is valid and within chunk
-                    if first_in_chunk < stop and first_in_chunk < chunk_end:
-                        touched_chunks.append(chunk_idx)
-
-                else:  # step < 0
-                    # Backward iteration: find smallest k where start + k*step < chunk_end
-                    k_min = 0 if start < chunk_end else (chunk_end - 1 - start) // step
-                    first_in_chunk = start + k_min * step
-
-                    # Check if this element is valid and within chunk
-                    if first_in_chunk > stop and first_in_chunk >= chunk_start:
-                        touched_chunks.append(chunk_idx)
-
-            if not touched_chunks:
-                # Empty slice - return empty block
-                block_slices.append(builtins.slice(0, 0))
-                adjusted_slices.append(builtins.slice(0, 0))
-                continue
-
-            # Chunks touched form a contiguous range
-            first_chunk = min(touched_chunks)
-            last_chunk = max(touched_chunks)
+            # Find first and last chunks touched by this slice
+            if step > 0:
+                if start >= stop:
+                    block_slices.append(builtins.slice(0, 0))
+                    adjusted_slices.append(builtins.slice(0, 0))
+                    continue  # Empty slice
+                first_chunk = bisect.bisect_right(chunk_bounds, start) - 1
+                last_chunk = bisect.bisect_right(chunk_bounds, stop - 1) - 1
+            else:  # step < 0
+                if start <= stop:
+                    block_slices.append(builtins.slice(0, 0))
+                    adjusted_slices.append(builtins.slice(0, 0))
+                    continue  # Empty slice
+                # Negative steps traverse from start down to stop (exclusive)
+                # so elements go from start to stop+1
+                first_chunk = bisect.bisect_right(chunk_bounds, start) - 1
+                last_chunk = bisect.bisect_right(chunk_bounds, stop + 1) - 1
+                # Ensure first_chunk <= last_chunk for contiguous block range
+                first_chunk, last_chunk = min(first_chunk, last_chunk), max(
+                    first_chunk, last_chunk
+                )
 
             # Block is the contiguous range of chunks
             if first_chunk == last_chunk:
@@ -795,27 +747,54 @@ def block_for_slice(
             if step < 0 and stop < first_chunk_start:
                 adjusted_stop = None
 
-            adjusted_slices.append(builtins.slice(adjusted_start, adjusted_stop, step))
+            # Normalize step=1 to step=None for consistency
+            normalized_step = None if step == 1 else step
+            adjusted_slices.append(
+                builtins.slice(adjusted_start, adjusted_stop, normalized_step)
+            )
 
-    # Simplify block slices: convert slice(n, n+1) to just n
-    simplified_block_slices = [
-        bs.start
-        if (
-            isinstance(bs, builtins.slice)
-            and bs.start is not None
-            and bs.stop == bs.start + 1
-            and (bs.step is None or bs.step == 1)
-        )
-        else bs
-        for bs in block_slices
+    return NDBlock(*block_slices), NDSlice(*adjusted_slices)
+
+
+def build_nested_grid(indices, callable=None, dim=0):
+    """Build a nested list structure from flat N-dimensional indices.
+
+    This function organizes a flat list of N-dimensional indices into a nested
+    list structure suitable for np.block(). The nesting depth matches the
+    dimensionality of the indices, with each level corresponding to one dimension.
+
+    This is particularly useful when you have a collection of array chunks indexed
+    by multi-dimensional coordinates and want to concatenate them efficiently using
+    np.block().
+
+    Parameters
+    ----------
+    indices : list[tuple[int, ...]]
+        A list of N-dimensional index tuples. The indices should be sorted in
+        lexicographic order (though groupby will work with any order that groups
+        consecutive identical prefixes together).
+    callable : callable, optional
+        Optional function to apply to each index tuple at the leaf level.
+        If None, the index tuple itself is returned. This is useful for
+        retrieving actual data arrays corresponding to each index.
+        For example: lambda idx: array_dict[idx]
+    dim : int, optional
+        Internal parameter used during recursion to track current dimension.
+        Should not be set by users (defaults to 0).
+
+    Returns
+    -------
+    nested_list : list or object
+        A nested list structure where the nesting depth equals len(indices[0]).
+        At the leaf level, either the index tuples themselves or the result of
+        callable(index) is stored.
+    """
+    if dim == len(indices[0]):
+        return callable(indices[0]) if callable else indices[0]
+
+    groups = [
+        build_nested_grid(list(g), callable, dim + 1)
+        for _, g in itertools.groupby(indices, key=lambda p: p[dim])
     ]
 
-    # Simplify adjusted slices: normalize step=1 to step=None for consistency
-    simplified_adjusted_slices = [
-        builtins.slice(adj.start, adj.stop, None)
-        if (isinstance(adj, builtins.slice) and adj.step == 1)
-        else adj
-        for adj in adjusted_slices
-    ]
-
-    return NDBlock(*simplified_block_slices), NDSlice(*simplified_adjusted_slices)
+    return groups

--- a/tiled/ndslice.py
+++ b/tiled/ndslice.py
@@ -607,3 +607,181 @@ class NDBlock(NDSlice):
                 slice_.append(slice(start, stop))
 
         return NDSlice(*slice_)
+
+
+def block_for_slice(
+    chunks: Chunks, slice: Optional[Union[tuple, "NDSlice"]] = None
+) -> tuple["NDBlock", "NDSlice"]:
+    """Convert a slice on a chunked array into block indices and a slice within the block
+
+    Given an array's chunking scheme and a slice to apply, this function determines:
+    1. Which blocks (chunks) are touched by the slice (returned as NDBlock)
+    2. What slice to apply within the concatenated blocks to get the final result
+
+    This is useful for reading data using block-based access (e.g., read_block()) instead
+    of full array slicing, which can be more efficient for large datasets by avoiding
+    expensive path resolution operations.
+
+    Parameters
+    ----------
+    chunks : Chunks
+        The chunking scheme as a tuple of tuples, where chunks[i] gives the sizes
+        of chunks along dimension i. For example: ((10, 10, 10), (50, 50))
+        represents an array chunked into 3 chunks of size 10 along axis 0 and
+        2 chunks of size 50 along axis 1.
+    slice : tuple or NDSlice, optional
+        The slice to apply to the full array. Can be:
+        - None: returns all blocks and identity slice
+        - tuple: e.g., (slice(10, 50), slice(20, 30))
+        - NDSlice: instance of NDSlice class
+        If the slice contains Ellipsis or unresolved dimensions, it will be
+        expanded using the shape derived from chunks.
+
+    Returns
+    -------
+    block : NDBlock
+        The contiguous block indices touched by the slice. This is an NDBlock
+        (subclass of NDSlice) representing which chunks to read. Each dimension
+        contains either an integer (single chunk) or a slice with step=1
+        (contiguous range of chunks).
+    slice_within_blocks : NDSlice
+        The slice to apply to the array formed by concatenating the selected blocks
+        to produce the final result. This accounts for:
+        - Offsets within the first touched chunk
+        - Trimming of the last touched chunk
+        - Step sizes in the original slice
+
+    Examples
+    --------
+    >>> # Array with shape (100, 200), chunks ((10, 10, 10, ...), (50, 50, ...))
+    >>> chunks = ((10, 10, 10, 10, 10, 10, 10, 10, 10, 10), (50, 50, 50, 50))
+    >>>
+    >>> # Want to read arr[15:35, 40:110]
+    >>> block, slice_in_block = block_for_slice(chunks, (slice(15, 35), slice(40, 110)))
+    >>> # block = NDBlock(slice(1, 4), slice(0, 3))  # chunks [1:4, 0:3]
+    >>> # slice_in_block = NDSlice(slice(5, 25), slice(40, 60))  # within concatenated blocks
+    >>>
+    >>> # With step
+    >>> block, slice_in_block = block_for_slice(chunks, (slice(15, 35, 2), slice(40, 110)))
+    >>> # block = NDBlock(slice(1, 4), slice(0, 3))  # same blocks
+    >>> # slice_in_block = NDSlice(slice(5, 25, 2), slice(40, 60))  # step preserved
+    """
+
+    # If empty slice, return all blocks and identity slice
+    slice = NDSlice(slice or ())
+    if not slice:
+        return (
+            NDBlock(*[builtins.slice(0, len(dim_chunks)) for dim_chunks in chunks]),
+            NDSlice(),
+        )
+
+    # Expand the slice for the specific shape (handles Ellipsis, etc.)
+    shape = tuple(sum(dim_chunks) for dim_chunks in chunks)
+    slice = slice.expand_for_shape(shape)
+
+    # For each dimension, determine which chunks are touched and the adjusted slice
+    block_slices, adjusted_slices = [], []
+
+    for dim_idx, (slc, dim_chunks) in enumerate(zip(slice, chunks)):
+        # Compute chunk boundaries: [0, chunks[0], chunks[0]+chunks[1], ...]
+        chunk_bounds = [0, *itertools.accumulate(dim_chunks)]
+
+        if isinstance(slc, int):
+            # Single index - find which chunk it falls in and adjust
+            for chunk_idx in range(len(dim_chunks)):
+                if chunk_bounds[chunk_idx] <= slc < chunk_bounds[chunk_idx + 1]:
+                    block_slices.append(chunk_idx)
+                    adjusted_slices.append(slc - chunk_bounds[chunk_idx])
+                    break
+            else:
+                raise IndexError(
+                    f"Index {slc} out of bounds for dimension {dim_idx} with shape {shape[dim_idx]}"
+                )
+
+        elif isinstance(slc, builtins.slice):
+            # Normalize slice indices for this dimension
+            start, stop, step = slc.indices(shape[dim_idx])
+
+            if step == 0:
+                raise ValueError("slice step cannot be zero")
+
+            # Find all chunks touched by this slice
+            touched_chunks = []
+
+            for chunk_idx in range(len(dim_chunks)):
+                chunk_start = chunk_bounds[chunk_idx]
+                chunk_end = chunk_bounds[chunk_idx + 1]
+
+                # Check if any element from range(start, stop, step) falls in [chunk_start, chunk_end)
+                if step > 0:
+                    # Forward iteration: find smallest k where start + k*step >= chunk_start
+                    k_min = (
+                        0
+                        if start >= chunk_start
+                        else (chunk_start - start + step - 1) // step
+                    )
+                    first_in_chunk = start + k_min * step
+
+                    # Check if this element is valid and within chunk
+                    if first_in_chunk < stop and first_in_chunk < chunk_end:
+                        touched_chunks.append(chunk_idx)
+
+                else:  # step < 0
+                    # Backward iteration: find smallest k where start + k*step < chunk_end
+                    k_min = 0 if start < chunk_end else (chunk_end - 1 - start) // step
+                    first_in_chunk = start + k_min * step
+
+                    # Check if this element is valid and within chunk
+                    if first_in_chunk > stop and first_in_chunk >= chunk_start:
+                        touched_chunks.append(chunk_idx)
+
+            if not touched_chunks:
+                # Empty slice - return empty block
+                block_slices.append(builtins.slice(0, 0))
+                adjusted_slices.append(builtins.slice(0, 0))
+                continue
+
+            # Chunks touched form a contiguous range
+            first_chunk = min(touched_chunks)
+            last_chunk = max(touched_chunks)
+
+            # Block is the contiguous range of chunks
+            if first_chunk == last_chunk:
+                block_slices.append(first_chunk)
+            else:
+                block_slices.append(builtins.slice(first_chunk, last_chunk + 1))
+
+            # Compute adjusted slice within concatenated blocks
+            first_chunk_start = chunk_bounds[first_chunk]
+            adjusted_start = start - first_chunk_start
+            adjusted_stop = stop - first_chunk_start
+
+            # Special case: for negative steps, if stop would go before the start of
+            # the first chunk, set it to None to indicate "go to the beginning"
+            if step < 0 and stop < first_chunk_start:
+                adjusted_stop = None
+
+            adjusted_slices.append(builtins.slice(adjusted_start, adjusted_stop, step))
+
+    # Simplify block slices: convert slice(n, n+1) to just n
+    simplified_block_slices = [
+        bs.start
+        if (
+            isinstance(bs, builtins.slice)
+            and bs.start is not None
+            and bs.stop == bs.start + 1
+            and (bs.step is None or bs.step == 1)
+        )
+        else bs
+        for bs in block_slices
+    ]
+
+    # Simplify adjusted slices: normalize step=1 to step=None for consistency
+    simplified_adjusted_slices = [
+        builtins.slice(adj.start, adj.stop, None)
+        if (isinstance(adj, builtins.slice) and adj.step == 1)
+        else adj
+        for adj in adjusted_slices
+    ]
+
+    return NDBlock(*simplified_block_slices), NDSlice(*simplified_adjusted_slices)


### PR DESCRIPTION
This adds utility methods for computing blocks of chunks needed to be fetched to serve a given slice of the full array. These methods are useful for transforming `.read(slice=...)` methods applied to array adapters to a series of equivalent `.read_block(slice_in_block=...)` methods with subsequent concatenation of results.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
