### PR TITLE
Limit the Number of Concurrent httpx Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Added
 
 - Utility methods for fetching chunked arrays for a given slice.
+- Added `max_connections` parameter to `Context` (and `Context.from_app`) to
+  cap the number of simultaneous outgoing HTTP connections and concurrent
+  data-fetch requests (array chunks, dataframe partitions) issued by dask
+  workers. The default is 16. This prevents spike loads on the server when
+  computing large dask arrays or dataframes. The limit is enforced by both an
+  `httpx.Limits` connection pool on the HTTP client and a `threading.Semaphore`
+  acquired inside `_get_slice`, `_get_block`, and `_get_partition`.
 
 
 ## v0.2.10 (2026-05-22)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,17 @@
 import logging
+import threading
 from pathlib import Path
 
 import httpx
+import numpy
+import pandas
 import pytest
 import yaml
 from pydantic import ValidationError
 from starlette.status import HTTP_400_BAD_REQUEST
 
+from tiled.adapters.array import ArrayAdapter
+from tiled.adapters.dataframe import DataFrameAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context, from_context, from_profile, record_history
 from tiled.profiles import load_profiles, paths
@@ -22,6 +27,12 @@ def test_configurable_timeout():
     with Context.from_app(build_app(tree), timeout=httpx.Timeout(17)) as context:
         assert context.http_client.timeout.connect == 17
         assert context.http_client.timeout.read == 17
+
+
+def test_configurable_max_connections():
+    "max_connections is reflected in the semaphore on the Context."
+    with Context.from_app(build_app(tree), max_connections=3) as context:
+        assert context._concurrent_request_semaphore._value == 3
 
 
 def test_client_version_check(caplog):
@@ -164,3 +175,81 @@ def test_jump_down_tree():
     with record_history() as h:
         client["e"]["d"]["c"]["b"]["a"]
     assert len(h.requests) == 5
+
+
+class TrackingSemaphore:
+    "Drop-in replacement for `threading.Semaphore` that also records peak concurrent holders"
+
+    def __init__(self, value):
+        self._sem = threading.Semaphore(value)
+        self._lock = threading.Lock()
+        self.current = 0
+        self.peak = 0
+
+    def acquire(self, *args, **kwargs):
+        self._sem.acquire(*args, **kwargs)
+        with self._lock:
+            self.current += 1
+            if self.current > self.peak:
+                self.peak = self.current
+
+    def release(self):
+        with self._lock:
+            self.current -= 1
+        self._sem.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *_):
+        self.release()
+
+
+def test_semaphore_limits_concurrent_array_fetches():
+    """When dask computes a chunked array the semaphore must cap concurrent fetches.
+
+    We use max_connections=2 and an array split across 10 chunks so that dask
+    would fire all requests at once without the semaphore.
+    """
+    MAX_CONNECTIONS = 2
+
+    import dask.array as da
+
+    arr = da.zeros((10, 300, 400), chunks=(1, 300, 400), dtype="float32")
+    tree = MapAdapter({"data": ArrayAdapter.from_array(arr)})
+    app = build_app(tree)
+
+    with Context.from_app(app, max_connections=MAX_CONNECTIONS) as context:
+        sem = TrackingSemaphore(MAX_CONNECTIONS)
+        context._concurrent_request_semaphore = sem
+
+        client = from_context(context, structure_clients="dask")["data"]
+        client.read().compute()
+
+    assert sem.peak <= MAX_CONNECTIONS
+    # Sanity: 10 chunks > MAX_CONNECTIONS, so the cap had something to constrain.
+    assert sem.peak > 0
+
+
+def test_semaphore_limits_concurrent_partition_fetches():
+    "When dask computes a partitioned dataframe the semaphore must cap concurrent fetches"
+
+    MAX_CONNECTIONS = 2
+    N_PARTITIONS = 8  # well above the cap
+
+    df = pandas.DataFrame({"x": numpy.arange(N_PARTITIONS * 10, dtype="float64")})
+    tree = MapAdapter(
+        {"data": DataFrameAdapter.from_pandas(df, npartitions=N_PARTITIONS)}
+    )
+    app = build_app(tree)
+
+    with Context.from_app(app, max_connections=MAX_CONNECTIONS) as context:
+        sem = TrackingSemaphore(MAX_CONNECTIONS)
+        context._concurrent_request_semaphore = sem
+
+        client = from_context(context, structure_clients="dask")["data"]
+        client.read().compute()
+
+    assert sem.peak <= MAX_CONNECTIONS
+    assert sem.peak > 0

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -38,6 +38,20 @@ def test_pickle_context(server_url):
         pickle.loads(pickle.dumps(context))
 
 
+def test_pickle_context_preserves_max_connections(server_url):
+    """max_connections survives a pickle/unpickle round-trip."""
+    try:
+        httpx.get(server_url).raise_for_status()
+    except Exception:
+        raise pytest.skip(f"Could not connect to {server_url}")
+    with Context.from_any_uri(server_url, api_key="secret", max_connections=3)[
+        0
+    ] as context:
+        assert context._concurrent_request_semaphore._value == 3
+        restored = pickle.loads(pickle.dumps(context))
+        assert restored._concurrent_request_semaphore._value == 3
+
+
 @pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
 def test_pickle_clients(server_url, structure_clients, tmpdir):
     try:

--- a/tiled/client/array.py
+++ b/tiled/client/array.py
@@ -130,15 +130,16 @@ class _DaskArrayClient(BaseClient):
             "expected_shape": ",".join(map(str, exp_shape)) or "scalar",
         }
         params = params | ({"slice": block_slice.to_numpy_str()} if block_slice else {})
-        for attempt in retry_context():
-            with attempt:
-                content = handle_error(
-                    self.context.http_client.get(
-                        url_path,
-                        headers={"Accept": media_type},
-                        params=params,
-                    )
-                ).read()
+        with self.context._concurrent_request_semaphore:
+            for attempt in retry_context():
+                with attempt:
+                    content = handle_error(
+                        self.context.http_client.get(
+                            url_path,
+                            headers={"Accept": media_type},
+                            params=params,
+                        )
+                    ).read()
 
         return numpy.frombuffer(content, dtype=self.dtype).reshape(exp_shape)
 
@@ -176,15 +177,16 @@ class _DaskArrayClient(BaseClient):
             "expected_shape": ",".join(map(str, exp_shape)) or "scalar",
         }
         params = params | ({"slice": slice.to_numpy_str()} if slice else {})
-        for attempt in retry_context():
-            with attempt:
-                content = handle_error(
-                    self.context.http_client.get(
-                        url_path,
-                        headers={"Accept": media_type},
-                        params=params,
-                    )
-                ).read()
+        with self.context._concurrent_request_semaphore:
+            for attempt in retry_context():
+                with attempt:
+                    content = handle_error(
+                        self.context.http_client.get(
+                            url_path,
+                            headers={"Accept": media_type},
+                            params=params,
+                        )
+                    ).read()
 
         return numpy.frombuffer(content, dtype=self.dtype).reshape(exp_shape)
 

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -10,7 +10,7 @@ import httpx
 
 from ..utils import import_object, prepend_to_sys_path
 from .container import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Container
-from .context import DEFAULT_TIMEOUT_PARAMS, UNSET, Context, MAX_CONCURRENT_CONNECTIONS
+from .context import DEFAULT_TIMEOUT_PARAMS, MAX_CONCURRENT_CONNECTIONS, UNSET, Context
 from .utils import MSGPACK_MIME_TYPE, client_for_item, handle_error, retry_context
 
 
@@ -268,7 +268,8 @@ def from_profile(name, structure_clients=None, **kwargs):
         config = merged.pop("direct", None)
         with prepend_to_sys_path(filepath.parent):
             app = build_app_from_config(config)
-        context = Context.from_app(app)
+        max_connections = merged.pop("max_connections", MAX_CONCURRENT_CONNECTIONS)
+        context = Context.from_app(app, max_connections=max_connections)
         return from_context(context, **merged)
     else:
         return from_uri(**merged)

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -10,7 +10,7 @@ import httpx
 
 from ..utils import import_object, prepend_to_sys_path
 from .container import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Container
-from .context import DEFAULT_TIMEOUT_PARAMS, UNSET, Context
+from .context import DEFAULT_TIMEOUT_PARAMS, UNSET, Context, MAX_CONCURRENT_CONNECTIONS
 from .utils import MSGPACK_MIME_TYPE, client_for_item, handle_error, retry_context
 
 
@@ -29,6 +29,7 @@ def from_uri(
     timeout=None,
     include_data_sources=False,
     auth: Optional[httpx.Auth] = None,
+    max_connections: int = MAX_CONCURRENT_CONNECTIONS,
 ):
     """
     Connect to a Node on a local or remote server.
@@ -65,6 +66,9 @@ def from_uri(
         Default False. If True, fetch information about underlying data sources.
     auth : httpx.Auth, optional
         Custom authentication handler.
+    max_connections : int, optional
+        If provided, use this value for the maximum number of concurrent
+        connections in the HTTP client.
     """
     EXPLAIN_LOGIN = """
 
@@ -91,6 +95,7 @@ For non-interactive authentication, use an API key or add custom auth
         headers=headers,
         timeout=timeout,
         verify=verify,
+        max_connections=max_connections,
     )
     if auth is not None:
         if isinstance(auth, httpx.Auth):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -2,6 +2,7 @@ import getpass
 import os
 import re
 import sys
+import threading
 import time
 import urllib.parse
 import warnings
@@ -30,6 +31,10 @@ from .utils import (
 
 USER_AGENT = f"python-tiled/{tiled_version}"
 API_KEY_AUTH_HEADER_PATTERN = re.compile(r"^Apikey (\w+)$")
+# Default cap on simultaneous outgoing HTTP connections and in-flight
+# data-fetch requests.  Keeps spike loads on the server bounded while
+# still allowing reasonable parallelism from dask's threaded scheduler.
+MAX_CONCURRENT_CONNECTIONS = 10
 
 
 def raise_if_cannot_prompt():
@@ -173,6 +178,7 @@ class Context:
         verify=True,
         app=None,
         raise_server_exceptions=True,
+        max_connections=MAX_CONCURRENT_CONNECTIONS,
     ):
         # The uri is expected to reach the root API route.
         uri = httpx.URL(uri)
@@ -224,9 +230,13 @@ class Context:
             timeout = httpx.Timeout(**DEFAULT_TIMEOUT_PARAMS)
         if cache is UNSET:
             cache = None
+        limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_connections,
+        )
         if app is None:
             client = httpx.Client(
-                transport=Transport(cache=cache),
+                transport=Transport(cache=cache, limits=limits),
                 verify=verify,
                 timeout=timeout,
                 follow_redirects=True,
@@ -257,8 +267,6 @@ class Context:
             # We are abusing it slightly to enable interactive use of the
             # TestClient.
 
-            import threading
-
             # The threading module has its own (internal) atexit
             # mechanism that runs at thread shutdown, prior to the atexit
             # mechanism that runs at interpreter shutdown.
@@ -270,6 +278,11 @@ class Context:
         self._verify = verify
         self._cache = cache
         self._token_cache = Path(TILED_CACHE_DIR / "tokens")
+        # Semaphore that caps the number of concurrent data-fetch requests
+        # (array blocks, dataframe partitions, etc.) issued by dask workers.
+        # This is intentionally separate from the HTTP connection pool limit so
+        # that it can be tuned independently; by default it mirrors the pool size.
+        self._concurrent_request_semaphore = threading.Semaphore(max_connections)
 
         # Make an initial "safe" request to:
         # (1) Get the server_info.
@@ -480,6 +493,7 @@ class Context:
         api_key=UNSET,
         raise_server_exceptions=True,
         uri=None,
+        max_connections=MAX_CONCURRENT_CONNECTIONS,
     ):
         """
         Construct a Context around a FastAPI app. Primarily for testing.
@@ -492,6 +506,7 @@ class Context:
             timeout=timeout,
             app=app,
             raise_server_exceptions=raise_server_exceptions,
+            max_connections=max_connections,
         )
         if api_key is UNSET:
             if not context.server_info.authentication.providers:

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -245,9 +245,17 @@ class Context:
             client.headers = headers
         else:
             # Set up an ASGI client.
-            # Because we have been handed an app, we can infer that
-            # starlette is available.
+            # Because we have been handed an app, we can infer that starlette is available.
             from starlette.testclient import TestClient
+
+            # Note: neither `timeout` nor `limits` (max_connections) are
+            # enforced in ASGI mode.  Starlette's _TestClientTransport
+            # dispatches requests in-process via anyio and bypasses the real
+            # HTTP stack entirely, so there is no I/O wait for timeouts to
+            # fire and no TCP connections for the pool limit to count.
+            # The semaphore (_concurrent_request_semaphore) is still
+            # effective because it is enforced in Python before the request
+            # is dispatched, regardless of transport.
 
             base_uri = f"{uri.scheme}://{uri.netloc}"
             # verify parameter is dropped, as there is no SSL in ASGI mode
@@ -374,6 +382,7 @@ class Context:
             self._token_cache,
             self.server_info,
             self.cache,
+            self._concurrent_request_semaphore._value,
         )
 
     def __setstate__(self, state):
@@ -388,6 +397,7 @@ class Context:
             token_cache,
             server_info,
             cache,
+            max_connections,
         ) = state
         if state_tiled_version != tiled_version:
             raise TypeError(
@@ -401,9 +411,13 @@ class Context:
             cookies.set(
                 cookie.name, cookie.value, domain=cookie.domain, path=cookie.path
             )
+        limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_connections,
+        )
         self.http_client = httpx.Client(
             verify=verify,
-            transport=Transport(cache=cache),
+            transport=Transport(cache=cache, limits=limits),
             cookies=cookies,
             timeout=timeout,
             headers=headers,
@@ -414,6 +428,7 @@ class Context:
         self._cache = cache
         self._verify = verify
         self.server_info = server_info
+        self._concurrent_request_semaphore = threading.Semaphore(max_connections)
 
     @classmethod
     def from_any_uri(
@@ -426,6 +441,7 @@ class Context:
         timeout=None,
         verify=True,
         app=None,
+        max_connections=MAX_CONCURRENT_CONNECTIONS,
     ):
         """
         Accept a URI to a specific node.
@@ -479,6 +495,7 @@ class Context:
             timeout=timeout,
             verify=verify,
             app=app,
+            max_connections=max_connections,
         )
         return context, node_path_parts
 

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -34,7 +34,7 @@ API_KEY_AUTH_HEADER_PATTERN = re.compile(r"^Apikey (\w+)$")
 # Default cap on simultaneous outgoing HTTP connections and in-flight
 # data-fetch requests.  Keeps spike loads on the server bounded while
 # still allowing reasonable parallelism from dask's threaded scheduler.
-MAX_CONCURRENT_CONNECTIONS = 10
+MAX_CONCURRENT_CONNECTIONS = 16
 
 
 def raise_if_cannot_prompt():

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -119,31 +119,32 @@ class _DaskDataFrameClient(BaseClient):
         url_length_for_get_request = len(URL_PATH) + sum(
             _EXTRA_CHARS_PER_ITEM + len(column) for column in (columns or ())
         )
-        if url_length_for_get_request > self.URL_CHARACTER_LIMIT:
-            for attempt in retry_context():
-                with attempt:
-                    content = handle_error(
-                        self.context.http_client.post(
-                            URL_PATH,
-                            headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
-                            json=columns,
-                            params=params,
-                        )
-                    ).read()
-        else:
-            if columns:
-                # Note: The singular/plural inconsistency here is because
-                # ["A", "B"] will be encoded in the URL as column=A&column=B
-                params["column"] = columns
-            for attempt in retry_context():
-                with attempt:
-                    content = handle_error(
-                        self.context.http_client.get(
-                            URL_PATH,
-                            headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
-                            params=params,
-                        )
-                    ).read()
+        with self.context._concurrent_request_semaphore:
+            if url_length_for_get_request > self.URL_CHARACTER_LIMIT:
+                for attempt in retry_context():
+                    with attempt:
+                        content = handle_error(
+                            self.context.http_client.post(
+                                URL_PATH,
+                                headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
+                                json=columns,
+                                params=params,
+                            )
+                        ).read()
+            else:
+                if columns:
+                    # Note: The singular/plural inconsistency here is because
+                    # ["A", "B"] will be encoded in the URL as column=A&column=B
+                    params["column"] = columns
+                for attempt in retry_context():
+                    with attempt:
+                        content = handle_error(
+                            self.context.http_client.get(
+                                URL_PATH,
+                                headers={"Accept": APACHE_ARROW_FILE_MIME_TYPE},
+                                params=params,
+                            )
+                        ).read()
         return deserialize_arrow(content)
 
     def read_partition(self, partition, columns=None):

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -30,6 +30,7 @@ class Transport(httpx.BaseTransport):
         *,
         transport: tp.Optional[httpx.BaseTransport] = None,
         cache: tp.Optional[Cache] = None,
+        limits: tp.Optional[httpx.Limits] = None,
         cacheable_methods: tp.Tuple[str, ...] = ("GET",),
         cacheable_status_codes: tp.Tuple[int, ...] = (
             httpx.codes.OK,
@@ -45,7 +46,12 @@ class Transport(httpx.BaseTransport):
             cacheable_status_codes=cacheable_status_codes,
             always_cache=always_cache,
         )
-        self.transport = transport or httpx.HTTPTransport()
+        if transport is not None:
+            self.transport = transport
+        elif limits is not None:
+            self.transport = httpx.HTTPTransport(limits=limits)
+        else:
+            self.transport = httpx.HTTPTransport()
         self.cache = cache
 
     def close(self) -> None:

--- a/tiled/config_schemas/client_profiles.yml
+++ b/tiled/config_schemas/client_profiles.yml
@@ -162,6 +162,11 @@ properties:
       subdirectory of `TILED_CACHE_DIR`, which is
       system-dependent and can be inspected at
       `tiled.client.context.TILED_CACHE_DIR`.
+  max_connections:
+    type: integer
+    description: |
+      If provided, use this value for the maximum number of concurrent
+      connections in the HTTP client. Default is 16.
   verify:
     type: boolean
     description: |


### PR DESCRIPTION
Added `max_connections` parameter to `Context` (and `Context.from_app`) to cap the number of simultaneous outgoing HTTP connections and concurrent data-fetch requests (array chunks, dataframe partitions) issued by dask workers. The default is 16. This prevents spike loads on the server when computing large dask arrays or dataframes. The limit is enforced by both an `httpx.Limits` connection pool on the HTTP client and a `threading.Semaphore` acquired inside `_get_slice`, `_get_block`, and `_get_partition`.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
