### PR TITLE
Clean-Up Logging

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,12 +3,15 @@ from pathlib import Path
 
 import httpx
 import pytest
+import stamina
 import yaml
 from pydantic import ValidationError
 from starlette.status import HTTP_400_BAD_REQUEST
 
 from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context, from_context, from_profile, record_history
+from tiled.client.logger import hide_logs
+from tiled.client.utils import retry_context
 from tiled.profiles import load_profiles, paths
 from tiled.queries import Key
 from tiled.server.app import build_app
@@ -164,3 +167,53 @@ def test_jump_down_tree():
     with record_history() as h:
         client["e"]["d"]["c"]["b"]["a"]
     assert len(h.requests) == 5
+
+
+def test_hide_logs_does_not_suppress_third_party_stamina(caplog):
+    "Calling hide_logs() must not suppress retry warnings from other libraries' stamina usage."
+    hide_logs()
+
+    # Simulate a third-party library retrying via stamina directly.
+    # Re-enable stamina for this test (conftest disables it globally for speed).
+    stamina.set_active(True)
+    try:
+        n = 0
+        with caplog.at_level(logging.WARNING, logger="stamina"):
+            for attempt in stamina.retry_context(on=Exception, attempts=2, timeout=10):
+                with attempt:
+                    n += 1
+                    if n < 2:
+                        raise ValueError("third-party transient error")
+
+        # The stamina logger should still have emitted its own WARNING for the retry.
+        stamina_messages = [r for r in caplog.records if r.name == "stamina"]
+        assert (
+            len(stamina_messages) >= 1
+        ), "Third-party stamina retries should still be logged after hide_logs()"
+    finally:
+        stamina.set_active(False)
+
+
+def test_tiled_retry_logging_follows_show_hide(caplog):
+    "Tiled retries log to tiled.client at DEBUG; hidden by default, visible after show_logs()."
+    hide_logs()
+
+    # Re-enable stamina for this test (conftest disables it globally for speed).
+    stamina.set_active(True)
+    try:
+        # Force a single retry inside tiled's retry_context.
+        n = 0
+        with caplog.at_level(logging.DEBUG, logger="tiled.client"):
+            for attempt in retry_context():
+                with attempt:
+                    n += 1
+                    if n < 2:
+                        raise httpx.ReadTimeout("simulated timeout")
+
+        tiled_messages = [r for r in caplog.records if r.name == "tiled.client"]
+        assert (
+            len(tiled_messages) >= 1
+        ), "Tiled retries should emit DEBUG messages on tiled.client logger"
+        assert all(r.levelno == logging.DEBUG for r in tiled_messages)
+    finally:
+        stamina.set_active(False)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -228,6 +228,8 @@ def test_tiled_retry_logging_follows_show_hide(caplog):
         assert all(r.levelno == logging.DEBUG for r in tiled_messages)
     finally:
         stamina.set_active(False)
+
+
 class TrackingSemaphore:
     "Drop-in replacement for `threading.Semaphore` that also records peak concurrent holders"
 

--- a/tiled/client/logger.py
+++ b/tiled/client/logger.py
@@ -2,6 +2,7 @@ import collections
 import contextlib
 import logging
 import os
+import urllib.parse
 
 from ..utils import bytesize_repr
 
@@ -18,7 +19,7 @@ class ClientLogRecord(logging.LogRecord):
                 size = f"({bytesize_repr(int(request.headers['content-length']))})"
             else:
                 size = ""
-            message = f"-> {size} {request.method} '{request.url}' " + " ".join(
+            message = f"-> {size} {request.method} '{urllib.parse.unquote(str(request.url))}' " + " ".join(
                 f"'{k}:{v}'" for k, v in request.headers.items() if k != "authorization"
             )
             # Handle the authorization header specially.

--- a/tiled/client/logger.py
+++ b/tiled/client/logger.py
@@ -19,8 +19,13 @@ class ClientLogRecord(logging.LogRecord):
                 size = f"({bytesize_repr(int(request.headers['content-length']))})"
             else:
                 size = ""
-            message = f"-> {size} {request.method} '{urllib.parse.unquote(str(request.url))}' " + " ".join(
-                f"'{k}:{v}'" for k, v in request.headers.items() if k != "authorization"
+            message = (
+                f"-> {size} {request.method} '{urllib.parse.unquote(str(request.url))}' "
+                + " ".join(
+                    f"'{k}:{v}'"
+                    for k, v in request.headers.items()
+                    if k != "authorization"
+                )
             )
             # Handle the authorization header specially.
             # For debugging, it can be useful to show it so that the log message

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -1,4 +1,5 @@
 import builtins
+import logging
 import os
 import uuid
 from collections import defaultdict
@@ -144,25 +145,21 @@ def polling_retry_context(timeout: float):
     )
 
 
-# Retries are logged at WARNING level.
-def init_retry_logging(log_level: int = 30) -> stamina.instrumentation.RetryHook:
+# Retries are logged at DEBUG level on the tiled.client logger so they are
+# suppressed by default and only appear when the user calls show_logs().
+def init_retry_logging(log_level: int = logging.DEBUG) -> stamina.instrumentation.RetryHook:
     """
     Initialize logging using the standard library.
 
-    Returned hook logs scheduled retries at *log_level*.
-
-    .. versionadded:: 23.2.0
+    Returned hook logs scheduled retries at *log_level* on the ``tiled.client``
+    logger.  This means retry messages are hidden by default and only shown
+    when the user calls :func:`tiled.client.logger.show_logs`.
     """
-    import logging
-
-    logger = logging.getLogger("stamina")
-
-    # Avoid Tiled-specific language here, because this hook will apply to any
-    # applications in this process that happen to use stamina.
+    logger = logging.getLogger("tiled.client")
 
     def log_retries(details: stamina.instrumentation.RetryDetails) -> None:
         logger.log(
-            logging.WARNING,
+            log_level,
             f"Scheduled retry in {details.wait_for:.2} seconds due to "
             f"{details.caused_by!r} (attempt {details.retry_num})",
             extra={

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -13,7 +13,7 @@ from weakref import WeakValueDictionary
 
 import httpx
 import msgpack
-import stamina.instrumentation
+import stamina
 
 from ..structures.core import Spec
 from ..type_aliases import Chunks
@@ -120,14 +120,55 @@ TILED_RETRY_TIMEOUT = float(os.getenv("TILED_RETRY_TIMEOUT", "45.0"))
 
 TILED_DEVICE_FLOW_ATTEMPTS = int(os.getenv("TILED_DEVICE_FLOW_ATTEMPTS", "100"))
 
+_retry_logger = logging.getLogger("tiled.client")
+
+
+class _LoggingAttempt:
+    """Wraps a stamina ``Attempt`` to log retries to the ``tiled.client`` logger.
+
+    Logging happens at DEBUG level so messages are suppressed by default and
+    only appear when the user calls :func:`tiled.client.logger.show_logs`.
+
+    Using a wrapper here — rather than a global stamina ``RetryHook`` — means
+    tiled's retry logging is completely isolated: retries triggered by *other*
+    libraries that also use stamina are not affected, and tiled's own retries
+    are not routed through the global stamina hook machinery.
+    """
+
+    __slots__ = ("_attempt",)
+
+    def __init__(self, attempt):
+        self._attempt = attempt
+
+    @property
+    def num(self):
+        return self._attempt.num
+
+    def __enter__(self):
+        return self._attempt.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        result = self._attempt.__exit__(exc_type, exc_val, exc_tb)
+        # stamina returns True from __exit__ when it suppresses the exception
+        # and schedules a retry.  That is the moment we want to log.
+        if exc_val is not None and result:
+            _retry_logger.debug(
+                "Retry %d scheduled in %.2fs due to %r",
+                self._attempt.num,
+                self._attempt.next_wait,
+                exc_val,
+            )
+        return result
+
 
 def retry_context():
     "Iterable that yields a context manager per retry attempt"
-    return stamina.retry_context(
+    for attempt in stamina.retry_context(
         on=should_retry,
         attempts=TILED_RETRY_ATTEMPTS,
         timeout=TILED_RETRY_TIMEOUT,
-    )
+    ):
+        yield _LoggingAttempt(attempt)
 
 
 def should_poll_for_tokens(exception: Exception) -> bool:
@@ -138,46 +179,12 @@ def should_poll_for_tokens(exception: Exception) -> bool:
 
 
 def polling_retry_context(timeout: float):
-    return stamina.retry_context(
+    for attempt in stamina.retry_context(
         on=should_poll_for_tokens,
         attempts=TILED_DEVICE_FLOW_ATTEMPTS,
         timeout=timeout,
-    )
-
-
-# Retries are logged at DEBUG level on the tiled.client logger so they are
-# suppressed by default and only appear when the user calls show_logs().
-def init_retry_logging(log_level: int = logging.DEBUG) -> stamina.instrumentation.RetryHook:
-    """
-    Initialize logging using the standard library.
-
-    Returned hook logs scheduled retries at *log_level* on the ``tiled.client``
-    logger.  This means retry messages are hidden by default and only shown
-    when the user calls :func:`tiled.client.logger.show_logs`.
-    """
-    logger = logging.getLogger("tiled.client")
-
-    def log_retries(details: stamina.instrumentation.RetryDetails) -> None:
-        logger.log(
-            log_level,
-            f"Scheduled retry in {details.wait_for:.2} seconds due to "
-            f"{details.caused_by!r} (attempt {details.retry_num})",
-            extra={
-                "stamina.callable": details.name,
-                "stamina.args": tuple(repr(a) for a in details.args),
-                "stamina.kwargs": dict(details.kwargs.items()),
-                "stamina.retry_num": details.retry_num,
-                "stamina.caused_by": repr(details.caused_by),
-                "stamina.wait_for": round(details.wait_for, 2),
-                "stamina.waited_so_far": round(details.waited_so_far, 2),
-            },
-        )
-
-    return log_retries
-
-
-LoggingOnRetryHook = stamina.instrumentation.RetryHookFactory(init_retry_logging)
-stamina.instrumentation.set_on_retry_hooks([LoggingOnRetryHook])
+    ):
+        yield _LoggingAttempt(attempt)
 
 
 class TiledResponse(httpx.Response):

--- a/tiled/server/logging_config.py
+++ b/tiled/server/logging_config.py
@@ -1,3 +1,28 @@
+import urllib.parse
+from copy import copy
+from logging import LogRecord
+
+from uvicorn.logging import AccessFormatter as _UvicornAccessFormatter
+
+
+class AccessFormatter(_UvicornAccessFormatter):
+    """Uvicorn AccessFormatter that decodes percent-encoded URLs in logs."""
+
+    def formatMessage(self, record: LogRecord) -> str:
+        recordcopy = copy(record)
+        (
+            client_addr,
+            method,
+            full_path,
+            http_version,
+            status_code,
+        ) = recordcopy.args  # type: ignore[misc]
+        # Decode percent-encoded characters for readability
+        full_path = urllib.parse.unquote(full_path)
+        recordcopy.args = (client_addr, method, full_path, http_version, status_code)
+        return super().formatMessage(recordcopy)
+
+
 LOGGING_CONFIG = {
     "disable_existing_loggers": False,
     "filters": {
@@ -12,7 +37,7 @@ LOGGING_CONFIG = {
     },
     "formatters": {
         "access": {
-            "()": "uvicorn.logging.AccessFormatter",
+            "()": "tiled.server.logging_config.AccessFormatter",
             "datefmt": "%Y-%m-%dT%H:%M:%S",
             "format": (
                 "[%(correlation_id)s] "


### PR DESCRIPTION

1. Decode percent-encoded characters in server and client logs for readability.
2. Suppress stamina-generated messages, e.g. `Scheduled retry in 0.28 seconds due to ConnectError('[Errno 61] Connection refused') (attempt 1)` by default; they can be shown with `show_logs()`.

```
In [9]: arr[:20, 10:50:2, -30:]
11:33:35.959 ->  GET 'http://localhost:8000/api/v1/array/full//e2b4bfb8-d41c-4a14-bf0a-48d0ca8a3ea4?expected_shape=20,20,30&slice=:20:1,10:49:2,270:300:1' 'host:localhost:8000' ...
```

```
[1b801a92d73b3177] 127.0.0.1:59031 (singleuser) - "GET /api/v1/array/full//e2b4bfb8-d41c-4a14-bf0a-48d0ca8a3ea4?expected_shape=20,20,30&slice=:20:1,10:49:2,270:300:1 HTTP/1.1" 200 OK
```

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
