### PR TITLE
Adding a check before attempting to re-authenticate for from_context()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
-- Checking if the context is authenticated to prevent the user from being re-prompted to login in addition to the check of if an API key is set.
+- Fixed authentication check in from_context to prevent the user from being re-prompted to login.
 
 
 ## v0.2.11 (2026-05-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
   The spinner is animated in Jupyter notebooks as well as TTY terminals.
 - Respect the `Retry-After` header on HTTP 429 (Too Many Requests) responses.
 
+### Fixed
+
+- Checking if the context is authenticated to prevent the user from being re-prompted to login in addition to the check of if an API key is set.
+
 
 ## v0.2.11 (2026-05-27)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -705,3 +705,4 @@ def test_remaining_authenticated_when_tokens_not_remembered(config):
         context.configure_auth(tokens, remember_me=False)
         # This will timeout if waiting for a prompt response
         client = from_context(context, remember_me=False)
+        assert client.context.authenticated

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -18,7 +18,7 @@ from tiled.adapters.array import ArrayAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context, from_context
 from tiled.client.auth import CannotRefreshAuthentication
-from tiled.client.context import PasswordRejected
+from tiled.client.context import PasswordRejected, password_grant
 from tiled.server import authentication
 from tiled.server.app import build_app_from_config
 
@@ -692,3 +692,16 @@ def test_admin_delete_principal_apikey(
         context.api_key = api_key_info["secret"]
         with fail_with_status_code(HTTP_401_UNAUTHORIZED):
             context.whoami()
+
+
+@pytest.mark.timeout(5)
+def test_remaining_authenticated_when_tokens_not_remembered(config):
+    with Context.from_app(build_app_from_config(config)) as context:
+        provider = context.server_info.authentication.providers[0]
+        auth_endpoint = provider.links["auth_endpoint"]
+        tokens = password_grant(
+            context.http_client, auth_endpoint, provider.provider, "alice", "secret1"
+        )
+        context.configure_auth(tokens, remember_me=False)
+        # This will timeout if waiting for a prompt response
+        client = from_context(context, remember_me=False)

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -159,10 +159,13 @@ def from_context(
             )
 
         if has_providers and not context.has_external_auth:
-            found_valid_tokens = remember_me and context.use_cached_tokens() 
-            if (not context.authenticated) and (not found_valid_tokens) and auth_is_required: 
+            found_valid_tokens = remember_me and context.use_cached_tokens()
+            if (
+                (not context.authenticated)
+                and (not found_valid_tokens)
+                and auth_is_required
+            ):
                 context.authenticate(remember_me=remember_me)
-
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"
     params = parse_qs(urlparse(item_uri).query)

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -159,9 +159,10 @@ def from_context(
             )
 
         if has_providers and not context.has_external_auth:
-            found_valid_tokens = remember_me and context.use_cached_tokens()
-            if (not found_valid_tokens) and auth_is_required:
+            found_valid_tokens = remember_me and context.use_cached_tokens() 
+            if (not context.authenticated) and (not found_valid_tokens) and auth_is_required: 
                 context.authenticate(remember_me=remember_me)
+
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"
     params = parse_qs(urlparse(item_uri).query)

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -143,10 +143,11 @@ def from_context(
     if isinstance(structure_clients, str):
         structure_clients = DEFAULT_STRUCTURE_CLIENT_DISPATCH[structure_clients]
     # To construct a user-facing client object, we may be required to authenticate.
-    # 1. If any API key set, we are already authenticated and there is nothing to do.
+    # 1. If the context is authenticated, such as if an API key is set, we are already
+    #    authenticated and there is nothing to do.
     # 2. If there are cached valid credentials for this server, use them.
     # 3. If not, and the server requires authentication, prompt for authentication.
-    if context.api_key is None:
+    if not context.authenticated:
         auth_is_required = context.server_info.authentication.required
         has_providers = len(context.server_info.authentication.providers) > 0
         if auth_is_required and not has_providers:
@@ -160,11 +161,7 @@ def from_context(
 
         if has_providers and not context.has_external_auth:
             found_valid_tokens = remember_me and context.use_cached_tokens()
-            if (
-                (not context.authenticated)
-                and (not found_valid_tokens)
-                and auth_is_required
-            ):
+            if (not found_valid_tokens) and auth_is_required:
                 context.authenticate(remember_me=remember_me)
     # Context ensures that context.api_uri has a trailing slash.
     item_uri = f"{context.api_uri}metadata/{'/'.join(node_path_parts)}"


### PR DESCRIPTION
This PR is looking to address the issue presented in [#1120](https://github.com/bluesky/tiled/issues/1120). It is checking context.authenticated prior to attempting to re-authenticate to prevent the user from being re-prompted to login with a username and password. This replaces the check of whether an API key is set as this is included in checking context.authenticated in from_context.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
