### PR TITLE
revisions_count: implement pagination for metadata revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
-- The metadata revisions endpoint now reports the total revision count, so 
-all revisions can be paged through via the API.
+- The metadata revisions endpoint now reports the total revision count, so
+  all revisions can be paged through via the API.
 
 
 ## v0.2.11 (2026-05-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
   retry cannot fix: an unsupported URL scheme and an invalid request such as an
   illegal header value.
 
+### Fixed
+
+- The metadata revisions endpoint now reports the total revision count, so 
+all revisions can be paged through via the API.
+
 
 ## v0.2.11 (2026-05-27)
 

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -473,6 +473,20 @@ def test_metadata_revisions(tree):
             ac.metadata_revisions.delete_revision(1)
 
 
+def test_metadata_revisions_count(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        ac = client.write_array([1, 2, 3], key="paginate_me")
+        ac.update_metadata(metadata={"a": 1})
+        ac.update_metadata(metadata={"a": 2})
+        ac.update_metadata(metadata={"a": 3})
+        # `len` reads the total count from the server, which was always 0 before.
+        assert len(ac.metadata_revisions) == 3
+        # Revisions are returned ordered by revision number.
+        revision_numbers = [r["revision_number"] for r in ac.metadata_revisions[:]]
+        assert revision_numbers == sorted(revision_numbers)
+
+
 def test_replace_metadata(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -487,6 +487,24 @@ def test_metadata_revisions_count(tree):
         assert revision_numbers == sorted(revision_numbers)
 
 
+def test_metadata_revisions_pagination(tree):
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        ac = client.write_array([1, 2, 3], key="paginate_revisions")
+        ac.update_metadata(metadata={"a": 1})
+        ac.update_metadata(metadata={"a": 2})
+        ac.update_metadata(metadata={"a": 3})
+        # Walk one revision per page via the 'next' links (never generated before
+        # #1389) and confirm all three come back, in order, with no overlap.
+        url = ac.uri.replace("/metadata/", "/revisions/") + "?page[limit]=1"
+        revision_numbers = []
+        while url is not None:
+            page = context.http_client.get(url).json()
+            revision_numbers += [r["revision_number"] for r in page["data"]]
+            url = page["links"]["next"]
+        assert revision_numbers == [1, 2, 3]
+
+
 def test_replace_metadata(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -487,6 +487,36 @@ def test_metadata_revisions_count(tree):
         assert revision_numbers == [1, 2, 3]
 
 
+def test_metadata_revisions_count_empty(tree):
+    """Cover the empty-page branch of `revisions_with_count`.
+
+    The windowed COUNT emits no rows when the SELECT is empty, so the
+    adapter falls back to a plain COUNT query.  Exercise both empty
+    cases: (a) a node with zero revisions and (b) a page whose offset is
+    past the end of a non-empty revision list.
+    """
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+
+        # (a) Zero revisions on this node.
+        ac = client.write_array([1, 2, 3], key="no_revisions")
+        url = ac.uri.replace("/metadata/", "/revisions/")
+        page = context.http_client.get(url).json()
+        assert page["meta"]["count"] == 0
+        assert page["data"] == []
+        assert page["links"]["next"] is None
+
+        # (b) Offset past the end of a node that does have revisions.
+        ac = client.write_array([1, 2, 3], key="past_end")
+        ac.update_metadata(metadata={"a": 1})
+        ac.update_metadata(metadata={"a": 2})
+        url = ac.uri.replace("/metadata/", "/revisions/") + "?page[offset]=10"
+        page = context.http_client.get(url).json()
+        assert page["meta"]["count"] == 2
+        assert page["data"] == []
+        assert page["links"]["next"] is None
+
+
 def test_metadata_revisions_pagination(tree):
     with Context.from_app(build_app(tree)) as context:
         client = from_context(context)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -484,7 +484,7 @@ def test_metadata_revisions_count(tree):
         assert len(ac.metadata_revisions) == 3
         # Revisions are returned ordered by revision number.
         revision_numbers = [r["revision_number"] for r in ac.metadata_revisions[:]]
-        assert revision_numbers == sorted(revision_numbers)
+        assert revision_numbers == [1, 2, 3]
 
 
 def test_metadata_revisions_pagination(tree):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -981,6 +981,17 @@ class CatalogNodeAdapter:
             ).all()
             return [Revision.from_orm(o[0]) for o in revision_orms]
 
+    async def revisions_count(self) -> int:
+        "Get the total number of revisions for this node."
+        async with self.context.session() as db:
+            return (
+                await db.execute(
+                    select(func.count())
+                    .select_from(orm.Revision)
+                    .where(orm.Revision.node_id == self.node.id)
+                )
+            ).scalar_one()
+
     async def delete(self, recursive=False, external_only=True):
         """Delete the Node, its descendants, and associated DataSources and Assets
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -975,6 +975,7 @@ class CatalogNodeAdapter:
                 await db.execute(
                     select(orm.Revision)
                     .where(orm.Revision.node_id == self.node.id)
+                    .order_by(orm.Revision.revision_number)
                     .offset(offset)
                     .limit(limit)
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -998,16 +998,40 @@ class CatalogNodeAdapter:
             ).all()
             return [Revision.from_orm(o[0]) for o in revision_orms]
 
-    async def revisions_count(self) -> int:
-        "Get the total number of revisions for this node."
+    async def revisions_with_count(self, offset: int = 0, limit=None):
+        """Return a page of revisions and the total revision count.
+
+        Uses a single windowed query so the count is consistent with the
+        page and requires only one database round-trip.  If the page is
+        empty (either because there are no revisions or because ``offset``
+        is past the end), a follow-up ``COUNT`` runs in the same session
+        to obtain an accurate total.
+        """
         async with self.context.session() as db:
-            return (
+            rows = (
                 await db.execute(
-                    select(func.count())
-                    .select_from(orm.Revision)
+                    select(orm.Revision, func.count().over().label("_total"))
                     .where(orm.Revision.node_id == self.node.id)
+                    .order_by(orm.Revision.revision_number)
+                    .offset(offset)
+                    .limit(limit)
                 )
-            ).scalar_one()
+            ).all()
+            if rows:
+                revisions = [Revision.from_orm(row[0]) for row in rows]
+                total = rows[0]._total
+            else:
+                revisions = []
+                # Window functions emit no rows when the SELECT is empty, so fall back
+                # to a plain COUNT to distinguish "no revisions" from "offset past end".
+                total = (
+                    await db.execute(
+                        select(func.count())
+                        .select_from(orm.Revision)
+                        .where(orm.Revision.node_id == self.node.id)
+                    )
+                ).scalar_one()
+        return revisions, total
 
     async def delete(self, recursive=False, external_only=True):
         """Delete the Node, its descendants, and associated DataSources and Assets

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -348,7 +348,7 @@ async def construct_revisions_response(
             },
         }
         data.append(item)
-    count = len(data)
+    count = await entry.revisions_count()
     links = pagination_links(base_url, route, path_parts, page, None, count)
     return schemas.Response(data=data, links=links, meta={"count": count})
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -337,7 +337,13 @@ async def construct_revisions_response(
     media_type,
 ):
     path_parts = [segment for segment in path.split("/") if segment]
-    revisions = await entry.revisions(page.offset, page.limit)
+    combined = getattr(entry, "revisions_with_count", None)
+    if combined is not None:
+        revisions, count = await combined(page.offset, page.limit)
+    else:
+        # Backward compatibility for third-party adapters that only implement `revisions()` API.
+        revisions = await entry.revisions(page.offset, page.limit)
+        count = len(revisions)
     data = []
     for revision in revisions:
         item = {
@@ -349,7 +355,6 @@ async def construct_revisions_response(
             },
         }
         data.append(item)
-    count = await entry.revisions_count()
     links = pagination_links(base_url, route, path_parts, page, None, count)
     return schemas.Response(data=data, links=links, meta={"count": count})
 


### PR DESCRIPTION
This PR closes #1389 (@genematx).

The revisions endpoint used the current page size as the count, so `meta.count` was just `len(data)` and the `next` pagination link was never generated.

Add `CatalogNodeAdapter.revisions_count()` (a COUNT query) and use it as the length hint in `construct_revisions_response`. 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
