### PR TITLE
Updating alembic migration scripts to align with linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ Write the date in place of the "Unreleased" in the case a new version is release
   The spinner is animated in Jupyter notebooks as well as TTY terminals.
 - Respect the `Retry-After` header on HTTP 429 (Too Many Requests) responses.
 
-### Fixed
-
-- Modified the alembic templates to generate code consistent with the linter.
-
 
 ## v0.2.11 (2026-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
   The spinner is animated in Jupyter notebooks as well as TTY terminals.
 - Respect the `Retry-After` header on HTTP 429 (Too Many Requests) responses.
 
+### Fixed
+
+- Modified the alembic templates to generate code consistent with the linter.
+
 
 ## v0.2.11 (2026-05-27)
 

--- a/tiled/authn_database/migrations/script.py.mako
+++ b/tiled/authn_database/migrations/script.py.mako
@@ -5,15 +5,14 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from alembic import op
-import sqlalchemy as sa
+import sqlalchemy as sa  # noqa
+from alembic import op  # noqa
 ${imports if imports else ""}
-
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+revision = ${repr(up_revision).replace("'", '"')}
+down_revision = ${repr(down_revision).replace("'", '"')}
+branch_labels = ${repr(branch_labels).replace("'", '"')}
+depends_on = ${repr(depends_on).replace("'", '"')}
 
 
 def upgrade():

--- a/tiled/authn_database/migrations/script.py.mako
+++ b/tiled/authn_database/migrations/script.py.mako
@@ -9,10 +9,26 @@ import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 ${imports if imports else ""}
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision).replace("'", '"')}
-down_revision = ${repr(down_revision).replace("'", '"')}
-branch_labels = ${repr(branch_labels).replace("'", '"')}
-depends_on = ${repr(depends_on).replace("'", '"')}
+% if isinstance(up_revision, str):
+revision = ${'"' + up_revision + '"'}
+% else:
+revision = ${repr(up_revision)}
+% endif
+% if isinstance(down_revision, str):
+down_revision = ${'"' + down_revision + '"'}
+% else:
+down_revision = ${repr(down_revision)}
+% endif
+% if isinstance(branch_labels, str):
+branch_labels = ${'"' + branch_labels + '"'}
+% else:
+branch_labels = ${repr(branch_labels)}
+% endif
+% if isinstance(depends_on, str):
+branch_labels = ${'"' + depends_on + '"'}
+% else:
+depends_on = ${repr(depends_on)}
+% endif
 
 
 def upgrade():

--- a/tiled/catalog/migrations/script.py.mako
+++ b/tiled/catalog/migrations/script.py.mako
@@ -5,15 +5,14 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from alembic import op
-import sqlalchemy as sa
+import sqlalchemy as sa  # noqa
+from alembic import op  # noqa
 ${imports if imports else ""}
-
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+revision = ${repr(up_revision).replace("'", '"')}
+down_revision = ${repr(down_revision).replace("'", '"')}
+branch_labels = ${repr(branch_labels).replace("'", '"')}
+depends_on = ${repr(depends_on).replace("'", '"')}
 
 
 def upgrade():

--- a/tiled/catalog/migrations/script.py.mako
+++ b/tiled/catalog/migrations/script.py.mako
@@ -9,10 +9,26 @@ import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 ${imports if imports else ""}
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision).replace("'", '"')}
-down_revision = ${repr(down_revision).replace("'", '"')}
-branch_labels = ${repr(branch_labels).replace("'", '"')}
-depends_on = ${repr(depends_on).replace("'", '"')}
+% if isinstance(up_revision, str):
+revision = ${'"' + up_revision + '"'}
+% else:
+revision = ${repr(up_revision)}
+% endif
+% if isinstance(down_revision, str):
+down_revision = ${'"' + down_revision + '"'}
+% else:
+down_revision = ${repr(down_revision)}
+% endif
+% if isinstance(branch_labels, str):
+branch_labels = ${'"' + branch_labels + '"'}
+% else:
+branch_labels = ${repr(branch_labels)}
+% endif
+% if isinstance(depends_on, str):
+branch_labels = ${'"' + depends_on + '"'}
+% else:
+depends_on = ${repr(depends_on)}
+% endif
 
 
 def upgrade():


### PR DESCRIPTION
Updating the alembic migration scripts for catalog and authn_database to follow the format of the pre-commit linter. This involves modifying the imports and quotation marks used. This PR addresses issue [#1227](https://github.com/bluesky/tiled/issues/1227).

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
