### PR TITLE
retries for alembic migration for authn on startup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
   a sub-path (the `trees:` config form).
 - Skip the `array-ref` streaming-cache update in `put_data_source` when the
   data source is not an array.
+- Retry (with jitter) the automatic `database.init_if_not_exists` schema
+  initialization on startup instead of crashing when multiple server
+  processes/replicas start concurrently against the same brand-new database
+  and race to create tables/stamp the alembic revision.
 - Strengthen the server-side backcompatibility. Strip the newly added `Asset.size` field
   from metadata responses when the request comes from a `python-tiled` client older than
   v0.2.13, whose `Asset` dataclass has no `size` field and would otherwise crash

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -692,7 +692,7 @@ def build_app(
                     await check_database(engine, REQUIRED_REVISION, ALL_REVISIONS)
                 except UninitializedDatabase:
                     if settings.database_init_if_not_exists:
-                        # The alembic stamping can only be does synchronously.
+                        # The alembic stamping can only be done synchronously.
                         # The cleanest option available is to start a subprocess
                         # because SQLite is allergic to threads.
                         await _ensure_authn_database_initialized(engine)

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -116,6 +116,50 @@ def custom_openapi(app):
     return app.openapi_schema
 
 
+async def _ensure_authn_database_initialized(engine) -> None:
+    """
+    Create tables and stamp the alembic revision, via `tiled admin initialize-database`.
+
+    Multiple processes may call this concurrently against the same brand-new
+    database (e.g. several replicas starting up at once). Only one wins the
+    race; retry, re-checking in case another process has since finished,
+    rather than crashing.
+    """
+    import subprocess
+
+    import stamina
+
+    from ..alembic_utils import UninitializedDatabase, check_database
+    from ..authn_database.core import ALL_REVISIONS, REQUIRED_REVISION
+
+    async for attempt in stamina.retry_context(
+        on=(subprocess.CalledProcessError, UninitializedDatabase),
+        attempts=5,
+        wait_initial=0.5,
+        wait_max=2.0,
+        wait_jitter=0.5,
+        timeout=None,
+    ):
+        with attempt:
+            try:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "tiled",
+                        "admin",
+                        "initialize-database",
+                        str(engine.url),
+                    ],
+                    capture_output=True,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                # Another process may have already won the race and
+                # initialized the database.
+                await check_database(engine, REQUIRED_REVISION, ALL_REVISIONS)
+
+
 def build_app(
     tree,
     authentication: Optional[Authentication] = None,
@@ -651,21 +695,7 @@ def build_app(
                         # The alembic stamping can only be does synchronously.
                         # The cleanest option available is to start a subprocess
                         # because SQLite is allergic to threads.
-                        import subprocess
-
-                        # TODO Check if catalog exists.
-                        subprocess.run(
-                            [
-                                sys.executable,
-                                "-m",
-                                "tiled",
-                                "admin",
-                                "initialize-database",
-                                str(engine.url),
-                            ],
-                            capture_output=True,
-                            check=True,
-                        )
+                        await _ensure_authn_database_initialized(engine)
                     else:
                         print(
                             dedent(


### PR DESCRIPTION
added this retry code to startup to try and try again if we have many replicas on startup. this should mitigate having to bootstrap a cluster manually with 1 replica on, then spinning up more.

not sure if the code is in the right place. tried conforming to lazy imports, but moved function outside of deeply nested app startup code. since that is tough to read.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
