### PR TITLE
Ensuring that requesting to update the metadata with values that do not serialize as a JSON object raises an exception in the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
   The spinner is animated in Jupyter notebooks as well as TTY terminals.
 - Respect the `Retry-After` header on HTTP 429 (Too Many Requests) responses.
 
+### Fixed
+
+- Ensuring that the metadata parameter value entered when calling update_metadata is of the proper type (will serialize as a JSON object) before altering the metadata.
+
 
 ## v0.2.11 (2026-05-27)
 

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -5,6 +5,7 @@ Persistent stores are being developed externally to the tiled package.
 """
 
 import base64
+import collections
 import math
 import os
 import threading
@@ -515,6 +516,43 @@ def test_replace_metadata(tiled_websocket_context):
         ac.replace_metadata(metadata={"3": 1}, drop_revision=True)  # update #3
         # Wait for all messages to be received
         assert received_event.wait(timeout=5.0), "Timeout waiting for messages"
+
+
+def test_invalid_metadata(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        client.write_array([1, 2, 3], key="invalid_check")
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata="test")
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=["test1", "test2"])
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=1)
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=[1, 2])
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=1.2)
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=True)
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata=(1, 2))
+        with pytest.raises(ValueError):
+            client["invalid_check"].update_metadata(metadata={1})
+
+
+def test_valid_update_metadata(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        client.write_array([1, 2, 3], key="valid_check")
+
+        client["valid_check"].update_metadata(metadata={"a": 1, "b": 2})
+        assert client["valid_check"].metadata == {"a": 1, "b": 2}
+
+        d1 = {"a": 1}
+        d2 = {"b": 2}
+        d = collections.ChainMap(d1, d2)
+        client["valid_check"].update_metadata(metadata=d)
+        assert client["valid_check"].metadata == d
 
 
 def test_drop_revision(tree):

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -8,6 +8,7 @@ import base64
 import collections
 import math
 import os
+import pathlib
 import threading
 import uuid
 from datetime import datetime
@@ -106,6 +107,21 @@ def tree(tmpdir, tmp_minio_bucket):
     writable_storage.append(f"file://localhost{str(tmpdir / 'data')}")
 
     return in_memory(writable_storage=writable_storage)
+
+
+@pytest.fixture(scope="module")
+def module_tmp_path(tmp_path_factory: pytest.TempdirFactory) -> pathlib.Path:
+    return tmp_path_factory.mktemp("temp")
+
+
+@pytest.fixture(scope="module")
+def metadata_client(module_tmp_path):
+    catalog = in_memory(writable_storage=str(module_tmp_path))
+    app = build_app(catalog)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+        client.write_array([1, 2, 3], key="invalid_check")
+        yield client
 
 
 def test_write_array_full(tree):
@@ -518,26 +534,12 @@ def test_replace_metadata(tiled_websocket_context):
         assert received_event.wait(timeout=5.0), "Timeout waiting for messages"
 
 
-def test_invalid_metadata(tree):
-    with Context.from_app(build_app(tree)) as context:
-        client = from_context(context)
-        client.write_array([1, 2, 3], key="invalid_check")
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata="test")
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=["test1", "test2"])
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=1)
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=[1, 2])
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=1.2)
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=True)
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata=(1, 2))
-        with pytest.raises(ValueError):
-            client["invalid_check"].update_metadata(metadata={1})
+@pytest.mark.parametrize(
+    "tested_metadata", ["test", ["test1", "test2"], 1, [1, 2], 1.2, True, (1, 2), {1}]
+)
+def test_invalid_metadata(metadata_client, tested_metadata):
+    with pytest.raises(ValueError):
+        metadata_client["invalid_check"].update_metadata(metadata=tested_metadata)
 
 
 def test_valid_update_metadata(tree):

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -1,3 +1,4 @@
+import collections.abc
 import time
 from copy import copy, deepcopy
 from dataclasses import asdict
@@ -608,9 +609,9 @@ class BaseClient:
         if metadata is None:
             metadata_patch = []
         else:
-            if not isinstance(metadata, dict):
+            if not isinstance(metadata, collections.abc.Mapping):
                 raise ValueError(
-                    f"Metadata must be of type dict, cannot be {type(metadata)}."
+                    f"Metadata must serialize as a JSON object, cannot be {type(metadata)}."
                 )
             md_copy = deepcopy(self._item["attributes"]["metadata"])
             metadata_patch = jsonpatch.JsonPatch.from_diff(

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -608,6 +608,10 @@ class BaseClient:
         if metadata is None:
             metadata_patch = []
         else:
+            if not isinstance(metadata, dict):
+                raise ValueError(
+                    f"Metadata must be of type dict, cannot be {type(metadata)}."
+                )
             md_copy = deepcopy(self._item["attributes"]["metadata"])
             metadata_patch = jsonpatch.JsonPatch.from_diff(
                 self._item["attributes"]["metadata"],


### PR DESCRIPTION
This PR is intended to fix the issue where trying to update the metadata with update_metadata() with a parameter that is not of the right type (will serialize as a JSON object) allows for the modification but then causes server errors when trying to access. To fix this issue, this PR checks to see if the metadata does not match the collections.abc.Mapping type when it contains a value with calling update_metadata(metadata=value).

This issue was initially brought up in [#1226](https://github.com/bluesky/tiled/issues/1226).

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
