### PR TITLE
Fix Bytes Export Compression Truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix truncation of `blosc2`-encoded downloads at exactly 65536 bytes. Streaming
+  responses (e.g. `raw_export` of a `bytes` node via `/asset/bytes`) are emitted
+  in 64 KiB chunks, and the server compresses each chunk into an independent
+  blosc2 frame. The client `Blosc2Decoder` decoded only the first frame; it now
+  walks every concatenated frame and reassembles the full payload.
 - Fix the webhook `history` and `delete` endpoints when a catalog is mounted under
   a sub-path (the `trees:` config form).
 - Skip the `array-ref` streaming-cache update in `put_data_source` when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix the `raw_export` download progress bar, which showed a wrong total (e.g.
+  `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar
+  now seeds each task's total from the known asset size, and raw-asset downloads
+  no longer negotiate `blosc2` (whose client decoder buffers the whole response
+  in memory and emits it only at the end, freezing the bar and spiking memory).
+  Downloads instead stream via `zstd`/`gzip`; pass `compression=False` to
+  `raw_export` to download uncompressed (`Accept-Encoding: identity`).
 - Fix truncation of `blosc2`-encoded downloads at exactly 65536 bytes. Streaming
   responses (e.g. `raw_export` of a `bytes` node via `/asset/bytes`) are emitted
   in 64 KiB chunks, and the server compresses each chunk into an independent

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -6,16 +6,19 @@ asset through `/asset/bytes/{path}?id=N`, gated by `settings.expose_raw_assets`.
 These tests exercise that full round-trip end-to-end.
 """
 
+import os
 import warnings
 from pathlib import Path
+from unittest import mock
 
 import pytest
+from rich.progress import Progress
 
 from tiled.adapters.bytes import BytesAdapter
 from tiled.catalog import in_memory
 from tiled.client import Context, from_context, record_history
 from tiled.client.bytes import BytesClient
-from tiled.client.download import STREAMING_ACCEPT_ENCODING
+from tiled.client.download import STREAMING_ACCEPT_ENCODING, download
 from tiled.server.app import build_app
 from tiled.structures.bytes import BytesStructure
 from tiled.structures.core import StructureFamily
@@ -32,9 +35,17 @@ def http_client(tmpdir):
 
 
 def _register_bytes_node(
-    client, tmp_path, payload, key="blob", mimetype="application/octet-stream"
+    client,
+    tmp_path,
+    payload,
+    key="blob",
+    mimetype="application/octet-stream",
+    size="auto",
 ):
-    """Write `payload` to a file and register it as an external bytes node."""
+    """Write `payload` to a file and register it as an external bytes node.
+
+    `size` defaults to the payload length; pass `None` to register an asset
+    whose size is unknown (mimicking a legacy row)."""
     p = tmp_path / f"{key}.bin"
     p.write_bytes(payload)
     data_source = DataSource(
@@ -43,7 +54,7 @@ def _register_bytes_node(
             Asset(
                 data_uri=p.as_uri(),
                 is_directory=False,
-                size=len(payload),
+                size=len(payload) if size == "auto" else size,
                 parameter="data_uris",
                 num=0,
             )
@@ -446,6 +457,73 @@ def test_raw_export_compression_false_uses_identity(http_client, tmp_path):
     assert request.headers["Accept-Encoding"] == "identity"
     assert response.headers.get("Content-Encoding") in (None, "identity")
     assert int(response.headers["Content-Length"]) == len(payload)
+
+
+def _captured_task_totals(client, key, **export_kwargs):
+    """Run `raw_export` and record the `total` each progress task is seeded
+    with (via `Progress.add_task`)."""
+    totals = []
+    original = Progress.add_task
+
+    def spy(self, description, *args, total=None, **kwargs):
+        totals.append(total)
+        return original(self, description, *args, total=total, **kwargs)
+
+    with mock.patch.object(Progress, "add_task", spy):
+        client[key].raw_export(**export_kwargs)
+    return totals
+
+
+def test_raw_export_seeds_progress_total_from_asset_size(http_client, tmp_path):
+    """The progress task is seeded with the known asset size, so the bar shows
+    the right total even when the server omits `Content-Length` (compressed
+    streaming). When the size is unknown the total is `None` (indeterminate)."""
+    payload = (b"the quick brown fox " * 1024) * 8  # ~160 KiB
+    _register_bytes_node(http_client, tmp_path, payload, key="known")
+    _register_bytes_node(http_client, tmp_path, payload, key="unknown", size=None)
+
+    known_dest = tmp_path / "known_out"
+    known_dest.mkdir()
+    assert _captured_task_totals(http_client, "known", destination=known_dest) == [
+        len(payload)
+    ]
+
+    unknown_dest = tmp_path / "unknown_out"
+    unknown_dest.mkdir()
+    assert _captured_task_totals(http_client, "unknown", destination=unknown_dest) == [
+        None
+    ]
+
+
+@pytest.mark.parametrize("compression", [True, False])
+def test_raw_export_unknown_size_roundtrips(http_client, tmp_path, compression):
+    """A `bytes` node whose asset size is unknown (e.g. a legacy row) exports
+    correctly under both compression modes. With compression the bar is
+    indeterminate (no `Content-Length`); without it, `Content-Length` is present
+    so the bar is determinate."""
+    payload = os.urandom(200 * 1024)  # incompressible so zstd does not shrink it
+    _register_bytes_node(http_client, tmp_path, payload, key="blob", size=None)
+    dest = tmp_path / f"out_{compression}"
+    dest.mkdir()
+    with record_history() as history:
+        paths = http_client["blob"].raw_export(dest, compression=compression)
+    assert Path(paths[0]).read_bytes() == payload
+    _, response = _asset_bytes_exchange(history)
+    if compression:
+        assert "Content-Length" not in response.headers
+    else:
+        assert int(response.headers["Content-Length"]) == len(payload)
+
+
+def test_download_rejects_mismatched_totals(http_client):
+    """`download()` requires `totals` (when given) to be parallel to `urls`."""
+    with pytest.raises(ValueError, match="as many totals as URLs"):
+        download(
+            http_client.context.http_client,
+            ["u1", "u2"],
+            ["t1", "t2"],
+            totals=[1],
+        )
 
 
 def test_raw_export_handles_missing_content_length(http_client, tmp_path):

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -13,8 +13,9 @@ import pytest
 
 from tiled.adapters.bytes import BytesAdapter
 from tiled.catalog import in_memory
-from tiled.client import Context, from_context
+from tiled.client import Context, from_context, record_history
 from tiled.client.bytes import BytesClient
+from tiled.client.download import STREAMING_ACCEPT_ENCODING
 from tiled.server.app import build_app
 from tiled.structures.bytes import BytesStructure
 from tiled.structures.core import StructureFamily
@@ -402,6 +403,52 @@ def test_raw_export_blosc2_streaming_not_truncated(http_client, tmp_path):
     assert response.status_code == 200
     assert response.headers.get("Content-Encoding") == "blosc2"
     assert response.content == payload
+
+
+def _asset_bytes_exchange(history):
+    """Return the (request, response) pair for the `/asset/bytes` download."""
+    for request, response in zip(history.requests, history.responses):
+        if "/asset/bytes/" in str(request.url):
+            return request, response
+    raise AssertionError("no /asset/bytes request was recorded")
+
+
+def test_raw_export_streams_with_compression_but_not_blosc2(http_client, tmp_path):
+    """By default `raw_export` keeps on-the-fly compression but excludes blosc2.
+
+    blosc2's client decoder buffers the whole body (no streaming), so raw-asset
+    downloads advertise every supported encoding *except* blosc2. The server
+    then streams via zstd, which decompresses incrementally.
+    """
+    payload = (b"the quick brown fox " * 1024) * 8  # ~160 KiB, compressible
+    _register_bytes_node(http_client, tmp_path, payload, key="big")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with record_history() as history:
+        paths = http_client["big"].raw_export(dest)
+    assert Path(paths[0]).read_bytes() == payload
+    request, response = _asset_bytes_exchange(history)
+    # blosc2 must not be advertised on the download request...
+    assert request.headers["Accept-Encoding"] == STREAMING_ACCEPT_ENCODING
+    assert "blosc2" not in request.headers["Accept-Encoding"]
+    # ...and the server streams a compressed (zstd) response.
+    assert response.headers.get("Content-Encoding") == "zstd"
+
+
+def test_raw_export_compression_false_uses_identity(http_client, tmp_path):
+    """`compression=False` downloads uncompressed: `Accept-Encoding: identity`,
+    no `Content-Encoding`, and a `Content-Length` (so the bar is determinate)."""
+    payload = (b"the quick brown fox " * 1024) * 8  # ~160 KiB, compressible
+    _register_bytes_node(http_client, tmp_path, payload, key="big")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with record_history() as history:
+        paths = http_client["big"].raw_export(dest, compression=False)
+    assert Path(paths[0]).read_bytes() == payload
+    request, response = _asset_bytes_exchange(history)
+    assert request.headers["Accept-Encoding"] == "identity"
+    assert response.headers.get("Content-Encoding") in (None, "identity")
+    assert int(response.headers["Content-Length"]) == len(payload)
 
 
 def test_raw_export_handles_missing_content_length(http_client, tmp_path):

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -365,14 +365,11 @@ def test_raw_export_destination_directory_kwarg_is_deprecated(http_client, tmp_p
 
 
 def test_raw_export_blosc2_streaming_not_truncated(http_client, tmp_path):
-    """Regression: a streaming `blosc2`-encoded body must round-trip in full.
+    """A streaming `blosc2`-encoded body must round-trip in full.
 
     `/asset/bytes` streams via `FileResponse` in 64 KiB chunks, and
     `BloscBuffer` compresses each chunk into an independent blosc2 frame, so the
-    wire body is `frame0 ++ frame1 ++ ...`. The client `Blosc2Decoder` used to
-    call `blosc2.decompress` once, decoding only the first frame and truncating
-    downloads at exactly 65536 bytes. The decoder now walks every frame, so the
-    full payload is recovered.
+    wire body is `frame0 ++ frame1 ++ ...`.
     """
     # Comfortably larger than the 65536-byte FileResponse chunk size, so the
     # body spans several chunks (i.e. several blosc2 frames). Compressible so

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -363,6 +363,47 @@ def test_raw_export_destination_directory_kwarg_is_deprecated(http_client, tmp_p
         http_client["blob"].raw_export(dest, destination_directory=dest)
 
 
+def test_raw_export_blosc2_streaming_not_truncated(http_client, tmp_path):
+    """Regression: a streaming `blosc2`-encoded body must round-trip in full.
+
+    `/asset/bytes` streams via `FileResponse` in 64 KiB chunks, and
+    `BloscBuffer` compresses each chunk into an independent blosc2 frame, so the
+    wire body is `frame0 ++ frame1 ++ ...`. The client `Blosc2Decoder` used to
+    call `blosc2.decompress` once, decoding only the first frame and truncating
+    downloads at exactly 65536 bytes. The decoder now walks every frame, so the
+    full payload is recovered.
+    """
+    # Comfortably larger than the 65536-byte FileResponse chunk size, so the
+    # body spans several chunks (i.e. several blosc2 frames). Compressible so
+    # the middleware actually engages.
+    payload = (b"the quick brown fox " * 1024) * 8  # ~160 KiB, > 2 chunks
+    assert len(payload) > 2 * 65536
+    _register_bytes_node(http_client, tmp_path, payload, key="big")
+    # Prefer blosc2 so the server selects it (server-preferred among these) and
+    # the multi-frame streaming path is exercised end-to-end.
+    http_client.context.http_client.headers["Accept-Encoding"] = "blosc2, zstd, gzip"
+    dest = tmp_path / "out"
+    dest.mkdir()
+    paths = http_client["big"].raw_export(dest)
+    assert len(paths) == 1
+    downloaded = Path(paths[0]).read_bytes()
+    # The bug truncated this to exactly 65536 bytes; assert full length + bytes.
+    assert len(downloaded) == len(payload)
+    assert downloaded == payload
+    # Confirm we actually exercised the blosc2 streaming path (and its Content-
+    # Encoding), not a fallback encoding.
+    ds = http_client.context.http_client.get(
+        "/api/v1/metadata/big", params={"include_data_sources": True}
+    ).json()["data"]["attributes"]["data_sources"][0]
+    asset_id = ds["assets"][0]["id"]
+    response = http_client.context.http_client.get(
+        "/api/v1/asset/bytes/big", params={"id": asset_id}
+    )
+    assert response.status_code == 200
+    assert response.headers.get("Content-Encoding") == "blosc2"
+    assert response.content == payload
+
+
 def test_raw_export_handles_missing_content_length(http_client, tmp_path):
     """Regression: large compressed responses have no `Content-Length` header
     (the compression middleware strips it when streaming a chunked body).

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -43,3 +43,37 @@ def test_blosc2(client):
     (request,) = h.requests
     assert "blosc2" in request.headers["Accept-Encoding"]
     assert "blosc2" in response.headers["Content-Encoding"]
+
+
+def test_blosc2_decoder_multi_frame():
+    """`Blosc2Decoder` must reassemble a body made of several concatenated
+    blosc2 frames.
+
+    Streaming responses are compressed one frame per server-side write(), so
+    the wire body is `frame0 ++ frame1 ++ ...`. A decoder that calls
+    `blosc2.decompress` once decodes only the first frame and truncates the
+    payload; the decoder must instead walk every frame.
+    """
+    pytest.importorskip("blosc2")
+    import blosc2
+
+    from tiled.client.decoders import Blosc2Decoder
+
+    parts = [
+        b"the quick brown fox " * 4096,
+        b"jumps over the lazy dog " * 4096,
+        b"pack my box with five dozen liquor jugs " * 4096,
+    ]
+    expected = b"".join(parts)
+
+    # Feed the frames across arbitrary `decode` calls to mimic streaming.
+    decoder = Blosc2Decoder()
+    assert decoder.decode(blosc2.compress(parts[0])) == b""
+    assert decoder.decode(blosc2.compress(parts[1])) == b""
+    assert decoder.decode(blosc2.compress(parts[2])) == b""
+    assert decoder.flush() == expected
+
+    # A single-frame body still round-trips.
+    single = Blosc2Decoder()
+    single.decode(blosc2.compress(expected))
+    assert single.flush() == expected

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -379,7 +379,7 @@ class BaseClient:
                 manifests[asset.id] = manifest
         return manifests
 
-    def raw_export(self, destination=None, max_workers=4, **kwargs):
+    def raw_export(self, destination=None, max_workers=4, compression=True, **kwargs):
         """Download the raw assets backing this node.
 
         This may produce a single file or a directory.
@@ -396,6 +396,13 @@ class BaseClient:
             the current working directory.
         max_workers : int, optional
             Number of parallel workers downloading data. Default is 4.
+        compression : bool, optional
+            Whether to let the server compress the response on the fly. Default
+            is `True`, which streams via zstd/gzip (blosc2 is excluded because
+            its client decoder cannot stream). Set to `False` to download
+            uncompressed (`Accept-Encoding: identity`), which avoids wasting CPU
+            on already-incompressible assets and yields a `Content-Length` (and
+            thus a determinate progress bar).
 
         Returns
         -------
@@ -428,10 +435,15 @@ class BaseClient:
             destination = Path(destination or Path.cwd())
 
         # Import here to defer the import of rich (for progress bar).
-        from .download import ATTACHMENT_FILENAME_PLACEHOLDER, download
+        from .download import (
+            ATTACHMENT_FILENAME_PLACEHOLDER,
+            STREAMING_ACCEPT_ENCODING,
+            download,
+        )
 
         urls = []
         targets = []  # Paths or posix-style string keys.
+        sizes = []  # Known content lengths (parallel to urls); None if unknown.
         data_sources = self.include_data_sources().data_sources()
         asset_manifest = self.asset_manifest(data_sources)
         if len(data_sources) != 1:
@@ -466,6 +478,8 @@ class BaseClient:
                             for relative_path in relative_paths
                         ]
                     )
+                    # Per-file sizes within a directory asset are not known.
+                    sizes.extend([None] * len(relative_paths))
                     if in_memory:
                         targets.extend(
                             [f"{base}/{rp}" if base else rp for rp in relative_paths]
@@ -482,6 +496,7 @@ class BaseClient:
                             },
                         )
                     )
+                    sizes.append(asset.size)
                     if in_memory:
                         targets.append(
                             f"{base}/{ATTACHMENT_FILENAME_PLACEHOLDER}"
@@ -490,6 +505,7 @@ class BaseClient:
                         )
                     else:
                         targets.append(Path(base, ATTACHMENT_FILENAME_PLACEHOLDER))
+        accept_encoding = STREAMING_ACCEPT_ENCODING if compression else "identity"
         if in_memory:
             return download(
                 self.context.http_client,
@@ -497,9 +513,16 @@ class BaseClient:
                 targets,
                 mapping=destination,
                 max_workers=max_workers,
+                totals=sizes,
+                accept_encoding=accept_encoding,
             )
         return download(
-            self.context.http_client, urls, targets, max_workers=max_workers
+            self.context.http_client,
+            urls,
+            targets,
+            max_workers=max_workers,
+            totals=sizes,
+            accept_encoding=accept_encoding,
         )
 
     @property

--- a/tiled/client/decoders.py
+++ b/tiled/client/decoders.py
@@ -20,11 +20,25 @@ if modules_available("blosc2"):
             # Hide this here to defer the numpy import that it triggers.
             import blosc2
 
-            if len(self._data) == 1:
-                (data,) = self._data
-            else:
-                data = b"".join(self._data)
-            return blosc2.decompress(data)
+            data = self._data[0] if len(self._data) == 1 else b"".join(self._data)
+            # A streaming response may arrive as several concatenated blosc2
+            # frames (the server emits one frame per write() call). Since
+            # blosc2.decompress reads only the first frame, walk the buffer
+            # frame by frame -- each frame header reports its own compressed
+            # length (cbytes) -- and concatenate the decompressed pieces.
+            view = memoryview(data)
+            chunks = []
+            offset = 0
+            while offset < len(view):
+                _, cbytes, _ = blosc2.get_cbuffer_sizes(view[offset:])
+                if cbytes <= 0:
+                    break
+                frame = view[offset : offset + cbytes]  # noqa: E203
+                chunks.append(blosc2.decompress(frame))
+                offset += cbytes
+            if len(chunks) == 1:
+                return chunks[0]
+            return b"".join(chunks)
 
     SUPPORTED_DECODERS["blosc2"] = Blosc2Decoder
 

--- a/tiled/client/download.py
+++ b/tiled/client/download.py
@@ -8,6 +8,7 @@ from threading import Event, Lock
 from typing import Iterable, MutableMapping, Optional, Union
 
 import httpx
+from httpx._decoders import SUPPORTED_DECODERS
 from rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -21,6 +22,16 @@ from .utils import handle_error, retry_context
 
 # This extracts the filename to the Content-Disposition header.
 CONTENT_DISPOSITION_PATTERN = re.compile(r"^attachment; ?filename=\"(.*)\"$")
+
+# Accept-Encoding advertised when downloading raw assets *with* compression.
+# We deliberately omit "blosc2": its client decoder buffers the entire response
+# in memory and only emits it on flush(), which defeats streaming (the progress
+# bar cannot advance, and a large asset is held wholly in RAM). The remaining
+# decoders (zstd, gzip, ...) decompress incrementally, so downloads stream and
+# report progress. "identity" is used instead when compression is disabled.
+STREAMING_ACCEPT_ENCODING = ", ".join(
+    encoding for encoding in SUPPORTED_DECODERS if encoding != "blosc2"
+)
 
 # This is used by the caller of download(...) as a placeholder
 # that should be substituted with the filename provided by the
@@ -57,26 +68,32 @@ def _download_url(
     target: Union[Path, str],
     mapping: Optional[MutableMapping],
     lock: Optional[Lock],
+    accept_encoding: Optional[str],
 ):
     """Fetch `url` and write the body to disk (when `mapping is None`) or to
     a `BytesIO` stored in `mapping` (otherwise). Returns the resolved target."""
     progress.console.log(f"Requesting {url}")
     resolved = target
+    # Override the client's default Accept-Encoding so that raw-asset downloads
+    # do not negotiate blosc2 (see STREAMING_ACCEPT_ENCODING) or, when the
+    # caller disables compression, are served uncompressed with a
+    # Content-Length (and thus a determinate progress bar).
+    headers = {"Accept-Encoding": accept_encoding} if accept_encoding else None
     try:
         if mapping is None:
             target.parent.mkdir(exist_ok=True, parents=True)
         for attempt in retry_context():
             with attempt:
-                with client.stream("GET", url) as response:
+                with client.stream("GET", url, headers=headers) as response:
                     handle_error(response)
                     resolved = _resolve_placeholder(target, response)
                     # Content-Length is absent when the server streams a
-                    # chunked response (e.g. when compression middleware
-                    # re-encodes the body). Fall back to an indeterminate
-                    # progress bar in that case.
+                    # compressed (chunked) response. In that case keep the
+                    # task's pre-seeded total (the asset size supplied by the
+                    # caller, or None for an indeterminate bar).
                     content_length = response.headers.get("Content-Length")
-                    total = int(content_length) if content_length else None
-                    progress.update(task_id, total=total)
+                    if content_length is not None:
+                        progress.update(task_id, total=int(content_length))
                     progress.start_task(task_id)
                     if mapping is None:
                         sink = open(resolved, "wb")
@@ -109,6 +126,8 @@ def download(
     *,
     mapping: Optional[MutableMapping] = None,
     max_workers: int = 4,
+    totals: Optional[Iterable[Optional[int]]] = None,
+    accept_encoding: Optional[str] = None,
 ):
     """Download multiple URLs in parallel.
 
@@ -120,6 +139,15 @@ def download(
     A target may embed `ATTACHMENT_FILENAME_PLACEHOLDER`, which is replaced
     with the filename advertised by the server via `Content-Disposition`.
     Returns the list of resolved targets in submission order.
+
+    `totals`, if given, must be parallel to `urls`; each entry pre-seeds the
+    known content length so the progress bar is determinate even when the
+    server omits `Content-Length` (e.g. a compressed streaming response). Use
+    `None` for an entry whose size is unknown (an indeterminate bar).
+
+    `accept_encoding`, if given, overrides the `Accept-Encoding` header for
+    every request (e.g. `STREAMING_ACCEPT_ENCODING` to keep compression while
+    excluding blosc2, or `"identity"` to disable compression).
     """
     if len(urls) != len(targets):
         kind = "keys" if mapping is not None else "paths"
@@ -127,6 +155,13 @@ def download(
             f"Must provide a list of URLs and a list of {kind} "
             f"with equal length. Received {len(urls)=} and "
             f"len({kind})={len(targets)}."
+        )
+    if totals is None:
+        totals = [None] * len(urls)
+    elif len(totals) != len(urls):
+        raise ValueError(
+            f"Must provide as many totals as URLs. "
+            f"Received {len(urls)=} and {len(totals)=}."
         )
 
     progress = Progress(
@@ -152,8 +187,8 @@ def download(
     try:
         with progress:
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                for url, target in zip(urls, targets):
-                    task_id = progress.add_task("download", start=False)
+                for url, target, total in zip(urls, targets, totals):
+                    task_id = progress.add_task("download", start=False, total=total)
                     future = pool.submit(
                         _download_url,
                         progress,
@@ -164,6 +199,7 @@ def download(
                         target,
                         mapping,
                         lock,
+                        accept_encoding,
                     )
                     futures.append(future)
                 wait(futures)

--- a/tiled/media_type_registration.py
+++ b/tiled/media_type_registration.py
@@ -368,5 +368,12 @@ if modules_available("blosc2"):
         def close(self):
             pass
 
+    # NB: BloscBuffer.write emits an independent blosc2 frame per call. Array
+    # responses are serialized as a single body, so they compress to a single
+    # frame; but streaming byte payloads (application/octet-stream via
+    # FileResponse) are written in 64 KiB chunks, so each chunk becomes its own
+    # frame and the wire body is `frame0 ++ frame1 ++ ...`. The client-side
+    # Blosc2Decoder walks all frames, so this concatenation round-trips
+    # correctly.
     for media_type in ["application/octet-stream", APACHE_ARROW_FILE_MIME_TYPE]:
         default_compression_registry.register(media_type, "blosc2", BloscBuffer)


### PR DESCRIPTION
Applies two bug fixes related to raw exports of bytes-structured datasets:

1. Fix truncation of `blosc2`-encoded downloads at exactly 65536 bytes. Streaming responses (e.g. `raw_export` of a `bytes` node via `/asset/bytes`) are emitted in 64 KiB chunks, and the server compresses each chunk into an independent blosc2 frame. The client `Blosc2Decoder` decoded only the first frame; it now walks every concatenated frame and reassembles the full payload.

2. Fix the `raw_export` download progress bar, which showed a wrong total (e.g. `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar now seeds each task's total from the known asset size, and raw-asset downloads no longer negotiate `blosc2` (whose client decoder buffers the whole response in memory and emits it only at the end, freezing the bar and spiking memory). Downloads instead stream via `zstd`/`gzip`; pass `compression=False` to `raw_export` to download uncompressed (`Accept-Encoding: identity`).

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
