### PR TITLE
Add ARM64 support and `ragged` dependency to `pixi.toml`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Dan Allan <dallan@bnl.gov>"]
 channels = ["conda-forge"]
 name = "tiled"
-platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64", "osx-64", "win-64"]
 version = "0.2.2"
 
 [tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ numpy = "*"
 
 [feature.awkward.dependencies]
 awkward = ">=2.4.3"
+ragged = "*"
 
 [feature.client.dependencies]
 entrypoints = "*"


### PR DESCRIPTION
```
❯ pixi info --json | jq .platform
"linux-aarch64"
❯ pixi install --all
✔ The following environments have been installed: default, all, client, dev, server, py310, py311, py312, py313.
```