### PR TITLE
Handle `object`-dtype Data in `HDF5Adapter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Expand the functionality of HDF5Adapter to handle `object`-dtyped data:
+  variable-length strings are coerced to fixed-length bytes, non-string object
+  dtypes (e.g. vlen arrays) fall back to an empty placeholder that preserves
+  the original shape.
+
 
 ## v0.2.12 (2026-06-16)
 

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -88,9 +88,32 @@ def example_file_with_vlen_str_in_dataset(tmp_path_factory):
         c = b.create_group("c")
         # Need to do this to make a vlen str dataset
         dt = h5py.string_dtype(encoding="utf-8")
+        # "d": sparsely populated vlen str
         dset = c.create_dataset("d", (100,), dtype=dt)
         assert dset.dtype == "object"
         dset[0] = b"test"
+        # "e": size-1 vlen str
+        c.create_dataset("e", data=numpy.array(["hello world"], dtype=object), dtype=dt)
+        # "f": multi-element vlen str with all values populated
+        f_dset = c.create_dataset("f", (3,), dtype=dt)
+        for i, v in enumerate([b"alpha", b"beta", b"gamma"]):
+            f_dset[i] = v
+        # "g": non-string object dtype (vlen array) -- exercises the
+        # branch where h5py.check_string_dtype returns None.
+        g_dset = c.create_dataset("g", (3,), dtype=h5py.vlen_dtype(numpy.int32))
+        g_dset[0] = numpy.arange(2, dtype=numpy.int32)
+        g_dset[1] = numpy.arange(5, dtype=numpy.int32)
+        g_dset[2] = numpy.arange(1, dtype=numpy.int32)
+        # "h": multi-dimensional vlen str -- shape preserved beyond 1-D.
+        h_dset = c.create_dataset("h", (2, 3), dtype=dt)
+        h_dset[...] = [[b"a", b"bb", b"ccc"], [b"d", b"ee", b"fff"]]
+        # "i": non-ASCII UTF-8 strings -- byte-level fidelity through the
+        # bytes coercion. "héllo" is 6 bytes in UTF-8.
+        c.create_dataset(
+            "i",
+            data=numpy.array(["héllo", "wörld"], dtype=object),
+            dtype=dt,
+        )
 
     yield ensure_uri(file_path)
 
@@ -184,8 +207,6 @@ def test_from_file_with_empty_data(example_file_with_empty_data, buffer, key):
 @pytest.mark.parametrize("num", [1, 5])
 def test_from_file_with_scalars(example_file_with_scalars, buffer, key: str, num: int):
     """Serve HDF5 file(s) containing scalars."""
-    if key in {"str", "bytes"}:
-        pytest.xfail("HDF5Adapter treats object dtypes differently.")
     h5py = pytest.importorskip("h5py")
     tree = HDF5Adapter.from_uris(*[example_file_with_scalars] * num)
     with Context.from_app(build_app(tree)) as context:
@@ -199,19 +220,58 @@ def test_from_file_with_scalars(example_file_with_scalars, buffer, key: str, num
 
 
 @pytest.mark.filterwarnings("ignore: The dataset")
-def test_from_file_with_vlen_str_dataset(example_file_with_vlen_str_in_dataset, buffer):
+@pytest.mark.parametrize(
+    "key, expected_shape, expected_values",
+    [
+        # Sparsely populated vlen str (only [0] set).
+        ("d", (100,), None),
+        # Size-1 vlen str.
+        ("e", (1,), [b"hello world"]),
+        # Fully populated multi-element vlen str.
+        ("f", (3,), [b"alpha", b"beta", b"gamma"]),
+        # Non-string object dtype (vlen array): served as an empty
+        # placeholder of the original shape.
+        ("g", (3,), None),
+        # Multi-dimensional vlen str.
+        (
+            "h",
+            (2, 3),
+            [[b"a", b"bb", b"ccc"], [b"d", b"ee", b"fff"]],
+        ),
+        # Non-ASCII UTF-8 strings preserved as raw bytes.
+        ("i", (2,), [b"h\xc3\xa9llo", b"w\xc3\xb6rld"]),
+    ],
+)
+def test_from_file_with_vlen_str_dataset(
+    example_file_with_vlen_str_in_dataset, buffer, key, expected_shape, expected_values
+):
     """Serve a single HDF5 file at top level."""
     h5py = pytest.importorskip("h5py")
     tree = HDF5Adapter.from_uris(example_file_with_vlen_str_in_dataset)
     with pytest.warns(UserWarning):
         with Context.from_app(build_app(tree)) as context:
             client = from_context(context)
-    arr = client["a"]["b"]["c"]["d"].read()
+    arr = client["a"]["b"]["c"][key].read()
     assert isinstance(arr, numpy.ndarray)
+    assert arr.shape == expected_shape
+    if expected_values is not None:
+        assert numpy.array_equal(arr, numpy.asarray(expected_values, dtype=bytes))
     with pytest.warns(UserWarning):
         client.export(buffer, format="application/x-hdf5")
     file = h5py.File(buffer, "r")
-    assert file["a"]["b"]["c"]["d"] is not None
+    assert file["a"]["b"]["c"][key] is not None
+
+
+@pytest.mark.filterwarnings("ignore: The dataset")
+@pytest.mark.parametrize("num", [2, 3])
+def test_from_multiple_files_with_vlen_str(example_file_with_vlen_str_in_dataset, num):
+    """Vlen string datasets must concatenate along axis 0 across files."""
+    tree = HDF5Adapter.from_uris(*[example_file_with_vlen_str_in_dataset] * num)
+    arr = tree["a"]["b"]["c"]["f"].read()
+    # Per-file shape is (3,) -> num*3 concatenated along axis 0.
+    assert arr.shape == (3 * num,)
+    expected = numpy.asarray([b"alpha", b"beta", b"gamma"] * num, dtype=bytes)
+    assert numpy.array_equal(arr, expected)
 
 
 def test_from_group(example_file, buffer):

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -186,35 +186,52 @@ class HDF5ArrayAdapter(ArrayAdapter):
         shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
         dtype = shapes_chunks_dtypes[0][2]
         if dtype == numpy.dtype("O"):
-            # TODO: It should be possible to put this in dask.delayed too -- needs to be thoroughly tested
+            # h5py uses NumPy's object dtype to represent variable-length
+            # strings, vlen arrays, and HDF5 references. These are a
+            # Python-only h5py feature not supported by HDF5 in general.
+            # See https://docs.h5py.org/en/stable/special.html.
+            #
+            # Variable-length strings are repackaged into a fixed-length
+            # bytes array (which dask can chunk). For any other object
+            # dtype we serve an empty placeholder preserving the original
+            # shape, since we cannot generally read it as a numpy array
+            # (and dask cannot auto-chunk object dtype).
             warnings.warn(
                 f"The dataset {dataset} is of object type, using a "
                 "Python-only feature of h5py that is not supported by "
                 "HDF5 in general. Read more about that feature at "
                 "https://docs.h5py.org/en/stable/special.html. "
                 "Consider using a fixed-length field instead. "
-                "Tiled will serve an empty placeholder, unless the "
-                "object is of size 1, where it will attempt to repackage "
-                "the data into a numpy array."
+                "If the data are variable-length strings, Tiled will "
+                "repackage them as a fixed-length bytes array; "
+                "otherwise an empty placeholder of the same shape "
+                "will be served."
             )
 
-            check_str_dtype = h5py.check_string_dtype(dtype)
-            if check_str_dtype.length is None:
-                # TODO: refactor and test
+            is_vlen_string = h5py.check_string_dtype(dtype) is not None
+
+            def _read_as_bytes(fpath: Union[str, Path]) -> NDArray:
                 with h5open(
-                    file_paths[0],
-                    dataset=dataset,
-                    swmr=swmr,
-                    libver=libver,
-                    locking=locking,
-                ) as value:
-                    dataset_names = value.file[value.file.name + "/" + dataset][...][()]
-                    if value.size == 1:
-                        arr = dask.array.from_array(numpy.array(dataset_names))
-                    else:
-                        arr = dask.array.empty(shape=())
-                return arr
-            return dask.array.empty(shape=())
+                    fpath, dataset, swmr=swmr, libver=libver, locking=locking
+                ) as ds:
+                    if is_vlen_string:
+                        # Coerce vlen-string object array to fixed-length bytes
+                        return numpy.asarray(ds[()], dtype=bytes)
+                    # Non-string object dtype: serve an empty placeholder
+                    # of the same shape (zero-length bytes).
+                    return numpy.empty(ds.shape, dtype="S0")
+
+            arrays = [_read_as_bytes(fp) for fp in file_paths]
+            # Mirror the empty/scalar vs. multi-dim behavior of the
+            # non-object branch below: stack (adding a leading axis) only
+            # for true scalars; otherwise concatenate along axis 0.
+            if arrays[0].shape == () or 0 in arrays[0].shape:
+                stacked = numpy.stack(arrays)
+            elif len(arrays) > 1:
+                stacked = numpy.concatenate(arrays, axis=0)
+            else:
+                stacked = arrays[0]
+            return dask.array.from_array(stacked, chunks=stacked.shape)
 
         if all((not shp) or (0 in shp) for shp, _, _ in shapes_chunks_dtypes):
             # Treat empty arrays and scalars separately: all shapes are empty or has 0

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -147,16 +147,18 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
             true_shape = tuple(map(sum, self._chunks))
             if true_shape != struct_shape:
                 # The trailing dimensions must match (can be generalized in the future)
-                if (math.prod(true_shape) != math.prod(struct_shape)) or (
-                    struct_shape[-len(true_shape[1:]) :] != true_shape[1:]  # noqa: E203
-                ):
+                if (math.prod(true_shape) != math.prod(struct_shape)):
                     raise RuntimeError(
-                        f"True shape {true_shape} derived from storage does not "
-                        f"match the shape {struct_shape} derived from the structure."
+                        f"Array with shape {true_shape} derived from storage can not be reshaped "
+                        f"to match the desired structure, {struct_shape}."
                     )
 
                 # The leading dimensions define stacking and the indices of files we need to read
-                stack_shape = struct_shape[: -len(true_shape[1:])]
+                stack_shape = (
+                    struct_shape[: -len(true_shape[1:])]
+                    if len(true_shape) > 1
+                    else struct_shape
+                )
                 slice = NDSlice(slice).expand_for_shape(struct_shape)  # typing: ignore
                 file_indx_slice = slice[: len(stack_shape)]
                 file_indx_list = (

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -147,7 +147,7 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
             true_shape = tuple(map(sum, self._chunks))
             if true_shape != struct_shape:
                 # The trailing dimensions must match (can be generalized in the future)
-                if (math.prod(true_shape) != math.prod(struct_shape)):
+                if math.prod(true_shape) != math.prod(struct_shape):
                     raise RuntimeError(
                         f"Array with shape {true_shape} derived from storage can not be reshaped "
                         f"to match the desired structure, {struct_shape}."


### PR DESCRIPTION
Expands the functionality of HDF5Adapter to handle `object`-dtyped data

1. Coerce variable-length strings to fixed-length bytes, so the resulting dask array has a real, chunkable dtype. This handles size 1, multi-element, multi-dimensional, and non-ASCII UTF-8 datasets uniformly.
2. Handle non-string object dtypes (vlen arrays, references) without crashing. h5py.check_string_dtype(...) returns None for these, and the previous code dereferenced .length on it. They now fall back to an empty placeholder that preserves the original shape (previously dask.array.empty(shape=()) regardless of true shape).

- For variable-length strings this is a net improvement (real data is served instead of an empty placeholder); for non-string object dtypes (vlen arrays, refs) the data is still not served (a fixed-length-bytes-typed empty placeholder of the correct shape is returned).
- No behavior change for non-object-dtype datasets.

Minor bug fix: reshaping in `SequenceAdapter` with stacked scalars.

Issue: #1405 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
