### PR TITLE
Ensure Row Ordering in SQLAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   computing large dask arrays or dataframes. The limit is enforced by both an
   `httpx.Limits` connection pool on the HTTP client and a `threading.Semaphore`
   acquired inside `_get_slice`, `_get_block`, and `_get_partition`.
-- Deterministic row ordering in SQL-based adapters when an `order_by_column` is
-  specified in the data source parameters.
+- Deterministic row ordering in SQL-based adapters when `order_by_args` is
+  specified in the data source parameters; the `primary_key` parameter allows
+  to enforce the uniqueness of rows in the table.
 
 
 ## v0.2.10 (2026-05-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
   computing large dask arrays or dataframes. The limit is enforced by both an
   `httpx.Limits` connection pool on the HTTP client and a `threading.Semaphore`
   acquired inside `_get_slice`, `_get_block`, and `_get_partition`.
+- Deterministic row ordering in SQL-based adapters when an `order_by_column` is
+  specified in the data source parameters.
 
 
 ## v0.2.10 (2026-05-22)

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Generator, Union, cast
+from typing import Any, Callable, Generator, Optional, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -42,18 +42,46 @@ batch1 = pa.record_batch(data1, names=names)
 batch2 = pa.record_batch(data2, names=names)
 
 
+def adapter_from_data_source(
+    data_source: DataSource[TableStructure], **kwargs: Any
+) -> SQLAdapter:
+    """Construct a SQLAdapter from an already-initialised DataSource.
+
+    Extra keyword arguments are forwarded to SQLAdapter.__init__, making it
+    easy to pass order_by_column, unique_ordering, etc. without repeating the
+    four positional arguments every time.
+    """
+    return SQLAdapter(
+        data_source.assets[0].data_uri,
+        data_source.structure,
+        data_source.parameters["table_name"],
+        data_source.parameters["dataset_id"],
+        **kwargs,
+    )
+
+
 @pytest.fixture
-def data_source_from_init_storage() -> Callable[[str, int], DataSource[TableStructure]]:
+def data_source_from_init_storage() -> (
+    Callable[
+        [str, int, Optional[pa.Table], Optional[dict[str, Any]]],
+        DataSource[TableStructure],
+    ]
+):
     def _data_source_from_init_storage(
-        data_uri: str, num_partitions: int
+        data_uri: str,
+        num_partitions: int,
+        table: Optional[pa.Table] = None,
+        parameters: Optional[dict[str, Any]] = None,
     ) -> DataSource[TableStructure]:
-        table = pa.Table.from_arrays(data0, names)
+        if table is None:
+            table = pa.Table.from_arrays(data0, names)
         structure = TableStructure.from_arrow_table(table, npartitions=num_partitions)
         data_source = DataSource(
             management=Management.writable,
             mimetype="application/x-tiled-sql-table",
             structure_family=StructureFamily.table,
             structure=structure,
+            parameters=parameters or {},
             assets=[],
         )
 
@@ -71,12 +99,7 @@ def adapter_duckdb_one_partition(
     duckdb_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(duckdb_uri, 1)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
 
 @pytest.fixture
@@ -86,12 +109,7 @@ def adapter_duckdb_many_partitions(
     duckdb_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(duckdb_uri, 3)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
 
 def test_attributes_duckdb_one_part(adapter_duckdb_one_partition: SQLAdapter) -> None:
@@ -113,12 +131,7 @@ def adapter_sqlite_one_partition(
     sqlite_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(sqlite_uri, 1)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
 
 @pytest.fixture
@@ -128,12 +141,7 @@ def adapter_sqlite_many_partitions(
     sqlite_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(sqlite_uri, 3)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
 
 def test_attributes_sql_one_part(adapter_sqlite_one_partition: SQLAdapter) -> None:
@@ -152,12 +160,7 @@ def adapter_psql_one_partition(
     postgres_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(postgres_uri, 1)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
     # Close all connections and dispose of the storage
     storage = get_storage(sanitize_uri(postgres_uri)[0])
@@ -170,12 +173,7 @@ def adapter_psql_many_partitions(
     postgres_uri: str,
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(postgres_uri, 3)
-    yield SQLAdapter(
-        data_source.assets[0].data_uri,
-        data_source.structure,
-        data_source.parameters["table_name"],
-        data_source.parameters["dataset_id"],
-    )
+    yield adapter_from_data_source(data_source)
 
     # Close all connections and dispose of the storage
     storage = get_storage(sanitize_uri(postgres_uri)[0])
@@ -797,3 +795,293 @@ def test_append_nullable(
     assert deep_array_equal(result_part, result_full)
 
     storage.dispose()  # Close all connections
+
+
+# ============================================================================
+# Tests for order_by functionality
+# ============================================================================
+
+# Shared schema and sample tables used across order_by tests.
+_ts_value_schema = pa.schema(
+    [pa.field("ts", pa.int64()), pa.field("value", pa.float64())]
+)
+_ts_val_schema = pa.schema([pa.field("ts", pa.int64()), pa.field("val", pa.int32())])
+_order_by_params = {"order_by_column": "ts"}
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+@pytest.mark.parametrize(
+    "schema, order_col, chunks, expected_order_col_values",
+    [
+        pytest.param(
+            _ts_value_schema,
+            "ts",
+            [
+                pa.table({"ts": [30, 40], "value": [3.0, 4.0]}),
+                pa.table({"ts": [10, 20], "value": [1.0, 2.0]}),
+            ],
+            [10, 20, 30, 40],
+            id="integer_ts_out_of_order_chunks",
+        ),
+        pytest.param(
+            _ts_value_schema,
+            "ts",
+            [
+                pa.table({"ts": [100, 200], "value": [10.0, 20.0]}),
+                pa.table({"ts": [50, 150], "value": [5.0, 15.0]}),
+                pa.table({"ts": [75, 300], "value": [7.0, 30.0]}),
+            ],
+            [50, 75, 100, 150, 200, 300],
+            id="integer_ts_incremental_appends",
+        ),
+        pytest.param(
+            pa.schema([pa.field("name", pa.string()), pa.field("score", pa.int32())]),
+            "name",
+            [pa.table({"name": ["charlie", "alice", "bob"], "score": [3, 1, 2]})],
+            ["alice", "bob", "charlie"],
+            id="string_column_lexicographic",
+        ),
+        pytest.param(
+            pa.schema([pa.field("Timestamp", pa.int64()), pa.field("val", pa.int32())]),
+            "Timestamp",
+            [pa.table({"Timestamp": [30, 10, 20], "val": [3, 1, 2]})],
+            [10, 20, 30],
+            id="mixed_case_column_name",
+        ),
+    ],
+)
+def test_order_by_single_partition(
+    data_uri: str,
+    schema: pa.Schema,
+    order_col: str,
+    chunks: list[pa.Table],
+    expected_order_col_values: list[Any],
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Appending data out of order and reading it back should always return rows sorted
+    ASC by the order_by_column, regardless of insertion order, column type, or case."""
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        schema.empty_table(),
+        {"order_by_column": order_col},
+    )
+    adapter = adapter_from_data_source(data_source, order_by_column=order_col)
+
+    for chunk in chunks:
+        adapter.append_partition(0, chunk)
+
+    result = adapter.read()
+    assert result[order_col].tolist() == expected_order_col_values
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_multi_partition(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """With order_by_column set, both full-table and single-partition reads return rows
+    sorted ASC by that column, regardless of which partition they were written to."""
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        2,
+        _ts_value_schema.empty_table(),
+        _order_by_params,
+    )
+    adapter = adapter_from_data_source(data_source, order_by_column="ts")
+
+    # Partition 0 has later timestamps than partition 1 — order must cross partition boundaries
+    adapter.append_partition(
+        0, pa.table({"ts": [50, 30, 60], "value": [5.0, 3.0, 6.0]})
+    )
+    adapter.append_partition(
+        1, pa.table({"ts": [40, 10, 20], "value": [4.0, 1.0, 2.0]})
+    )
+
+    assert adapter.read()["ts"].tolist() == [
+        10,
+        20,
+        30,
+        40,
+        50,
+        60,
+    ], "Full-table read must be ordered by 'ts' across partitions"
+    assert adapter.read_partition(0)["ts"].tolist() == [
+        30,
+        50,
+        60,
+    ], "Single-partition read must also be ordered by 'ts'"
+    assert adapter.read_partition(1)["ts"].tolist() == [10, 20, 40]
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_subset_fields_read(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Reading a subset of fields with order_by_column set should still return rows in
+    the correct order, even when the order_by_column itself is not in the selected fields.
+    """
+    schema = pa.schema(
+        [
+            pa.field("ts", pa.int64()),
+            pa.field("a", pa.int32()),
+            pa.field("b", pa.float64()),
+        ]
+    )
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        schema.empty_table(),
+        _order_by_params,
+    )
+    adapter = adapter_from_data_source(data_source, order_by_column="ts")
+    adapter.append_partition(
+        0, pa.table({"ts": [30, 10, 20], "a": [3, 1, 2], "b": [3.0, 1.0, 2.0]})
+    )
+
+    assert adapter.read(fields=["a"])["a"].tolist() == [1, 2, 3]
+    assert adapter.read(fields=["b"])["b"].tolist() == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_no_order_by_does_not_crash(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Without order_by_column, no ORDER BY clause is added — the adapter should
+    initialise and read data without errors, and order_by_column attribute should be None.
+    """
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_value_schema.empty_table(),
+    )
+    adapter = adapter_from_data_source(data_source)
+    assert adapter.order_by_column is None
+    assert adapter.unique_ordering is False
+
+    adapter.append_partition(0, pa.table({"ts": [10, 20], "value": [1.0, 2.0]}))
+    result = adapter.read()
+    assert set(result["ts"].tolist()) == {10, 20}
+
+
+def test_order_by_table_name_hash() -> None:
+    """get_table_name incorporates the order_by_column into the hash only when
+    unique_ordering=True. This is a pure unit test: no database is needed."""
+    structure = TableStructure.from_arrow_table(_ts_value_schema.empty_table())
+
+    def make_ds(
+        order_by_col: Optional[str], unique: bool
+    ) -> DataSource[TableStructure]:
+        params: dict[str, Any] = {}
+        if order_by_col:
+            params["order_by_column"] = order_by_col
+        if unique:
+            params["unique_ordering"] = True
+        return DataSource(
+            management=Management.writable,
+            mimetype="application/x-tiled-sql-table",
+            structure_family=StructureFamily.table,
+            structure=structure,
+            parameters=params,
+            assets=[],
+        )
+
+    # unique_ordering=True with different columns → different table names
+    assert SQLAdapter.get_table_name(
+        make_ds("ts", unique=True)
+    ) != SQLAdapter.get_table_name(
+        make_ds("value", unique=True)
+    ), "Different order_by_column with unique_ordering should produce different table names"
+
+    # unique_ordering=False → same table name regardless of order_by_column
+    assert SQLAdapter.get_table_name(
+        make_ds(None, unique=False)
+    ) == SQLAdapter.get_table_name(
+        make_ds("ts", unique=False)
+    ), "order_by_column without unique_ordering should not affect the table name"
+
+    # unique_ordering=True vs False → different table names
+    assert SQLAdapter.get_table_name(
+        make_ds("ts", unique=True)
+    ) != SQLAdapter.get_table_name(
+        make_ds(None, unique=False)
+    ), "unique_ordering=True should produce a different table name than unique_ordering=False"
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_column_not_in_schema_is_ignored(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Back-compat: if order_by_column is set on the data source but the column does
+    not exist in the schema (e.g. after a catalog edit gone wrong), the adapter should
+    silently ignore it — order_by_column becomes None and reads succeed without errors.
+    """
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_val_schema.empty_table(),
+    )
+    adapter = adapter_from_data_source(
+        data_source, order_by_column="nonexistent_column"
+    )
+    assert (
+        adapter.order_by_column is None
+    ), "order_by_column not in schema should be silently dropped"
+
+    adapter.append_partition(0, pa.table({"ts": [20, 10], "val": [2, 1]}))
+    result = adapter.read()
+    assert set(result["ts"].tolist()) == {10, 20}
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_added_to_existing_table_without_unique_index(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Back-compat: a table originally created without order_by_column can later have
+    order_by_column added to the adapter (e.g. via a catalog parameter update). Reads
+    should return rows ordered correctly. No uniqueness constraint is added post-factum
+    since init_storage is not called again."""
+    # Step 1: create and populate the table WITHOUT order_by_column
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_val_schema.empty_table(),
+    )
+    writer = adapter_from_data_source(data_source)
+
+    # Append in non-sorted order
+    writer.append_partition(0, pa.table({"ts": [30, 10], "val": [3, 1]}))
+    writer.append_partition(0, pa.table({"ts": [20], "val": [2]}))
+
+    # Step 2: simulate a catalog parameter update — create a new adapter instance
+    # pointing at the same table, now with order_by_column set (but no new init_storage)
+    reader = adapter_from_data_source(
+        data_source,
+        order_by_column="ts",
+        unique_ordering=False,  # must NOT be True — no unique index was created
+    )
+    assert reader.order_by_column == "ts"
+    assert reader.unique_ordering is False
+
+    result = reader.read()
+    assert result["ts"].tolist() == [
+        10,
+        20,
+        30,
+    ], "After adding order_by_column to an existing table, reads should return ordered rows"
+    assert result["val"].tolist() == [1, 2, 3]
+
+    # Duplicate ts values must not be rejected (no unique constraint was added)
+    writer.append_partition(0, pa.table({"ts": [10, 30], "val": [11, 31]}))
+    result = reader.read()
+    assert result["ts"].tolist() == [10, 10, 20, 30, 30]

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -65,14 +65,16 @@ def adapter_from_data_source(
 
 
 @pytest.fixture
-def data_source_from_init_storage() -> Generator[
-    Callable[
-        [str, int, Optional[pa.Table], Optional[dict[str, Any]]],
-        DataSource[TableStructure],
-    ],
-    None,
-    None,
-]:
+def data_source_from_init_storage() -> (
+    Generator[
+        Callable[
+            [str, int, Optional[pa.Table], Optional[dict[str, Any]]],
+            DataSource[TableStructure],
+        ],
+        None,
+        None,
+    ]
+):
     registered: list[SQLStorage] = []
 
     def _data_source_from_init_storage(

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -1168,6 +1168,7 @@ def test_order_by_args_with_primary_key(
         adapter.append_partition(0, pa.table({"ts": [10], "val": [99]}))
 
 
+@pytest.mark.parametrize("data_uri", ["duckdb_uri", "postgres_uri"])
 @pytest.mark.parametrize(
     "arrow_type",
     [
@@ -1177,15 +1178,18 @@ def test_order_by_args_with_primary_key(
     ],
 )
 def test_order_by_nested_type_raises(
+    data_uri: str,
     arrow_type: pa.DataType,
-    duckdb_uri: str,
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
 ) -> None:
     """Columns with nested Arrow types (list, large_list) cannot be sorted in SQL
     and must be rejected with a ValueError when used in order_by_args.
-    Tested on DuckDB only because SQLite does not support nested column types."""
+    Tested on DuckDB and Postgres only — SQLite does not support nested column types."""
     schema = pa.schema([pa.field("id", pa.int64()), pa.field("nested", arrow_type)])
-    data_source = data_source_from_init_storage(duckdb_uri, 1, schema.empty_table())
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri), 1, schema.empty_table()
+    )
     with pytest.raises(ValueError, match="nested"):
         adapter_from_data_source(
             data_source,

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -805,53 +805,70 @@ def test_append_nullable(
 
 
 # ============================================================================
-# Tests for order_by functionality
+# Tests for order_by_args and primary_key functionality
 # ============================================================================
 
-# Shared schema and sample tables used across order_by tests.
+# Shared schemas used across order_by tests.
 _ts_value_schema = pa.schema(
     [pa.field("ts", pa.int64()), pa.field("value", pa.float64())]
 )
 _ts_val_schema = pa.schema([pa.field("ts", pa.int64()), pa.field("val", pa.int32())])
-_order_by_params = {"order_by_column": "ts"}
+
+# Canonical order_by_args parameter: list of {"column": ..., "direction": ...} dicts.
+_order_by_ts_asc = [{"column": "ts", "direction": "asc"}]
 
 
 @pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
 @pytest.mark.parametrize(
-    "schema, order_col, chunks, expected_order_col_values",
+    "schema, order_args, chunks, expected_col, expected_values",
     [
         pytest.param(
             _ts_value_schema,
-            "ts",
+            [{"column": "ts", "direction": "asc"}],
             [
                 pa.table({"ts": [30, 40], "value": [3.0, 4.0]}),
                 pa.table({"ts": [10, 20], "value": [1.0, 2.0]}),
             ],
+            "ts",
             [10, 20, 30, 40],
-            id="integer_ts_out_of_order_chunks",
+            id="integer_ts_out_of_order_chunks_asc",
         ),
         pytest.param(
             _ts_value_schema,
+            [{"column": "ts", "direction": "desc"}],
+            [
+                pa.table({"ts": [30, 40], "value": [3.0, 4.0]}),
+                pa.table({"ts": [10, 20], "value": [1.0, 2.0]}),
+            ],
             "ts",
+            [40, 30, 20, 10],
+            id="integer_ts_desc",
+        ),
+        pytest.param(
+            _ts_value_schema,
+            [{"column": "ts", "direction": "asc"}],
             [
                 pa.table({"ts": [100, 200], "value": [10.0, 20.0]}),
                 pa.table({"ts": [50, 150], "value": [5.0, 15.0]}),
                 pa.table({"ts": [75, 300], "value": [7.0, 30.0]}),
             ],
+            "ts",
             [50, 75, 100, 150, 200, 300],
             id="integer_ts_incremental_appends",
         ),
         pytest.param(
             pa.schema([pa.field("name", pa.string()), pa.field("score", pa.int32())]),
-            "name",
+            [{"column": "name", "direction": "asc"}],
             [pa.table({"name": ["charlie", "alice", "bob"], "score": [3, 1, 2]})],
+            "name",
             ["alice", "bob", "charlie"],
             id="string_column_lexicographic",
         ),
         pytest.param(
             pa.schema([pa.field("Timestamp", pa.int64()), pa.field("val", pa.int32())]),
-            "Timestamp",
+            [{"column": "Timestamp", "direction": "asc"}],
             [pa.table({"Timestamp": [30, 10, 20], "val": [3, 1, 2]})],
+            "Timestamp",
             [10, 20, 30],
             id="mixed_case_column_name",
         ),
@@ -860,27 +877,65 @@ _order_by_params = {"order_by_column": "ts"}
 def test_order_by_single_partition(
     data_uri: str,
     schema: pa.Schema,
-    order_col: str,
+    order_args: list[dict[str, Any]],
     chunks: list[pa.Table],
-    expected_order_col_values: list[Any],
+    expected_col: str,
+    expected_values: list[Any],
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
     request: pytest.FixtureRequest,
 ) -> None:
-    """Appending data out of order and reading it back should always return rows sorted
-    ASC by the order_by_column, regardless of insertion order, column type, or case."""
+    """Appending data out of order and reading it back should return rows in the
+    requested order, regardless of insertion order, column type, case, or direction."""
     data_source = data_source_from_init_storage(
         request.getfixturevalue(data_uri),
         1,
         schema.empty_table(),
-        {"order_by_column": order_col},
+        {"order_by_args": order_args},
     )
-    adapter = adapter_from_data_source(data_source, order_by_column=order_col)
+    adapter = adapter_from_data_source(data_source, order_by_args=order_args)
 
     for chunk in chunks:
         adapter.append_partition(0, chunk)
 
     result = adapter.read()
-    assert result[order_col].tolist() == expected_order_col_values
+    assert result[expected_col].tolist() == expected_values
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_multi_column(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Multi-column order_by_args: rows are sorted by the first column, then by the
+    second column for ties."""
+    schema = pa.schema(
+        [pa.field("category", pa.string()), pa.field("ts", pa.int64())]
+    )
+    order_args = [
+        {"column": "category", "direction": "asc"},
+        {"column": "ts", "direction": "desc"},
+    ]
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        schema.empty_table(),
+        {"order_by_args": order_args},
+    )
+    adapter = adapter_from_data_source(data_source, order_by_args=order_args)
+    adapter.append_partition(
+        0,
+        pa.table(
+            {
+                "category": ["b", "a", "a", "b"],
+                "ts": [20, 30, 10, 5],
+            }
+        ),
+    )
+
+    result = adapter.read()
+    assert result["category"].tolist() == ["a", "a", "b", "b"]
+    assert result["ts"].tolist() == [30, 10, 20, 5]
 
 
 @pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
@@ -889,15 +944,15 @@ def test_order_by_multi_partition(
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
     request: pytest.FixtureRequest,
 ) -> None:
-    """With order_by_column set, both full-table and single-partition reads return rows
-    sorted ASC by that column, regardless of which partition they were written to."""
+    """With order_by_args set, both full-table and single-partition reads return rows
+    sorted correctly, regardless of which partition they were written to."""
     data_source = data_source_from_init_storage(
         request.getfixturevalue(data_uri),
         2,
         _ts_value_schema.empty_table(),
-        _order_by_params,
+        {"order_by_args": _order_by_ts_asc},
     )
-    adapter = adapter_from_data_source(data_source, order_by_column="ts")
+    adapter = adapter_from_data_source(data_source, order_by_args=_order_by_ts_asc)
 
     # Partition 0 has later timestamps than partition 1 — order must cross partition boundaries
     adapter.append_partition(
@@ -929,9 +984,8 @@ def test_order_by_subset_fields_read(
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
     request: pytest.FixtureRequest,
 ) -> None:
-    """Reading a subset of fields with order_by_column set should still return rows in
-    the correct order, even when the order_by_column itself is not in the selected fields.
-    """
+    """Reading a subset of fields with order_by_args set should return rows in the
+    correct order even when the sort column is not in the selected fields."""
     schema = pa.schema(
         [
             pa.field("ts", pa.int64()),
@@ -943,9 +997,9 @@ def test_order_by_subset_fields_read(
         request.getfixturevalue(data_uri),
         1,
         schema.empty_table(),
-        _order_by_params,
+        {"order_by_args": _order_by_ts_asc},
     )
-    adapter = adapter_from_data_source(data_source, order_by_column="ts")
+    adapter = adapter_from_data_source(data_source, order_by_args=_order_by_ts_asc)
     adapter.append_partition(
         0, pa.table({"ts": [30, 10, 20], "a": [3, 1, 2], "b": [3.0, 1.0, 2.0]})
     )
@@ -960,17 +1014,15 @@ def test_no_order_by_does_not_crash(
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
     request: pytest.FixtureRequest,
 ) -> None:
-    """Without order_by_column, no ORDER BY clause is added — the adapter should
-    initialise and read data without errors, and order_by_column attribute should be None.
-    """
+    """Without order_by_args, no ORDER BY clause is added — the adapter should
+    initialise and read data without errors, and order_by_args should be empty."""
     data_source = data_source_from_init_storage(
         request.getfixturevalue(data_uri),
         1,
         _ts_value_schema.empty_table(),
     )
     adapter = adapter_from_data_source(data_source)
-    assert adapter.order_by_column is None
-    assert adapter.unique_ordering is False
+    assert adapter.order_by_args == []
 
     adapter.append_partition(0, pa.table({"ts": [10, 20], "value": [1.0, 2.0]}))
     result = adapter.read()
@@ -978,18 +1030,15 @@ def test_no_order_by_does_not_crash(
 
 
 def test_order_by_table_name_hash() -> None:
-    """get_table_name incorporates the order_by_column into the hash only when
-    unique_ordering=True. This is a pure unit test: no database is needed."""
+    """get_table_name incorporates the primary_key into the hash — tables with different
+    primary_key columns get different names. order_by_args is read-time only and does
+    not affect the hash. This is a pure unit test: no database is needed."""
     structure = TableStructure.from_arrow_table(_ts_value_schema.empty_table())
 
-    def make_ds(
-        order_by_col: Optional[str], unique: bool
-    ) -> DataSource[TableStructure]:
+    def make_ds(primary_key: Optional[list[str]]) -> DataSource[TableStructure]:
         params: dict[str, Any] = {}
-        if order_by_col:
-            params["order_by_column"] = order_by_col
-        if unique:
-            params["unique_ordering"] = True
+        if primary_key is not None:
+            params["primary_key"] = primary_key
         return DataSource(
             management=Management.writable,
             mimetype="application/x-tiled-sql-table",
@@ -999,96 +1048,125 @@ def test_order_by_table_name_hash() -> None:
             assets=[],
         )
 
-    # unique_ordering=True with different columns → different table names
-    assert SQLAdapter.get_table_name(
-        make_ds("ts", unique=True)
-    ) != SQLAdapter.get_table_name(
-        make_ds("value", unique=True)
-    ), "Different order_by_column with unique_ordering should produce different table names"
+    # No primary_key → same table name regardless of order_by_args (read-time param)
+    assert SQLAdapter.get_table_name(make_ds(None)) == SQLAdapter.get_table_name(
+        make_ds(None)
+    ), "Same schema and no primary_key should always produce the same table name"
 
-    # unique_ordering=False → same table name regardless of order_by_column
+    # Different primary_key columns → different table names
     assert SQLAdapter.get_table_name(
-        make_ds(None, unique=False)
-    ) == SQLAdapter.get_table_name(
-        make_ds("ts", unique=False)
-    ), "order_by_column without unique_ordering should not affect the table name"
-
-    # unique_ordering=True vs False → different table names
-    assert SQLAdapter.get_table_name(
-        make_ds("ts", unique=True)
+        make_ds(["ts"])
     ) != SQLAdapter.get_table_name(
-        make_ds(None, unique=False)
-    ), "unique_ordering=True should produce a different table name than unique_ordering=False"
+        make_ds(["value"])
+    ), "Different primary_key columns should produce different table names"
+
+    # primary_key vs no primary_key → different table names
+    assert SQLAdapter.get_table_name(make_ds(["ts"])) != SQLAdapter.get_table_name(
+        make_ds(None)
+    ), "primary_key set vs unset should produce different table names"
 
 
 @pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
-def test_order_by_column_not_in_schema_is_ignored(
+def test_order_by_column_not_in_schema_raises(
     data_uri: str,
     data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
     request: pytest.FixtureRequest,
 ) -> None:
-    """Back-compat: if order_by_column is set on the data source but the column does
-    not exist in the schema (e.g. after a catalog edit gone wrong), the adapter should
-    silently ignore it — order_by_column becomes None and reads succeed without errors.
+    """Passing an order_by_args column that does not exist in the schema should raise
+    a ValueError immediately on adapter construction."""
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_val_schema.empty_table(),
+    )
+    with pytest.raises(ValueError, match="nonexistent_column"):
+        adapter_from_data_source(
+            data_source,
+            order_by_args=[{"column": "nonexistent_column", "direction": "asc"}],
+        )
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_invalid_direction_raises(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Passing an invalid direction string should raise a ValueError."""
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_val_schema.empty_table(),
+    )
+    with pytest.raises(ValueError, match="direction"):
+        adapter_from_data_source(
+            data_source,
+            order_by_args=[{"column": "ts", "direction": "sideways"}],
+        )
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_primary_key_enforces_uniqueness(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """When primary_key is set, init_storage creates a unique index. Appending a
+    duplicate (dataset_id, primary_key) combination must raise an error.
+
+    Note: DuckDB's ADBC driver does not enforce unique constraints during adbc_ingest,
+    so duplicates are silently accepted on that backend. The test is marked xfail for
+    duckdb_uri to document this known limitation.
+    """
+    if data_uri == "duckdb_uri":
+        pytest.xfail(
+            "DuckDB ADBC adbc_ingest does not enforce unique index constraints"
+        )
+    data_source = data_source_from_init_storage(
+        request.getfixturevalue(data_uri),
+        1,
+        _ts_val_schema.empty_table(),
+        {"primary_key": ["ts"]},
+    )
+    adapter = adapter_from_data_source(data_source)
+    adapter.append_partition(0, pa.table({"ts": [10, 20, 30], "val": [1, 2, 3]}))
+
+    # Attempting to append a duplicate ts value must fail
+    with pytest.raises(Exception):
+        adapter.append_partition(0, pa.table({"ts": [10], "val": [99]}))
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_order_by_args_with_primary_key(
+    data_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """order_by_args and primary_key can be combined: the unique index is created from
+    primary_key, and reads are sorted by order_by_args.
+
+    The duplicate-rejection assertion is xfail for duckdb_uri because DuckDB's ADBC
+    driver does not enforce unique constraints during adbc_ingest.
     """
     data_source = data_source_from_init_storage(
         request.getfixturevalue(data_uri),
         1,
         _ts_val_schema.empty_table(),
+        {"primary_key": ["ts"]},
     )
     adapter = adapter_from_data_source(
-        data_source, order_by_column="nonexistent_column"
+        data_source, order_by_args=[{"column": "ts", "direction": "asc"}]
     )
-    assert (
-        adapter.order_by_column is None
-    ), "order_by_column not in schema should be silently dropped"
+    adapter.append_partition(0, pa.table({"ts": [30, 10, 20], "val": [3, 1, 2]}))
 
-    adapter.append_partition(0, pa.table({"ts": [20, 10], "val": [2, 1]}))
     result = adapter.read()
-    assert set(result["ts"].tolist()) == {10, 20}
-
-
-@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
-def test_order_by_added_to_existing_table_without_unique_index(
-    data_uri: str,
-    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
-    request: pytest.FixtureRequest,
-) -> None:
-    """Back-compat: a table originally created without order_by_column can later have
-    order_by_column added to the adapter (e.g. via a catalog parameter update). Reads
-    should return rows ordered correctly. No uniqueness constraint is added post-factum
-    since init_storage is not called again."""
-    # Step 1: create and populate the table WITHOUT order_by_column
-    data_source = data_source_from_init_storage(
-        request.getfixturevalue(data_uri),
-        1,
-        _ts_val_schema.empty_table(),
-    )
-    writer = adapter_from_data_source(data_source)
-
-    # Append in non-sorted order
-    writer.append_partition(0, pa.table({"ts": [30, 10], "val": [3, 1]}))
-    writer.append_partition(0, pa.table({"ts": [20], "val": [2]}))
-
-    # Step 2: simulate a catalog parameter update — create a new adapter instance
-    # pointing at the same table, now with order_by_column set (but no new init_storage)
-    reader = adapter_from_data_source(
-        data_source,
-        order_by_column="ts",
-        unique_ordering=False,  # must NOT be True — no unique index was created
-    )
-    assert reader.order_by_column == "ts"
-    assert reader.unique_ordering is False
-
-    result = reader.read()
-    assert result["ts"].tolist() == [
-        10,
-        20,
-        30,
-    ], "After adding order_by_column to an existing table, reads should return ordered rows"
+    assert result["ts"].tolist() == [10, 20, 30]
     assert result["val"].tolist() == [1, 2, 3]
 
-    # Duplicate ts values must not be rejected (no unique constraint was added)
-    writer.append_partition(0, pa.table({"ts": [10, 30], "val": [11, 31]}))
-    result = reader.read()
-    assert result["ts"].tolist() == [10, 10, 20, 30, 30]
+    # Duplicate must be rejected — xfail on DuckDB (ADBC does not enforce unique constraints)
+    if data_uri == "duckdb_uri":
+        pytest.xfail(
+            "DuckDB ADBC adbc_ingest does not enforce unique index constraints"
+        )
+    with pytest.raises(Exception):
+        adapter.append_partition(0, pa.table({"ts": [10], "val": [99]}))

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -1166,3 +1166,80 @@ def test_order_by_args_with_primary_key(
         )
     with pytest.raises(Exception):
         adapter.append_partition(0, pa.table({"ts": [10], "val": [99]}))
+
+
+@pytest.mark.parametrize(
+    "arrow_type",
+    [
+        pa.list_(pa.int32()),
+        pa.large_list(pa.float64()),
+        pa.list_(pa.string()),
+    ],
+)
+def test_order_by_nested_type_raises(
+    arrow_type: pa.DataType,
+    duckdb_uri: str,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+) -> None:
+    """Columns with nested Arrow types (list, large_list) cannot be sorted in SQL
+    and must be rejected with a ValueError when used in order_by_args.
+    Tested on DuckDB only because SQLite does not support nested column types."""
+    schema = pa.schema([pa.field("id", pa.int64()), pa.field("nested", arrow_type)])
+    data_source = data_source_from_init_storage(duckdb_uri, 1, schema.empty_table())
+    with pytest.raises(ValueError, match="nested"):
+        adapter_from_data_source(
+            data_source,
+            order_by_args=[{"column": "nested", "direction": "asc"}],
+        )
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+@pytest.mark.parametrize(
+    "arrow_type, requires_nested_support",
+    [
+        (pa.float32(), False),
+        (pa.float64(), False),
+        # list types: only DuckDB and Postgres support them as column types
+        (pa.list_(pa.int32()), True),
+        (pa.large_list(pa.float64()), True),
+    ],
+)
+def test_primary_key_invalid_type_raises(
+    data_uri: str,
+    arrow_type: pa.DataType,
+    requires_nested_support: bool,
+    data_source_from_init_storage: Callable[..., DataSource[TableStructure]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Floating-point and nested columns must be rejected as primary_key both at
+    init_storage time and at adapter construction time.
+
+    Nested-type cases are skipped on sqlite_uri because SQLite does not support
+    list/large_list column types at all."""
+    if requires_nested_support and data_uri == "sqlite_uri":
+        pytest.skip("SQLite does not support nested (list) column types")
+
+    data_uri_val = request.getfixturevalue(data_uri)
+    schema = pa.schema([pa.field("id", pa.int64()), pa.field("bad_col", arrow_type)])
+
+    # init_storage must reject it before touching the DB
+    storage = cast(SQLStorage, parse_storage(data_uri_val))
+    register_storage(storage)
+    structure = TableStructure.from_arrow_table(schema.empty_table())
+    ds_with_pk = DataSource(
+        management=Management.writable,
+        mimetype="application/x-tiled-sql-table",
+        structure_family=StructureFamily.table,
+        structure=structure,
+        parameters={"primary_key": ["bad_col"]},
+        assets=[],
+    )
+    with pytest.raises(ValueError, match="bad_col"):
+        SQLAdapter.init_storage(data_source=ds_with_pk, storage=storage)
+    storage.dispose()
+    unregister_storage(storage)
+
+    # __init__ must also reject it independently
+    data_source = data_source_from_init_storage(data_uri_val, 1, schema.empty_table())
+    with pytest.raises(ValueError, match="bad_col"):
+        adapter_from_data_source(data_source, primary_key=["bad_col"])

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -909,9 +909,7 @@ def test_order_by_multi_column(
 ) -> None:
     """Multi-column order_by_args: rows are sorted by the first column, then by the
     second column for ties."""
-    schema = pa.schema(
-        [pa.field("category", pa.string()), pa.field("ts", pa.int64())]
-    )
+    schema = pa.schema([pa.field("category", pa.string()), pa.field("ts", pa.int64())])
     order_args = [
         {"column": "category", "direction": "asc"},
         {"column": "ts", "direction": "desc"},
@@ -1054,9 +1052,7 @@ def test_order_by_table_name_hash() -> None:
     ), "Same schema and no primary_key should always produce the same table name"
 
     # Different primary_key columns → different table names
-    assert SQLAdapter.get_table_name(
-        make_ds(["ts"])
-    ) != SQLAdapter.get_table_name(
+    assert SQLAdapter.get_table_name(make_ds(["ts"])) != SQLAdapter.get_table_name(
         make_ds(["value"])
     ), "Different primary_key columns should produce different table names"
 

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -11,11 +11,15 @@ from tiled.adapters.sql import (
     SQLAdapter,
     is_safe_identifier,
 )
-from tiled.storage import SQLStorage, get_storage, parse_storage, register_storage
+from tiled.storage import (
+    SQLStorage,
+    parse_storage,
+    register_storage,
+    unregister_storage,
+)
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import DataSource, Management
 from tiled.structures.table import TableStructure
-from tiled.utils import sanitize_uri
 
 names = ["f0", "f1", "f2", "f3"]
 data0 = [
@@ -61,12 +65,16 @@ def adapter_from_data_source(
 
 
 @pytest.fixture
-def data_source_from_init_storage() -> (
+def data_source_from_init_storage() -> Generator[
     Callable[
         [str, int, Optional[pa.Table], Optional[dict[str, Any]]],
         DataSource[TableStructure],
-    ]
-):
+    ],
+    None,
+    None,
+]:
+    registered: list[SQLStorage] = []
+
     def _data_source_from_init_storage(
         data_uri: str,
         num_partitions: int,
@@ -87,9 +95,14 @@ def data_source_from_init_storage() -> (
 
         storage = cast(SQLStorage, parse_storage(data_uri))
         register_storage(storage)
+        registered.append(storage)
         return SQLAdapter.init_storage(data_source=data_source, storage=storage)
 
-    return _data_source_from_init_storage
+    yield _data_source_from_init_storage
+
+    for storage in registered:
+        storage.dispose()
+        unregister_storage(storage)
 
 
 @pytest.fixture
@@ -162,10 +175,6 @@ def adapter_psql_one_partition(
     data_source = data_source_from_init_storage(postgres_uri, 1)
     yield adapter_from_data_source(data_source)
 
-    # Close all connections and dispose of the storage
-    storage = get_storage(sanitize_uri(postgres_uri)[0])
-    cast(SQLStorage, storage).dispose()
-
 
 @pytest.fixture
 def adapter_psql_many_partitions(
@@ -174,10 +183,6 @@ def adapter_psql_many_partitions(
 ) -> Generator[SQLAdapter, None, None]:
     data_source = data_source_from_init_storage(postgres_uri, 3)
     yield adapter_from_data_source(data_source)
-
-    # Close all connections and dispose of the storage
-    storage = get_storage(sanitize_uri(postgres_uri)[0])
-    cast(SQLStorage, storage).dispose()
 
 
 def test_psql(adapter_psql_one_partition: SQLAdapter) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,15 +35,15 @@ async def temp_postgres(uri):
     engine = create_async_engine(ensure_specified_sql_driver(uri))
     database_name = f"tiled_test_disposable_{uuid.uuid4().hex}"
     async with engine.connect() as connection:
-        await connection.execute(
-            text("COMMIT")
-        )  # close the automatically-started transaction
+        # close the automatically-started transaction
+        await connection.execute(text("COMMIT"))
         await connection.execute(text(f"CREATE DATABASE {database_name};"))
         await connection.commit()
     yield f"{uri}/{database_name}"
-    # Drop the database — terminate any lingering sessions first so DROP doesn't fail.
+    # Drop the database
     async with engine.connect() as connection:
-        await connection.execute(text("COMMIT"))  # close the automatically-started transaction
+        await connection.execute(text("COMMIT"))
+        # Terminate any lingering sessions first so DROP doesn't fail
         await connection.execute(
             text(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,11 +41,15 @@ async def temp_postgres(uri):
         await connection.execute(text(f"CREATE DATABASE {database_name};"))
         await connection.commit()
     yield f"{uri}/{database_name}"
-    # Drop the database.
+    # Drop the database — terminate any lingering sessions first so DROP doesn't fail.
     async with engine.connect() as connection:
+        await connection.execute(text("COMMIT"))  # close the automatically-started transaction
         await connection.execute(
-            text("COMMIT")
-        )  # close the automatically-started transaction
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{database_name}' AND pid <> pg_backend_pid();"
+            )
+        )
         await connection.execute(text(f"DROP DATABASE {database_name};"))
         await connection.commit()
 

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -73,6 +73,30 @@ class _OrderByArgs(TypedDict):
     direction: Literal["asc", "desc"]
 
 
+def _is_orderable_type(arrow_type: pyarrow.DataType) -> bool:
+    """Return True if the Arrow type can be used in a SQL ORDER BY clause.
+
+    Nested types (list, struct, map) cannot be sorted in SQL.
+    """
+    return not (
+        pyarrow.types.is_list(arrow_type)
+        or pyarrow.types.is_large_list(arrow_type)
+        or pyarrow.types.is_fixed_size_list(arrow_type)
+        or pyarrow.types.is_struct(arrow_type)
+        or pyarrow.types.is_map(arrow_type)
+    )
+
+
+def _is_primary_key_type(arrow_type: pyarrow.DataType) -> bool:
+    """Return True if the Arrow type is suitable for use as a primary key column.
+
+    In addition to the non-orderable nested types, floating-point columns are
+    rejected: NaN != NaN semantics and precision issues make float primary keys
+    almost always a mistake.
+    """
+    return _is_orderable_type(arrow_type) and not pyarrow.types.is_floating(arrow_type)
+
+
 class SQLAdapter(Adapter[TableStructure]):
     """SQLAdapter Class
 
@@ -114,9 +138,31 @@ class SQLAdapter(Adapter[TableStructure]):
         self.primary_key: List[str] = primary_key or []
 
         for arg in self.order_by_args:
-            if arg["column"] not in self.structure().columns:
+            column = arg["column"]
+            direction = arg["direction"]
+            if column not in self.structure().columns:
                 raise ValueError(
-                    f"order_by column '{arg['column']}' is not in the structure columns"
+                    f"order_by column '{column}' is not in the structure columns"
+                )
+            if direction not in ("asc", "desc"):
+                raise ValueError(
+                    f"order_by direction must be 'asc' or 'desc', got '{direction}'"
+                )
+            arrow_type = self.structure().arrow_schema_decoded.field(column).type
+            if not _is_orderable_type(arrow_type):
+                raise ValueError(
+                    f"order_by column '{column}' has type {arrow_type} which cannot be sorted in SQL"
+                )
+        for key in self.primary_key:
+            if key not in self.structure().columns:
+                raise ValueError(
+                    f"primary_key column '{key}' is not in the structure columns"
+                )
+            arrow_type = self.structure().arrow_schema_decoded.field(key).type
+            if not _is_primary_key_type(arrow_type):
+                raise ValueError(
+                    f"primary_key column '{key}' has type {arrow_type} which is not suitable "
+                    f"as a primary key (nested types and floating-point types are not allowed)"
                 )
             if arg["direction"] not in ("asc", "desc"):
                 raise ValueError(
@@ -193,6 +239,12 @@ class SQLAdapter(Adapter[TableStructure]):
                 if key not in data_source.structure.columns:
                     raise ValueError(
                         f"primary_key column '{key}' is not in the structure columns"
+                    )
+                arrow_type = data_source.structure.arrow_schema_decoded.field(key).type
+                if not _is_primary_key_type(arrow_type):
+                    raise ValueError(
+                        f"primary_key column '{key}' has type {arrow_type} which is not suitable "
+                        f"as a primary key (nested types and floating-point types are not allowed)"
                     )
 
         with closing(storage.connect()) as conn:

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -114,15 +114,13 @@ class SQLAdapter(Adapter[TableStructure]):
         self.primary_key: List[str] = primary_key or []
 
         for arg in self.order_by_args:
-            column = arg["column"]
-            direction = arg["direction"]
-            if column not in self.structure().columns:
+            if arg["column"] not in self.structure().columns:
                 raise ValueError(
-                    f"order_by column '{column}' is not in the structure columns"
+                    f"order_by column '{arg['column']}' is not in the structure columns"
                 )
-            if direction not in ("asc", "desc"):
+            if arg["direction"] not in ("asc", "desc"):
                 raise ValueError(
-                    f"order_by direction must be 'asc' or 'desc', got '{direction}'"
+                    f"order_by direction must be 'asc' or 'desc', got '{arg['direction']}'"
                 )
         for key in self.primary_key:
             if key not in self.structure().columns:
@@ -189,7 +187,7 @@ class SQLAdapter(Adapter[TableStructure]):
             schema, table_name, cast(DIALECTS, storage.dialect)
         )
 
-        # If there is a primary_key parameter, validate it against the table schema
+        # If there is a primary_key parameter, first validate it against the table schema
         if primary_key := data_source.parameters.get("primary_key"):
             for key in primary_key:
                 if key not in data_source.structure.columns:

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -3,7 +3,18 @@ import hashlib
 import re
 from collections.abc import Set
 from contextlib import closing
-from typing import Any, Callable, Iterator, List, Literal, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    cast,
+)
 
 import numpy
 import pandas
@@ -57,6 +68,11 @@ FORBIDDEN_CHARACTERS = re.compile(
 # Furthermore, user-specified table names can only be in lower case.
 
 
+class _OrderByArgs(TypedDict):
+    column: str
+    direction: Literal["asc", "desc"]
+
+
 class SQLAdapter(Adapter[TableStructure]):
     """SQLAdapter Class
 
@@ -82,8 +98,8 @@ class SQLAdapter(Adapter[TableStructure]):
         table_name: str,
         dataset_id: int,
         *,
-        order_by_column: Optional[str] = None,
-        unique_ordering: bool = False,
+        order_by_args: Optional[List[_OrderByArgs]] = None,
+        primary_key: Optional[List[str]] = None,
         metadata: Optional[JSON] = None,
         specs: Optional[List[Spec]] = None,
     ) -> None:
@@ -93,12 +109,27 @@ class SQLAdapter(Adapter[TableStructure]):
         self.specs = list(specs or [])
         self.table_name = table_name
         self.dataset_id = dataset_id
-        if order_by_column in structure.columns:
-            self.order_by_column: Optional[str] = order_by_column
-            self.unique_ordering = unique_ordering
-        else:
-            self.order_by_column = None
-            self.unique_ordering = False
+
+        self.order_by_args: List[_OrderByArgs] = order_by_args or []
+        self.primary_key: List[str] = primary_key or []
+
+        for arg in self.order_by_args:
+            column = arg["column"]
+            direction = arg["direction"]
+            if column not in self.structure().columns:
+                raise ValueError(
+                    f"order_by column '{column}' is not in the structure columns"
+                )
+            if direction not in ("asc", "desc"):
+                raise ValueError(
+                    f"order_by direction must be 'asc' or 'desc', got '{direction}'"
+                )
+        for key in self.primary_key:
+            if key not in self.structure().columns:
+                raise ValueError(
+                    f"primary_key column '{key}' is not in the structure columns"
+                )
+
         super().__init__(structure, metadata=metadata, specs=specs)
 
     def metadata(self) -> JSON:
@@ -118,10 +149,7 @@ class SQLAdapter(Adapter[TableStructure]):
     def get_table_name(cls, data_source: "DataSource[TableStructure]") -> str:
         "If not defined, generate a default table name based on the Arrow schema and parameters"
 
-        if data_source.parameters.get("unique_ordering", False):
-            suffix = data_source.parameters.get("order_by_column", "")
-        else:
-            suffix = ""
+        suffix = "".join(data_source.parameters.get("primary_key", ""))
         encoded = (data_source.structure.arrow_schema + suffix).encode()
         default = "table_" + hashlib.md5(encoded).hexdigest().lower()
         table_name: str = data_source.parameters.setdefault("table_name", default)
@@ -153,20 +181,28 @@ class SQLAdapter(Adapter[TableStructure]):
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
 
         # Prefix columns with internal _dataset_id, _partition_id, ...
-        table_name = cls.get_table_name(data_source)
         schema = data_source.structure.arrow_schema_decoded
         schema = schema.insert(0, pyarrow.field("_partition_id", pyarrow.int16()))
         schema = schema.insert(0, pyarrow.field("_dataset_id", pyarrow.int32()))
+        table_name = cls.get_table_name(data_source)
         create_table_statement = arrow_schema_to_create_table(
             schema, table_name, cast(DIALECTS, storage.dialect)
         )
+
+        # If there is a primary_key parameter, validate it against the table schema
+        if primary_key := data_source.parameters.get("primary_key"):
+            for key in primary_key:
+                if key not in data_source.structure.columns:
+                    raise ValueError(
+                        f"primary_key column '{key}' is not in the structure columns"
+                    )
 
         with closing(storage.connect()) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(create_table_statement)
 
             # Create an index on the dataset_id and partition_id columns to speed up queries.
-            # If there is an order_by_column, include it in the index and ensure uniqueness.
+            # If there is a primary_key parameter, include it in the index and ensure uniqueness.
             create_index_statement = (
                 "CREATE INDEX IF NOT EXISTS dataset_and_partition_index "
                 f'ON "{table_name}"(_dataset_id, _partition_id)'
@@ -174,12 +210,11 @@ class SQLAdapter(Adapter[TableStructure]):
             with conn.cursor() as cursor:
                 cursor.execute(create_index_statement)
 
-            order_by_column = data_source.parameters.get("order_by_column")
-            unique_ordering = data_source.parameters.get("unique_ordering", False)
-            if order_by_column in data_source.structure.columns and unique_ordering:
+            if primary_key:
+                pkey_columns = ", ".join([f'"{col.lower()}"' for col in primary_key])
                 create_unique_index_statement = (
                     "CREATE UNIQUE INDEX IF NOT EXISTS unique_ordering_per_dataset_index "
-                    f'ON "{table_name}"(_dataset_id, {order_by_column.lower()})'
+                    f'ON "{table_name}"(_dataset_id, {pkey_columns})'
                 )
                 with conn.cursor() as cursor:
                     cursor.execute(create_unique_index_statement)
@@ -363,15 +398,13 @@ class SQLAdapter(Adapter[TableStructure]):
 
         if partition is not None:
             query += f"AND _partition_id={int(partition)}"
-            order_by_cols = [self.order_by_column] if self.order_by_column else []
+            order_by_partition = []
         else:
-            order_by_cols = [
-                c for c in [self.order_by_column, "_partition_id"] if c is not None
-            ]
+            order_by_partition = [{"column": "_partition_id", "direction": "asc"}]
 
-        if order_by_cols:
+        if args := self.order_by_args + order_by_partition:
             query += " ORDER BY " + ", ".join(
-                [f'"{c.lower()}"' for c in order_by_cols if c is not None]
+                [f'"{c["column"].lower()}" {c["direction"].upper()}' for c in args]
             )
 
         with closing(self.storage.connect()) as conn:

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -82,6 +82,8 @@ class SQLAdapter(Adapter[TableStructure]):
         table_name: str,
         dataset_id: int,
         *,
+        order_by_column: Optional[str] = None,
+        unique_ordering: bool = False,
         metadata: Optional[JSON] = None,
         specs: Optional[List[Spec]] = None,
     ) -> None:
@@ -91,6 +93,12 @@ class SQLAdapter(Adapter[TableStructure]):
         self.specs = list(specs or [])
         self.table_name = table_name
         self.dataset_id = dataset_id
+        if order_by_column in structure.columns:
+            self.order_by_column: Optional[str] = order_by_column
+            self.unique_ordering = unique_ordering
+        else:
+            self.order_by_column = None
+            self.unique_ordering = False
         super().__init__(structure, metadata=metadata, specs=specs)
 
     def metadata(self) -> JSON:
@@ -107,6 +115,21 @@ class SQLAdapter(Adapter[TableStructure]):
         return {SQLStorage, EmbeddedSQLStorage, RemoteSQLStorage}
 
     @classmethod
+    def get_table_name(cls, data_source: "DataSource[TableStructure]") -> str:
+        "If not defined, generate a default table name based on the Arrow schema and parameters"
+
+        if data_source.parameters.get("unique_ordering", False):
+            suffix = data_source.parameters.get("order_by_column", "")
+        else:
+            suffix = ""
+        encoded = (data_source.structure.arrow_schema + suffix).encode()
+        default = "table_" + hashlib.md5(encoded).hexdigest().lower()
+        table_name: str = data_source.parameters.setdefault("table_name", default)
+        is_safe_identifier(table_name, TABLE_NAME_PATTERN, allow_reserved_words=False)
+
+        return table_name
+
+    @classmethod
     def init_storage(
         cls,
         storage: SQLStorage,
@@ -114,7 +137,7 @@ class SQLAdapter(Adapter[TableStructure]):
         path_parts: Optional[List[str]] = None,
     ) -> DataSource[TableStructure]:
         """
-        Class to initialize the list of assets for given uri.
+        Classmethod to initialize the list of assets for a given uri.
 
         Parameters
         ----------
@@ -129,30 +152,38 @@ class SQLAdapter(Adapter[TableStructure]):
         """
         data_source = copy.deepcopy(data_source)  # Do not mutate caller input.
 
-        # Create a table_name based on the hash of Arrow schema
-        schema = data_source.structure.arrow_schema_decoded
-        encoded = schema.serialize()
-        default_table_name = "table_" + hashlib.md5(encoded).hexdigest().lower()
-        table_name = data_source.parameters.setdefault("table_name", default_table_name)
-        is_safe_identifier(table_name, TABLE_NAME_PATTERN, allow_reserved_words=False)
-
         # Prefix columns with internal _dataset_id, _partition_id, ...
+        table_name = cls.get_table_name(data_source)
+        schema = data_source.structure.arrow_schema_decoded
         schema = schema.insert(0, pyarrow.field("_partition_id", pyarrow.int16()))
         schema = schema.insert(0, pyarrow.field("_dataset_id", pyarrow.int32()))
         create_table_statement = arrow_schema_to_create_table(
             schema, table_name, cast(DIALECTS, storage.dialect)
         )
 
-        create_index_statement = (
-            "CREATE INDEX IF NOT EXISTS dataset_and_partition_index "
-            f'ON "{table_name}"(_dataset_id, _partition_id)'
-        )
-
         with closing(storage.connect()) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(create_table_statement)
+
+            # Create an index on the dataset_id and partition_id columns to speed up queries.
+            # If there is an order_by_column, include it in the index and ensure uniqueness.
+            create_index_statement = (
+                "CREATE INDEX IF NOT EXISTS dataset_and_partition_index "
+                f'ON "{table_name}"(_dataset_id, _partition_id)'
+            )
             with conn.cursor() as cursor:
                 cursor.execute(create_index_statement)
+
+            order_by_column = data_source.parameters.get("order_by_column")
+            unique_ordering = data_source.parameters.get("unique_ordering", False)
+            if order_by_column in data_source.structure.columns and unique_ordering:
+                create_unique_index_statement = (
+                    "CREATE UNIQUE INDEX IF NOT EXISTS unique_ordering_per_dataset_index "
+                    f'ON "{table_name}"(_dataset_id, {order_by_column.lower()})'
+                )
+                with conn.cursor() as cursor:
+                    cursor.execute(create_unique_index_statement)
+
             # Just once, create a SEQUENCE (or the closest analogue in SQLite) to
             # provide unique dataset_id for each dataset in this database.
             # (If it exists, do nothing.)
@@ -207,13 +238,6 @@ class SQLAdapter(Adapter[TableStructure]):
         return init_adapter_from_catalog(cls, data_source, node, **kwargs)
 
     def structure(self) -> TableStructure:
-        """
-        The structure of the actual data.
-
-        Returns
-        -------
-        The structure of the data.
-        """
         return self._structure
 
     def get(self, key: str) -> Union[ArrayAdapter, None]:
@@ -336,11 +360,19 @@ class SQLAdapter(Adapter[TableStructure]):
             f'FROM "{self.table_name}" '
             f"WHERE _dataset_id={self.dataset_id} "
         )
-        query += (
-            f"AND _partition_id={int(partition)}"
-            if partition is not None
-            else "ORDER BY _partition_id"
-        )
+
+        if partition is not None:
+            query += f"AND _partition_id={int(partition)}"
+            order_by_cols = [self.order_by_column] if self.order_by_column else []
+        else:
+            order_by_cols = [
+                c for c in [self.order_by_column, "_partition_id"] if c is not None
+            ]
+
+        if order_by_cols:
+            query += " ORDER BY " + ", ".join(
+                [f'"{c.lower()}"' for c in order_by_cols if c is not None]
+            )
 
         with closing(self.storage.connect()) as conn:
             with conn.cursor() as cursor:

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -23,6 +23,7 @@ __all__ = [
     "Storage",
     "get_storage",
     "parse_storage",
+    "unregister_storage",
 ]
 
 
@@ -378,6 +379,11 @@ _STORAGE: Dict[str, Storage] = {}
 def register_storage(storage: Storage) -> None:
     "Stash Storage for later lookup by URI."
     _STORAGE[storage.uri] = storage
+
+
+def unregister_storage(storage: Storage) -> None:
+    "Remove Storage from the registry (call after dispose to release all references)."
+    _STORAGE.pop(storage.uri, None)
 
 
 def get_storage(uri: str) -> Storage:


### PR DESCRIPTION
This ensures the order of rows read from SQLAdapter is deterministic. It can be controlled by the new `order_by_args` parameter (list of `{"column": ..., "direction": ...}`). Additionally, setting `primary_key` to a list of column names would enforces the uniqueness of their values (this does not affect already created tables to ensure back-compatibility).

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
