### PR TITLE
Widen assets.size to BIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
   from metadata responses when the request comes from a `python-tiled` client older than
   v0.2.13, whose `Asset` dataclass has no `size` field and would otherwise crash
   in `DataSource.from_json` with an unexpected keyword argument.
+- Widen `assets.size` from `INTEGER` (int32) to `BIGINT` (int64) so the
+  server can register single files larger than ~2.1 GB without an
+  `int32 out of range` error from PostgreSQL. Includes an alembic
+  migration; SQLite is unaffected (its `INTEGER` affinity already stores
+  64-bit values).
 
 
 ## v0.2.13 (2026-07-08)

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "9bc9b57294b9",
     "b93c79d197f4",
     "e8956581ecd5",
     "bf2fe0eb8ee8",

--- a/tiled/catalog/migrations/versions/9bc9b57294b9_widen_assets_size_to_biginteger.py
+++ b/tiled/catalog/migrations/versions/9bc9b57294b9_widen_assets_size_to_biginteger.py
@@ -6,9 +6,8 @@ Create Date: 2026-07-09 14:32:49.251181
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "9bc9b57294b9"

--- a/tiled/catalog/migrations/versions/9bc9b57294b9_widen_assets_size_to_biginteger.py
+++ b/tiled/catalog/migrations/versions/9bc9b57294b9_widen_assets_size_to_biginteger.py
@@ -1,0 +1,42 @@
+"""Widen assets.size to BigInteger
+
+Revision ID: 9bc9b57294b9
+Revises: b93c79d197f4
+Create Date: 2026-07-09 14:32:49.251181
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9bc9b57294b9"
+down_revision = "b93c79d197f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "postgresql":
+        op.alter_column(
+            "assets",
+            "size",
+            existing_type=sa.Integer(),
+            type_=sa.BigInteger(),
+            existing_nullable=True,
+        )
+    # SQLite: INTEGER affinity already stores 64-bit values, no schema change needed.
+
+
+def downgrade():
+    connection = op.get_bind()
+    if connection.engine.dialect.name == "postgresql":
+        op.alter_column(
+            "assets",
+            "size",
+            existing_type=sa.BigInteger(),
+            type_=sa.Integer(),
+            existing_nullable=True,
+        )

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -2,6 +2,7 @@ from typing import List
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -534,7 +535,7 @@ class Asset(Timestamped, Base):
     is_directory = Column(Boolean, nullable=False)
     hash_type = Column(Unicode(63), nullable=True)
     hash_content = Column(Unicode(1023), nullable=True)
-    size = Column(Integer, nullable=True)
+    size = Column(BigInteger, nullable=True)
 
     # # many-to-many relationship to Asset, bypassing the `Association` class
     data_sources: Mapped[List["DataSource"]] = relationship(


### PR DESCRIPTION
The `assets.size` column was defined as `Integer` (int32), so registering a single file larger than ~2.1 GB failed on PostgreSQL with `value out of int32 range` during INSERT. Change the ORM column to `BigInteger` and add an alembic migration that runs `ALTER TABLE assets ALTER COLUMN size TYPE BIGINT` on PostgreSQL.

SQLite is unaffected because its `INTEGER` affinity already stores 64-bit values.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
