### PR TITLE
Fix device code auth 

### DIFF
--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -13,7 +13,7 @@ from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context
 from tiled.client.auth import TiledAuth
 from tiled.client.constructors import from_context
-from tiled.client.context import prompt_for_credentials
+from tiled.client.context import device_code_grant, prompt_for_credentials
 from tiled.server.app import build_app_from_config
 
 tree = MapAdapter({})
@@ -371,3 +371,142 @@ def test_logout(
         ).mock(return_value=httpx.Response(status_code=httpx.codes.OK))
 
         client.logout()
+
+
+@pytest.fixture
+def tiled_mediated_urls(base_url: str) -> Dict[str, str]:
+    return {
+        # Tiled server endpoint the client POSTs to in order to *start* the flow.
+        "auth_endpoint": f"{base_url}api/v1/auth/provider/keycloak_oidc/authorize",
+        # Third-party provider login page the *user* visits in a browser.
+        "authorization_uri": (
+            f"{base_url}protocol/openid-connect/auth"
+            "?client_id=tiled&response_type=code&scope=openid"
+            f"&redirect_uri={base_url}api/v1/auth/provider/keycloak_oidc/device_code"
+        ),
+        # Tiled's own /token endpoint the *client* polls for tokens.
+        "verification_uri": f"{base_url}api/v1/auth/provider/keycloak_oidc/token",
+    }
+
+
+@pytest.fixture
+def mock_tiled_mediated_server(
+    respx_mock: MockRouter,
+    tiled_mediated_urls: Dict[str, str],
+    tokens_response: Dict[str, Union[str, int]],
+) -> MockRouter:
+    """Mock the two Tiled server endpoints used by the "else" branch of
+    device_code_grant used by ExternalAuthenticator providers such as
+    OIDCAuthenticator, SAMLAuthenticator, ORCID, and Globus.
+
+    In this branch, the *server* returns a payload with two URLs:
+       - "authorization_uri": the third-party provider login page that the USER
+         opens in a browser
+       - "verification_uri": Tiled's own /token endpoint that the CLIENT polls
+         (POSTing the device_code) to obtain tokens
+    """
+    device_code = "FsYWEv-Fl4wkFlrtp-EWH7HR1pkCG2NIfBNeUKlZBAY"
+    user_code = "LCWE-ROXW"
+
+    # 1. POST to Tiled's /authorize starts the flow and returns the two URIs.
+    respx_mock.post(tiled_mediated_urls["auth_endpoint"], name="authorize").mock(
+        return_value=httpx.Response(
+            status_code=httpx.codes.OK,
+            json={
+                "authorization_uri": tiled_mediated_urls["authorization_uri"],
+                "verification_uri": tiled_mediated_urls["verification_uri"],
+                "interval": 5,
+                "device_code": device_code,
+                "expires_in": 600,
+                "user_code": user_code,
+            },
+        )
+    )
+
+    # 2. POST to Tiled's /token endpoint (the client polls this) returns tokens.
+    respx_mock.post(tiled_mediated_urls["verification_uri"], name="token_polling").mock(
+        return_value=httpx.Response(
+            status_code=httpx.codes.OK,
+            json=tokens_response,
+        )
+    )
+    return respx_mock
+
+
+@patch("tiled.client.context.time.sleep")
+def test_tiled_mediated_device_flow_browser_and_polling_urls(
+    _sleep: MagicMock,
+    mock_tiled_mediated_server: MockRouter,
+    tiled_mediated_urls: Dict[str, str],
+    tokens_response: Dict[str, Union[str, int]],
+    capsys,
+):
+    """In the Tiled-mediated (non-oauth2_spec) device flow, the
+    browser must be opened with the provider's ``authorization_uri`` and the
+    client must poll Tiled's ``verification_uri`` (the /token endpoint).
+    """
+    with patch("webbrowser.open", return_value=False) as mock_open:
+        tokens = device_code_grant(
+            httpx.Client(),
+            auth_endpoint=tiled_mediated_urls["auth_endpoint"],
+            client_id=None,  # forces the Tiled-mediated "else" branch
+            token_endpoint=None,  # forces the Tiled-mediated "else" branch
+        )
+
+    assert tokens == tokens_response
+
+    # The browser is opened with the third-party provider's authorization_uri,
+    # NOT with Tiled's /token endpoint.
+    mock_open.assert_called_once_with(tiled_mediated_urls["authorization_uri"])
+
+    # The URL printed for the user to visit is the authorization_uri.
+    out, _err = capsys.readouterr()
+    assert tiled_mediated_urls["authorization_uri"] in out
+    assert tiled_mediated_urls["verification_uri"] not in out
+
+    # The client polled Tiled's /token endpoint (verification_uri), and did NOT
+    # POST to the provider's authorization page.
+    token_polling_route = mock_tiled_mediated_server["token_polling"]
+    assert token_polling_route.called
+    assert token_polling_route.call_count == 1
+
+    # Sanity check: the polling request carried the device_code as JSON.
+    polled_request = token_polling_route.calls.last.request
+    assert b"device_code" in polled_request.content
+
+
+@patch("tiled.client.context.time.sleep")
+def test_tiled_mediated_device_flow_polling_pending(
+    _sleep: MagicMock,
+    mock_tiled_mediated_server: MockRouter,
+    tiled_mediated_urls: Dict[str, str],
+    tokens_response: Dict[str, Union[str, int]],
+):
+    """The client should keep polling Tiled's /token endpoint while it returns
+    ``authorization_pending`` and succeed once tokens are returned.
+
+    Tiled's /token endpoint nests the error under ``detail`` (unlike the
+    oauth2-spec branch), so the client reads ``response.json()["detail"]["error"]``.
+    """
+    token_polling_route = mock_tiled_mediated_server["token_polling"]
+    token_polling_route.return_value = None
+    token_polling_route.side_effect = [
+        httpx.Response(
+            status_code=httpx.codes.BAD_REQUEST,
+            json={"detail": {"error": "authorization_pending"}},
+        ),
+        httpx.Response(status_code=httpx.codes.OK, json=tokens_response),
+    ]
+
+    stamina.set_testing(testing=True, attempts=1)
+
+    with patch("webbrowser.open", return_value=False):
+        tokens = device_code_grant(
+            httpx.Client(),
+            auth_endpoint=tiled_mediated_urls["auth_endpoint"],
+            client_id=None,
+            token_endpoint=None,
+        )
+
+    assert tokens == tokens_response
+    assert token_polling_route.call_count == 2

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -1405,8 +1405,8 @@ def device_code_grant(
                 verification_response = http_client.post(auth_endpoint)
                 handle_error(verification_response)
                 verification = verification_response.json()
-                token_endpoint = verification["authorization_uri"]
-                verification_uri = verification["verification_uri"]
+                token_endpoint = verification["verification_uri"]
+                verification_uri = verification["authorization_uri"]
     print(
         f"""
 You have {int(verification['expires_in']) // 60} minutes to visit this URL


### PR DESCRIPTION
When I try to use OIDCAuthenticator to authenticate a device (the Tiled python client) with Keycloak I get what looks like a malformed URI:

api/v1/auth/provider/keycloak_oidc/token

This is a broken URI brings me to a page that says "method not allowed" or similar. Per the docs, the redirect URI should end in `code` or `device_code`.

I think I found the issue in `tiled.client.context:device_code_grant` 

```python
            else:
                # The device code will be given to Tiled's own implementation
                # of device code flow. Tiled will do authorization code from with the
                # external providers. (This handles cases that ORCID and Globus that do
                # not support device code flow.)
                oauth2_spec = False
                verification_response = http_client.post(auth_endpoint)
                handle_error(verification_response)
                verification = verification_response.json()
                token_endpoint = verification["authorization_uri"]
                verification_uri = verification["verification_uri"]
```

Here I think the authorization_uri and verification_uri are mistakenly swapped. When I swap the token_endpoint and verification_endpoint as in the PR, the device flow is able to contact Keycloak and initiate device auth.

verification_uri and authorization_uri (tiled and 3rd party auth endpoints respectively) are reversed, breaking the device code workflow. Results in no contact with the auth provider and an HTML yield to the downstream client which breaks its JSON decoder.