### PR TITLE
Fix no retry unsupported protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   for any tiled client request (connection failures, 5xx errors, 429 rate limits).
   The spinner is animated in Jupyter notebooks as well as TTY terminals.
 - Respect the `Retry-After` header on HTTP 429 (Too Many Requests) responses.
+- Fail fast instead of retrying on deterministic client request errors that a
+  retry cannot fix: an unsupported URL scheme and an invalid request such as an
+  illegal header value.
 
 
 ## v0.2.11 (2026-05-27)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -679,7 +679,9 @@ def test_should_not_retry_unsupported_protocol():
     """A bad URL scheme (e.g. 'htps://') must not trigger a retry loop."""
     from tiled.client.utils import should_retry
 
-    exc = httpx.UnsupportedProtocol("Request URL has an unsupported protocol 'htps://'.")
+    exc = httpx.UnsupportedProtocol(
+        "Request URL has an unsupported protocol 'htps://'."
+    )
     assert should_retry(exc) is False
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -676,10 +676,18 @@ def test_should_retry(status_code, headers, expected):
 
 
 def test_should_not_retry_unsupported_protocol():
-    """A bad URL scheme must not trigger a retry loop."""
+    """A bad URL scheme (e.g. 'htps://') must not trigger a retry loop."""
     from tiled.client.utils import should_retry
 
-    exc = httpx.UnsupportedProtocol("Request URL has an unsupported protocol. Do you mean http://?")
+    exc = httpx.UnsupportedProtocol("Request URL has an unsupported protocol 'htps://'.")
+    assert should_retry(exc) is False
+
+
+def test_should_not_retry_local_protocol_error():
+    """An invalid request (e.g. illegal header value) must not trigger a retry loop."""
+    from tiled.client.utils import should_retry
+
+    exc = httpx.LocalProtocolError("Illegal header value b'a\\r\\nInjected: 1'")
     assert should_retry(exc) is False
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -675,6 +675,14 @@ def test_should_retry(status_code, headers, expected):
     assert should_retry(exc) == expected
 
 
+def test_should_not_retry_unsupported_protocol():
+    """A bad URL scheme must not trigger a retry loop."""
+    from tiled.client.utils import should_retry
+
+    exc = httpx.UnsupportedProtocol("Request URL has an unsupported protocol. Do you mean http://?")
+    assert should_retry(exc) is False
+
+
 def test_handle_error_lets_429_propagate():
     """handle_error does not convert 429 into ClientError — lets it propagate for retry."""
     from tiled.client.utils import handle_error

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -129,6 +129,11 @@ def should_retry(exception: Exception) -> "bool | float":
             return True
         return exception.response.status_code >= 500
 
+    # An unsupported URL scheme (e.g. a typo'd 'htp://') is not transient;
+    # retrying will not fix it, so fail fast.
+    if isinstance(exception, httpx.UnsupportedProtocol):
+        return False
+
     # Otherwise retry on all httpx errors.
     return isinstance(exception, httpx.HTTPError)
 

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -129,9 +129,12 @@ def should_retry(exception: Exception) -> "bool | float":
             return True
         return exception.response.status_code >= 500
 
-    # An unsupported URL scheme (e.g. a typo'd 'htp://') is not transient;
-    # retrying will not fix it, so fail fast.
+    # do not retry for unsupported protocol errors, eg "htps://"
     if isinstance(exception, httpx.UnsupportedProtocol):
+        return False
+
+    # do not retry for local protocol errors, eg. carriage return in header value
+    if isinstance(exception, httpx.LocalProtocolError):
         return False
 
     # Otherwise retry on all httpx errors.


### PR DESCRIPTION
The client retries on every `httpx.HTTPError`, including ones where the exact same request will fail the same way every time. The clearest case is a typo in the URL scheme — `from_uri("htps://...")`  as mentioned in #1266.

This makes `should_retry` fail fast on two deterministic errors:

- `httpx.UnsupportedProtocol` if the URL scheme isn't `http`/`https` (e.g. a typod `htps://`). Retrying re-sends the same bad URL.
- `httpx.LocalProtocolError`** if the client built an invalid request
  (e.g. an illegal header value containing a carriage return). The request is
  rejected before it leaves the client

## Change
`tiled/client/utils.py` — `should_retry` returns `False` for the two errors above,
before the catch-all `isinstance(exception, httpx.HTTPError)`.

## Testing
Two focused unit tests in `tests/test_client.py` (`test_should_not_retry_unsupported_protocol`, `test_should_not_retry_local_protocol_error`) assert `should_retry(...) is False` for each.

### Checklist
- [x] Add a Changelog entry
- [X] Add the ticket number which this PR closes to the comment section