### PR TITLE
Move node access_blob column into association table

### DIFF
--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -867,9 +867,12 @@ def test_update_node_access_control(access_control_test_context_factory):
         cursor = db.cursor()
         cursor.execute(
             """
-            UPDATE access_blobs
-            SET kind = 'tags', username = NULL, tags = json(?)
-            WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+                UPDATE access_blobs
+                SET kind = 'tags', username = NULL, tags = json(?)
+                WHERE id = (
+                    SELECT access_blob_id FROM node_access_blobs
+                    WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+                )
             """,
             ('["undefined_tag", "biologists_tag"]', data),
         )
@@ -917,8 +920,8 @@ def test_empty_access_blob_access_control(access_control_test_context_factory):
         cursor = db.cursor()
         cursor.execute(
             """
-            DELETE FROM access_blobs
-            WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
+                DELETE FROM node_access_blobs
+                WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
             """
         )
         db.commit()

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -866,8 +866,12 @@ def test_update_node_access_control(access_control_test_context_factory):
         db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
         cursor = db.cursor()
         cursor.execute(
-            "UPDATE nodes SET access_blob = ? WHERE key = ?",
-            ('{"tags": ["undefined_tag", "biologists_tag"]}', data),
+            """
+            UPDATE access_blobs
+            SET kind = 'tags', username = NULL, tags = json(?)
+            WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+            """,
+            ('["undefined_tag", "biologists_tag"]', data),
         )
         db.commit()
         with fail_with_status_code(HTTP_403_FORBIDDEN):
@@ -899,9 +903,9 @@ def test_update_node_access_control(access_control_test_context_factory):
 
 def test_empty_access_blob_access_control(access_control_test_context_factory):
     """
-    Test the cases where a node in the catalog has an empty access blob.
+    Test the cases where a node in the catalog has no access blob row.
     This case occurs when migrating an older catalog without also
-      populating the access_blob column.
+      populating the access_blobs association table.
     """
     admin_client = access_control_test_context_factory("admin", "admin")
     alice_client = access_control_test_context_factory("alice", "alice")
@@ -912,7 +916,10 @@ def test_empty_access_blob_access_control(access_control_test_context_factory):
         db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
         cursor = db.cursor()
         cursor.execute(
-            "UPDATE nodes SET access_blob = json('{}') WHERE key == 'data_M'"
+            """
+            DELETE FROM access_blobs
+            WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
+            """
         )
         db.commit()
 

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -56,8 +56,8 @@ async def test_node_access_allowed(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (True, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (True, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -72,8 +72,8 @@ async def test_node_access_denied(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -91,8 +91,8 @@ async def test_node_modify_allowed(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (True, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (True, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -110,8 +110,8 @@ async def test_node_modify_denied(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -128,7 +128,7 @@ async def test_node_modify_denied_when_none_returned(
             principal=principal,
             authn_access_tags=set(),
             authn_scopes=set([]),
-            access_blob={"tags": {"beamline_x_user"}},
+            access_blob=AccessBlob(tags=["beamline_x_user"]),
         )
 
 
@@ -137,14 +137,14 @@ async def test_node_modify_with_same_not_modified(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = {"tags": {"beamline_x_user"}}
+    node.access_blob = AccessBlob(tags=["beamline_x_user"])
     assert await external_policy.modify_node(
         node=node,
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -240,7 +240,7 @@ async def test_empty_access_blob_public(
         authn_access_tags=set(),
         authn_scopes=set([]),
         access_blob=None,
-    ) == (allow if allow is not None else remote_allow, None)
+    ) == (allow if allow is not None else remote_allow, AccessBlob(tags=[]))
 
     if route:
         assert route.call_count == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import random
 import string
@@ -60,6 +61,22 @@ async def client(catalog_adapter):
     app = build_app(catalog_adapter)
     with Context.from_app(app) as context:
         yield from_context(context)
+
+
+@pytest.mark.asyncio
+async def test_root_node_has_default_access_blob(a):
+    tags = (
+        await a.context.execute(
+            "SELECT access_blobs.tags "
+            "FROM access_blobs "
+            "JOIN node_access_blobs "
+            "ON node_access_blobs.access_blob_id = access_blobs.id "
+            "WHERE node_access_blobs.node_id = 0"
+        )
+    ).scalar_one()
+    if isinstance(tags, str):
+        tags = json.loads(tags)
+    assert tags == ["public"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -1,5 +1,7 @@
 import pytest
-from sqlalchemy import delete as sa_delete, insert as sa_insert, select as sa_select
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import insert as sa_insert
+from sqlalchemy import select as sa_select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import insert as sa_insert
+from sqlalchemy import delete as sa_delete, insert as sa_insert, select as sa_select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 
@@ -7,7 +7,13 @@ from tiled.catalog import in_memory
 from tiled.catalog.core import initialize_database
 from tiled.config import Database
 from tiled.graph.schema import schema
-from tiled.graph.store import GraphSQLAlchemyStore, _nodes
+from tiled.graph.store import (
+    GraphSQLAlchemyStore,
+    _access_blobs,
+    _link_access_blobs,
+    _node_access_blobs,
+    _nodes,
+)
 from tiled.queries import AccessBlobFilter
 from tiled.server.app import build_app
 from tiled.server.authentication import (
@@ -179,9 +185,58 @@ async def _insert_node(store, node_id, access_blob, key="node", parent=None):
                 structure_family="container",
                 metadata={},
                 specs=[],
-                access_blob=access_blob,
             )
         )
+        access_blob_result = await conn.execute(
+            sa_insert(_access_blobs).values(
+                kind="user" if "user" in access_blob else "tags",
+                username=access_blob.get("user"),
+                tags=None if "user" in access_blob else access_blob.get("tags", []),
+            )
+        )
+        await conn.execute(
+            sa_insert(_node_access_blobs).values(
+                node_id=node_id,
+                access_blob_id=access_blob_result.inserted_primary_key[0],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_deleting_node_deletes_orphaned_access_blob(store):
+    await _insert_node(store, 1, {"tags": ["team"]})
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_node_access_blobs.c.access_blob_id).where(
+                _node_access_blobs.c.node_id == 1
+            )
+        )
+        await conn.execute(sa_delete(_nodes).where(_nodes.c.id == 1))
+        access_blob = await conn.scalar(
+            sa_select(_access_blobs.c.id).where(_access_blobs.c.id == access_blob_id)
+        )
+    assert access_blob is None
+
+
+@pytest.mark.asyncio
+async def test_access_blob_cannot_belong_to_node_and_link(store):
+    await _insert_node(store, 1, {"tags": ["team"]})
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        node_access_blob_id = await conn.scalar(
+            sa_select(_node_access_blobs.c.access_blob_id).where(
+                _node_access_blobs.c.node_id == 1
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_link_access_blobs).values(
+                    link_id=link.id,
+                    access_blob_id=node_access_blob_id,
+                )
+            )
 
 
 @pytest.mark.asyncio
@@ -336,6 +391,17 @@ async def test_link_crud_and_access_control(store, policy):
     )
     assert link_created.errors is None
     link_id = link_created.data["createLink"]["id"]
+    async with store._engine.connect() as conn:
+        access_blob = (
+            await conn.execute(
+                sa_select(_link_access_blobs, _access_blobs)
+                .join(_access_blobs)
+                .where(_link_access_blobs.c.link_id == link_id)
+            )
+        ).one()
+    assert access_blob.kind == "user"
+    assert access_blob.username == "alice"
+    assert access_blob.tags is None
 
     bob_read_ctx = _context(store, policy, "bob", {"read:metadata"})
     read_link = await _execute(

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -12,7 +12,10 @@ from tiled.graph.schema import schema
 from tiled.graph.store import (
     GraphSQLAlchemyStore,
     _access_blobs,
+    _entities,
+    _entity_access_blobs,
     _link_access_blobs,
+    _links,
     _node_access_blobs,
     _nodes,
 )
@@ -28,6 +31,7 @@ from tiled.server.connection_pool import (
     get_database_engine,
 )
 from tiled.server.settings import DatabaseSettings
+from tiled.type_aliases import AccessBlob
 
 CREATE_ENTITY_MUTATION = """
 mutation($input: CreateEntityInput!) {
@@ -58,12 +62,10 @@ class FakeTagPolicy:
         access_blob=None,
     ):
         if access_blob is None:
-            return (True, {"user": principal})
-        if "tags" in access_blob:
+            return (True, AccessBlob(username=principal))
+        if access_blob.tags is not None:
             return (False, access_blob)
-        raise ValueError(
-            "access_blob must be either null or {'tags': [...]} for this test"
-        )
+        raise ValueError("access_blob updates must use tags for this test")
 
     async def modify_node(
         self,
@@ -73,9 +75,9 @@ class FakeTagPolicy:
         authn_scopes,
         access_blob,
     ):
-        if "tags" in access_blob:
+        if access_blob.tags is not None:
             return (False, access_blob)
-        raise ValueError("access_blob updates must use {'tags': [...]} for this test")
+        raise ValueError("access_blob updates must use tags for this test")
 
     async def allowed_scopes(
         self,
@@ -84,10 +86,10 @@ class FakeTagPolicy:
         authn_access_tags,
         authn_scopes,
     ):
-        access_blob = getattr(node, "access_blob", {}) or {}
-        if access_blob.get("user") == principal:
+        access_blob = node.access_blob
+        if access_blob.username == principal:
             return set(authn_scopes)
-        tags = set(access_blob.get("tags", []))
+        tags = set(access_blob.tags or [])
         if tags.intersection(self.user_tags.get(principal, set())):
             return set(authn_scopes)
         return set()
@@ -242,6 +244,88 @@ async def test_access_blob_cannot_belong_to_node_and_link(store):
 
 
 @pytest.mark.asyncio
+async def test_entity_access_blob_cleanup_and_node_exclusivity(store):
+    entity = await store.create_entity(
+        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+    )
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_entity_access_blobs.c.access_blob_id).where(
+                _entity_access_blobs.c.entity_id == entity.id
+            )
+        )
+        await conn.execute(
+            sa_insert(_nodes).values(
+                id=2,
+                parent=None,
+                key="unassociated-node",
+                structure_family="container",
+                metadata={},
+                specs=[],
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_node_access_blobs).values(
+                    node_id=2, access_blob_id=access_blob_id
+                )
+            )
+        await conn.execute(sa_delete(_entities).where(_entities.c.id == entity.id))
+        assert (
+            await conn.scalar(
+                sa_select(_access_blobs.c.id).where(
+                    _access_blobs.c.id == access_blob_id
+                )
+            )
+            is None
+        )
+
+
+@pytest.mark.asyncio
+async def test_entity_access_blob_cannot_belong_to_link(store):
+    entity = await store.create_entity(
+        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+    )
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_entity_access_blobs.c.access_blob_id).where(
+                _entity_access_blobs.c.entity_id == entity.id
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_link_access_blobs).values(
+                    link_id=link.id, access_blob_id=access_blob_id
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_deleting_link_deletes_orphaned_access_blob(store):
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_link_access_blobs.c.access_blob_id).where(
+                _link_access_blobs.c.link_id == link.id
+            )
+        )
+        await conn.execute(sa_delete(_links).where(_links.c.id == link.id))
+        assert (
+            await conn.scalar(
+                sa_select(_access_blobs.c.id).where(
+                    _access_blobs.c.id == access_blob_id
+                )
+            )
+            is None
+        )
+
+
+@pytest.mark.asyncio
 async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
     store, policy
 ):
@@ -257,7 +341,7 @@ async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
     entity_id = result.data["createEntity"]["id"]
 
     record = await store.get_entity(entity_id)
-    assert record.access_blob == {"user": "alice"}
+    assert record.access_blob == AccessBlob(username="alice")
 
     alice_read = await _execute(READ_ENTITY_QUERY, alice_ctx, {"id": entity_id})
     assert alice_read.errors is None
@@ -566,14 +650,14 @@ async def test_entity_node_access_blob_trigger_rejects_both_set(store):
             entity_type="sample",
             name="bad",
             node_id=1,
-            access_blob={"tags": ["team"]},
+            access_blob=AccessBlob(tags=["team"]),
         )
 
     entity = await store.create_entity(
         entity_type="sample", name="ok", node_id=1, access_blob=None
     )
     with pytest.raises(IntegrityError):
-        await store.update_entity(entity.id, access_blob={"tags": ["team"]})
+        await store.update_entity(entity.id, access_blob=AccessBlob(tags=["team"]))
 
 
 @pytest.mark.asyncio
@@ -657,7 +741,7 @@ async def test_update_entity_detaching_node_reinitializes_access_blob(store, pol
 
     record = await store.get_entity(entity_id)
     assert record.node_id is None
-    assert record.access_blob == {"user": "alice"}
+    assert record.access_blob == AccessBlob(username="alice")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -220,8 +220,8 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         # Intermediate nodes should have empty specs and access_blob.
         assert client["X"].specs == []
         assert client["X"]["Y"].specs == []
-        assert not client["X"].access_blob
-        assert not client["X"]["Y"].access_blob
+        assert client["X"].access_blob.get("tags") == []
+        assert client["X"]["Y"].access_blob.get("tags") == []
         # The leaf (mount node) should carry the configured specs.
         assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]
         assert client["X"]["Y"]["Z"].access_blob.get("tags") == ["_ROOT_NODE"]

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -493,8 +493,8 @@ class CustomAccessPolicy(AccessPolicy):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def modify_node(
         self,
@@ -502,9 +502,9 @@ class CustomAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+        access_blob: Optional[AccessBlob],
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def allowed_scopes(
         self,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -44,6 +44,7 @@ from tiled.server.webhooks import (
     _sign,
     check_url_ssrf_safety,
 )
+from tiled.type_aliases import AccessBlob
 
 from .conftest import TOY_AUTHENTICATION
 from .utils import enter_username_password
@@ -853,7 +854,7 @@ def _make_close_stream_adapter(
     mock_node.key = node_key
     mock_node.structure_family = "container"
     mock_node.specs = []
-    mock_node.access_blob = {}
+    mock_node.access_blob = AccessBlob(tags=[])
 
     adapter = CatalogNodeAdapter(mock_context, mock_node)
     adapter.path_segments = AsyncMock(return_value=[node_key])

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -44,6 +44,7 @@ from tiled.server.webhooks import (
     _sign,
     check_url_ssrf_safety,
 )
+from tiled.type_aliases import AccessBlob
 
 from .conftest import TOY_AUTHENTICATION
 from .utils import enter_username_password
@@ -710,7 +711,7 @@ def _make_close_stream_adapter(
     mock_node.key = node_key
     mock_node.structure_family = "container"
     mock_node.specs = []
-    mock_node.access_blob = {}
+    mock_node.access_blob = AccessBlob(tags=[])
 
     adapter = CatalogNodeAdapter(mock_context, mock_node)
     adapter.path_segments = AsyncMock(return_value=[node_key])

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -10,7 +10,7 @@ from ..adapters.protocols import BaseAdapter
 from ..queries import AccessBlobFilter
 from ..server.schemas import Principal
 from ..type_aliases import AccessBlob, AccessTags, Filters, Scopes
-from ..utils import Sentinel, import_object
+from ..utils import Sentinel, access_blob_matches, import_object
 from .protocols import AccessPolicy
 from .scopes import ALL_SCOPES, NO_SCOPES, PUBLIC_SCOPES
 
@@ -118,17 +118,17 @@ class TagBasedAccessPolicy(AccessPolicy):
             identifier = self._get_id(principal)
 
         if access_blob:
-            if len(access_blob) != 1 or "tags" not in access_blob:
+            if access_blob.username is not None or access_blob.tags is None:
                 raise ValueError(
                     f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                     f"""Received {access_blob=}"""
                 )
-            if not access_blob["tags"]:
+            if not access_blob.tags:
                 if not self._is_admin(authn_scopes):
                     raise ValueError(
                         "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                     )
-            access_tags = set(access_blob["tags"])
+            access_tags = set(access_blob.tags)
             include_public_tag = False
             for tag in access_tags:
                 if authn_access_tags is not None:
@@ -161,7 +161,7 @@ class TagBasedAccessPolicy(AccessPolicy):
             if include_public_tag:
                 access_tags_from_policy.add(self.public_tag)
 
-            access_blob_from_policy = {"tags": list(access_tags_from_policy)}
+            access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
             access_blob_modified = access_tags != access_tags_from_policy
 
             # admin principals are not subject to scope reduction restriction
@@ -183,7 +183,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                     f"Current API key does not permit action on user-owned nodes.\n"
                     f"Please provide a tag allowed by this API key: {authn_access_tags}"
                 )
-            access_blob_from_policy = {"user": identifier}
+            access_blob_from_policy = AccessBlob(username=identifier)
             access_blob_modified = True
 
         logger.info(
@@ -205,24 +205,24 @@ class TagBasedAccessPolicy(AccessPolicy):
         else:
             identifier = self._get_id(principal)
 
-        if access_blob == node.access_blob:
+        if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
             )
             return False, node.access_blob
 
-        if len(access_blob) != 1 or "tags" not in access_blob:
+        if access_blob is None or access_blob.username is not None or access_blob.tags is None:
             raise ValueError(
                 f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                 f"""Received {access_blob=}\n"""
                 f"""If this was a merge patch on a user-owned node, use a replace op instead."""
             )
-        if not access_blob["tags"]:
+        if not access_blob.tags:
             if not self._is_admin(authn_scopes):
                 raise ValueError(
                     "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                 )
-        access_tags = set(access_blob["tags"])
+        access_tags = set(access_blob.tags)
         include_public_tag = False
         # check for tags that need to be added
         for tag in access_tags:
@@ -231,7 +231,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                     raise ValueError(
                         f"Cannot apply tag to node: API key is restricted to access tags: {authn_access_tags}."
                     )
-            if tag in node.access_blob.get("tags", []):
+            if tag in (node.access_blob.tags or []):
                 # node already has this tag - no action.
                 # or: access_blob does not have "tags" key,
                 # so it must have a "user" key currently
@@ -265,8 +265,8 @@ class TagBasedAccessPolicy(AccessPolicy):
             access_tags_from_policy.add(self.public_tag)
 
         # check for tags that need to be removed
-        if "tags" in node.access_blob:
-            for tag in set(node.access_blob["tags"]).difference(
+        if node.access_blob.tags is not None:
+            for tag in set(node.access_blob.tags).difference(
                 access_tags_from_policy
             ):
                 if authn_access_tags is not None:
@@ -295,7 +295,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                         f"Cannot remove tag from node: '{tag}' is not a valid tag name."
                     )
 
-        access_blob_from_policy = {"tags": list(access_tags_from_policy)}
+        access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
         access_blob_modified = access_tags != access_tags_from_policy
 
         # admin principals are not subject to scope reduction restriction
@@ -343,11 +343,11 @@ class TagBasedAccessPolicy(AccessPolicy):
                 identifier = self._get_id(principal)
 
             allowed = set()
-            if "user" in node.access_blob:
-                if authn_access_tags is None and identifier == node.access_blob["user"]:
+            if node.access_blob.username is not None:
+                if authn_access_tags is None and identifier == node.access_blob.username:
                     allowed = self.scopes
-            elif "tags" in node.access_blob:
-                for tag in node.access_blob["tags"]:
+            elif node.access_blob.tags is not None:
+                for tag in node.access_blob.tags:
                     if authn_access_tags is not None:
                         if tag not in authn_access_tags:
                             continue
@@ -518,7 +518,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
     ) -> Tuple[bool, Optional[AccessBlob]]:
-        if access_blob == node.access_blob:
+        if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
             )

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -39,7 +39,7 @@ class DummyAccessPolicy(AccessPolicy):
         access_blob: Optional[AccessBlob] = None,
     ) -> Tuple[bool, AccessBlob]:
         "Do nothing; there is no persistent state to initialize."
-        return (False, access_blob)
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def allowed_scopes(
         self,
@@ -503,16 +503,16 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         if access_blob is None and self._empty_access_blob_public is not None:
-            return self._empty_access_blob_public, access_blob
+            return self._empty_access_blob_public, AccessBlob(tags=[])
         decision = await self._get_external_decision(
             self._create_node,
             self.build_input(principal, authn_access_tags, authn_scopes, access_blob),
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob)
+            return (decision.result, access_blob or AccessBlob(tags=[]))
         raise ValueError("Permission denied not able to add the node")
 
     async def modify_node(
@@ -522,7 +522,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
@@ -534,7 +534,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob)
+            return (decision.result, access_blob or AccessBlob(tags=[]))
         raise ValueError("Permission denied not able to add the node")
 
     async def filters(

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -211,7 +211,11 @@ class TagBasedAccessPolicy(AccessPolicy):
             )
             return False, node.access_blob
 
-        if access_blob is None or access_blob.username is not None or access_blob.tags is None:
+        if (
+            access_blob is None
+            or access_blob.username is not None
+            or access_blob.tags is None
+        ):
             raise ValueError(
                 f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                 f"""Received {access_blob=}\n"""
@@ -266,9 +270,7 @@ class TagBasedAccessPolicy(AccessPolicy):
 
         # check for tags that need to be removed
         if node.access_blob.tags is not None:
-            for tag in set(node.access_blob.tags).difference(
-                access_tags_from_policy
-            ):
+            for tag in set(node.access_blob.tags).difference(access_tags_from_policy):
                 if authn_access_tags is not None:
                     if tag not in authn_access_tags:
                         raise ValueError(
@@ -344,7 +346,10 @@ class TagBasedAccessPolicy(AccessPolicy):
 
             allowed = set()
             if node.access_blob.username is not None:
-                if authn_access_tags is None and identifier == node.access_blob.username:
+                if (
+                    authn_access_tags is None
+                    and identifier == node.access_blob.username
+                ):
                     allowed = self.scopes
             elif node.access_blob.tags is not None:
                 for tag in node.access_blob.tags:

--- a/tiled/access_control/protocols.py
+++ b/tiled/access_control/protocols.py
@@ -14,7 +14,7 @@ class AccessPolicy(ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         pass
 
     async def modify_node(
@@ -24,8 +24,8 @@ class AccessPolicy(ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     @abstractmethod
     async def allowed_scopes(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -38,6 +38,7 @@ from sqlalchemy import (
     not_,
     or_,
     select,
+    String,
     text,
     true,
     type_coerce,
@@ -1539,11 +1540,19 @@ class CatalogNodeAdapter:
                 )
             if access_blob is not None:
                 await db.execute(
-                    delete(orm.AccessBlob).where(orm.AccessBlob.node_id == self.node.id)
+                    delete(orm.NodeAccessBlob).where(
+                        orm.NodeAccessBlob.node_id == self.node.id
+                    )
                 )
                 access_blob_orm = _access_blob_to_orm(access_blob)
-                access_blob_orm.node_id = self.node.id
                 db.add(access_blob_orm)
+                await db.flush()
+                db.add(
+                    orm.NodeAccessBlob(
+                        node_id=self.node.id,
+                        access_blob_id=access_blob_orm.id,
+                    )
+                )
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2405,7 +2414,7 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = select(orm.AccessBlob.node_id).where(
+                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                     orm.AccessBlob.kind == "tags",
                     select(1)
                     .select_from(access_tags_json)
@@ -2413,15 +2422,17 @@ def access_blob_filter(query, tree):
                     .exists(),
                 )
             elif dialect_name == "postgresql":
-                tags_match = select(orm.AccessBlob.node_id).where(
+                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                     orm.AccessBlob.kind == "tags",
-                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT))),
+                    type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
+                        sql_cast(query.tags, ARRAY(String()))
+                    ),
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
-            user_match = select(orm.AccessBlob.node_id).where(
+            user_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                 orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
             )
             filters.append(orm.Node.id.in_(user_match))
@@ -2598,12 +2609,17 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
                 )
                 access_blob_orm = _access_blob_to_orm(node_access_blob)
-                await conn.execute(
+                access_blob_result = await conn.execute(
                     insert(orm.AccessBlob).values(
-                        node_id=node_id,
                         kind=access_blob_orm.kind,
                         username=access_blob_orm.username,
                         tags=access_blob_orm.tags,
+                    )
+                )
+                await conn.execute(
+                    insert(orm.NodeAccessBlob).values(
+                        node_id=node_id,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
                     )
                 )
                 logger.info(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -154,6 +154,12 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class AccessBlobMock:
+    username: str | None = None
+    tags: list[str] | None = None
+
+
 class RootNode:
     """
     Node representing the root of the tree.
@@ -174,7 +180,17 @@ class RootNode:
         self.specs = specs or []
         self.key = ""
         self.data_sources = None
-        self.access_blob = top_level_access_blob or {}
+
+        if top_level_access_blob is None:
+            self.access_blob = None
+        elif "user" in top_level_access_blob:
+            self.access_blob = AccessBlobMock(
+                username=top_level_access_blob["user"]
+            )
+        else:
+            self.access_blob = AccessBlobMock(
+                tags=top_level_access_blob["tags"]
+            )
 
 
 class Context:
@@ -1301,7 +1317,6 @@ class CatalogNodeAdapter:
                     # SQLAlchemy reserved word 'metadata'.
                     metadata_=current.metadata_,
                     specs=current.specs,
-                    access_blob=current.access_blob,
                     node_id=current.id,
                     revision_number=next_revision_number,
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -2147,21 +2147,23 @@ def access_blob_filter(query, tree):
                     "value"
                 )
                 tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.kind == "tags",
                     select(1)
                     .select_from(access_tags_json)
                     .where(access_tags_json.c.value.in_(query.tags))
-                    .exists()
+                    .exists(),
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
-                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                    orm.AccessBlob.kind == "tags",
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT))),
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
             user_match = select(orm.AccessBlob.node_id).where(
-                orm.AccessBlob.username == query.user_id
+                orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
             )
             filters.append(orm.Node.id.in_(user_match))
         condition = or_(*filters) if filters else false()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -178,6 +178,12 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class AccessBlobMock:
+    username: str | None = None
+    tags: list[str] | None = None
+
+
 class RootNode:
     """
     Node representing the root of the tree.
@@ -198,7 +204,17 @@ class RootNode:
         self.specs = specs or []
         self.key = ""
         self.data_sources = None
-        self.access_blob = top_level_access_blob or {}
+
+        if top_level_access_blob is None:
+            self.access_blob = None
+        elif "user" in top_level_access_blob:
+            self.access_blob = AccessBlobMock(
+                username=top_level_access_blob["user"]
+            )
+        else:
+            self.access_blob = AccessBlobMock(
+                tags=top_level_access_blob["tags"]
+            )
 
 
 class Context:
@@ -1509,7 +1525,6 @@ class CatalogNodeAdapter:
                     # SQLAlchemy reserved word 'metadata'.
                     metadata_=current.metadata_,
                     specs=current.specs,
-                    access_blob=current.access_blob,
                     node_id=current.id,
                     revision_number=next_revision_number,
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 import anyio
 from fastapi import HTTPException
 from sqlalchemy import (
+    String,
     delete,
     exists,
     false,
@@ -38,7 +39,6 @@ from sqlalchemy import (
     not_,
     or_,
     select,
-    String,
     text,
     true,
     type_coerce,
@@ -2414,26 +2414,39 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                    orm.AccessBlob.kind == "tags",
-                    select(1)
-                    .select_from(access_tags_json)
-                    .where(access_tags_json.c.value.in_(query.tags))
-                    .exists(),
+                tags_match = (
+                    select(orm.NodeAccessBlob.node_id)
+                    .join(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.kind == "tags",
+                        select(1)
+                        .select_from(access_tags_json)
+                        .where(access_tags_json.c.value.in_(query.tags))
+                        .exists(),
+                    )
                 )
             elif dialect_name == "postgresql":
-                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                    orm.AccessBlob.kind == "tags",
-                    type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
-                        sql_cast(query.tags, ARRAY(String()))
-                    ),
+                tags_match = (
+                    select(orm.NodeAccessBlob.node_id)
+                    .join(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.kind == "tags",
+                        type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
+                            sql_cast(query.tags, ARRAY(String()))
+                        ),
+                    )
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
-            user_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
+            user_match = (
+                select(orm.NodeAccessBlob.node_id)
+                .join(orm.AccessBlob)
+                .where(
+                    orm.AccessBlob.kind == "user",
+                    orm.AccessBlob.username == query.user_id,
+                )
             )
             filters.append(orm.Node.id.in_(user_match))
         condition = or_(*filters) if filters else false()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1085,7 +1085,11 @@ class CatalogNodeAdapter:
                     "specs": [spec.model_dump() for spec in (specs or [])],
                     "metadata": metadata,
                     "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                    "access_blob": refreshed_node.access_blob,
+                    "access_blob": (
+                        {"user": refreshed_node.access_blob.username}
+                        if refreshed_node.access_blob.username is not None
+                        else {"tags": refreshed_node.access_blob.tags}
+                    ),
                 }
 
                 # Cache data in Redis with a TTL, and publish
@@ -2389,35 +2393,40 @@ def specs(query, tree):
 
 def access_blob_filter(query, tree):
     dialect_name = tree.context.engine.url.get_dialect().name
-    access_blob = orm.Node.access_blob
     if not (query.user_id or query.tags):
         # Results cannot possibly match an empty value or list,
         # so put a False condition in the list ensuring that
         # there are no rows returned.
         condition = false()
-    elif dialect_name == "sqlite":
-        attr_id = access_blob["user"]
-        attr_tags = access_blob["tags"]
-        access_tags_json = func.json_each(attr_tags).table_valued("value")
-        condition = (
-            select(1)
-            .select_from(access_tags_json)
-            .where(access_tags_json.c.value.in_(query.tags))
-            .exists()
-        )
-        if query.user_id is not None:
-            user_match = (
-                func.json_extract(func.json_quote(attr_id), "$") == query.user_id
-            )
-            condition = or_(condition, user_match)
-    elif dialect_name == "postgresql":
-        access_blob_jsonb = type_coerce(access_blob, JSONB)
-        condition = access_blob_jsonb["tags"].has_any(sql_cast(query.tags, ARRAY(TEXT)))
-        if query.user_id is not None:
-            user_match = access_blob_jsonb["user"].astext == query.user_id
-            condition = or_(condition, user_match)
     else:
-        raise UnsupportedQueryType("access_blob_filter")
+        filters = []
+        if query.tags:
+            if dialect_name == "sqlite":
+                access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
+                    "value"
+                )
+                tags_match = (
+                    select(orm.AccessBlob.node_id)
+                    .where(
+                        select(1)
+                        .select_from(access_tags_json)
+                        .where(access_tags_json.c.value.in_(query.tags))
+                        .exists()
+                    )
+                )
+            elif dialect_name == "postgresql":
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                )
+            else:
+                raise UnsupportedQueryType("access_blob_filter")
+            filters.append(orm.Node.id.in_(tags_match))
+        if query.user_id is not None:
+            user_match = select(orm.AccessBlob.node_id).where(
+                orm.AccessBlob.username == query.user_id
+            )
+            filters.append(orm.Node.id.in_(user_match))
+        condition = or_(*filters) if filters else false()
 
     return tree.new_variation(conditions=tree.conditions + [condition])
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -109,6 +109,7 @@ from ..storage import (
     register_storage,
 )
 from ..structures.core import Spec, StructureFamily
+from ..type_aliases import AccessBlob
 from ..utils import (
     UNCHANGED,
     Conflicts,
@@ -119,7 +120,6 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
-from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -2405,14 +2405,11 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = (
-                    select(orm.AccessBlob.node_id)
-                    .where(
-                        select(1)
-                        .select_from(access_tags_json)
-                        .where(access_tags_json.c.value.in_(query.tags))
-                        .exists()
-                    )
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    select(1)
+                    .select_from(access_tags_json)
+                    .where(access_tags_json.c.value.in_(query.tags))
+                    .exists()
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
@@ -2595,7 +2592,9 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     )
                 )
                 node_id = result.inserted_primary_key[0]
-                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                node_access_blob = (
+                    access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                )
                 access_blob_orm = _access_blob_to_orm(node_access_blob)
                 await conn.execute(
                     insert(orm.AccessBlob).values(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -883,7 +883,11 @@ class CatalogNodeAdapter:
                     "specs": [spec.model_dump() for spec in (specs or [])],
                     "metadata": metadata,
                     "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                    "access_blob": refreshed_node.access_blob,
+                    "access_blob": (
+                        {"user": refreshed_node.access_blob.username}
+                        if refreshed_node.access_blob.username is not None
+                        else {"tags": refreshed_node.access_blob.tags}
+                    ),
                 }
 
                 # Cache data in Redis with a TTL, and publish
@@ -2130,35 +2134,40 @@ def specs(query, tree):
 
 def access_blob_filter(query, tree):
     dialect_name = tree.context.engine.url.get_dialect().name
-    access_blob = orm.Node.access_blob
     if not (query.user_id or query.tags):
         # Results cannot possibly match an empty value or list,
         # so put a False condition in the list ensuring that
         # there are no rows returned.
         condition = false()
-    elif dialect_name == "sqlite":
-        attr_id = access_blob["user"]
-        attr_tags = access_blob["tags"]
-        access_tags_json = func.json_each(attr_tags).table_valued("value")
-        condition = (
-            select(1)
-            .select_from(access_tags_json)
-            .where(access_tags_json.c.value.in_(query.tags))
-            .exists()
-        )
-        if query.user_id is not None:
-            user_match = (
-                func.json_extract(func.json_quote(attr_id), "$") == query.user_id
-            )
-            condition = or_(condition, user_match)
-    elif dialect_name == "postgresql":
-        access_blob_jsonb = type_coerce(access_blob, JSONB)
-        condition = access_blob_jsonb["tags"].has_any(sql_cast(query.tags, ARRAY(TEXT)))
-        if query.user_id is not None:
-            user_match = access_blob_jsonb["user"].astext == query.user_id
-            condition = or_(condition, user_match)
     else:
-        raise UnsupportedQueryType("access_blob_filter")
+        filters = []
+        if query.tags:
+            if dialect_name == "sqlite":
+                access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
+                    "value"
+                )
+                tags_match = (
+                    select(orm.AccessBlob.node_id)
+                    .where(
+                        select(1)
+                        .select_from(access_tags_json)
+                        .where(access_tags_json.c.value.in_(query.tags))
+                        .exists()
+                    )
+                )
+            elif dialect_name == "postgresql":
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                )
+            else:
+                raise UnsupportedQueryType("access_blob_filter")
+            filters.append(orm.Node.id.in_(tags_match))
+        if query.user_id is not None:
+            user_match = select(orm.AccessBlob.node_id).where(
+                orm.AccessBlob.username == query.user_id
+            )
+            filters.append(orm.Node.id.in_(user_match))
+        condition = or_(*filters) if filters else false()
 
     return tree.new_variation(conditions=tree.conditions + [condition])
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -119,6 +119,7 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
+from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -178,12 +179,6 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
-@dataclasses.dataclass(frozen=True)
-class AccessBlobMock:
-    username: str | None = None
-    tags: list[str] | None = None
-
-
 class RootNode:
     """
     Node representing the root of the tree.
@@ -206,15 +201,21 @@ class RootNode:
         self.data_sources = None
 
         if top_level_access_blob is None:
-            self.access_blob = None
+            self.access_blob = AccessBlob(tags=[])
         elif "user" in top_level_access_blob:
-            self.access_blob = AccessBlobMock(
-                username=top_level_access_blob["user"]
-            )
+            self.access_blob = AccessBlob(username=top_level_access_blob["user"])
         else:
-            self.access_blob = AccessBlobMock(
-                tags=top_level_access_blob["tags"]
-            )
+            self.access_blob = AccessBlob(tags=top_level_access_blob["tags"])
+
+
+def _access_blob_to_orm(access_blob: AccessBlob | None) -> orm.AccessBlob:
+    if access_blob is None:
+        return orm.AccessBlob(kind="tags", tags=[])
+    if access_blob.username is not None:
+        return orm.AccessBlob(kind="user", username=access_blob.username)
+    if access_blob.tags is not None:
+        return orm.AccessBlob(kind="tags", tags=access_blob.tags)
+    return orm.AccessBlob(kind="tags", tags=[])
 
 
 class Context:
@@ -937,7 +938,8 @@ class CatalogNodeAdapter:
         data_sources=None,
         access_blob=None,
     ):
-        access_blob = access_blob or {}
+        if access_blob is None:
+            access_blob = AccessBlob(tags=[])
         key = key or self.context.key_maker()
         data_sources = data_sources or []
 
@@ -947,8 +949,8 @@ class CatalogNodeAdapter:
             metadata_=metadata,
             structure_family=structure_family,
             specs=specs or [],
-            access_blob=access_blob,
         )
+        node.access_blob = _access_blob_to_orm(access_blob)
         async with self.context.session() as db:
             # TODO Consider using nested transitions to ensure that
             # both the node is created (name not already taken)
@@ -1501,8 +1503,6 @@ class CatalogNodeAdapter:
             values["metadata_"] = metadata
         if specs is not None:
             values["specs"] = specs
-        if access_blob is not None:
-            values["access_blob"] = access_blob
         async with self.context.session() as db:
             if not drop_revision:
                 current = (
@@ -1529,9 +1529,17 @@ class CatalogNodeAdapter:
                     revision_number=next_revision_number,
                 )
                 db.add(revision)
-            await db.execute(
-                update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
-            )
+            if values:
+                await db.execute(
+                    update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
+                )
+            if access_blob is not None:
+                await db.execute(
+                    delete(orm.AccessBlob).where(orm.AccessBlob.node_id == self.node.id)
+                )
+                access_blob_orm = _access_blob_to_orm(access_blob)
+                access_blob_orm.node_id = self.node.id
+                db.add(access_blob_orm)
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2555,7 +2563,6 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
     from sqlalchemy import insert
 
     specs = specs or []
-    access_blob = access_blob or {}
     async with engine.begin() as conn:
         parent_id = 0  # root node id
         for i, segment in enumerate(mount_path):
@@ -2576,10 +2583,19 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                         structure_family=StructureFamily.container,
                         metadata_={},
                         specs=specs if is_leaf else [],
-                        access_blob=access_blob if is_leaf else {},
                     )
                 )
                 node_id = result.inserted_primary_key[0]
+                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                access_blob_orm = _access_blob_to_orm(node_access_blob)
+                await conn.execute(
+                    insert(orm.AccessBlob).values(
+                        node_id=node_id,
+                        kind=access_blob_orm.kind,
+                        username=access_blob_orm.username,
+                        tags=access_blob_orm.tags,
+                    )
+                )
                 logger.info(
                     "Created container node %r (id=%d) under parent_id=%d.",
                     segment,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1539,18 +1539,19 @@ class CatalogNodeAdapter:
                     update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
                 )
             if access_blob is not None:
-                await db.execute(
-                    delete(orm.NodeAccessBlob).where(
-                        orm.NodeAccessBlob.node_id == self.node.id
-                    )
-                )
                 access_blob_orm = _access_blob_to_orm(access_blob)
-                db.add(access_blob_orm)
-                await db.flush()
-                db.add(
-                    orm.NodeAccessBlob(
-                        node_id=self.node.id,
-                        access_blob_id=access_blob_orm.id,
+                await db.execute(
+                    update(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.id
+                        == select(orm.NodeAccessBlob.access_blob_id)
+                        .where(orm.NodeAccessBlob.node_id == self.node.id)
+                        .scalar_subquery()
+                    )
+                    .values(
+                        kind=access_blob_orm.kind,
+                        username=access_blob_orm.username,
+                        tags=access_blob_orm.tags,
                     )
                 )
             await db.commit()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -106,6 +106,7 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
+from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -154,12 +155,6 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
-@dataclasses.dataclass(frozen=True)
-class AccessBlobMock:
-    username: str | None = None
-    tags: list[str] | None = None
-
-
 class RootNode:
     """
     Node representing the root of the tree.
@@ -182,15 +177,21 @@ class RootNode:
         self.data_sources = None
 
         if top_level_access_blob is None:
-            self.access_blob = None
+            self.access_blob = AccessBlob(tags=[])
         elif "user" in top_level_access_blob:
-            self.access_blob = AccessBlobMock(
-                username=top_level_access_blob["user"]
-            )
+            self.access_blob = AccessBlob(username=top_level_access_blob["user"])
         else:
-            self.access_blob = AccessBlobMock(
-                tags=top_level_access_blob["tags"]
-            )
+            self.access_blob = AccessBlob(tags=top_level_access_blob["tags"])
+
+
+def _access_blob_to_orm(access_blob: AccessBlob | None) -> orm.AccessBlob:
+    if access_blob is None:
+        return orm.AccessBlob(kind="tags", tags=[])
+    if access_blob.username is not None:
+        return orm.AccessBlob(kind="user", username=access_blob.username)
+    if access_blob.tags is not None:
+        return orm.AccessBlob(kind="tags", tags=access_blob.tags)
+    return orm.AccessBlob(kind="tags", tags=[])
 
 
 class Context:
@@ -735,7 +736,8 @@ class CatalogNodeAdapter:
         data_sources=None,
         access_blob=None,
     ):
-        access_blob = access_blob or {}
+        if access_blob is None:
+            access_blob = AccessBlob(tags=[])
         key = key or self.context.key_maker()
         data_sources = data_sources or []
 
@@ -745,8 +747,8 @@ class CatalogNodeAdapter:
             metadata_=metadata,
             structure_family=structure_family,
             specs=specs or [],
-            access_blob=access_blob,
         )
+        node.access_blob = _access_blob_to_orm(access_blob)
         async with self.context.session() as db:
             # TODO Consider using nested transitions to ensure that
             # both the node is created (name not already taken)
@@ -1293,8 +1295,6 @@ class CatalogNodeAdapter:
             values["metadata_"] = metadata
         if specs is not None:
             values["specs"] = specs
-        if access_blob is not None:
-            values["access_blob"] = access_blob
         async with self.context.session() as db:
             if not drop_revision:
                 current = (
@@ -1321,9 +1321,17 @@ class CatalogNodeAdapter:
                     revision_number=next_revision_number,
                 )
                 db.add(revision)
-            await db.execute(
-                update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
-            )
+            if values:
+                await db.execute(
+                    update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
+                )
+            if access_blob is not None:
+                await db.execute(
+                    delete(orm.AccessBlob).where(orm.AccessBlob.node_id == self.node.id)
+                )
+                access_blob_orm = _access_blob_to_orm(access_blob)
+                access_blob_orm.node_id = self.node.id
+                db.add(access_blob_orm)
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2296,7 +2304,6 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
     from sqlalchemy import insert
 
     specs = specs or []
-    access_blob = access_blob or {}
     async with engine.begin() as conn:
         parent_id = 0  # root node id
         for i, segment in enumerate(mount_path):
@@ -2317,10 +2324,19 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                         structure_family=StructureFamily.container,
                         metadata_={},
                         specs=specs if is_leaf else [],
-                        access_blob=access_blob if is_leaf else {},
                     )
                 )
                 node_id = result.inserted_primary_key[0]
+                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                access_blob_orm = _access_blob_to_orm(node_access_blob)
+                await conn.execute(
+                    insert(orm.AccessBlob).values(
+                        node_id=node_id,
+                        kind=access_blob_orm.kind,
+                        username=access_blob_orm.username,
+                        tags=access_blob_orm.tags,
+                    )
+                )
                 logger.info(
                     "Created container node %r (id=%d) under parent_id=%d.",
                     segment,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -96,6 +96,7 @@ from ..storage import (
     register_storage,
 )
 from ..structures.core import Spec, StructureFamily
+from ..type_aliases import AccessBlob
 from ..utils import (
     UNCHANGED,
     Conflicts,
@@ -106,7 +107,6 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
-from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -2146,14 +2146,11 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = (
-                    select(orm.AccessBlob.node_id)
-                    .where(
-                        select(1)
-                        .select_from(access_tags_json)
-                        .where(access_tags_json.c.value.in_(query.tags))
-                        .exists()
-                    )
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    select(1)
+                    .select_from(access_tags_json)
+                    .where(access_tags_json.c.value.in_(query.tags))
+                    .exists()
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
@@ -2336,7 +2333,9 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     )
                 )
                 node_id = result.inserted_primary_key[0]
-                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                node_access_blob = (
+                    access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                )
                 access_blob_orm = _access_blob_to_orm(node_access_blob)
                 await conn.execute(
                     insert(orm.AccessBlob).values(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -2406,21 +2406,23 @@ def access_blob_filter(query, tree):
                     "value"
                 )
                 tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.kind == "tags",
                     select(1)
                     .select_from(access_tags_json)
                     .where(access_tags_json.c.value.in_(query.tags))
-                    .exists()
+                    .exists(),
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
-                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                    orm.AccessBlob.kind == "tags",
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT))),
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
             user_match = select(orm.AccessBlob.node_id).where(
-                orm.AccessBlob.username == query.user_id
+                orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
             )
             filters.append(orm.Node.id.in_(user_match))
         condition = or_(*filters) if filters else false()

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -1,4 +1,4 @@
-from sqlalchemy import text
+from sqlalchemy import insert, select, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..alembic_utils import DatabaseUpgradeNeeded, UninitializedDatabase, check_database
@@ -49,6 +49,21 @@ async def initialize_database(engine: AsyncEngine):
             await connection.execute(text("create extension btree_gin;"))
         # Create all tables.
         await connection.run_sync(Base.metadata.create_all)
+        root_access_blob_id = await connection.scalar(
+            select(orm.NodeAccessBlob.access_blob_id).where(
+                orm.NodeAccessBlob.node_id == 0
+            )
+        )
+        if root_access_blob_id is None:
+            result = await connection.execute(
+                insert(orm.AccessBlob).values(kind="tags", tags=["public"])
+            )
+            await connection.execute(
+                insert(orm.NodeAccessBlob).values(
+                    node_id=0,
+                    access_blob_id=result.inserted_primary_key[0],
+                )
+            )
         if engine.dialect.name == "sqlite":
             # Use write-ahead log mode. This persists across all future connections
             # until/unless manually switched.

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "de302a096358",
     "b93c79d197f4",
     "e8956581ecd5",
     "bf2fe0eb8ee8",

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "de302a096358",
     "c31f6a1d7e20",
     "9bc9b57294b9",
     "b93c79d197f4",

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -311,21 +311,33 @@ def downgrade():
     dialect_name = connection.engine.dialect.name
 
     if dialect_name == "sqlite":
-        connection.execute(sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup"))
-        connection.execute(sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup"))
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup")
+        )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup")
+        )
         for table in ("node_access_blobs", "link_access_blobs"):
             connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob")
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob"
+                )
             )
             connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob")
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob"
+                )
             )
     elif dialect_name == "postgresql":
         connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs")
+            sa.text(
+                "DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs"
+            )
         )
         connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs")
+            sa.text(
+                "DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs"
+            )
         )
         for table in ("node_access_blobs", "link_access_blobs"):
             connection.execute(
@@ -333,7 +345,9 @@ def downgrade():
                     f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
                 )
             )
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob"))
+        connection.execute(
+            sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob")
+        )
         connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
         connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
         connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -5,8 +5,6 @@ Revises: c31f6a1d7e20
 Create Date: 2026-07-03 14:27:39.197261
 
 """
-import json
-
 import sqlalchemy as sa
 from alembic import op
 
@@ -22,48 +20,115 @@ depends_on = None
 def _copy_access_blobs(
     connection, source_table, association_table, owner_column, where=""
 ):
-    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
-        sa.ARRAY(sa.String()), "postgresql"
+    """Convert a JSON ``access_blob`` column into ``access_blobs`` rows plus an
+    association row per owner, using set-based SQL so the migration scales to
+    very large catalogs.
+
+    Correlation between a newly inserted ``access_blobs`` row and its owner is
+    done through a temporary ``_migrate_owner`` column (dropped at the end),
+    which avoids needing per-row ``RETURNING``.
+
+    * a blob containing a ``"user"`` key becomes ``kind='user'``;
+    * otherwise ``kind='tags'`` with ``tags`` taken from the ``"tags"`` key,
+      defaulting to an empty list;
+    * the root node (``nodes.id = 0``) with an empty blob or ``tags == []`` is
+      promoted to ``{"tags": ["public"]}``.
+    """
+    dialect_name = connection.engine.dialect.name
+
+    # Add a temporary column to correlate each access_blobs row to its owner.
+    owner_type = "INTEGER" if owner_column == "node_id" else "VARCHAR"
+    connection.execute(
+        sa.text(f"ALTER TABLE access_blobs ADD COLUMN _migrate_owner {owner_type}")
     )
-    access_blobs = sa.table(
-        "access_blobs",
-        sa.column("id", sa.Integer),
-        sa.column("kind", sa.Enum("user", "tags", name="access_kind")),
-        sa.column("username", sa.String),
-        sa.column("tags", access_tags_variant),
-    )
-    associations = sa.table(
-        association_table,
-        sa.column(owner_column),
-        sa.column("access_blob_id", sa.Integer),
-    )
-    rows = connection.execute(
-        sa.text(f"SELECT id, access_blob FROM {source_table} {where}")
-    )
-    for row in rows:
-        access_blob = row.access_blob
-        if isinstance(access_blob, str):
-            access_blob = json.loads(access_blob)
-        access_blob = access_blob or {}
-        if (
-            source_table == "nodes"
-            and row.id == 0
-            and (not access_blob or access_blob.get("tags") == [])
-        ):
-            access_blob = {"tags": ["public"]}
-        values = (
-            {"kind": "user", "username": access_blob["user"], "tags": None}
-            if "user" in access_blob
-            else {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
-        )
-        access_blob_id = connection.execute(
-            access_blobs.insert().values(**values).returning(access_blobs.c.id)
-        ).scalar_one()
-        connection.execute(
-            associations.insert().values(
-                **{owner_column: row.id, "access_blob_id": access_blob_id}
+
+    # Per-dialect JSON extraction. Both branches must yield, per source row:
+    #   kind      -> 'user' when a "user" key is present, else 'tags'
+    #   username  -> the "user" value when kind='user', else NULL
+    #   tags      -> the "tags" array when kind='tags', else NULL
+    # honoring the root-node "public" promotion and (for entities) the
+    # caller-supplied WHERE clause that skips node-delegated rows.
+    root_public = source_table == "nodes"
+    if dialect_name == "sqlite":
+        # In SQLite the column is TEXT; treat SQL NULL / JSON 'null' as '{}'.
+        blob = "COALESCE(NULLIF(access_blob, 'null'), '{}')"
+        has_user = f"json_extract({blob}, '$.user') IS NOT NULL"
+        user_val = f"json_extract({blob}, '$.user')"
+        # json_extract of a missing/absent "tags" yields NULL; default to [].
+        tags_val = f"COALESCE(json_extract({blob}, '$.tags'), json('[]'))"
+        if root_public:
+            # Root node with empty tags or empty blob -> ["public"].
+            is_empty_root = (
+                f"id = 0 AND ("
+                f"json_extract({blob}, '$.user') IS NULL AND ("
+                f"json_extract({blob}, '$.tags') IS NULL OR "
+                f"json_array_length(json_extract({blob}, '$.tags')) = 0))"
             )
+            tags_val = (
+                f"CASE WHEN {is_empty_root} THEN json('[\"public\"]') "
+                f"ELSE {tags_val} END"
+            )
+        kind_expr = f"CASE WHEN {has_user} THEN 'user' ELSE 'tags' END"
+        username_expr = f"CASE WHEN {has_user} THEN {user_val} ELSE NULL END"
+        tags_expr = f"CASE WHEN {has_user} THEN NULL ELSE {tags_val} END"
+    elif dialect_name == "postgresql":
+        # nodes.access_blob is jsonb but the c31-era entities/links access_blob
+        # columns are plain json; cast so COALESCE unifies on jsonb either way.
+        blob = "COALESCE(access_blob::jsonb, '{}'::jsonb)"
+        has_user = f"({blob} ? 'user')"
+        user_val = f"{blob} ->> 'user'"
+        # Build a text[] from the JSON "tags" array; default to empty array.
+        tags_val = (
+            f"COALESCE("
+            f"ARRAY(SELECT jsonb_array_elements_text({blob} -> 'tags')), "
+            f"ARRAY[]::varchar[])"
         )
+        if root_public:
+            is_empty_root = (
+                f"id = 0 AND NOT ({blob} ? 'user') AND ("
+                f"NOT ({blob} ? 'tags') OR "
+                f"jsonb_array_length(COALESCE({blob} -> 'tags', '[]'::jsonb)) = 0)"
+            )
+            tags_val = (
+                f"CASE WHEN {is_empty_root} THEN ARRAY['public']::varchar[] "
+                f"ELSE {tags_val} END"
+            )
+        # The CASE yields text; the target column is the access_kind enum and
+        # INSERT ... SELECT does not implicitly cast, so cast explicitly.
+        kind_expr = f"(CASE WHEN {has_user} THEN 'user' ELSE 'tags' END)::access_kind"
+        username_expr = f"CASE WHEN {has_user} THEN {user_val} ELSE NULL END"
+        # Likewise cast to the column's varchar[] type: jsonb_array_elements_text
+        # produces text[], and mixed CASE/COALESCE branches resolve to text[].
+        tags_expr = f"(CASE WHEN {has_user} THEN NULL ELSE {tags_val} END)::varchar[]"
+    else:
+        raise RuntimeError(f"Unsupported dialect for migration: {dialect_name}")
+
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO access_blobs (kind, username, tags, _migrate_owner)
+SELECT {kind_expr}, {username_expr}, {tags_expr}, id
+FROM {source_table}
+{where}
+"""
+        )
+    )
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO {association_table} ({owner_column}, access_blob_id)
+SELECT _migrate_owner, id
+FROM access_blobs
+WHERE _migrate_owner IS NOT NULL
+"""
+        )
+    )
+    # Drop the temporary correlation column now that associations are populated.
+    # Use a native ALTER rather than Alembic's batch mode, which would rebuild
+    # the access_blobs table and disturb the foreign keys the association tables
+    # hold against it.
+    # ALTER TABLE ... DROP COLUMN requires SQLite >= 3.35 (2021).
+    connection.execute(sa.text("ALTER TABLE access_blobs DROP COLUMN _migrate_owner"))
 
 
 def _restore_access_blobs(
@@ -100,7 +165,9 @@ def _restore_access_blobs(
                     SELECT CASE
                         WHEN access_blobs.kind = 'user' THEN
                             json_object('user', access_blobs.username)
-                        ELSE json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                        ELSE json_object(
+                            'tags', json(COALESCE(access_blobs.tags, '[]'))
+                        )
                     END FROM {source_table}
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
@@ -117,7 +184,7 @@ def _create_association_triggers(connection):
     dialect_name = connection.engine.dialect.name
     tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
     error_message = (
-        "An entity with node_id set must not have its own access blob; "
+        "An entity with node_id set must not have its own access_blob; "
         "access is controlled by the referenced node."
     )
     if dialect_name == "sqlite":
@@ -161,35 +228,47 @@ BEGIN
 END"""
                 )
             )
-        for operation in ("INSERT", "UPDATE OF node_id"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER entities_node_access_blob_{operation.split()[0].lower()}
-BEFORE {operation} ON entities
+        # Only guard UPDATE OF node_id: the INSERT case cannot occur in a
+        # single statement (an entities INSERT sets only node_id, while the
+        # blob lives in a separate entity_access_blobs row guarded by
+        # entity_access_blobs_insert_reject_node_backed_entity). This mirrors
+        # the PostgreSQL branch and tiled.graph.orm's create_all path.
+        connection.execute(
+            sa.text(
+                f"""
+CREATE TRIGGER entities_node_access_blob_update
+BEFORE UPDATE OF node_id ON entities
 WHEN NEW.node_id IS NOT NULL AND EXISTS (
     SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
 )
 BEGIN
     SELECT RAISE(ABORT, '{error_message}');
 END"""
-                )
             )
+        )
     elif dialect_name == "postgresql":
         # asyncpg cannot run multiple statements in one prepared execute, so
         # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
+        # One cleanup function per association table, matching the objects
+        # created by the create_all path (node's lives in tiled.catalog.orm,
+        # entity's and link's in tiled.graph.orm). Keeping them per-table -
+        # rather than a single shared function - keeps each feature's DDL
+        # self-contained and avoids graph objects depending on a catalog-owned
+        # function (or vice versa).
+        for table in tables:
+            singular = table.replace("_access_blobs", "")
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE OR REPLACE FUNCTION delete_{singular}_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;"""
+                )
             )
-        )
         connection.execute(
             sa.text(
                 """
@@ -213,13 +292,22 @@ END;
 $$ LANGUAGE plpgsql;"""
             )
         )
+        # PostgreSQL does not allow subqueries in a trigger WHEN clause
+        # ("cannot use subquery in trigger WHEN condition"), so the EXISTS
+        # check against entity_access_blobs lives in the function body; the
+        # trigger WHEN clause keeps only the cheap scalar column test.
         connection.execute(
             sa.text(
                 f"""
 CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
-    RAISE EXCEPTION '{error_message}';
+    IF EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{error_message}';
+    END IF;
+    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;"""
             )
@@ -239,12 +327,13 @@ $$ LANGUAGE plpgsql;"""
             )
         )
         for table in tables:
+            singular = table.replace("_access_blobs", "")
             connection.execute(
                 sa.text(
                     f"""
 CREATE TRIGGER {table}_delete_cleanup
 AFTER DELETE ON {table}
-FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();"""
+FOR EACH ROW EXECUTE FUNCTION delete_{singular}_access_blob();"""
                 )
             )
             connection.execute(
@@ -268,9 +357,7 @@ FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
                 """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE UPDATE OF node_id ON entities
-FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL)
 EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
@@ -296,10 +383,9 @@ def _drop_association_triggers(connection):
                     f"DROP TRIGGER IF EXISTS entity_access_blobs_{operation}_reject_node_backed_entity"
                 )
             )
-        for operation in ("insert", "update"):
-            connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS entities_node_access_blob_{operation}")
-            )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS entities_node_access_blob_update")
+        )
     elif dialect_name == "postgresql":
         for table in tables:
             connection.execute(
@@ -321,7 +407,9 @@ def _drop_association_triggers(connection):
             )
         )
         for function in (
-            "delete_orphaned_access_blob",
+            "delete_node_access_blob",
+            "delete_entity_access_blob",
+            "delete_link_access_blob",
             "reject_shared_access_blob",
             "entities_reject_node_access_blob",
             "entity_access_blob_reject_node_backed_entity",
@@ -453,6 +541,11 @@ def upgrade():
         batch_op.drop_column("access_blob")
     with op.batch_alter_table("entities") as batch_op:
         batch_op.drop_column("access_blob")
+    # The Revision model no longer tracks access_blob; drop the column so that
+    # inserting a revision (on metadata update) does not violate its former
+    # NOT NULL constraint now that the ORM stops populating it.
+    with op.batch_alter_table("revisions") as batch_op:
+        batch_op.drop_column("access_blob")
     op.create_index(
         "top_level_metadata",
         "nodes",
@@ -467,6 +560,15 @@ def downgrade():
     dialect_name = connection.engine.dialect.name
 
     _drop_association_triggers(connection)
+
+    # Restore the revisions.access_blob column dropped on upgrade. The former
+    # data is not recoverable (revisions no longer carried it), so recreate it
+    # with the same NOT NULL + server_default('{}') shape as migration
+    # a963a6c32a0c, which is what a database at that revision would have.
+    with op.batch_alter_table("revisions") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
 
     with op.batch_alter_table("entities") as batch_op:
         batch_op.add_column(sa.Column("access_blob", JSONVariant, nullable=True))

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,10 +1,12 @@
-"""Convert access_blob column to assoc. table
+"""Convert node and link access_blob columns to assoc. tables
 
 Revision ID: de302a096358
-Revises: b93c79d197f4
+Revises: c31f6a1d7e20
 Create Date: 2026-07-03 14:27:39.197261
 
 """
+import json
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -12,25 +14,111 @@ from tiled.catalog.orm import JSONVariant
 
 # revision identifiers, used by Alembic.
 revision = "de302a096358"
-down_revision = "b93c79d197f4"
+down_revision = "c31f6a1d7e20"
 branch_labels = None
 depends_on = None
+
+
+def _copy_access_blobs(connection, source_table, association_table, owner_column):
+    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
+        sa.ARRAY(sa.String()), "postgresql"
+    )
+    access_blobs = sa.table(
+        "access_blobs",
+        sa.column("id", sa.Integer),
+        sa.column("kind", sa.Enum("user", "tags", name="access_kind")),
+        sa.column("username", sa.String),
+        sa.column("tags", access_tags_variant),
+    )
+    associations = sa.table(
+        association_table,
+        sa.column(owner_column),
+        sa.column("access_blob_id", sa.Integer),
+    )
+    rows = connection.execute(sa.text(f"SELECT id, access_blob FROM {source_table}"))
+    for row in rows:
+        access_blob = row.access_blob
+        if isinstance(access_blob, str):
+            access_blob = json.loads(access_blob)
+        access_blob = access_blob or {}
+        if (
+            source_table == "nodes"
+            and row.id == 0
+            and (not access_blob or access_blob.get("tags") == [])
+        ):
+            access_blob = {"tags": ["public"]}
+        values = (
+            {"kind": "user", "username": access_blob["user"], "tags": None}
+            if "user" in access_blob
+            else {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
+        )
+        access_blob_id = connection.execute(
+            access_blobs.insert().values(**values).returning(access_blobs.c.id)
+        ).scalar_one()
+        connection.execute(
+            associations.insert().values(
+                **{owner_column: row.id, "access_blob_id": access_blob_id}
+            )
+        )
+
+
+def _restore_access_blobs(dialect_name, source_table, id_column, destination_table):
+    if dialect_name == "postgresql":
+        op.execute(
+            f"""
+            UPDATE {destination_table}
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            jsonb_build_object('user', access_blobs.username)
+                        ELSE jsonb_build_object(
+                            'tags', to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
+                        )
+                    END FROM {source_table}
+                    JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
+                    WHERE {source_table}.{id_column} = {destination_table}.id
+                ),
+                '{{}}'::jsonb
+            )
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            f"""
+            UPDATE {destination_table}
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            json_object('user', access_blobs.username)
+                        ELSE json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                    END FROM {source_table}
+                    JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
+                    WHERE {source_table}.{id_column} = {destination_table}.id
+                ),
+                json('{{}}')
+            )
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
 
 
 def upgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
-    access_tags_variant = sa.JSON().with_variant(sa.ARRAY(sa.String()), "postgresql")
+    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
+        sa.ARRAY(sa.String()), "postgresql"
+    )
 
     op.create_table(
         "access_blobs",
         sa.Column(
-            "node_id",
+            "id",
             sa.Integer(),
-            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
             nullable=False,
             primary_key=True,
-            unique=True,
         ),
         sa.Column("kind", sa.Enum("user", "tags", name="access_kind"), nullable=False),
         sa.Column("username", sa.String(), nullable=True),
@@ -49,9 +137,44 @@ def upgrade():
         postgresql_where=sa.text("kind = 'user' AND username IS NOT NULL"),
     )
     op.create_index(
-        "ix_access_blobs_kind_node_id",
+        "ix_access_blobs_kind_id",
         "access_blobs",
-        ["kind", "node_id"],
+        ["kind", "id"],
+    )
+
+    op.create_table(
+        "node_access_blobs",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
+    op.create_table(
+        "link_access_blobs",
+        sa.Column(
+            "link_id",
+            sa.String(),
+            sa.ForeignKey("links.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
     )
     if dialect_name == "postgresql":
         op.create_index(
@@ -61,49 +184,116 @@ def upgrade():
             postgresql_using="gin",
             postgresql_where=sa.text("kind = 'tags' AND tags IS NOT NULL"),
         )
+    _copy_access_blobs(connection, "nodes", "node_access_blobs", "node_id")
+    _copy_access_blobs(connection, "links", "link_access_blobs", "link_id")
 
-    if dialect_name == "postgresql":
-        op.execute(
-            """
-            INSERT INTO access_blobs (node_id, kind, username, tags)
-            SELECT
-                id AS node_id,
-                CASE
-                    WHEN access_blob ? 'user' THEN 'user'::access_kind
-                    ELSE 'tags'::access_kind
-                END AS kind,
-                access_blob ->> 'user' AS username,
-                CASE
-                    WHEN access_blob ? 'user' THEN NULL
-                    WHEN access_blob ? 'tags' THEN ARRAY(
-                        SELECT jsonb_array_elements_text(access_blob -> 'tags')
-                    )::varchar[]
-                    ELSE ARRAY[]::varchar[]
-                END AS tags
-            FROM nodes
-            """
+    if dialect_name == "sqlite":
+        for association_table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {association_table}_delete_cleanup
+AFTER DELETE ON {association_table}
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+                )
+            )
+        for table, other_table in (
+            ("node_access_blobs", "link_access_blobs"),
+            ("link_access_blobs", "node_access_blobs"),
+        ):
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    sa.text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
+END"""
+                    )
+                )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION delete_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
         )
-    elif dialect_name == "sqlite":
-        op.execute(
-            """
-            INSERT INTO access_blobs (node_id, kind, username, tags)
-            SELECT
-                id AS node_id,
-                CASE
-                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN 'user'
-                    ELSE 'tags'
-                END AS kind,
-                json_extract(access_blob, '$.user') AS username,
-                CASE
-                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN NULL
-                    WHEN json_type(access_blob, '$.tags') IS NOT NULL THEN json_extract(access_blob, '$.tags')
-                    ELSE json('[]')
-                END AS tags
-            FROM nodes
-            """
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
+"""
+            )
         )
-    else:
-        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION delete_link_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
+"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
+"""
+                )
+            )
+
+    with op.batch_alter_table("links") as batch_op:
+        batch_op.drop_column("access_blob")
 
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
@@ -120,6 +310,43 @@ def downgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
 
+    if dialect_name == "sqlite":
+        connection.execute(sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup"))
+        connection.execute(sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup"))
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob")
+            )
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob")
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs")
+        )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs")
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
+                )
+            )
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))
+
+    with op.batch_alter_table("links") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
+
+    _restore_access_blobs(dialect_name, "link_access_blobs", "link_id", "links")
+
+    op.drop_table("link_access_blobs")
+
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
         batch_op.add_column(
@@ -132,52 +359,9 @@ def downgrade():
         postgresql_using="gin",
     )
 
-    if dialect_name == "postgresql":
-        op.execute(
-            """
-            UPDATE nodes
-            SET access_blob = COALESCE(
-                (
-                    SELECT CASE
-                        WHEN access_blobs.kind = 'user' THEN
-                            jsonb_build_object('user', access_blobs.username)
-                        WHEN access_blobs.kind = 'tags' THEN
-                            jsonb_build_object(
-                                'tags',
-                                to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
-                            )
-                        ELSE '{}'::jsonb
-                    END
-                    FROM access_blobs
-                    WHERE access_blobs.node_id = nodes.id
-                ),
-                '{}'::jsonb
-            )
-            """
-        )
-    elif dialect_name == "sqlite":
-        op.execute(
-            """
-            UPDATE nodes
-            SET access_blob = COALESCE(
-                (
-                    SELECT CASE
-                        WHEN access_blobs.kind = 'user' THEN
-                            json_object('user', access_blobs.username)
-                        WHEN access_blobs.kind = 'tags' THEN
-                            json_object('tags', COALESCE(access_blobs.tags, json('[]')))
-                        ELSE json('{}')
-                    END
-                    FROM access_blobs
-                    WHERE access_blobs.node_id = nodes.id
-                ),
-                json('{}')
-            )
-            """
-        )
-    else:
-        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+    _restore_access_blobs(dialect_name, "node_access_blobs", "node_id", "nodes")
 
+    op.drop_table("node_access_blobs")
     op.drop_table("access_blobs")
     if dialect_name == "postgresql":
         op.execute("DROP TYPE IF EXISTS access_kind")

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -91,7 +91,7 @@ def _restore_access_blobs(
             """
         )
     elif dialect_name == "sqlite":
-        fallback = "json('{{}}')" if default_empty else "NULL"
+        fallback = "json('{}')" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -176,16 +176,23 @@ END"""
                 )
             )
     elif dialect_name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute, so
+        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
         connection.execute(
             sa.text(
-                f"""
+                """
 CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -203,13 +210,23 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
 CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '{error_message}';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
 CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -227,7 +244,12 @@ $$ LANGUAGE plpgsql;"""
                     f"""
 CREATE TRIGGER {table}_delete_cleanup
 AFTER DELETE ON {table}
-FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();
+FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();"""
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"""
 CREATE TRIGGER {table}_reject_shared_access_blob
 BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
 FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
@@ -238,7 +260,12 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
                 """
 CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
 BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE UPDATE OF node_id ON entities
 FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
@@ -471,6 +498,7 @@ END"""
                 )
             )
     elif dialect_name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute.
         connection.execute(
             sa.text(
                 f"""
@@ -479,7 +507,12 @@ RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '{error_message}';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE INSERT OR UPDATE ON entities
 FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,7 +1,7 @@
 """Convert access_blob column to assoc. table
 
 Revision ID: de302a096358
-Revises: e8956581ecd5
+Revises: b93c79d197f4
 Create Date: 2026-07-03 14:27:39.197261
 
 """
@@ -12,7 +12,7 @@ from tiled.catalog.orm import JSONVariant
 
 # revision identifiers, used by Alembic.
 revision = "de302a096358"
-down_revision = "e8956581ecd5"
+down_revision = "b93c79d197f4"
 branch_labels = None
 depends_on = None
 

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,0 +1,163 @@
+"""Convert access_blob column to assoc. table
+
+Revision ID: de302a096358
+Revises: e8956581ecd5
+Create Date: 2026-07-03 14:27:39.197261
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.catalog.orm import JSONVariant
+
+# revision identifiers, used by Alembic.
+revision = "de302a096358"
+down_revision = "e8956581ecd5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+    access_tags_variant = sa.JSON().with_variant(sa.ARRAY(sa.String()), "postgresql")
+
+    op.create_table(
+        "access_blobs",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+            unique=True,
+        ),
+        sa.Column("kind", sa.Enum("user", "tags", name="access_kind"), nullable=False),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("tags", access_tags_variant, nullable=True),
+        sa.CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
+    )
+
+    if dialect_name == "postgresql":
+        op.execute(
+            """
+            INSERT INTO access_blobs (node_id, kind, username, tags)
+            SELECT
+                id AS node_id,
+                CASE
+                    WHEN access_blob ? 'user' THEN 'user'::access_kind
+                    ELSE 'tags'::access_kind
+                END AS kind,
+                access_blob ->> 'user' AS username,
+                CASE
+                    WHEN access_blob ? 'user' THEN NULL
+                    WHEN access_blob ? 'tags' THEN ARRAY(
+                        SELECT jsonb_array_elements_text(access_blob -> 'tags')
+                    )::varchar[]
+                    ELSE ARRAY[]::varchar[]
+                END AS tags
+            FROM nodes
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            """
+            INSERT INTO access_blobs (node_id, kind, username, tags)
+            SELECT
+                id AS node_id,
+                CASE
+                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN 'user'
+                    ELSE 'tags'
+                END AS kind,
+                json_extract(access_blob, '$.user') AS username,
+                CASE
+                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN NULL
+                    WHEN json_type(access_blob, '$.tags') IS NOT NULL THEN json_extract(access_blob, '$.tags')
+                    ELSE json('[]')
+                END AS tags
+            FROM nodes
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+    op.drop_index("top_level_metadata", table_name="nodes")
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.drop_column("access_blob")
+    op.create_index(
+        "top_level_metadata",
+        "nodes",
+        ["parent", "time_created", "id", "metadata"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+
+    op.drop_index("top_level_metadata", table_name="nodes")
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
+    op.create_index(
+        "top_level_metadata",
+        "nodes",
+        ["parent", "time_created", "id", "metadata", "access_blob"],
+        postgresql_using="gin",
+    )
+
+    if dialect_name == "postgresql":
+        op.execute(
+            """
+            UPDATE nodes
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            jsonb_build_object('user', access_blobs.username)
+                        WHEN access_blobs.kind = 'tags' THEN
+                            jsonb_build_object(
+                                'tags',
+                                to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
+                            )
+                        ELSE '{}'::jsonb
+                    END
+                    FROM access_blobs
+                    WHERE access_blobs.node_id = nodes.id
+                ),
+                '{}'::jsonb
+            )
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            """
+            UPDATE nodes
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            json_object('user', access_blobs.username)
+                        WHEN access_blobs.kind = 'tags' THEN
+                            json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                        ELSE json('{}')
+                    END
+                    FROM access_blobs
+                    WHERE access_blobs.node_id = nodes.id
+                ),
+                json('{}')
+            )
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+    op.drop_table("access_blobs")
+    if dialect_name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS access_kind")

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,4 +1,4 @@
-"""Convert node and link access_blob columns to assoc. tables
+"""Convert node, entity, and link access_blob columns to assoc. tables
 
 Revision ID: de302a096358
 Revises: c31f6a1d7e20
@@ -19,7 +19,9 @@ branch_labels = None
 depends_on = None
 
 
-def _copy_access_blobs(connection, source_table, association_table, owner_column):
+def _copy_access_blobs(
+    connection, source_table, association_table, owner_column, where=""
+):
     access_tags_variant = sa.JSON(none_as_null=True).with_variant(
         sa.ARRAY(sa.String()), "postgresql"
     )
@@ -35,7 +37,9 @@ def _copy_access_blobs(connection, source_table, association_table, owner_column
         sa.column(owner_column),
         sa.column("access_blob_id", sa.Integer),
     )
-    rows = connection.execute(sa.text(f"SELECT id, access_blob FROM {source_table}"))
+    rows = connection.execute(
+        sa.text(f"SELECT id, access_blob FROM {source_table} {where}")
+    )
     for row in rows:
         access_blob = row.access_blob
         if isinstance(access_blob, str):
@@ -62,8 +66,11 @@ def _copy_access_blobs(connection, source_table, association_table, owner_column
         )
 
 
-def _restore_access_blobs(dialect_name, source_table, id_column, destination_table):
+def _restore_access_blobs(
+    dialect_name, source_table, id_column, destination_table, default_empty=True
+):
     if dialect_name == "postgresql":
+        fallback = "'{}'::jsonb" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -79,11 +86,12 @@ def _restore_access_blobs(dialect_name, source_table, id_column, destination_tab
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
                 ),
-                '{{}}'::jsonb
+                {fallback}
             )
             """
         )
     elif dialect_name == "sqlite":
+        fallback = "json('{{}}')" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -97,12 +105,201 @@ def _restore_access_blobs(dialect_name, source_table, id_column, destination_tab
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
                 ),
-                json('{{}}')
+                {fallback}
             )
             """
         )
     else:
         raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+
+def _create_association_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    error_message = (
+        "An entity with node_id set must not have its own access blob; "
+        "access is controlled by the referenced node."
+    )
+    if dialect_name == "sqlite":
+        for table in tables:
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+                )
+            )
+            others = " OR ".join(
+                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
+                for other in tables
+                if other != table
+            )
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    sa.text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN {others}
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
+END"""
+                    )
+                )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_blobs
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
+                )
+            )
+        for operation in ("INSERT", "UPDATE OF node_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entities_node_access_blob_{operation.split()[0].lower()}
+BEFORE {operation} ON entities
+WHEN NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+)
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
+                )
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '{error_message}';
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{error_message}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        for table in tables:
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
+                )
+            )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+CREATE TRIGGER entities_node_access_blob_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
+            )
+        )
+
+
+def _drop_association_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    if dialect_name == "sqlite":
+        for table in tables:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup")
+            )
+            for operation in ("insert", "update"):
+                connection.execute(
+                    sa.text(
+                        f"DROP TRIGGER IF EXISTS {table}_{operation}_reject_shared_access_blob"
+                    )
+                )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS entity_access_blobs_{operation}_reject_node_backed_entity"
+                )
+            )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS entities_node_access_blob_{operation}")
+            )
+    elif dialect_name == "postgresql":
+        for table in tables:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup ON {table}")
+            )
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
+                )
+            )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entity_access_blobs_reject_node_backed_entity ON entity_access_blobs"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entities_node_access_blob_check ON entities"
+            )
+        )
+        for function in (
+            "delete_orphaned_access_blob",
+            "reject_shared_access_blob",
+            "entities_reject_node_access_blob",
+            "entity_access_blob_reject_node_backed_entity",
+        ):
+            connection.execute(sa.text(f"DROP FUNCTION IF EXISTS {function}"))
 
 
 def upgrade():
@@ -176,6 +373,23 @@ def upgrade():
             unique=True,
         ),
     )
+    op.create_table(
+        "entity_access_blobs",
+        sa.Column(
+            "entity_id",
+            sa.String(),
+            sa.ForeignKey("entities.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
     if dialect_name == "postgresql":
         op.create_index(
             "ix_access_blobs_tags_gin",
@@ -186,111 +400,23 @@ def upgrade():
         )
     _copy_access_blobs(connection, "nodes", "node_access_blobs", "node_id")
     _copy_access_blobs(connection, "links", "link_access_blobs", "link_id")
+    _copy_access_blobs(
+        connection,
+        "entities",
+        "entity_access_blobs",
+        "entity_id",
+        "WHERE access_blob IS NOT NULL",
+    )
 
+    # Replace c31's JSON-column delegation checks before dropping that column.
     if dialect_name == "sqlite":
-        for association_table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER {association_table}_delete_cleanup
-AFTER DELETE ON {association_table}
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-END"""
-                )
-            )
-        for table, other_table in (
-            ("node_access_blobs", "link_access_blobs"),
-            ("link_access_blobs", "node_access_blobs"),
-        ):
-            for operation in ("INSERT", "UPDATE OF access_blob_id"):
-                connection.execute(
-                    sa.text(
-                        f"""
-CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
-BEFORE {operation} ON {table}
-WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
-BEGIN
-    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
-END"""
-                    )
-                )
+        connection.execute(sa.text("DROP TRIGGER entities_node_access_blob_insert"))
+        connection.execute(sa.text("DROP TRIGGER entities_node_access_blob_update"))
     elif dialect_name == "postgresql":
         connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_node_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
+            sa.text("DROP TRIGGER entities_node_access_blob_check ON entities")
         )
-        connection.execute(
-            sa.text(
-                """
-CREATE TRIGGER node_access_blobs_delete_cleanup
-AFTER DELETE ON node_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_link_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE TRIGGER link_access_blobs_delete_cleanup
-AFTER DELETE ON link_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION reject_shared_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
-        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
-        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER {table}_reject_shared_access_blob
-BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
-FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
-"""
-                )
-            )
+        connection.execute(sa.text("DROP FUNCTION entities_reject_node_access_blob"))
 
     with op.batch_alter_table("links") as batch_op:
         batch_op.drop_column("access_blob")
@@ -298,59 +424,68 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
         batch_op.drop_column("access_blob")
+    with op.batch_alter_table("entities") as batch_op:
+        batch_op.drop_column("access_blob")
     op.create_index(
         "top_level_metadata",
         "nodes",
         ["parent", "time_created", "id", "metadata"],
         postgresql_using="gin",
     )
+    _create_association_triggers(connection)
 
 
 def downgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
 
+    _drop_association_triggers(connection)
+
+    with op.batch_alter_table("entities") as batch_op:
+        batch_op.add_column(sa.Column("access_blob", JSONVariant, nullable=True))
+    _restore_access_blobs(
+        dialect_name,
+        "entity_access_blobs",
+        "entity_id",
+        "entities",
+        default_empty=False,
+    )
+    op.drop_table("entity_access_blobs")
+
+    # Restore c31's JSON-column delegation checks.
+    error_message = (
+        "An entity with node_id set must not have its own access_blob; "
+        "access is controlled by the referenced node."
+    )
     if dialect_name == "sqlite":
-        connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup")
-        )
-        connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup")
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
+        for operation in ("INSERT", "UPDATE"):
             connection.execute(
                 sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob"
-                )
-            )
-            connection.execute(
-                sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob"
+                    f"""
+CREATE TRIGGER entities_node_access_blob_{operation.lower()}
+BEFORE {operation} ON entities
+WHEN NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
                 )
             )
     elif dialect_name == "postgresql":
         connection.execute(
             sa.text(
-                "DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs"
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '{error_message}';
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entities_node_access_blob_check
+BEFORE INSERT OR UPDATE ON entities
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
-        connection.execute(
-            sa.text(
-                "DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs"
-            )
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
-                )
-            )
-        connection.execute(
-            sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob")
-        )
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))
 
     with op.batch_alter_table("links") as batch_op:
         batch_op.add_column(

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -41,6 +41,26 @@ def upgrade():
             name="ck_access_blob_user_xor_tags",
         ),
     )
+    op.create_index(
+        "ix_access_blobs_username_user",
+        "access_blobs",
+        ["username"],
+        sqlite_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+        postgresql_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_access_blobs_kind_node_id",
+        "access_blobs",
+        ["kind", "node_id"],
+    )
+    if dialect_name == "postgresql":
+        op.create_index(
+            "ix_access_blobs_tags_gin",
+            "access_blobs",
+            ["tags"],
+            postgresql_using="gin",
+            postgresql_where=sa.text("kind = 'tags' AND tags IS NOT NULL"),
+        )
 
     if dialect_name == "postgresql":
         op.execute(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -75,7 +75,6 @@ class Node(Timestamped, Base):
     structure_family = Column(Enum(StructureFamily), nullable=False)
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     data_sources = relationship(
         "DataSource",
@@ -87,6 +86,11 @@ class Node(Timestamped, Base):
     revisions = relationship(
         "Revision",
         backref="node",
+        passive_deletes=True,
+    )
+    access_blob = relationship(
+        "AccessBlob",
+        uselist=False,
         passive_deletes=True,
     )
 
@@ -106,7 +110,6 @@ class Node(Timestamped, Base):
             "time_created",
             "id",
             "metadata",
-            "access_blob",
             postgresql_using="gin",
         ),
         # B-tree index supporting cursor-based pagination (WHERE parent = ?
@@ -133,6 +136,30 @@ class NodesClosure(Base):
     __table_args__ = (
         Index("idx_nodes_closure_ancestor", "ancestor"),
         Index("idx_nodes_closure_descendant", "descendant"),
+    )
+
+
+class AccessBlob(Base):
+    """
+    An access blob contains a set of tags that are used to control access to nodes.
+    May otherwise contain information indicating that a node is "user-owned".
+
+    Relationship is one-to-one with the nodes table.
+    """
+
+    __tablename__ = "access_blobs"
+
+    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
+    username = Column(String, nullable=True)
+    tags = Column(ARRAY(String), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
     )
 
 
@@ -372,8 +399,8 @@ EXECUTE FUNCTION update_closure_table_when_inserting();
     connection.execute(
         text(
             """
-INSERT INTO nodes(id, key, parent, structure_family, metadata, specs, access_blob)
-SELECT 0, '', NULL, 'container', '{}', '[]', '{}';
+INSERT INTO nodes(id, key, parent, structure_family, metadata, specs)
+SELECT 0, '', NULL, 'container', '{}', '[]';
 """
         )
     )
@@ -550,7 +577,7 @@ class Asset(Timestamped, Base):
 
 class Revision(Timestamped, Base):
     """
-    This tracks history of metadata, specs, and access_blob supporting 'undo' functionality.
+    This tracks history of metadata and specs supporting 'undo' functionality.
     """
 
     __tablename__ = "revisions"
@@ -566,7 +593,6 @@ class Revision(Timestamped, Base):
 
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     __table_args__ = (
         UniqueConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -171,6 +171,23 @@ class AccessBlob(Base):
             "(username IS NULL AND tags IS NOT NULL)",
             name="ck_access_blob_user_xor_tags",
         ),
+        # Tight partial index for owner lookups used by access_blob_filter.
+        Index(
+            "ix_access_blobs_username_user",
+            "username",
+            postgresql_where=text("kind = 'user' AND username IS NOT NULL"),
+            sqlite_where=text("kind = 'user' AND username IS NOT NULL"),
+        ),
+        # Helps narrow to the relevant subset for tags/user branches quickly,
+        # including SQLite where tags membership itself is not index-friendly.
+        Index("ix_access_blobs_kind_node_id", "kind", "node_id"),
+        # PostgreSQL can index array overlap checks directly.
+        Index(
+            "ix_access_blobs_tags_gin",
+            "tags",
+            postgresql_using="gin",
+            postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
+        ),
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
+from sqlalchemy.schema import CheckConstraint, PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -92,6 +92,8 @@ class Node(Timestamped, Base):
         "AccessBlob",
         uselist=False,
         passive_deletes=True,
+        cascade="all, delete-orphan",
+        single_parent=True,
     )
 
     # This is a self-referencing relationship between parent and children
@@ -149,7 +151,12 @@ class AccessBlob(Base):
 
     __tablename__ = "access_blobs"
 
-    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    node_id = Column(
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        primary_key=True,
+        unique=True,
+        nullable=False,
+    )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
     tags = Column(ARRAY(String), nullable=True)

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
+from sqlalchemy.schema import CheckConstraint, PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -201,6 +201,44 @@ class NodeAccessBlob(Base):
     )
 
 
+@event.listens_for(NodeAccessBlob.__table__, "after_create")
+def create_node_access_blob_cleanup_trigger(target, connection, **kw):
+    if connection.engine.dialect.name == "sqlite":
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION delete_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
+"""
+            )
+        )
+
+
 class DataSourceAssetAssociation(Base):
     """
     This describes which Assets are used by which DataSources, and how.

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from sqlalchemy import (
+    ARRAY,
     JSON,
     Boolean,
     Column,
@@ -9,6 +10,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    String,
     Table,
     Unicode,
     event,
@@ -18,7 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management
@@ -27,6 +29,7 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
+AccessTagsVariant = JSON().with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -91,6 +94,7 @@ class Node(Timestamped, Base):
     access_blob = relationship(
         "AccessBlob",
         uselist=False,
+        lazy="selectin",
         passive_deletes=True,
         cascade="all, delete-orphan",
         single_parent=True,
@@ -159,7 +163,7 @@ class AccessBlob(Base):
     )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
-    tags = Column(ARRAY(String), nullable=True)
+    tags = Column(AccessTagsVariant, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from sqlalchemy import (
+    ARRAY,
     JSON,
     BigInteger,
     Boolean,
@@ -10,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    String,
     Table,
     Unicode,
     event,
@@ -19,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management
@@ -28,6 +30,7 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
+AccessTagsVariant = JSON().with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -92,6 +95,7 @@ class Node(Timestamped, Base):
     access_blob = relationship(
         "AccessBlob",
         uselist=False,
+        lazy="selectin",
         passive_deletes=True,
         cascade="all, delete-orphan",
         single_parent=True,
@@ -160,7 +164,7 @@ class AccessBlob(Base):
     )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
-    tags = Column(ARRAY(String), nullable=True)
+    tags = Column(AccessTagsVariant, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -172,6 +172,23 @@ class AccessBlob(Base):
             "(username IS NULL AND tags IS NOT NULL)",
             name="ck_access_blob_user_xor_tags",
         ),
+        # Tight partial index for owner lookups used by access_blob_filter.
+        Index(
+            "ix_access_blobs_username_user",
+            "username",
+            postgresql_where=text("kind = 'user' AND username IS NOT NULL"),
+            sqlite_where=text("kind = 'user' AND username IS NOT NULL"),
+        ),
+        # Helps narrow to the relevant subset for tags/user branches quickly,
+        # including SQLite where tags membership itself is not index-friendly.
+        Index("ix_access_blobs_kind_node_id", "kind", "node_id"),
+        # PostgreSQL can index array overlap checks directly.
+        Index(
+            "ix_access_blobs_tags_gin",
+            "tags",
+            postgresql_using="gin",
+            postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
+        ),
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -76,7 +76,6 @@ class Node(Timestamped, Base):
     structure_family = Column(Enum(StructureFamily), nullable=False)
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     data_sources = relationship(
         "DataSource",
@@ -88,6 +87,11 @@ class Node(Timestamped, Base):
     revisions = relationship(
         "Revision",
         backref="node",
+        passive_deletes=True,
+    )
+    access_blob = relationship(
+        "AccessBlob",
+        uselist=False,
         passive_deletes=True,
     )
 
@@ -107,7 +111,6 @@ class Node(Timestamped, Base):
             "time_created",
             "id",
             "metadata",
-            "access_blob",
             postgresql_using="gin",
         ),
         # B-tree index supporting cursor-based pagination (WHERE parent = ?
@@ -134,6 +137,30 @@ class NodesClosure(Base):
     __table_args__ = (
         Index("idx_nodes_closure_ancestor", "ancestor"),
         Index("idx_nodes_closure_descendant", "descendant"),
+    )
+
+
+class AccessBlob(Base):
+    """
+    An access blob contains a set of tags that are used to control access to nodes.
+    May otherwise contain information indicating that a node is "user-owned".
+
+    Relationship is one-to-one with the nodes table.
+    """
+
+    __tablename__ = "access_blobs"
+
+    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
+    username = Column(String, nullable=True)
+    tags = Column(ARRAY(String), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
     )
 
 
@@ -373,8 +400,8 @@ EXECUTE FUNCTION update_closure_table_when_inserting();
     connection.execute(
         text(
             """
-INSERT INTO nodes(id, key, parent, structure_family, metadata, specs, access_blob)
-SELECT 0, '', NULL, 'container', '{}', '[]', '{}';
+INSERT INTO nodes(id, key, parent, structure_family, metadata, specs)
+SELECT 0, '', NULL, 'container', '{}', '[]';
 """
         )
     )
@@ -551,7 +578,7 @@ class Asset(Timestamped, Base):
 
 class Revision(Timestamped, Base):
     """
-    This tracks history of metadata, specs, and access_blob supporting 'undo' functionality.
+    This tracks history of metadata and specs supporting 'undo' functionality.
     """
 
     __tablename__ = "revisions"
@@ -567,7 +594,6 @@ class Revision(Timestamped, Base):
 
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     __table_args__ = (
         UniqueConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -30,7 +30,7 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
-AccessTagsVariant = JSON().with_variant(ARRAY(String()), "postgresql")
+AccessTagsVariant = JSON(none_as_null=True).with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -94,11 +94,10 @@ class Node(Timestamped, Base):
     )
     access_blob = relationship(
         "AccessBlob",
+        secondary="node_access_blobs",
         uselist=False,
         lazy="selectin",
         passive_deletes=True,
-        cascade="all, delete-orphan",
-        single_parent=True,
     )
 
     # This is a self-referencing relationship between parent and children
@@ -151,17 +150,13 @@ class AccessBlob(Base):
     An access blob contains a set of tags that are used to control access to nodes.
     May otherwise contain information indicating that a node is "user-owned".
 
-    Relationship is one-to-one with the nodes table.
+    Associated with catalog nodes and graph links through separate association
+    tables.
     """
 
     __tablename__ = "access_blobs"
 
-    node_id = Column(
-        ForeignKey("nodes.id", ondelete="CASCADE"),
-        primary_key=True,
-        unique=True,
-        nullable=False,
-    )
+    id = Column(Integer, primary_key=True, autoincrement=True)
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
     tags = Column(AccessTagsVariant, nullable=True)
@@ -181,7 +176,7 @@ class AccessBlob(Base):
         ),
         # Helps narrow to the relevant subset for tags/user branches quickly,
         # including SQLite where tags membership itself is not index-friendly.
-        Index("ix_access_blobs_kind_node_id", "kind", "node_id"),
+        Index("ix_access_blobs_kind_id", "kind", "id"),
         # PostgreSQL can index array overlap checks directly.
         Index(
             "ix_access_blobs_tags_gin",
@@ -189,6 +184,20 @@ class AccessBlob(Base):
             postgresql_using="gin",
             postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
         ),
+    )
+
+
+class NodeAccessBlob(Base):
+    __tablename__ = "node_access_blobs"
+
+    node_id = Column(
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    access_blob_id = Column(
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -93,6 +93,8 @@ class Node(Timestamped, Base):
         "AccessBlob",
         uselist=False,
         passive_deletes=True,
+        cascade="all, delete-orphan",
+        single_parent=True,
     )
 
     # This is a self-referencing relationship between parent and children
@@ -150,7 +152,12 @@ class AccessBlob(Base):
 
     __tablename__ = "access_blobs"
 
-    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    node_id = Column(
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        primary_key=True,
+        unique=True,
+        nullable=False,
+    )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
     tags = Column(ARRAY(String), nullable=True)

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -19,12 +19,12 @@ is declared as a Core table on ``Base.metadata`` in ``tiled.catalog.orm``.
 from __future__ import annotations
 
 from sqlalchemy import (
-    JSON,
     Column,
     DateTime,
     ForeignKey,
     Index,
     Integer,
+    JSON,
     String,
     Table,
     event,
@@ -146,12 +146,115 @@ links = Table(
         nullable=False,
     ),
     Column("properties", JSON, nullable=False),
-    Column("access_blob", JSON, nullable=False),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Index("links_subject_predicate_idx", "subject_id", "predicate"),
     Index("links_predicate_object_idx", "predicate", "object_id"),
     Index("links_triple_idx", "subject_id", "predicate", "object_id"),
 )
+
+link_access_blobs = Table(
+    "link_access_blobs",
+    metadata,
+    Column(
+        "link_id",
+        String,
+        ForeignKey("links.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "access_blob_id",
+        Integer,
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    ),
+)
+
+
+@event.listens_for(link_access_blobs, "after_create")
+def _create_access_blob_cleanup_triggers(target, connection, **kw):
+    if connection.engine.dialect.name == "sqlite":
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+        for table, other_table in (
+            ("node_access_blobs", "link_access_blobs"),
+            ("link_access_blobs", "node_access_blobs"),
+        ):
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                trigger_operation = operation.split()[0].lower()
+                connection.execute(
+                    text(
+                        f"""
+CREATE TRIGGER {table}_{trigger_operation}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
+END"""
+                    )
+                )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION delete_link_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                text(
+                    f"""
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
+"""
+                )
+            )
 
 namespaces = Table(
     "namespaces",

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -61,71 +61,6 @@ ENTITY_NODE_ACCESS_BLOB_ERROR = (
 )
 
 
-@event.listens_for(metadata, "after_create")
-def _create_entities_node_access_blob_trigger(target, connection, **kw):
-    """
-    Enforce, at the database level, that an entity pointing to a catalog
-    node (node_id set) does not also carry its own access_blob. This
-    mirrors the trigger created by the
-    de302a096358_convert_access_blob_column_to_assoc_ alembic migration,
-    which applies the same DDL for databases provisioned via `alembic
-    upgrade` rather than `create_all` (e.g.
-    tiled.catalog.core.initialize_database, which is what the test suite
-    exercises).
-    """
-    if connection.engine.dialect.name == "sqlite":
-        connection.execute(
-            text(
-                f"""
-CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_insert
-BEFORE INSERT ON entities
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
-END"""
-            )
-        )
-        connection.execute(
-            text(
-                f"""
-CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
-BEFORE UPDATE ON entities
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
-END"""
-            )
-        )
-    elif connection.engine.dialect.name == "postgresql":
-        connection.execute(
-            text(
-                f"""
-CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
-END;
-$$ LANGUAGE plpgsql;"""
-            )
-        )
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER entities_node_access_blob_check
-BEFORE UPDATE OF node_id ON entities
-FOR EACH ROW
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-EXECUTE FUNCTION entities_reject_node_access_blob();"""
-            )
-        )
-
-
 links = Table(
     "links",
     metadata,
@@ -185,6 +120,68 @@ entity_access_blobs = Table(
         unique=True,
     ),
 )
+
+
+@event.listens_for(entity_access_blobs, "after_create")
+def _create_entities_node_access_blob_trigger(target, connection, **kw):
+    """
+    Enforce, at the database level, that an entity pointing to a catalog
+    node (node_id set) does not also carry its own access_blob.
+    """
+    if connection.engine.dialect.name == "sqlite":
+        # Only an UPDATE that sets node_id can turn an existing blob-bearing
+        # entity into an illegal node-backed-with-blob row. The INSERT case
+        # cannot occur in a single statement: an entities INSERT sets only
+        # node_id, while the blob lives in a separate entity_access_blobs row
+        # written by a separate INSERT -- which is itself guarded by
+        # entity_access_blobs_insert_reject_node_backed_entity. This mirrors
+        # the PostgreSQL branch, which likewise only guards UPDATE OF node_id.
+        connection.execute(
+            text(
+                f"""
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
+BEFORE UPDATE OF node_id ON entities
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+            )
+        )
+    elif connection.engine.dialect.name == "postgresql":
+        # PostgreSQL does not allow subqueries in a trigger WHEN clause
+        # ("cannot use subquery in trigger WHEN condition"), so the EXISTS
+        # check against entity_access_blobs lives in the function body; the
+        # trigger WHEN clause keeps only the cheap scalar column test.
+        connection.execute(
+            text(
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        # OR REPLACE keeps this belt-and-suspenders idempotent even though the
+        # table-level listener already fires only once (PostgreSQL 14+).
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE TRIGGER entities_node_access_blob_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW
+WHEN (NEW.node_id IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
+            )
+        )
 
 
 @event.listens_for(link_access_blobs, "after_create")

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -270,20 +270,31 @@ END"""
                     )
                 )
     elif connection.engine.dialect.name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute, so
+        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
         connection.execute(
             text(
-                f"""
+                """
 CREATE OR REPLACE FUNCTION delete_entity_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE TRIGGER entity_access_blobs_delete_cleanup
 AFTER DELETE ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();
-
+FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();"""
+            )
+        )
+        connection.execute(
+            text(
+                f"""
 CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -292,11 +303,20 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
 BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
-
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -314,8 +334,7 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
-"""
+$$ LANGUAGE plpgsql;"""
             )
         )
         for table in tables:

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -49,14 +49,6 @@ entities = Table(
     Column("name", String, nullable=False),
     Column("uri", String, nullable=True),
     Column("properties", JSON, nullable=False),
-    # Nullable: an entity with node_id set must not have its own
-    # access_blob (enforced by the trigger below and in
-    # tiled.graph.schema); access control for such an entity is delegated
-    # to the node it points to. none_as_null=True: without it, SQLAlchemy's
-    # JSON type stores Python None as the JSON literal 'null' (a non-NULL
-    # string), which would defeat both the trigger's and our own
-    # IS NULL / IS NOT NULL checks.
-    Column("access_blob", JSON(none_as_null=True), nullable=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Index("entities_node_id_idx", "node_id"),
     Index("entities_type_created_idx", "entity_type", "created_at"),
@@ -69,13 +61,13 @@ ENTITY_NODE_ACCESS_BLOB_ERROR = (
 )
 
 
-@event.listens_for(entities, "after_create")
+@event.listens_for(metadata, "after_create")
 def _create_entities_node_access_blob_trigger(target, connection, **kw):
     """
     Enforce, at the database level, that an entity pointing to a catalog
     node (node_id set) does not also carry its own access_blob. This
     mirrors the trigger created by the
-    c31f6a1d7e20_add_graph_entities_and_links_tables alembic migration,
+    de302a096358_convert_access_blob_column_to_assoc_ alembic migration,
     which applies the same DDL for databases provisioned via `alembic
     upgrade` rather than `create_all` (e.g.
     tiled.catalog.core.initialize_database, which is what the test suite
@@ -85,9 +77,11 @@ def _create_entities_node_access_blob_trigger(target, connection, **kw):
         connection.execute(
             text(
                 f"""
-CREATE TRIGGER entities_node_access_blob_insert
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_insert
 BEFORE INSERT ON entities
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 BEGIN
     SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
 END"""
@@ -96,9 +90,11 @@ END"""
         connection.execute(
             text(
                 f"""
-CREATE TRIGGER entities_node_access_blob_update
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
 BEFORE UPDATE ON entities
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 BEGIN
     SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
 END"""
@@ -120,9 +116,11 @@ $$ LANGUAGE plpgsql;"""
             text(
                 """
 CREATE TRIGGER entities_node_access_blob_check
-BEFORE INSERT OR UPDATE ON entities
+BEFORE UPDATE OF node_id ON entities
 FOR EACH ROW
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
@@ -170,9 +168,27 @@ link_access_blobs = Table(
     ),
 )
 
+entity_access_blobs = Table(
+    "entity_access_blobs",
+    metadata,
+    Column(
+        "entity_id",
+        String,
+        ForeignKey("entities.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "access_blob_id",
+        Integer,
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    ),
+)
+
 
 @event.listens_for(link_access_blobs, "after_create")
-def _create_access_blob_cleanup_triggers(target, connection, **kw):
+def _create_link_access_blob_cleanup_trigger(target, connection, **kw):
     if connection.engine.dialect.name == "sqlite":
         connection.execute(
             text(
@@ -184,23 +200,6 @@ BEGIN
 END"""
             )
         )
-        for table, other_table in (
-            ("node_access_blobs", "link_access_blobs"),
-            ("link_access_blobs", "node_access_blobs"),
-        ):
-            for operation in ("INSERT", "UPDATE OF access_blob_id"):
-                trigger_operation = operation.split()[0].lower()
-                connection.execute(
-                    text(
-                        f"""
-CREATE TRIGGER {table}_{trigger_operation}_reject_shared_access_blob
-BEFORE {operation} ON {table}
-WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
-BEGIN
-    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
-END"""
-                    )
-                )
     elif connection.engine.dialect.name == "postgresql":
         connection.execute(
             text(
@@ -224,20 +223,94 @@ FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
 """
             )
         )
+
+
+@event.listens_for(link_access_blobs, "after_create")
+def _create_access_blob_association_triggers(target, connection, **kw):
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    if connection.engine.dialect.name == "sqlite":
         connection.execute(
             text(
                 """
+CREATE TRIGGER entity_access_blobs_delete_cleanup
+AFTER DELETE ON entity_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                text(
+                    f"""
+CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_blobs
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+                )
+            )
+        for table in tables:
+            others = " OR ".join(
+                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
+                for other in tables
+                if other != table
+            )
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN {others}
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
+END"""
+                    )
+                )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                f"""
+CREATE OR REPLACE FUNCTION delete_entity_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entity_access_blobs_delete_cleanup
+AFTER DELETE ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();
+
+CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
-        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
         SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
     END IF;
     RETURN NEW;
 END;
@@ -245,14 +318,13 @@ $$ LANGUAGE plpgsql;
 """
             )
         )
-        for table in ("node_access_blobs", "link_access_blobs"):
+        for table in tables:
             connection.execute(
                 text(
                     f"""
 CREATE TRIGGER {table}_reject_shared_access_blob
 BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
-FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
-"""
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
                 )
             )
 

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -19,12 +19,12 @@ is declared as a Core table on ``Base.metadata`` in ``tiled.catalog.orm``.
 from __future__ import annotations
 
 from sqlalchemy import (
+    JSON,
     Column,
     DateTime,
     ForeignKey,
     Index,
     Integer,
-    JSON,
     String,
     Table,
     event,
@@ -255,6 +255,7 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
 """
                 )
             )
+
 
 namespaces = Table(
     "namespaces",

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -151,9 +151,15 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
 
 
 def _access_blob_from_input(access_blob: dict) -> AccessBlob:
-    if "user" in access_blob:
+    if "user" in access_blob and set(access_blob) == {"user"}:
         return AccessBlob(username=access_blob["user"])
-    return AccessBlob(tags=access_blob.get("tags", []))
+    if set(access_blob) <= {"tags"}:
+        return AccessBlob(tags=access_blob.get("tags", []))
+    raise GraphQLError(
+        'access_blob must be either {"user": <username>} or '
+        '{"tags": [<tag>, ...]}. '
+        f"Received {access_blob!r}"
+    )
 
 
 async def _init_access_blob(

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -37,6 +37,7 @@ from strawberry.types.unset import UNSET, UnsetType
 
 from tiled.access_control.access_policies import NO_ACCESS
 from tiled.queries import AccessBlobFilter
+from tiled.type_aliases import AccessBlob
 
 from .curie import compact_term, compact_value, expand_term, expand_value
 from .orm import ENTITY_NODE_ACCESS_BLOB_ERROR
@@ -71,11 +72,13 @@ async def _namespaces(info: Info) -> dict[str, str]:
 
 
 class _PolicyNode:
-    def __init__(self, access_blob: Optional[dict]):
-        self.access_blob = access_blob or {}
+    def __init__(self, access_blob: Optional[AccessBlob]):
+        self.access_blob = access_blob or AccessBlob(tags=[])
 
 
-async def _is_allowed(info: Info, access_blob: Optional[dict], scope: str) -> bool:
+async def _is_allowed(
+    info: Info, access_blob: Optional[AccessBlob], scope: str
+) -> bool:
     authn_scopes = info.context["authn_scopes"]
     if scope not in authn_scopes:
         return False
@@ -91,12 +94,14 @@ async def _is_allowed(info: Info, access_blob: Optional[dict], scope: str) -> bo
     return scope in allowed
 
 
-async def _assert_allowed(info: Info, access_blob: Optional[dict], scope: str) -> None:
+async def _assert_allowed(
+    info: Info, access_blob: Optional[AccessBlob], scope: str
+) -> None:
     if not await _is_allowed(info, access_blob, scope):
         raise GraphQLError("Not permitted")
 
 
-async def _effective_access_blob(info: Info, record: EntityRecord) -> Optional[dict]:
+async def _effective_access_blob(info: Info, record: EntityRecord) -> AccessBlob:
     """
     An entity that points to a catalog node (node_id set) delegates its
     access control to that node, rather than carrying its own access_blob
@@ -104,8 +109,10 @@ async def _effective_access_blob(info: Info, record: EntityRecord) -> Optional[d
     trigger in tiled.graph.store). Resolve whichever one is authoritative.
     """
     if record.node_id is not None:
-        return await _store(info).get_node_access_blob(record.node_id)
-    return record.access_blob
+        return await _store(info).get_node_access_blob(record.node_id) or AccessBlob(
+            tags=[]
+        )
+    return record.access_blob or AccessBlob(tags=[])
 
 
 def _assert_authn_scope(info: Info, scope: str) -> None:
@@ -127,7 +134,7 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
         return []
 
     queries = await policy.filters(
-        _PolicyNode({}),
+        _PolicyNode(AccessBlob(tags=[])),
         info.context["principal"],
         info.context["authn_access_tags"],
         info.context["authn_scopes"],
@@ -143,7 +150,15 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
     return queries
 
 
-async def _init_access_blob(info: Info, access_blob: Optional[dict]) -> dict:
+def _access_blob_from_input(access_blob: dict) -> AccessBlob:
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    return AccessBlob(tags=access_blob.get("tags", []))
+
+
+async def _init_access_blob(
+    info: Info, access_blob: Optional[AccessBlob]
+) -> AccessBlob:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "init_node"):
         try:
@@ -155,13 +170,17 @@ async def _init_access_blob(info: Info, access_blob: Optional[dict]) -> dict:
             )
         except ValueError as exc:
             raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
+        if not isinstance(new_access_blob, AccessBlob):
+            raise TypeError("access policy must return an AccessBlob")
         return new_access_blob
-    return access_blob or {}
+    return access_blob or AccessBlob(tags=[])
 
 
 async def _modify_access_blob(
-    info: Info, current_access_blob: Optional[dict], requested_access_blob: dict
-) -> dict:
+    info: Info,
+    current_access_blob: Optional[AccessBlob],
+    requested_access_blob: Optional[AccessBlob],
+) -> AccessBlob:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "modify_node"):
         try:
@@ -174,8 +193,10 @@ async def _modify_access_blob(
             )
         except ValueError as exc:
             raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
+        if not isinstance(new_access_blob, AccessBlob):
+            raise TypeError("access policy must return an AccessBlob")
         return new_access_blob
-    return current_access_blob
+    return current_access_blob or AccessBlob(tags=[])
 
 
 # ---------------------------------------------------------------------------
@@ -297,13 +318,18 @@ def _entity_from_record(r: EntityRecord, namespaces: dict[str, str]) -> Entity:
 
 def _link_from_record(r: LinkRecord, namespaces: dict[str, str]) -> Link:
     properties = compact_value(r.properties, namespaces) if r.properties else None
+    access_blob = (
+        {"user": r.access_blob.username}
+        if r.access_blob.username is not None
+        else {"tags": r.access_blob.tags or []}
+    )
     return Link(
         id=strawberry.ID(r.id),
         subject_id=strawberry.ID(r.subject_id),
         predicate=compact_term(r.predicate, namespaces),
         object_id=strawberry.ID(r.object_id),
         properties=properties,
-        access_blob=r.access_blob if r.access_blob else None,
+        access_blob=access_blob,
         created_at=r.created_at.isoformat(),
     )
 
@@ -452,7 +478,14 @@ class Mutation:
                 raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
             access_blob = None
         else:
-            access_blob = await _init_access_blob(info, input.access_blob)
+            access_blob = await _init_access_blob(
+                info,
+                (
+                    _access_blob_from_input(input.access_blob)
+                    if input.access_blob is not None
+                    else None
+                ),
+            )
         record = await _store(info).create_entity(
             entity_type=input.entity_type,
             name=input.name,
@@ -485,7 +518,14 @@ class Mutation:
         await _assert_allowed(
             info, await _effective_access_blob(info, object_), "write:metadata"
         )
-        access_blob = await _init_access_blob(info, input.access_blob)
+        access_blob = await _init_access_blob(
+            info,
+            (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            ),
+        )
         record = await _store(info).create_link(
             subject_id=str(input.subject_id),
             predicate=expand_term(input.predicate, namespaces),
@@ -534,9 +574,15 @@ class Mutation:
                 raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
             access_blob = None
         elif input.access_blob is not UNSET:
-            requested_access_blob = input.access_blob or {}
+            requested_access_blob = (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            )
             access_blob = await _modify_access_blob(
-                info, current.access_blob, requested_access_blob
+                info,
+                current.access_blob,
+                requested_access_blob,
             )
         elif input.node_id is not UNSET and current.access_blob is None:
             # Detaching from a node (node_id set to null) with no
@@ -579,7 +625,11 @@ class Mutation:
         namespaces = await _namespaces(info)
         access_blob = UNSET
         if input.access_blob is not UNSET:
-            requested_access_blob = input.access_blob or {}
+            requested_access_blob = (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            )
             access_blob = await _modify_access_blob(
                 info, current.access_blob, requested_access_blob
             )

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -32,17 +32,20 @@ from sqlalchemy import (
     type_coerce,
     update,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TEXT
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.sql.expression import cast as sql_cast
 
-from ..catalog.orm import AccessBlob, Node, NodeAccessBlob
+from ..catalog.orm import AccessBlob as AccessBlobORM
+from ..catalog.orm import Node, NodeAccessBlob
 from ..queries import AccessBlobFilter
 from ..server.connection_pool import get_database_engine
 from ..server.settings import DatabaseSettings
+from ..type_aliases import AccessBlob
 from ..utils import UnsupportedQueryType
 from .orm import entities as _entities
+from .orm import entity_access_blobs as _entity_access_blobs
 from .orm import link_access_blobs as _link_access_blobs
 from .orm import links as _links
 from .orm import namespaces as _namespaces
@@ -51,7 +54,7 @@ UNSET = object()
 
 # The catalog ``nodes`` table, used to resolve entities.node_id by catalog path.
 _nodes = Node.__table__
-_access_blobs = AccessBlob.__table__
+_access_blobs = AccessBlobORM.__table__
 _node_access_blobs = NodeAccessBlob.__table__
 
 # ---------------------------------------------------------------------------
@@ -69,7 +72,7 @@ class EntityRecord(BaseModel):
     uri: Optional[str]
     properties: dict
     # None when node_id is set: access control is delegated to the node.
-    access_blob: Optional[dict] = None
+    access_blob: Optional[AccessBlob] = None
     created_at: datetime
 
 
@@ -81,63 +84,8 @@ class LinkRecord(BaseModel):
     predicate: str
     object_id: str
     properties: dict
-    access_blob: dict
+    access_blob: AccessBlob
     created_at: datetime
-
-
-def _json_access_blob_condition(
-    dialect_name: str, access_blob_column, query: AccessBlobFilter
-):
-    """
-    Translate one AccessBlobFilter into a SQL condition on a JSON
-    access_blob column, mirroring tiled.catalog.adapter.access_blob_filter
-    so that pagination (LIMIT/OFFSET) is applied to already-filtered rows
-    instead of filtering a page after the fact.
-    """
-    if not (query.user_id or query.tags):
-        # Results cannot possibly match an empty value or list,
-        # so put a False condition in the list ensuring that
-        # there are no rows returned.
-        return false()
-    if dialect_name == "sqlite":
-        access_tags_json = func.json_each(access_blob_column["tags"]).table_valued(
-            "value"
-        )
-        condition = (
-            select(1)
-            .select_from(access_tags_json)
-            .where(access_tags_json.c.value.in_(query.tags))
-            .exists()
-        )
-        if query.user_id is not None:
-            user_match = (
-                func.json_extract(func.json_quote(access_blob_column["user"]), "$")
-                == query.user_id
-            )
-            condition = or_(condition, user_match)
-    elif dialect_name == "postgresql":
-        access_blob_jsonb = type_coerce(access_blob_column, JSONB)
-        condition = access_blob_jsonb["tags"].has_any(sql_cast(query.tags, ARRAY(TEXT)))
-        if query.user_id is not None:
-            user_match = access_blob_jsonb["user"].astext == query.user_id
-            condition = or_(condition, user_match)
-    else:
-        raise UnsupportedQueryType("access_blob_filter")
-    return condition
-
-
-def _json_access_filters_condition(
-    dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
-):
-    condition = _json_access_blob_condition(
-        dialect_name, access_blob_column, queries[0]
-    )
-    for query in queries[1:]:
-        condition = and_(
-            condition,
-            _json_access_blob_condition(dialect_name, access_blob_column, query),
-        )
-    return condition
 
 
 def _access_blob_association_condition(
@@ -182,17 +130,16 @@ def _access_blob_association_filters_condition(
     return condition
 
 
-def _access_blob_from_association(row) -> dict:
-    if row.kind == "user":
-        return {"user": row.username}
-    return {"tags": row.tags or []}
+def _access_blob_from_association(row) -> AccessBlob:
+    return AccessBlob(username=row.username, tags=row.tags)
 
 
-def _access_blob_values(access_blob: Optional[dict]) -> dict:
-    access_blob = access_blob or {}
-    if "user" in access_blob:
-        return {"kind": "user", "username": access_blob["user"], "tags": None}
-    return {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
+def _access_blob_values(access_blob: AccessBlob) -> dict:
+    if not isinstance(access_blob, AccessBlob):
+        raise TypeError("access_blob must be an AccessBlob")
+    if access_blob.username is not None:
+        return {"kind": "user", "username": access_blob.username, "tags": None}
+    return {"kind": "tags", "username": None, "tags": access_blob.tags or []}
 
 
 class GraphSQLAlchemyStore:
@@ -226,9 +173,12 @@ class GraphSQLAlchemyStore:
             name=row.name,
             uri=row.uri,
             properties=row.properties or {},
-            # Preserve None as-is (rather than coercing to {}): None means
-            # access control is delegated to the node (node_id is set).
-            access_blob=row.access_blob,
+            # No association means access control is delegated to node_id.
+            access_blob=(
+                AccessBlob(username=row.access_blob_username, tags=row.access_blob_tags)
+                if row.access_blob_id is not None
+                else None
+            ),
             created_at=row.created_at,
         )
 
@@ -244,6 +194,32 @@ class GraphSQLAlchemyStore:
             created_at=row.created_at,
         )
 
+    @staticmethod
+    def _entity_statement(id: Optional[str] = None, entity_access_blobs_value=None):
+        if entity_access_blobs_value is None:
+            entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
+        stmt = (
+            select(
+                _entities,
+                entity_access_blobs_value.c.id.label("access_blob_id"),
+                entity_access_blobs_value.c.username.label("access_blob_username"),
+                entity_access_blobs_value.c.tags.label("access_blob_tags"),
+            )
+            .outerjoin(
+                _entity_access_blobs, _entities.c.id == _entity_access_blobs.c.entity_id
+            )
+            .outerjoin(
+                entity_access_blobs_value,
+                _entity_access_blobs.c.access_blob_id == entity_access_blobs_value.c.id,
+            )
+        )
+        if id is not None:
+            stmt = stmt.where(_entities.c.id == id)
+        return stmt
+
+    async def _entity_row(self, conn, id: str):
+        return (await conn.execute(self._entity_statement(id))).one_or_none()
+
     async def create_entity(
         self,
         entity_type: str,
@@ -251,10 +227,14 @@ class GraphSQLAlchemyStore:
         node_id: Optional[int] = None,
         uri: Optional[str] = None,
         properties: Optional[dict] = None,
-        access_blob: Optional[dict] = None,
+        access_blob: Optional[AccessBlob] = None,
     ) -> EntityRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
+        if access_blob is not None and not isinstance(access_blob, AccessBlob):
+            raise TypeError("access_blob must be an AccessBlob")
+        if node_id is not None and access_blob is not None:
+            raise IntegrityError("entity node access blob", {}, None)
         async with self._engine.begin() as conn:
             await conn.execute(
                 insert(_entities).values(
@@ -264,25 +244,30 @@ class GraphSQLAlchemyStore:
                     name=name,
                     uri=uri,
                     properties=properties or {},
-                    # Not coerced to {}: passing None here (as the caller
-                    # must when node_id is set) stores SQL NULL.
-                    access_blob=access_blob,
                     created_at=now,
                 )
             )
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id_))
-            ).one()
+            if node_id is None:
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(
+                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
+                    )
+                )
+                await conn.execute(
+                    insert(_entity_access_blobs).values(
+                        entity_id=id_,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
+            row = await self._entity_row(conn, id_)
         return self._to_entity(row)
 
     async def get_entity(self, id: str) -> Optional[EntityRecord]:
         async with self._engine.connect() as conn:
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id))
-            ).one_or_none()
+            row = await self._entity_row(conn, id)
         return self._to_entity(row) if row else None
 
-    async def get_node_access_blob(self, node_id: int) -> Optional[dict]:
+    async def get_node_access_blob(self, node_id: int) -> Optional[AccessBlob]:
         """
         Look up a catalog node's access_blob, for resolving the effective
         access control of an entity that points to it (node_id is set).
@@ -308,7 +293,11 @@ class GraphSQLAlchemyStore:
         offset: int = 0,
         access_filters: Optional[list[AccessBlobFilter]] = None,
     ) -> list[EntityRecord]:
-        stmt = select(_entities).order_by(_entities.c.created_at)
+        entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
+        node_access_blobs_value = _access_blobs.alias("node_access_blobs_value")
+        stmt = self._entity_statement(
+            entity_access_blobs_value=entity_access_blobs_value
+        ).order_by(_entities.c.created_at)
         if entity_type is not None:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
         if access_filters:
@@ -319,21 +308,21 @@ class GraphSQLAlchemyStore:
                     _entities.c.node_id == _node_access_blobs.c.node_id,
                 )
                 .outerjoin(
-                    _access_blobs,
-                    _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    node_access_blobs_value,
+                    _node_access_blobs.c.access_blob_id == node_access_blobs_value.c.id,
                 )
                 .where(
                     or_(
                         and_(
                             _entities.c.node_id.is_(None),
-                            _json_access_filters_condition(
-                                dialect_name, _entities.c.access_blob, access_filters
+                            _access_blob_association_filters_condition(
+                                dialect_name, entity_access_blobs_value, access_filters
                             ),
                         ),
                         and_(
                             _entities.c.node_id.isnot(None),
                             _access_blob_association_filters_condition(
-                                dialect_name, _access_blobs, access_filters
+                                dialect_name, node_access_blobs_value, access_filters
                             ),
                         ),
                     )
@@ -368,15 +357,74 @@ class GraphSQLAlchemyStore:
         if entity_type is not None:
             values["entity_type"] = entity_type
         if access_blob is not UNSET:
-            values["access_blob"] = access_blob
+            if access_blob is not None and not isinstance(access_blob, AccessBlob):
+                raise TypeError("access_blob must be an AccessBlob")
         async with self._engine.begin() as conn:
+            existing = await self._entity_row(conn, id)
+            if existing is None:
+                return None
+            effective_node_id = node_id if node_id is not UNSET else existing.node_id
+            if (
+                access_blob is not UNSET
+                and effective_node_id is not None
+                and access_blob is not None
+            ):
+                raise IntegrityError("entity node access blob", {}, None)
+            if existing.node_id is None and effective_node_id is not None:
+                await conn.execute(
+                    delete(_entity_access_blobs).where(
+                        _entity_access_blobs.c.entity_id == id
+                    )
+                )
             if values:
                 await conn.execute(
                     update(_entities).where(_entities.c.id == id).values(**values)
                 )
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id))
-            ).one_or_none()
+            if access_blob is not UNSET:
+                if access_blob is None:
+                    await conn.execute(
+                        delete(_entity_access_blobs).where(
+                            _entity_access_blobs.c.entity_id == id
+                        )
+                    )
+                elif existing.access_blob_id is None:
+                    access_blob_result = await conn.execute(
+                        insert(_access_blobs).values(**_access_blob_values(access_blob))
+                    )
+                    await conn.execute(
+                        insert(_entity_access_blobs).values(
+                            entity_id=id,
+                            access_blob_id=access_blob_result.inserted_primary_key[0],
+                        )
+                    )
+                else:
+                    await conn.execute(
+                        update(_access_blobs)
+                        .where(
+                            _access_blobs.c.id
+                            == select(_entity_access_blobs.c.access_blob_id)
+                            .where(_entity_access_blobs.c.entity_id == id)
+                            .scalar_subquery()
+                        )
+                        .values(**_access_blob_values(access_blob))
+                    )
+            if (
+                existing.node_id is not None
+                and effective_node_id is None
+                and access_blob is UNSET
+            ):
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(
+                        **_access_blob_values(AccessBlob(tags=[]))
+                    )
+                )
+                await conn.execute(
+                    insert(_entity_access_blobs).values(
+                        entity_id=id,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
+            row = await self._entity_row(conn, id)
         return self._to_entity(row) if row else None
 
     async def create_link(
@@ -385,10 +433,12 @@ class GraphSQLAlchemyStore:
         predicate: str,
         object_id: str,
         properties: Optional[dict] = None,
-        access_blob: Optional[dict] = None,
+        access_blob: Optional[AccessBlob] = None,
     ) -> LinkRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
+        if access_blob is not None and not isinstance(access_blob, AccessBlob):
+            raise TypeError("access_blob must be an AccessBlob")
         # The subject_id/object_id foreign keys reference entities.id, so the
         # database rejects a link to a nonexistent entity (SQLite enforces this
         # too: the shared pool sets PRAGMA foreign_keys=ON). Insert directly and
@@ -407,7 +457,9 @@ class GraphSQLAlchemyStore:
                     )
                 )
                 access_blob_result = await conn.execute(
-                    insert(_access_blobs).values(**_access_blob_values(access_blob))
+                    insert(_access_blobs).values(
+                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
+                    )
                 )
                 await conn.execute(
                     insert(_link_access_blobs).values(
@@ -514,6 +566,8 @@ class GraphSQLAlchemyStore:
                     update(_links).where(_links.c.id == id).values(**values)
                 )
             if access_blob is not UNSET:
+                if access_blob is not None and not isinstance(access_blob, AccessBlob):
+                    raise TypeError("access_blob must be an AccessBlob")
                 await conn.execute(
                     update(_access_blobs)
                     .where(
@@ -522,7 +576,7 @@ class GraphSQLAlchemyStore:
                         .where(_link_access_blobs.c.link_id == id)
                         .scalar_subquery()
                     )
-                    .values(**_access_blob_values(access_blob))
+                    .values(**_access_blob_values(access_blob or AccessBlob(tags=[])))
                 )
             row = (
                 await conn.execute(

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -22,8 +22,8 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
     JSON,
+    String,
     and_,
-    case,
     delete,
     false,
     func,
@@ -38,12 +38,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.sql.expression import cast as sql_cast
 
-from ..catalog.orm import Node
+from ..catalog.orm import AccessBlob, Node, NodeAccessBlob
 from ..queries import AccessBlobFilter
 from ..server.connection_pool import get_database_engine
 from ..server.settings import DatabaseSettings
 from ..utils import UnsupportedQueryType
 from .orm import entities as _entities
+from .orm import link_access_blobs as _link_access_blobs
 from .orm import links as _links
 from .orm import namespaces as _namespaces
 
@@ -51,6 +52,8 @@ UNSET = object()
 
 # The catalog ``nodes`` table, used to resolve entities.node_id by catalog path.
 _nodes = Node.__table__
+_access_blobs = AccessBlob.__table__
+_node_access_blobs = NodeAccessBlob.__table__
 
 # ---------------------------------------------------------------------------
 # Data records
@@ -83,7 +86,7 @@ class LinkRecord(BaseModel):
     created_at: datetime
 
 
-def _access_blob_condition(
+def _json_access_blob_condition(
     dialect_name: str, access_blob_column, query: AccessBlobFilter
 ):
     """
@@ -124,15 +127,65 @@ def _access_blob_condition(
     return condition
 
 
-def _access_filters_condition(
+def _json_access_filters_condition(
     dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
 ):
-    condition = _access_blob_condition(dialect_name, access_blob_column, queries[0])
+    condition = _json_access_blob_condition(dialect_name, access_blob_column, queries[0])
     for query in queries[1:]:
         condition = and_(
-            condition, _access_blob_condition(dialect_name, access_blob_column, query)
+            condition, _json_access_blob_condition(dialect_name, access_blob_column, query)
         )
     return condition
+
+
+def _access_blob_association_condition(dialect_name: str, table, query: AccessBlobFilter):
+    if not (query.user_id or query.tags):
+        return false()
+    tags_match = false()
+    if query.tags:
+        if dialect_name == "sqlite":
+            tags = func.json_each(table.c.tags).table_valued("value")
+            tags_match = and_(
+                table.c.kind == "tags",
+                select(1).select_from(tags).where(tags.c.value.in_(query.tags)).exists(),
+            )
+        elif dialect_name == "postgresql":
+            tags_match = and_(
+                table.c.kind == "tags",
+                type_coerce(table.c.tags, ARRAY(String())).overlap(
+                    sql_cast(query.tags, ARRAY(String()))
+                ),
+            )
+        else:
+            raise UnsupportedQueryType("access_blob_filter")
+    user_match = false()
+    if query.user_id is not None:
+        user_match = and_(table.c.kind == "user", table.c.username == query.user_id)
+    return or_(tags_match, user_match)
+
+
+def _access_blob_association_filters_condition(
+    dialect_name: str, table, queries: list[AccessBlobFilter]
+):
+    condition = _access_blob_association_condition(dialect_name, table, queries[0])
+    for query in queries[1:]:
+        condition = and_(
+            condition, _access_blob_association_condition(dialect_name, table, query)
+        )
+    return condition
+
+
+def _access_blob_from_association(row) -> dict:
+    if row.kind == "user":
+        return {"user": row.username}
+    return {"tags": row.tags or []}
+
+
+def _access_blob_values(access_blob: Optional[dict]) -> dict:
+    access_blob = access_blob or {}
+    if "user" in access_blob:
+        return {"kind": "user", "username": access_blob["user"], "tags": None}
+    return {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
 
 
 class GraphSQLAlchemyStore:
@@ -180,7 +233,7 @@ class GraphSQLAlchemyStore:
             predicate=row.predicate,
             object_id=row.object_id,
             properties=row.properties or {},
-            access_blob=row.access_blob or {},
+            access_blob=_access_blob_from_association(row),
             created_at=row.created_at,
         )
 
@@ -230,10 +283,16 @@ class GraphSQLAlchemyStore:
         async with self._engine.connect() as conn:
             row = (
                 await conn.execute(
-                    select(_nodes.c.access_blob).where(_nodes.c.id == node_id)
+                    select(_access_blobs)
+                    .join(
+                        _node_access_blobs,
+                        _access_blobs.c.id == _node_access_blobs.c.access_blob_id,
+                    )
+                    .join(_nodes, _node_access_blobs.c.node_id == _nodes.c.id)
+                    .where(_nodes.c.id == node_id)
                 )
             ).one_or_none()
-        return row.access_blob if row else None
+        return _access_blob_from_association(row) if row else None
 
     async def list_entities(
         self,
@@ -247,18 +306,25 @@ class GraphSQLAlchemyStore:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
-            # An entity's effective access_blob is its node's access_blob
-            # when node_id is set, else its own access_blob.
-            effective_access_blob = type_coerce(
-                case(
-                    (_entities.c.node_id.isnot(None), _nodes.c.access_blob),
-                    else_=_entities.c.access_blob,
-                ),
-                JSON,
-            )
-            stmt = stmt.outerjoin(_nodes, _entities.c.node_id == _nodes.c.id).where(
-                _access_filters_condition(
-                    dialect_name, effective_access_blob, access_filters
+            stmt = stmt.outerjoin(
+                _node_access_blobs, _entities.c.node_id == _node_access_blobs.c.node_id
+            ).outerjoin(
+                _access_blobs,
+                _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+            ).where(
+                or_(
+                    and_(
+                        _entities.c.node_id.is_(None),
+                        _json_access_filters_condition(
+                            dialect_name, _entities.c.access_blob, access_filters
+                        ),
+                    ),
+                    and_(
+                        _entities.c.node_id.isnot(None),
+                        _access_blob_association_filters_condition(
+                            dialect_name, _access_blobs, access_filters
+                        ),
+                    ),
                 )
             )
         stmt = stmt.limit(limit).offset(offset)
@@ -325,12 +391,31 @@ class GraphSQLAlchemyStore:
                         predicate=predicate,
                         object_id=object_id,
                         properties=properties or {},
-                        access_blob=access_blob or {},
                         created_at=now,
                     )
                 )
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(**_access_blob_values(access_blob))
+                )
+                await conn.execute(
+                    insert(_link_access_blobs).values(
+                        link_id=id_,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
                 row = (
-                    await conn.execute(select(_links).where(_links.c.id == id_))
+                    await conn.execute(
+                        select(_links, _access_blobs)
+                        .join(
+                            _link_access_blobs,
+                            _links.c.id == _link_access_blobs.c.link_id,
+                        )
+                        .join(
+                            _access_blobs,
+                            _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                        )
+                        .where(_links.c.id == id_)
+                    )
                 ).one()
         except IntegrityError as exc:
             # A foreign-key violation means one of the endpoints is missing.
@@ -346,7 +431,18 @@ class GraphSQLAlchemyStore:
     async def get_link(self, id: str) -> Optional[LinkRecord]:
         async with self._engine.connect() as conn:
             row = (
-                await conn.execute(select(_links).where(_links.c.id == id))
+                await conn.execute(
+                    select(_links, _access_blobs)
+                    .join(
+                        _link_access_blobs,
+                        _links.c.id == _link_access_blobs.c.link_id,
+                    )
+                    .join(
+                        _access_blobs,
+                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    )
+                    .where(_links.c.id == id)
+                )
             ).one_or_none()
         return self._to_link(row) if row else None
 
@@ -359,7 +455,15 @@ class GraphSQLAlchemyStore:
         offset: int = 0,
         access_filters: Optional[list[AccessBlobFilter]] = None,
     ) -> list[LinkRecord]:
-        stmt = select(_links).order_by(_links.c.created_at)
+        stmt = (
+            select(_links, _access_blobs)
+            .join(_link_access_blobs, _links.c.id == _link_access_blobs.c.link_id)
+            .join(
+                _access_blobs,
+                _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+            )
+            .order_by(_links.c.created_at)
+        )
         if subject_id is not None:
             stmt = stmt.where(_links.c.subject_id == subject_id)
         if predicate is not None:
@@ -369,8 +473,8 @@ class GraphSQLAlchemyStore:
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
             stmt = stmt.where(
-                _access_filters_condition(
-                    dialect_name, _links.c.access_blob, access_filters
+                _access_blob_association_filters_condition(
+                    dialect_name, _access_blobs, access_filters
                 )
             )
         stmt = stmt.limit(limit).offset(offset)
@@ -392,15 +496,35 @@ class GraphSQLAlchemyStore:
         values: dict = {}
         if predicate is not UNSET:
             values["predicate"] = predicate
-        if access_blob is not UNSET:
-            values["access_blob"] = access_blob
         async with self._engine.begin() as conn:
             if values:
                 await conn.execute(
                     update(_links).where(_links.c.id == id).values(**values)
                 )
+            if access_blob is not UNSET:
+                await conn.execute(
+                    update(_access_blobs)
+                    .where(
+                        _access_blobs.c.id
+                        == select(_link_access_blobs.c.access_blob_id)
+                        .where(_link_access_blobs.c.link_id == id)
+                        .scalar_subquery()
+                    )
+                    .values(**_access_blob_values(access_blob))
+                )
             row = (
-                await conn.execute(select(_links).where(_links.c.id == id))
+                await conn.execute(
+                    select(_links, _access_blobs)
+                    .join(
+                        _link_access_blobs,
+                        _links.c.id == _link_access_blobs.c.link_id,
+                    )
+                    .join(
+                        _access_blobs,
+                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    )
+                    .where(_links.c.id == id)
+                )
             ).one_or_none()
         return self._to_link(row) if row else None
 

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -21,7 +21,6 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
-    JSON,
     String,
     and_,
     delete,
@@ -130,15 +129,20 @@ def _json_access_blob_condition(
 def _json_access_filters_condition(
     dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
 ):
-    condition = _json_access_blob_condition(dialect_name, access_blob_column, queries[0])
+    condition = _json_access_blob_condition(
+        dialect_name, access_blob_column, queries[0]
+    )
     for query in queries[1:]:
         condition = and_(
-            condition, _json_access_blob_condition(dialect_name, access_blob_column, query)
+            condition,
+            _json_access_blob_condition(dialect_name, access_blob_column, query),
         )
     return condition
 
 
-def _access_blob_association_condition(dialect_name: str, table, query: AccessBlobFilter):
+def _access_blob_association_condition(
+    dialect_name: str, table, query: AccessBlobFilter
+):
     if not (query.user_id or query.tags):
         return false()
     tags_match = false()
@@ -147,7 +151,10 @@ def _access_blob_association_condition(dialect_name: str, table, query: AccessBl
             tags = func.json_each(table.c.tags).table_valued("value")
             tags_match = and_(
                 table.c.kind == "tags",
-                select(1).select_from(tags).where(tags.c.value.in_(query.tags)).exists(),
+                select(1)
+                .select_from(tags)
+                .where(tags.c.value.in_(query.tags))
+                .exists(),
             )
         elif dialect_name == "postgresql":
             tags_match = and_(
@@ -306,25 +313,30 @@ class GraphSQLAlchemyStore:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
-            stmt = stmt.outerjoin(
-                _node_access_blobs, _entities.c.node_id == _node_access_blobs.c.node_id
-            ).outerjoin(
-                _access_blobs,
-                _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
-            ).where(
-                or_(
-                    and_(
-                        _entities.c.node_id.is_(None),
-                        _json_access_filters_condition(
-                            dialect_name, _entities.c.access_blob, access_filters
+            stmt = (
+                stmt.outerjoin(
+                    _node_access_blobs,
+                    _entities.c.node_id == _node_access_blobs.c.node_id,
+                )
+                .outerjoin(
+                    _access_blobs,
+                    _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                )
+                .where(
+                    or_(
+                        and_(
+                            _entities.c.node_id.is_(None),
+                            _json_access_filters_condition(
+                                dialect_name, _entities.c.access_blob, access_filters
+                            ),
                         ),
-                    ),
-                    and_(
-                        _entities.c.node_id.isnot(None),
-                        _access_blob_association_filters_condition(
-                            dialect_name, _access_blobs, access_filters
+                        and_(
+                            _entities.c.node_id.isnot(None),
+                            _access_blob_association_filters_condition(
+                                dialect_name, _access_blobs, access_filters
+                            ),
                         ),
-                    ),
+                    )
                 )
             )
         stmt = stmt.limit(limit).offset(offset)

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -382,6 +382,14 @@ class GraphSQLAlchemyStore:
                 )
             if access_blob is not UNSET:
                 if access_blob is None:
+                    if effective_node_id is None:
+                        raise IntegrityError(
+                            "Refusing to clear access_blob on a standalone entity "
+                            "(no node_id): it would leave the entity without access "
+                            "control. Provide an AccessBlob or set node_id.",
+                            {},
+                            None,
+                        )
                     await conn.execute(
                         delete(_entity_access_blobs).where(
                             _entity_access_blobs.c.entity_id == id

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -496,7 +496,14 @@ async def construct_resource(
         else:
             attributes["metadata"] = entry.metadata()
     if schemas.EntryFields.access_blob in fields and hasattr(entry, "access_blob"):
-        attributes["access_blob"] = entry.access_blob
+        if entry.access_blob is None:
+            attributes["access_blob"] = {}
+        elif entry.access_blob.username is not None:
+            attributes["access_blob"] = {"user": entry.access_blob.username}
+        elif entry.access_blob.tags is not None:
+            attributes["access_blob"] = {"tags": entry.access_blob.tags}
+        else:
+            attributes["access_blob"] = {}
     if schemas.EntryFields.specs in fields:
         attributes["specs"] = []
         for spec in getattr(entry, "specs", []):

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -490,7 +490,14 @@ async def construct_resource(
         else:
             attributes["metadata"] = entry.metadata()
     if schemas.EntryFields.access_blob in fields and hasattr(entry, "access_blob"):
-        attributes["access_blob"] = entry.access_blob
+        if entry.access_blob is None:
+            attributes["access_blob"] = {}
+        elif entry.access_blob.username is not None:
+            attributes["access_blob"] = {"user": entry.access_blob.username}
+        elif entry.access_blob.tags is not None:
+            attributes["access_blob"] = {"tags": entry.access_blob.tags}
+        else:
+            attributes["access_blob"] = {}
     if schemas.EntryFields.specs in fields:
         attributes["specs"] = []
         for spec in getattr(entry, "specs", []):

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -128,11 +128,18 @@ ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 def _access_blob_from_payload(access_blob):
     if access_blob == {}:
         return None
-    if "user" in access_blob:
+    if "user" in access_blob and set(access_blob) == {"user"}:
         return AccessBlob(username=access_blob["user"])
-    if "tags" in access_blob:
+    if "tags" in access_blob and set(access_blob) == {"tags"}:
         return AccessBlob(tags=access_blob["tags"])
-    return AccessBlob(tags=[])
+    raise HTTPException(
+        status_code=HTTP_400_BAD_REQUEST,
+        detail=(
+            'access_blob must be either {"user": <username>} or '
+            '{"tags": [<tag>, ...]}. '
+            f"Received {access_blob!r}"
+        ),
+    )
 
 
 def _access_blob_to_payload(access_blob):
@@ -2426,8 +2433,11 @@ def get_router(
             entry_access_blob_copy = deepcopy(
                 _access_blob_to_payload(entry.access_blob)
             )
+            # Per RFC 7386, merging a non-object patch REPLACES the target, so
+            # the no-op default for an omitted access_blob must be {} (merge
+            # with an empty object leaves the target unchanged), never [].
             access_blob = _access_blob_from_payload(
-                apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
+                apply_merge_patch(entry_access_blob_copy, (body.access_blob or {}))
             )
         else:
             raise HTTPException(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -126,7 +126,7 @@ ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 
 
 def _access_blob_from_payload(access_blob):
-    if access_blob is None:
+    if access_blob == {}:
         return None
     if "user" in access_blob:
         return AccessBlob(username=access_blob["user"])
@@ -2423,7 +2423,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            entry_access_blob_copy = deepcopy(
+                _access_blob_to_payload(entry.access_blob)
+            )
             access_blob = _access_blob_from_payload(
                 apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
@@ -2466,7 +2468,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2546,7 +2550,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -52,8 +52,14 @@ from ..links import links_for_node
 from ..ndslice import NDBlock, NDSlice
 from ..stream_messages import ArrayPatch
 from ..structures.core import Spec, StructureFamily
-from ..type_aliases import AccessTags, Scopes
-from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
+from ..type_aliases import AccessBlob, AccessTags, Scopes
+from ..utils import (
+    BrokenLink,
+    access_blob_matches,
+    ensure_awaitable,
+    patch_mimetypes,
+    path_from_uri,
+)
 from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from .authentication import (
@@ -106,6 +112,26 @@ from .utils import (
 )
 
 T = TypeVar("T")
+
+
+def _access_blob_from_payload(access_blob):
+    if access_blob is None:
+        return None
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    if "tags" in access_blob:
+        return AccessBlob(tags=access_blob["tags"])
+    return AccessBlob(tags=[])
+
+
+def _access_blob_to_payload(access_blob):
+    if access_blob is None:
+        return {}
+    if access_blob.username is not None:
+        return {"user": access_blob.username}
+    if access_blob.tags is not None:
+        return {"tags": access_blob.tags}
+    return {}
 
 
 def _patch_route_signature(
@@ -1863,7 +1889,7 @@ def get_router(
             body.metadata,
             body.structure_family,
             body.specs,
-            body.access_blob,
+            _access_blob_from_payload(body.access_blob),
         )
         if structure_family == StructureFamily.container:
             structure = None
@@ -1890,7 +1916,10 @@ def get_router(
                     access_blob_modified,
                     access_blob,
                 ) = await request.app.state.access_policy.init_node(
-                    principal, authn_access_tags, authn_scopes, access_blob=access_blob
+                    principal,
+                    authn_access_tags,
+                    authn_scopes,
+                    access_blob=access_blob,
                 )
             except ValueError as e:
                 raise HTTPException(
@@ -1898,8 +1927,8 @@ def get_router(
                     detail=f"Access policy rejects the provided access blob.\n{e}",
                 )
         else:
-            access_blob_modified = access_blob != {}
-            access_blob = {}
+            access_blob_modified = access_blob is not None
+            access_blob = AccessBlob(tags=[])
 
         node = await entry.create_node(
             metadata=body.metadata,
@@ -1920,7 +1949,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
 
         return json_or_msgpack(request, response_data)
 
@@ -2344,7 +2373,11 @@ def get_router(
         if body.content_type == patch_mimetypes.JSON_PATCH:
             metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
             specs = apply_json_patch((entry.specs or []), (body.specs or []))
-            access_blob = apply_json_patch(entry.access_blob, (body.access_blob or []))
+            access_blob = _access_blob_from_payload(
+                apply_json_patch(
+                    _access_blob_to_payload(entry.access_blob), (body.access_blob or [])
+                )
+            )
         elif body.content_type == patch_mimetypes.MERGE_PATCH:
             metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
             # body.specs = [] clears specs, as per json merge patch specification
@@ -2357,9 +2390,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(entry.access_blob)
-            access_blob = apply_merge_patch(
-                entry_access_blob_copy, (body.access_blob or [])
+            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            access_blob = _access_blob_from_payload(
+                apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
         else:
             raise HTTPException(
@@ -2400,7 +2433,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2414,7 +2447,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
@@ -2452,7 +2485,11 @@ def get_router(
         metadata, specs, access_blob = (
             body.metadata if body.metadata is not None else entry.metadata(),
             body.specs if body.specs is not None else entry.specs,
-            body.access_blob if body.access_blob is not None else entry.access_blob,
+            (
+                _access_blob_from_payload(body.access_blob)
+                if body.access_blob is not None
+                else entry.access_blob
+            ),
         )
 
         metadata_modified, metadata = await validate_specs(
@@ -2476,7 +2513,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2490,7 +2527,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.get("/revisions/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -54,8 +54,14 @@ from ..links import links_for_node
 from ..ndslice import NDBlock, NDSlice
 from ..stream_messages import ArrayPatch
 from ..structures.core import Spec, StructureFamily
-from ..type_aliases import AccessTags, Scopes
-from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
+from ..type_aliases import AccessBlob, AccessTags, Scopes
+from ..utils import (
+    BrokenLink,
+    access_blob_matches,
+    ensure_awaitable,
+    patch_mimetypes,
+    path_from_uri,
+)
 from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from ._backcompat import (
@@ -117,6 +123,26 @@ T = TypeVar("T")
 # actually present on disk (a streaming append in progress), the client is told
 # to retry after this many seconds.
 ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
+
+
+def _access_blob_from_payload(access_blob):
+    if access_blob is None:
+        return None
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    if "tags" in access_blob:
+        return AccessBlob(tags=access_blob["tags"])
+    return AccessBlob(tags=[])
+
+
+def _access_blob_to_payload(access_blob):
+    if access_blob is None:
+        return {}
+    if access_blob.username is not None:
+        return {"user": access_blob.username}
+    if access_blob.tags is not None:
+        return {"tags": access_blob.tags}
+    return {}
 
 
 def _patch_route_signature(
@@ -1890,7 +1916,7 @@ def get_router(
             body.metadata,
             body.structure_family,
             body.specs,
-            body.access_blob,
+            _access_blob_from_payload(body.access_blob),
         )
         if structure_family == StructureFamily.container:
             structure = None
@@ -1917,7 +1943,10 @@ def get_router(
                     access_blob_modified,
                     access_blob,
                 ) = await request.app.state.access_policy.init_node(
-                    principal, authn_access_tags, authn_scopes, access_blob=access_blob
+                    principal,
+                    authn_access_tags,
+                    authn_scopes,
+                    access_blob=access_blob,
                 )
             except ValueError as e:
                 raise HTTPException(
@@ -1925,8 +1954,8 @@ def get_router(
                     detail=f"Access policy rejects the provided access blob.\n{e}",
                 )
         else:
-            access_blob_modified = access_blob != {}
-            access_blob = {}
+            access_blob_modified = access_blob is not None
+            access_blob = AccessBlob(tags=[])
 
         node = await entry.create_node(
             metadata=body.metadata,
@@ -1953,7 +1982,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
 
         return json_or_msgpack(request, response_data)
 
@@ -2377,7 +2406,11 @@ def get_router(
         if body.content_type == patch_mimetypes.JSON_PATCH:
             metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
             specs = apply_json_patch((entry.specs or []), (body.specs or []))
-            access_blob = apply_json_patch(entry.access_blob, (body.access_blob or []))
+            access_blob = _access_blob_from_payload(
+                apply_json_patch(
+                    _access_blob_to_payload(entry.access_blob), (body.access_blob or [])
+                )
+            )
         elif body.content_type == patch_mimetypes.MERGE_PATCH:
             metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
             # body.specs = [] clears specs, as per json merge patch specification
@@ -2390,9 +2423,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(entry.access_blob)
-            access_blob = apply_merge_patch(
-                entry_access_blob_copy, (body.access_blob or [])
+            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            access_blob = _access_blob_from_payload(
+                apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
         else:
             raise HTTPException(
@@ -2433,7 +2466,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2447,7 +2480,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
@@ -2485,7 +2518,11 @@ def get_router(
         metadata, specs, access_blob = (
             body.metadata if body.metadata is not None else entry.metadata(),
             body.specs if body.specs is not None else entry.specs,
-            body.access_blob if body.access_blob is not None else entry.access_blob,
+            (
+                _access_blob_from_payload(body.access_blob)
+                if body.access_blob is not None
+                else entry.access_blob
+            ),
         )
 
         metadata_modified, metadata = await validate_specs(
@@ -2509,7 +2546,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2523,7 +2560,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.get("/revisions/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -115,7 +115,7 @@ T = TypeVar("T")
 
 
 def _access_blob_from_payload(access_blob):
-    if access_blob is None:
+    if access_blob == {}:
         return None
     if "user" in access_blob:
         return AccessBlob(username=access_blob["user"])
@@ -2390,7 +2390,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            entry_access_blob_copy = deepcopy(
+                _access_blob_to_payload(entry.access_blob)
+            )
             access_blob = _access_blob_from_payload(
                 apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
@@ -2433,7 +2435,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2513,7 +2517,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -152,7 +152,6 @@ class Revision(pydantic.BaseModel):
     revision_number: int
     metadata: dict
     specs: Specs
-    access_blob: dict
     time_updated: datetime
 
     @classmethod
@@ -163,7 +162,6 @@ class Revision(pydantic.BaseModel):
             revision_number=orm.revision_number,
             metadata=orm.metadata_,
             specs=orm.specs,
-            access_blob=orm.access_blob,
             time_updated=orm.time_updated,
         )
 

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 
 from pydantic import AfterValidator
 
@@ -31,7 +32,13 @@ JSON = Mapping[str, JSON_ITEM]
 Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
-AccessBlob = Mapping[str, Any]
+
+@dataclass(frozen=True)
+class AccessBlob:
+    username: str | None = None
+    tags: list[str] | None = None
+
+
 AccessTags = Set[str]
 Chunks = Tuple[Tuple[int, ...], ...]
 
@@ -52,6 +59,7 @@ EntryPointString = Annotated[
 
 
 __all__ = [
+    "AccessBlob",
     "AppTask",
     "EllipsisType",
     "JSON",

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -33,6 +33,7 @@ Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
 
+
 @dataclass(frozen=True)
 class AccessBlob:
     username: str | None = None

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -511,6 +511,12 @@ def import_object(colon_separated_string, accept_live_object=True):
         )
 
 
+def access_blob_matches(left, right) -> bool:
+    if left is None or right is None:
+        return left is right
+    return (left.username, left.tags) == (right.username, right.tags)
+
+
 def modules_available(*module_names):
     for module_name in module_names:
         if not importlib.util.find_spec(module_name):

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -476,6 +476,12 @@ def import_object(colon_separated_string, accept_live_object=True):
         )
 
 
+def access_blob_matches(left, right) -> bool:
+    if left is None or right is None:
+        return left is right
+    return (left.username, left.tags) == (right.username, right.tags)
+
+
 def modules_available(*module_names):
     for module_name in module_names:
         if not importlib.util.find_spec(module_name):


### PR DESCRIPTION
This is WIP, an an intermediate step towards moving towards a streamlined AccessTags table.

This adds an `AccessBlob` dataclass and uses it throughout, rather than just a dict with specific keys.

This is the first in a series of stacked PRs.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
