### PR TITLE
Fix Webhook Endpoints with Catallog Trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix the webhook `history` and `delete` endpoints when a catalog is mounted under
+  a sub-path (the `trees:` config form).
 - Skip the `array-ref` streaming-cache update in `put_data_source` when the
   data source is not an array.
 - Strengthen the server-side backcompatibility. Strip the newly added `Asset.size` field
@@ -18,6 +20,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
   `int32 out of range` error from PostgreSQL. Includes an alembic
   migration; SQLite is unaffected (its `INTEGER` affinity already stores
   64-bit values).
+
 
 
 ## v0.2.13 (2026-07-08)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -637,9 +637,7 @@ def test_history_and_delete_on_sub_path_mounted_catalog(
 
                 http.delete(f"/api/v1/webhooks/{webhook.id}").raise_for_status()
                 assert (
-                    http.get(
-                        f"/api/v1/webhooks/history/{webhook.id}"
-                    ).status_code
+                    http.get(f"/api/v1/webhooks/history/{webhook.id}").status_code
                     == 404
                 )
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -26,7 +26,7 @@ from tiled.client import Context, from_context
 from tiled.client.container import Container
 from tiled.client.context import password_grant
 from tiled.config import Authentication, WebhooksConfig
-from tiled.server.app import build_app
+from tiled.server.app import build_app, build_app_from_config
 from tiled.server.schemas import (
     DeliveryResponse,
     EventType,
@@ -600,6 +600,48 @@ class TestWebhookIntegration:
         """Non-admin user must get 401 for all webhook endpoints."""
         resp = getattr(bob_http, method)(path, **kwargs)
         assert resp.status_code == 401
+
+
+def test_history_and_delete_on_sub_path_mounted_catalog(
+    sqlite_or_postgres_uri: str, tmpdir: Any
+) -> None:
+    "Webhook history and delete work when the catalog is mounted at a sub-path."
+    config = {
+        "trees": [
+            {
+                "path": "/sub",
+                "tree": "catalog",
+                "args": {
+                    "uri": sqlite_or_postgres_uri,
+                    "init_if_not_exists": True,
+                    "writable_storage": [tmpdir / "data"],
+                },
+            }
+        ],
+        "authentication": {"single_user_api_key": "secret"},
+        "webhooks": {"secret_keys": ["test-webhook-key"]},
+    }
+    with patch("tiled.server.webhook_router.check_url_ssrf_safety"):
+        with Context.from_app(build_app_from_config(config)) as context:
+            http = context.http_client
+            with respx.mock:
+                received = _capturing_mock()
+                webhook = _register_webhook(http, path="sub")
+                from_context(context)["sub"].create_container("x")
+                assert len(received) == 1
+
+                history = http.get(
+                    f"/api/v1/webhooks/history/{webhook.id}"
+                ).raise_for_status()
+                assert history.json()[0]["webhook_id"] == webhook.id
+
+                http.delete(f"/api/v1/webhooks/{webhook.id}").raise_for_status()
+                assert (
+                    http.get(
+                        f"/api/v1/webhooks/history/{webhook.id}"
+                    ).status_code
+                    == 404
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tiled/server/webhook_router.py
+++ b/tiled/server/webhook_router.py
@@ -131,6 +131,52 @@ async def _node_path_from_id(ctx, node_id: int) -> str:
     return "/".join(keys)
 
 
+def _iter_catalog_contexts(tree, prefix: tuple = ()):
+    """Yield ``(mount_prefix, catalog_context)`` pairs reachable from ``tree``.
+
+    A catalog-backed adapter exposes a ``context`` attribute.  When catalogs are
+    mounted under sub-paths (the ``trees:`` config form), the root is a
+    ``MapAdapter`` whose children are the mounted trees; descend into it to find
+    each catalog and remember the path prefix it is mounted at.
+    """
+    context = getattr(tree, "context", None)
+    if context is not None:
+        yield prefix, context
+        return
+    mapping = getattr(tree, "_mapping", None)
+    if mapping:
+        for key, child in mapping.items():
+            yield from _iter_catalog_contexts(child, prefix + (key,))
+
+
+async def _resolve_webhook_context(root_tree, webhook_id: int):
+    """Locate the catalog context owning ``webhook_id`` and load the webhook.
+
+    Returns ``(mount_prefix, context, webhook)``.  Searches every catalog
+    reachable from the root so that both root-mounted and sub-path-mounted
+    catalogs are supported.  Raises 404 if no catalog exists or the webhook is
+    not found in any of them.
+    """
+    contexts = list(_iter_catalog_contexts(root_tree))
+    if not contexts:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail="Webhooks are only supported on catalog-backed trees.",
+        )
+    for prefix, ctx in contexts:
+        async with ctx.session() as db:
+            wh = await db.get(orm.Webhook, webhook_id)
+            if wh is not None:
+                return prefix, ctx, wh
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Webhook not found.")
+
+
+def _global_node_path(prefix: tuple, local_path: str) -> str:
+    """Join a catalog's mount prefix with a node path local to that catalog."""
+    local_segments = local_path.split("/") if local_path else []
+    return "/".join([*prefix, *local_segments])
+
+
 def get_webhook_router(
     webhook_settings: WebhooksConfig,
     webhook_url_validator: UrlValidator | None = None,
@@ -253,34 +299,32 @@ def get_webhook_router(
         session_state: dict = Depends(get_session_state),
         _=Security(check_scopes, scopes=["write:webhooks"]),
     ):
-        root_ctx = _get_catalog_context(root_tree)
+        # Locate the catalog that owns this webhook (supports catalogs mounted
+        # at the root or under sub-paths).
+        prefix, ctx, wh = await _resolve_webhook_context(root_tree, webhook_id)
+        node_id = wh.node_id
 
-        # Load webhook, verify caller access, and delete
-        async with root_ctx.session() as db:
+        # Verify the caller has write:webhooks access to the webhook's node.
+        local_path = await _node_path_from_id(ctx, node_id)
+        node_path = _global_node_path(prefix, local_path)
+        await get_entry(
+            path=node_path,
+            security_scopes=["write:webhooks"],
+            principal=principal,
+            authn_access_tags=authn_access_tags,
+            authn_scopes=authn_scopes,
+            root_tree=root_tree,
+            session_state=session_state,
+            metrics=request.state.metrics,
+            structure_families=None,
+            access_policy=getattr(request.app.state, "access_policy", None),
+        )
+
+        async with ctx.session() as db:
             wh = await db.get(orm.Webhook, webhook_id)
-            if wh is None:
-                raise HTTPException(
-                    status_code=HTTP_404_NOT_FOUND, detail="Webhook not found."
-                )
-            node_id = wh.node_id
-
-            # Verify the caller has write:metadata access to the webhook's node.
-            node_path = await _node_path_from_id(root_ctx, node_id)
-            await get_entry(
-                path=node_path,
-                security_scopes=["write:webhooks"],
-                principal=principal,
-                authn_access_tags=authn_access_tags,
-                authn_scopes=authn_scopes,
-                root_tree=root_tree,
-                session_state=session_state,
-                metrics=request.state.metrics,
-                structure_families=None,
-                access_policy=getattr(request.app.state, "access_policy", None),
-            )
-
-            await db.delete(wh)
-            await db.commit()
+            if wh is not None:
+                await db.delete(wh)
+                await db.commit()
 
         return {"deleted": webhook_id}
 
@@ -300,19 +344,14 @@ def get_webhook_router(
         session_state: dict = Depends(get_session_state),
         _=Security(check_scopes, scopes=["read:webhooks"]),
     ):
-        root_ctx = _get_catalog_context(root_tree)
+        # Locate the catalog that owns this webhook (supports catalogs mounted
+        # at the root or under sub-paths).
+        prefix, ctx, wh = await _resolve_webhook_context(root_tree, webhook_id)
+        node_id = wh.node_id
 
-        # Load the webhook to find which node it belongs to.
-        async with root_ctx.session() as db:
-            wh = await db.get(orm.Webhook, webhook_id)
-            if wh is None:
-                raise HTTPException(
-                    status_code=HTTP_404_NOT_FOUND, detail="Webhook not found."
-                )
-            node_id = wh.node_id
-
-        # Verify the caller has read:metadata access to the webhook's node.
-        node_path = await _node_path_from_id(root_ctx, node_id)
+        # Verify the caller has read:webhooks access to the webhook's node.
+        local_path = await _node_path_from_id(ctx, node_id)
+        node_path = _global_node_path(prefix, local_path)
         await get_entry(
             path=node_path,
             security_scopes=["read:webhooks"],
@@ -326,7 +365,7 @@ def get_webhook_router(
             access_policy=getattr(request.app.state, "access_policy", None),
         )
 
-        async with root_ctx.session() as db:
+        async with ctx.session() as db:
             result = await db.execute(
                 select(orm.WebhookDelivery)
                 .where(orm.WebhookDelivery.webhook_id == webhook_id)


### PR DESCRIPTION
Fixes the webhook `history` and `delete `endpoints when a catalog is mounted under a sub-path (the `trees:` config form). The root tree is then a `MapAdapter` with no catalog context, so these endpoints previously returned a 404 ("Webhooks are only supported on catalog-backed trees.") instead of resolving the owning catalog. Registration and listing were unaffected.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
