### PR TITLE
Redis HA

### DIFF
--- a/docs/source/user-guide/deploy-tiled-multi-node.md
+++ b/docs/source/user-guide/deploy-tiled-multi-node.md
@@ -19,11 +19,15 @@ Sentinel) and configure Tiled with `sentinels` and `service_name` instead of a
 single `uri`; the client then follows Sentinel through a failover and resumes
 subscriptions against the newly promoted primary. Because Redis replication is
 asynchronous, a failover can drop a streamed write that was acknowledged by the
-old primary but not yet replicated. To bound that window, Tiled issues a Redis
-`WAIT` write-concern after each publish (`wait_num_replicas`, on by default
-under Sentinel); this is best-effort and never fails the client write, so
-subscribers needing stronger guarantees should treat delivery as at-least-once
-and dedupe on the `sequence` field. See {doc}`../reference/service-configuration`
-for the full `streaming_cache` field reference.
+old primary but not yet replicated. To bound that window, after each publish
+Tiled issues a Redis `WAIT` (`wait_num_replicas`, on by default under Sentinel)
+to wait for replicas to acknowledge the write. If the requested number of
+replicas do not confirm within `wait_timeout`, the publish fails the client
+request, just as any other failed write to Redis does. Note the durable write to
+the SQL database has already committed at that point, so a client retry can
+duplicate it; subscribers and writers should treat delivery as at-least-once and
+dedupe on the `sequence` field. See
+{doc}`../reference/service-configuration` for the full `streaming_cache` field
+reference.
 
 [Helm chart]: https://github.com/bluesky/tiled/pkgs/container/charts%2Ftiled

--- a/docs/source/user-guide/deploy-tiled-multi-node.md
+++ b/docs/source/user-guide/deploy-tiled-multi-node.md
@@ -17,16 +17,16 @@ the same Redis. To keep streaming available across a Redis outage, run Redis in
 a high-availability topology (a primary with replicas fronted by Redis
 Sentinel) and configure Tiled with `sentinels` and `service_name` instead of a
 single `uri`; the client then follows Sentinel through a failover and resumes
-subscriptions against the newly promoted primary. Because Redis replication is
-asynchronous, a failover can drop a streamed write that was acknowledged by the
-old primary but not yet replicated. To bound that window, after each publish
-Tiled issues a Redis `WAIT` (`wait_num_replicas`, on by default under Sentinel)
-to wait for replicas to acknowledge the write. If the requested number of
-replicas do not confirm within `wait_timeout`, the publish fails the client
-request, just as any other failed write to Redis does. Note the durable write to
-the SQL database has already committed at that point, so a client retry can
-duplicate it; subscribers and writers should treat delivery as at-least-once and
-dedupe on the `sequence` field. See
+subscriptions against the newly promoted primary.
+
+Live streaming is **best-effort, not a durable channel**: it rides Redis
+Pub/Sub, which is at-most-once, and the durable record is the SQL catalog, which
+is committed before the streaming publish. Because Redis replication is
+asynchronous and there is no per-write replication confirmation, a Sentinel
+failover can drop streamed updates that the old primary acknowledged but had not
+yet replicated to the promoted replica (the sequence counter may even rewind).
+Setting `min-replicas-to-write` / `min-replicas-max-lag` on the Redis primary
+narrows this window but does not close it. See
 {doc}`../reference/service-configuration` for the full `streaming_cache` field
 reference.
 

--- a/docs/source/user-guide/deploy-tiled-multi-node.md
+++ b/docs/source/user-guide/deploy-tiled-multi-node.md
@@ -21,12 +21,18 @@ subscriptions against the newly promoted primary.
 
 Live streaming is **best-effort, not a durable channel**: it rides Redis
 Pub/Sub, which is at-most-once, and the durable record is the SQL catalog, which
-is committed before the streaming publish. Because Redis replication is
-asynchronous and there is no per-write replication confirmation, a Sentinel
-failover can drop streamed updates that the old primary acknowledged but had not
-yet replicated to the promoted replica (the sequence counter may even rewind).
-Setting `min-replicas-to-write` / `min-replicas-max-lag` on the Redis primary
-narrows this window but does not close it. See
+is committed before the streaming publish. An ordinary connection drop is
+lossless — the client reconnects and resumes from the sequence number after the
+last one it received, and the server replays anything it missed — so a normal
+reconnect neither loses nor duplicates updates.
+
+The residual risk is a Sentinel failover to a **replica that had not yet caught
+up**. Redis replication is asynchronous and there is no per-write replication
+confirmation, so a write the old primary acknowledged but had not replicated is
+lost, and because the promoted replica's sequence counter is behind, it can
+re-issue already-used sequence numbers for new data (re-delivering them as
+duplicates). Setting `min-replicas-to-write` / `min-replicas-max-lag` on the
+Redis primary narrows this window but does not close it. See
 {doc}`../reference/service-configuration` for the full `streaming_cache` field
 reference.
 

--- a/docs/source/user-guide/deploy-tiled-multi-node.md
+++ b/docs/source/user-guide/deploy-tiled-multi-node.md
@@ -9,4 +9,21 @@ Another uses Ansible for orchestration of a fleet of VMs.
 We aim to expand this page to share more details, including host resources,
 load balancer configurations, and other recommendations.
 
+## Redis high availability for streaming
+
+Live data streaming (WebSocket subscriptions) is backed by a shared Redis
+`streaming_cache`, so in a multi-node deployment every Tiled node must point at
+the same Redis. To keep streaming available across a Redis outage, run Redis in
+a high-availability topology (a primary with replicas fronted by Redis
+Sentinel) and configure Tiled with `sentinels` and `service_name` instead of a
+single `uri`; the client then follows Sentinel through a failover and resumes
+subscriptions against the newly promoted primary. Because Redis replication is
+asynchronous, a failover can drop a streamed write that was acknowledged by the
+old primary but not yet replicated. To bound that window, Tiled issues a Redis
+`WAIT` write-concern after each publish (`wait_num_replicas`, on by default
+under Sentinel); this is best-effort and never fails the client write, so
+subscribers needing stronger guarantees should treat delivery as at-least-once
+and dedupe on the `sequence` field. See {doc}`../reference/service-configuration`
+for the full `streaming_cache` field reference.
+
 [Helm chart]: https://github.com/bluesky/tiled/pkgs/container/charts%2Ftiled

--- a/docs/source/user-guide/deploy-tiled-multi-node.md
+++ b/docs/source/user-guide/deploy-tiled-multi-node.md
@@ -19,19 +19,21 @@ Sentinel) and configure Tiled with `sentinels` and `service_name` instead of a
 single `uri`; the client then follows Sentinel through a failover and resumes
 subscriptions against the newly promoted primary.
 
-Live streaming is **best-effort, not a durable channel**: it rides Redis
-Pub/Sub, which is at-most-once, and the durable record is the SQL catalog, which
-is committed before the streaming publish. An ordinary connection drop is
+Live streaming is **best-effort**: it is delivered over Redis Pub/Sub, which is
+at-most-once, and the durable record is the SQL catalog, which is committed
+before the streaming publish. An ordinary connection drop is
 lossless — the client reconnects and resumes from the sequence number after the
 last one it received, and the server replays anything it missed — so a normal
 reconnect neither loses nor duplicates updates.
 
 The residual risk is a Sentinel failover to a **replica that had not yet caught
 up**. Redis replication is asynchronous and there is no per-write replication
-confirmation, so a write the old primary acknowledged but had not replicated is
-lost, and because the promoted replica's sequence counter is behind, it can
-re-issue already-used sequence numbers for new data (re-delivering them as
-duplicates). Setting `min-replicas-to-write` / `min-replicas-max-lag` on the
+confirmation, so two things can happen. First, any update the old primary
+accepted but had not yet copied to that replica is gone — subscribers never
+receive it. Second, the promoted replica's sequence counter is lower than the
+old primary's, so as new updates arrive it hands out sequence numbers that were
+already used, and subscribers receive those numbers a second time (now labeling
+different data). Setting `min-replicas-to-write` / `min-replicas-max-lag` on the
 Redis primary narrows this window but does not close it. See
 {doc}`../reference/service-configuration` for the full `streaming_cache` field
 reference.

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -67,6 +67,12 @@ def test_streaming_cache_config_source_validation():
     # ...and each sentinel must be host:port.
     with pytest.raises(ValidationError, match="must be 'host:port'"):
         StreamingCacheConfig(sentinels=["h1"], service_name="c")
+    # Sentinel-only fields with a 'uri' are rejected (ssl would otherwise leave
+    # a connection the operator thinks is encrypted running in plaintext).
+    with pytest.raises(ValidationError, match="'ssl' applies to the 'sentinels'"):
+        StreamingCacheConfig(uri="redis://h:6379", ssl=True)
+    with pytest.raises(ValidationError, match="'service_name' is only used"):
+        StreamingCacheConfig(uri="redis://h:6379", service_name="c")
 
     # Valid standalone (uri) and Sentinel configs.
     assert StreamingCacheConfig(uri="redis://h:6379").sentinels is None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -65,6 +65,41 @@ def test_streaming_cache_config_source_validation():
     assert config.service_name == "mymaster"
 
 
+def test_streaming_cache_wait_num_replicas_default():
+    from tiled.config import StreamingCacheConfig
+
+    # Standalone (uri only): the WAIT write-concern is off by default, so the
+    # standalone code path is unchanged.
+    standalone = StreamingCacheConfig(uri="redis://localhost:6379")
+    assert standalone.wait_num_replicas == 0
+    assert standalone.wait_timeout == 1000
+
+    # Sentinel/HA cluster: WAIT auto-defaults on (1 replica).
+    ha = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")
+    assert ha.wait_num_replicas == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_datastore_wait_no_op_when_disabled():
+    # With wait_num_replicas at its standalone default (0), no WAIT command is
+    # ever issued -- the standalone publish path behaves exactly as before.
+    datastore = streaming.RedisStreamingDatastore.__new__(
+        streaming.RedisStreamingDatastore
+    )
+    datastore.wait_num_replicas = 0
+    datastore.wait_timeout = 1000
+
+    calls = []
+
+    class _FakeClient:
+        async def execute_command(self, *args):
+            calls.append(args)
+
+    datastore._client = _FakeClient()
+    await datastore._wait_for_replicas("node-x")
+    assert calls == []
+
+
 def test_websocket_replay_and_live_events(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -48,54 +48,49 @@ def test_streaming_cache_unknown_backend():
         raise AssertionError("StreamingCache should reject unknown backends.")
 
 
-def _base_settings(**extra):
-    settings = {"socket_timeout": 5, "socket_connect_timeout": 5}
-    settings.update(extra)
-    return settings
-
-
-def test_build_redis_client_standalone():
-    # A ``uri`` builds a plain standalone client.
-    client = streaming._build_redis_client(_base_settings(uri="redis://localhost:6379"))
+def test_build_redis_client():
     from redis.asyncio.sentinel import SentinelConnectionPool
 
-    assert not isinstance(client.connection_pool, SentinelConnectionPool)
+    base = {
+        "socket_timeout": 5,
+        "socket_connect_timeout": 5,
+        "health_check_interval": 30,
+    }
 
+    # A ``uri`` builds a plain standalone client, with health_check_interval
+    # threaded through to the connection.
+    standalone = streaming._build_redis_client(
+        {**base, "uri": "redis://localhost:6379"}
+    )
+    assert not isinstance(standalone.connection_pool, SentinelConnectionPool)
+    assert standalone.connection_pool.connection_kwargs["health_check_interval"] == 30
 
-def test_build_redis_client_sentinel():
     # ``sentinels`` + ``service_name`` builds a Sentinel-managed client that
     # follows failover to the current primary.
-    from redis.asyncio.sentinel import SentinelConnectionPool
-
-    client = streaming._build_redis_client(
-        _base_settings(
-            sentinels=["h1:26379", "h2:26379"],
-            service_name="mymaster",
-            password="secret",
-        )
+    sentinel = streaming._build_redis_client(
+        {
+            **base,
+            "sentinels": ["h1:26379", "h2:26379"],
+            "service_name": "mymaster",
+            "password": "secret",
+        }
     )
-    assert isinstance(client.connection_pool, SentinelConnectionPool)
-    assert client.connection_pool.service_name == "mymaster"
+    assert isinstance(sentinel.connection_pool, SentinelConnectionPool)
+    assert sentinel.connection_pool.service_name == "mymaster"
 
 
-def test_streaming_cache_config_requires_source():
-    # Neither ``uri`` nor ``sentinels`` set is a configuration error.
+def test_streaming_cache_config_source_validation():
     from pydantic import ValidationError
 
     from tiled.config import StreamingCacheConfig
 
+    # Neither ``uri`` nor ``sentinels`` set is a configuration error, as is
+    # ``sentinels`` without a ``service_name``.
     with pytest.raises(ValidationError):
         StreamingCacheConfig()
-
-
-def test_streaming_cache_config_sentinels_require_service_name():
-    from pydantic import ValidationError
-
-    from tiled.config import StreamingCacheConfig
-
     with pytest.raises(ValidationError):
         StreamingCacheConfig(sentinels=["h1:26379"])
-    # With a service_name it validates.
+    # ``sentinels`` + ``service_name`` validates, leaving ``uri`` unset.
     config = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")
     assert config.uri is None
     assert config.service_name == "mymaster"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -53,16 +53,26 @@ def test_streaming_cache_config_source_validation():
 
     from tiled.config import StreamingCacheConfig
 
-    # Neither ``uri`` nor ``sentinels`` set is a configuration error, as is
-    # ``sentinels`` without a ``service_name``.
-    with pytest.raises(ValidationError):
+    # Exactly one source is required: neither is an error...
+    with pytest.raises(ValidationError, match="either 'uri' or 'sentinels'"):
         StreamingCacheConfig()
-    with pytest.raises(ValidationError):
+    # ...and setting both is ambiguous.
+    with pytest.raises(ValidationError, match="only one of 'uri' or 'sentinels'"):
+        StreamingCacheConfig(
+            uri="redis://h:6379", sentinels=["h1:26379"], service_name="c"
+        )
+    # The Sentinel path requires a service_name...
+    with pytest.raises(ValidationError, match="'service_name' is required"):
         StreamingCacheConfig(sentinels=["h1:26379"])
-    # ``sentinels`` + ``service_name`` validates, leaving ``uri`` unset.
-    config = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")
-    assert config.uri is None
-    assert config.service_name == "mymaster"
+    # ...and each sentinel must be host:port.
+    with pytest.raises(ValidationError, match="must be 'host:port'"):
+        StreamingCacheConfig(sentinels=["h1"], service_name="c")
+
+    # Valid standalone (uri) and Sentinel configs.
+    assert StreamingCacheConfig(uri="redis://h:6379").sentinels is None
+    ha = StreamingCacheConfig(sentinels=["h1:26379", "h2:26379"], service_name="c")
+    assert ha.uri is None
+    assert ha.service_name == "c"
 
 
 def test_websocket_replay_and_live_events(tiled_websocket_context):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -65,19 +65,6 @@ def test_streaming_cache_config_source_validation():
     assert config.service_name == "mymaster"
 
 
-def test_streaming_cache_wait_num_replicas_default():
-    from tiled.config import StreamingCacheConfig
-
-    # Standalone (uri only): the WAIT write-concern is off by default, so the
-    # standalone code path is unchanged.
-    standalone = StreamingCacheConfig(uri="redis://localhost:6379")
-    assert standalone.wait_num_replicas == 0
-
-    # Sentinel/HA cluster: WAIT auto-defaults on (1 replica).
-    ha = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")
-    assert ha.wait_num_replicas == 1
-
-
 def test_websocket_replay_and_live_events(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -79,27 +79,6 @@ def test_streaming_cache_wait_num_replicas_default():
     assert ha.wait_num_replicas == 1
 
 
-@pytest.mark.asyncio
-async def test_redis_datastore_wait_no_op_when_disabled():
-    # With wait_num_replicas at its standalone default (0), no WAIT command is
-    # ever issued -- the standalone publish path behaves exactly as before.
-    datastore = streaming.RedisStreamingDatastore.__new__(
-        streaming.RedisStreamingDatastore
-    )
-    datastore.wait_num_replicas = 0
-    datastore.wait_timeout = 1000
-
-    calls = []
-
-    class _FakeClient:
-        async def execute_command(self, *args):
-            calls.append(args)
-
-    datastore._client = _FakeClient()
-    await datastore._wait_for_replicas("node-x")
-    assert calls == []
-
-
 def test_websocket_replay_and_live_events(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -48,6 +48,59 @@ def test_streaming_cache_unknown_backend():
         raise AssertionError("StreamingCache should reject unknown backends.")
 
 
+def _base_settings(**extra):
+    settings = {"socket_timeout": 5, "socket_connect_timeout": 5}
+    settings.update(extra)
+    return settings
+
+
+def test_build_redis_client_standalone():
+    # A ``uri`` builds a plain standalone client.
+    client = streaming._build_redis_client(_base_settings(uri="redis://localhost:6379"))
+    from redis.asyncio.sentinel import SentinelConnectionPool
+
+    assert not isinstance(client.connection_pool, SentinelConnectionPool)
+
+
+def test_build_redis_client_sentinel():
+    # ``sentinels`` + ``service_name`` builds a Sentinel-managed client that
+    # follows failover to the current primary.
+    from redis.asyncio.sentinel import SentinelConnectionPool
+
+    client = streaming._build_redis_client(
+        _base_settings(
+            sentinels=["h1:26379", "h2:26379"],
+            service_name="mymaster",
+            password="secret",
+        )
+    )
+    assert isinstance(client.connection_pool, SentinelConnectionPool)
+    assert client.connection_pool.service_name == "mymaster"
+
+
+def test_streaming_cache_config_requires_source():
+    # Neither ``uri`` nor ``sentinels`` set is a configuration error.
+    from pydantic import ValidationError
+
+    from tiled.config import StreamingCacheConfig
+
+    with pytest.raises(ValidationError):
+        StreamingCacheConfig()
+
+
+def test_streaming_cache_config_sentinels_require_service_name():
+    from pydantic import ValidationError
+
+    from tiled.config import StreamingCacheConfig
+
+    with pytest.raises(ValidationError):
+        StreamingCacheConfig(sentinels=["h1:26379"])
+    # With a service_name it validates.
+    config = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")
+    assert config.uri is None
+    assert config.service_name == "mymaster"
+
+
 def test_websocket_replay_and_live_events(tiled_websocket_context):
     context = tiled_websocket_context
     client = from_context(context)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -48,37 +48,6 @@ def test_streaming_cache_unknown_backend():
         raise AssertionError("StreamingCache should reject unknown backends.")
 
 
-def test_build_redis_client():
-    from redis.asyncio.sentinel import SentinelConnectionPool
-
-    base = {
-        "socket_timeout": 5,
-        "socket_connect_timeout": 5,
-        "health_check_interval": 30,
-    }
-
-    # A ``uri`` builds a plain standalone client, with health_check_interval
-    # threaded through to the connection.
-    standalone = streaming._build_redis_client(
-        {**base, "uri": "redis://localhost:6379"}
-    )
-    assert not isinstance(standalone.connection_pool, SentinelConnectionPool)
-    assert standalone.connection_pool.connection_kwargs["health_check_interval"] == 30
-
-    # ``sentinels`` + ``service_name`` builds a Sentinel-managed client that
-    # follows failover to the current primary.
-    sentinel = streaming._build_redis_client(
-        {
-            **base,
-            "sentinels": ["h1:26379", "h2:26379"],
-            "service_name": "mymaster",
-            "password": "secret",
-        }
-    )
-    assert isinstance(sentinel.connection_pool, SentinelConnectionPool)
-    assert sentinel.connection_pool.service_name == "mymaster"
-
-
 def test_streaming_cache_config_source_validation():
     from pydantic import ValidationError
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -73,6 +73,8 @@ def test_streaming_cache_config_source_validation():
         StreamingCacheConfig(uri="redis://h:6379", ssl=True)
     with pytest.raises(ValidationError, match="'service_name' is only used"):
         StreamingCacheConfig(uri="redis://h:6379", service_name="c")
+    with pytest.raises(ValidationError, match="'password' is only used"):
+        StreamingCacheConfig(uri="redis://h:6379", password="secret")
 
     # Valid standalone (uri) and Sentinel configs.
     assert StreamingCacheConfig(uri="redis://h:6379").sentinels is None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -72,7 +72,6 @@ def test_streaming_cache_wait_num_replicas_default():
     # standalone code path is unchanged.
     standalone = StreamingCacheConfig(uri="redis://localhost:6379")
     assert standalone.wait_num_replicas == 0
-    assert standalone.wait_timeout == 1000
 
     # Sentinel/HA cluster: WAIT auto-defaults on (1 replica).
     ha = StreamingCacheConfig(sentinels=["h1:26379"], service_name="mymaster")

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -771,6 +771,44 @@ streaming_cache:
     assert config.streaming_cache.seq_ttl == 60
     assert config.streaming_cache.socket_timeout == 11
     assert config.streaming_cache.socket_connect_timeout == 12
+    # On the standalone path the HA-only fields take their (off) defaults.
+    assert config.streaming_cache.sentinels is None
+    assert config.streaming_cache.service_name is None
+    assert config.streaming_cache.ssl is False
+    assert config.streaming_cache.health_check_interval == 10
+
+
+def test_streaming_cache_sentinel_config(tmp_path):
+    "A Sentinel (HA) streaming_cache parses end-to-end, with uri left unset."
+    config_path = tmp_path / "config.yml"
+    with open(config_path, "w") as file:
+        file.write(
+            f"""
+trees:
+ - path: /
+   tree: catalog
+   args:
+     uri: "sqlite:///:memory:"
+     writable_storage:
+        - "file://localhost{str(tmp_path / "data")}"
+     init_if_not_exists: true
+streaming_cache:
+  sentinels:
+    - "redis-sentinel-1:26379"
+    - "redis-sentinel-2:26379"
+  service_name: "tiled-streaming-cache"
+  password: "secret"
+  ssl: true
+"""
+        )
+    config = parse_configs(config_path)
+    assert config.streaming_cache.uri is None
+    assert config.streaming_cache.sentinels == [
+        "redis-sentinel-1:26379",
+        "redis-sentinel-2:26379",
+    ]
+    assert config.streaming_cache.service_name == "tiled-streaming-cache"
+    assert config.streaming_cache.ssl is True
 
 
 def _receive_schema(websocket, envelope_format):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -856,22 +856,22 @@ class CatalogNodeAdapter:
                     data_sources_with_ids.append(ds)
 
                 # Notify subscribers of the *parent* node about the new child.
-                sequence = await self.context.streaming_cache.incr_seq(self.node.id)
-                metadata = {
-                    "type": "container-child-created",
-                    "sequence": sequence,
-                    "timestamp": datetime.now().isoformat(),
-                    "key": key,
-                    "structure_family": structure_family,
-                    "specs": [spec.model_dump() for spec in (specs or [])],
-                    "metadata": metadata,
-                    "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                    "access_blob": refreshed_node.access_blob,
-                }
-
-                # Cache data in Redis with a TTL, and publish
-                # a notification about it.
-                await self.context.streaming_cache.set(self.node.id, sequence, metadata)
+                # Cache data in Redis with a TTL, and publish a notification
+                # about it. Best-effort: a Redis failure will not fail the write.
+                await self.context.streaming_cache.publish_update(
+                    self.node.id,
+                    lambda sequence: {
+                        "type": "container-child-created",
+                        "sequence": sequence,
+                        "timestamp": datetime.now().isoformat(),
+                        "key": key,
+                        "structure_family": structure_family,
+                        "specs": [spec.model_dump() for spec in (specs or [])],
+                        "metadata": metadata,
+                        "data_sources": [d.model_dump() for d in data_sources_with_ids],
+                        "access_blob": refreshed_node.access_blob,
+                    },
+                )
             if self.context.webhook_dispatcher:
                 segments = list(await self.path_segments())
                 child_path = segments + [key]
@@ -978,19 +978,19 @@ class CatalogNodeAdapter:
             self.context.streaming_cache
             and data_source.structure_family == StructureFamily.array
         ):
-            sequence = await self.context.streaming_cache.incr_seq(self.node.id)
-            metadata = {
-                "type": "array-ref",
-                "sequence": sequence,
-                "timestamp": datetime.now().isoformat(),
-                "data_source": data_source.model_dump(),
-                "patch": patch.model_dump() if patch else None,
-                "shape": structure["shape"],
-            }
-
-            # Cache data in Redis with a TTL, and publish
-            # a notification about it.
-            await self.context.streaming_cache.set(self.node.id, sequence, metadata)
+            # Cache data in Redis with a TTL, and publish a notification about
+            # it. Best-effort: a Redis failure will not fail the write.
+            await self.context.streaming_cache.publish_update(
+                self.node.id,
+                lambda sequence: {
+                    "type": "array-ref",
+                    "sequence": sequence,
+                    "timestamp": datetime.now().isoformat(),
+                    "data_source": data_source.model_dump(),
+                    "patch": patch.model_dump() if patch else None,
+                    "shape": structure["shape"],
+                },
+            )
 
     async def revisions(self, offset: int = 0, limit=None):
         async with self.context.session() as db:
@@ -1319,19 +1319,23 @@ class CatalogNodeAdapter:
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
-                sequence = await self.context.streaming_cache.incr_seq(self.node.parent)
-                metadata = {
-                    "type": "container-child-metadata-updated",
-                    "key": self.node.key,
-                    "sequence": sequence,
-                    "timestamp": datetime.now().isoformat(),
-                    "specs": [spec.model_dump() for spec in (specs or [])],
-                    "metadata": metadata,
-                }
-                if not drop_revision:
-                    metadata["revision_number"] = next_revision_number
-                await self.context.streaming_cache.set(
-                    self.node.parent, sequence, metadata
+
+                def _build_metadata(sequence):
+                    payload = {
+                        "type": "container-child-metadata-updated",
+                        "key": self.node.key,
+                        "sequence": sequence,
+                        "timestamp": datetime.now().isoformat(),
+                        "specs": [spec.model_dump() for spec in (specs or [])],
+                        "metadata": metadata,
+                    }
+                    if not drop_revision:
+                        payload["revision_number"] = next_revision_number
+                    return payload
+
+                # Best-effort: a Redis failure will not fail the write.
+                await self.context.streaming_cache.publish_update(
+                    self.node.parent, _build_metadata
                 )
             if self.context.webhook_dispatcher:
                 segments = list(await self.path_segments())
@@ -1641,19 +1645,19 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
         )
 
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
-        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
-        metadata = {
-            "type": "array-data",
-            "sequence": sequence,
-            "timestamp": datetime.now().isoformat(),
-            "mimetype": media_type,
-            "shape": shape,
-            "offset": offset,
-            "block": block,
-        }
-
-        await self.context.streaming_cache.set(
-            self.node.id, sequence, metadata, payload=body
+        # Best-effort: a Redis failure will not fail the write.
+        await self.context.streaming_cache.publish_update(
+            self.node.id,
+            lambda sequence: {
+                "type": "array-data",
+                "sequence": sequence,
+                "timestamp": datetime.now().isoformat(),
+                "mimetype": media_type,
+                "shape": shape,
+                "offset": offset,
+                "block": block,
+            },
+            payload=body,
         )
 
     def make_ws_schema(self):
@@ -1769,18 +1773,19 @@ class CatalogRaggedAdapter(CatalogArrayAdapter):
         }
 
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
-        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
-        metadata = {
-            "type": "ragged-data",
-            "sequence": sequence,
-            "timestamp": datetime.now().isoformat(),
-            "mimetype": media_type,
-            "shape": shape,
-            "offset": offset,
-            "block": block,
-        }
-        await self.context.streaming_cache.set(
-            self.node.id, sequence, metadata, payload=body
+        # Best-effort: a Redis failure will not fail the write.
+        await self.context.streaming_cache.publish_update(
+            self.node.id,
+            lambda sequence: {
+                "type": "ragged-data",
+                "sequence": sequence,
+                "timestamp": datetime.now().isoformat(),
+                "mimetype": media_type,
+                "shape": shape,
+                "offset": offset,
+                "block": block,
+            },
+            payload=body,
         )
 
     async def write_block(
@@ -1857,18 +1862,18 @@ class CatalogTableAdapter(CatalogNodeAdapter):
         }
 
     async def _stream(self, media_type, entry, body, partition, append):
-        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
-        metadata = {
-            "type": "table-data",
-            "sequence": sequence,
-            "timestamp": datetime.now().isoformat(),
-            "mimetype": media_type,
-            "partition": partition,
-            "append": append,
-        }
-
-        await self.context.streaming_cache.set(
-            self.node.id, sequence, metadata, payload=body
+        # Best-effort: a Redis failure will not fail the write.
+        await self.context.streaming_cache.publish_update(
+            self.node.id,
+            lambda sequence: {
+                "type": "table-data",
+                "sequence": sequence,
+                "timestamp": datetime.now().isoformat(),
+                "mimetype": media_type,
+                "partition": partition,
+                "append": append,
+            },
+            payload=body,
         )
 
     async def get(self, *args, **kwargs):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -856,22 +856,22 @@ class CatalogNodeAdapter:
                     data_sources_with_ids.append(ds)
 
                 # Notify subscribers of the *parent* node about the new child.
-                # Cache data in Redis with a TTL, and publish a notification
-                # about it. Best-effort: a Redis failure will not fail the write.
-                await self.context.streaming_cache.publish_update(
-                    self.node.id,
-                    lambda sequence: {
-                        "type": "container-child-created",
-                        "sequence": sequence,
-                        "timestamp": datetime.now().isoformat(),
-                        "key": key,
-                        "structure_family": structure_family,
-                        "specs": [spec.model_dump() for spec in (specs or [])],
-                        "metadata": metadata,
-                        "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                        "access_blob": refreshed_node.access_blob,
-                    },
-                )
+                sequence = await self.context.streaming_cache.incr_seq(self.node.id)
+                metadata = {
+                    "type": "container-child-created",
+                    "sequence": sequence,
+                    "timestamp": datetime.now().isoformat(),
+                    "key": key,
+                    "structure_family": structure_family,
+                    "specs": [spec.model_dump() for spec in (specs or [])],
+                    "metadata": metadata,
+                    "data_sources": [d.model_dump() for d in data_sources_with_ids],
+                    "access_blob": refreshed_node.access_blob,
+                }
+
+                # Cache data in Redis with a TTL, and publish
+                # a notification about it.
+                await self.context.streaming_cache.set(self.node.id, sequence, metadata)
             if self.context.webhook_dispatcher:
                 segments = list(await self.path_segments())
                 child_path = segments + [key]
@@ -978,19 +978,19 @@ class CatalogNodeAdapter:
             self.context.streaming_cache
             and data_source.structure_family == StructureFamily.array
         ):
-            # Cache data in Redis with a TTL, and publish a notification about
-            # it. Best-effort: a Redis failure will not fail the write.
-            await self.context.streaming_cache.publish_update(
-                self.node.id,
-                lambda sequence: {
-                    "type": "array-ref",
-                    "sequence": sequence,
-                    "timestamp": datetime.now().isoformat(),
-                    "data_source": data_source.model_dump(),
-                    "patch": patch.model_dump() if patch else None,
-                    "shape": structure["shape"],
-                },
-            )
+            sequence = await self.context.streaming_cache.incr_seq(self.node.id)
+            metadata = {
+                "type": "array-ref",
+                "sequence": sequence,
+                "timestamp": datetime.now().isoformat(),
+                "data_source": data_source.model_dump(),
+                "patch": patch.model_dump() if patch else None,
+                "shape": structure["shape"],
+            }
+
+            # Cache data in Redis with a TTL, and publish
+            # a notification about it.
+            await self.context.streaming_cache.set(self.node.id, sequence, metadata)
 
     async def revisions(self, offset: int = 0, limit=None):
         async with self.context.session() as db:
@@ -1319,23 +1319,19 @@ class CatalogNodeAdapter:
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
-
-                def _build_metadata(sequence):
-                    payload = {
-                        "type": "container-child-metadata-updated",
-                        "key": self.node.key,
-                        "sequence": sequence,
-                        "timestamp": datetime.now().isoformat(),
-                        "specs": [spec.model_dump() for spec in (specs or [])],
-                        "metadata": metadata,
-                    }
-                    if not drop_revision:
-                        payload["revision_number"] = next_revision_number
-                    return payload
-
-                # Best-effort: a Redis failure will not fail the write.
-                await self.context.streaming_cache.publish_update(
-                    self.node.parent, _build_metadata
+                sequence = await self.context.streaming_cache.incr_seq(self.node.parent)
+                metadata = {
+                    "type": "container-child-metadata-updated",
+                    "key": self.node.key,
+                    "sequence": sequence,
+                    "timestamp": datetime.now().isoformat(),
+                    "specs": [spec.model_dump() for spec in (specs or [])],
+                    "metadata": metadata,
+                }
+                if not drop_revision:
+                    metadata["revision_number"] = next_revision_number
+                await self.context.streaming_cache.set(
+                    self.node.parent, sequence, metadata
                 )
             if self.context.webhook_dispatcher:
                 segments = list(await self.path_segments())
@@ -1645,19 +1641,19 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
         )
 
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
-        # Best-effort: a Redis failure will not fail the write.
-        await self.context.streaming_cache.publish_update(
-            self.node.id,
-            lambda sequence: {
-                "type": "array-data",
-                "sequence": sequence,
-                "timestamp": datetime.now().isoformat(),
-                "mimetype": media_type,
-                "shape": shape,
-                "offset": offset,
-                "block": block,
-            },
-            payload=body,
+        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
+        metadata = {
+            "type": "array-data",
+            "sequence": sequence,
+            "timestamp": datetime.now().isoformat(),
+            "mimetype": media_type,
+            "shape": shape,
+            "offset": offset,
+            "block": block,
+        }
+
+        await self.context.streaming_cache.set(
+            self.node.id, sequence, metadata, payload=body
         )
 
     def make_ws_schema(self):
@@ -1773,19 +1769,18 @@ class CatalogRaggedAdapter(CatalogArrayAdapter):
         }
 
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
-        # Best-effort: a Redis failure will not fail the write.
-        await self.context.streaming_cache.publish_update(
-            self.node.id,
-            lambda sequence: {
-                "type": "ragged-data",
-                "sequence": sequence,
-                "timestamp": datetime.now().isoformat(),
-                "mimetype": media_type,
-                "shape": shape,
-                "offset": offset,
-                "block": block,
-            },
-            payload=body,
+        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
+        metadata = {
+            "type": "ragged-data",
+            "sequence": sequence,
+            "timestamp": datetime.now().isoformat(),
+            "mimetype": media_type,
+            "shape": shape,
+            "offset": offset,
+            "block": block,
+        }
+        await self.context.streaming_cache.set(
+            self.node.id, sequence, metadata, payload=body
         )
 
     async def write_block(
@@ -1862,18 +1857,18 @@ class CatalogTableAdapter(CatalogNodeAdapter):
         }
 
     async def _stream(self, media_type, entry, body, partition, append):
-        # Best-effort: a Redis failure will not fail the write.
-        await self.context.streaming_cache.publish_update(
-            self.node.id,
-            lambda sequence: {
-                "type": "table-data",
-                "sequence": sequence,
-                "timestamp": datetime.now().isoformat(),
-                "mimetype": media_type,
-                "partition": partition,
-                "append": append,
-            },
-            payload=body,
+        sequence = await self.context.streaming_cache.incr_seq(self.node.id)
+        metadata = {
+            "type": "table-data",
+            "sequence": sequence,
+            "timestamp": datetime.now().isoformat(),
+            "mimetype": media_type,
+            "partition": partition,
+            "append": append,
+        }
+
+        await self.context.streaming_cache.set(
+            self.node.id, sequence, metadata, payload=body
         )
 
     async def get(self, *args, **kwargs):

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -258,9 +258,10 @@ class Context:
 
         self.streaming_cache = None
         if self.cache_config:
-            if self.cache_config["uri"].startswith("redis"):
+            uri = self.cache_config.get("uri")
+            if self.cache_config.get("sentinels") or (uri and uri.startswith("redis")):
                 self.cache_config["datastore"] = "redis"
-            elif self.cache_config["uri"].startswith("memory"):
+            elif uri and uri.startswith("memory"):
                 self.cache_config["datastore"] = "memory"
             self.streaming_cache = StreamingCache(self.cache_config)
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -244,6 +244,15 @@ class StreamingCacheConfig(BaseSettings):
     # redis-py detect a stalled connection (e.g. after a Sentinel failover) and
     # reconnect + re-subscribe instead of blocking on the dead primary.
     health_check_interval: int = 30
+    # Redis WAIT write-concern for streaming publishes. After each publish, block
+    # until this many replicas ack the write (up to ``wait_timeout`` ms) so an
+    # in-flight write survives a Sentinel failover. ``None`` auto-selects: 1 when
+    # a Sentinel cluster is configured, else 0 (disabled). In other words it is
+    # on by default under HA (opt-out) -- set to 0 to disable -- while 0 is a
+    # strict no-op that keeps the standalone path unchanged. Shortfalls are
+    # logged + counted, never failing the client write (best-effort end-to-end).
+    wait_num_replicas: Optional[int] = None
+    wait_timeout: int = 1000  # ms
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)
@@ -260,6 +269,10 @@ class StreamingCacheConfig(BaseSettings):
             raise ValueError(
                 "streaming_cache: set either 'uri' or 'sentinels' + 'service_name'."
             )
+        # HA-only activation: default WAIT on when a Sentinel cluster is
+        # configured, off for a single standalone node.
+        if self.wait_num_replicas is None:
+            self.wait_num_replicas = 1 if self.sentinels else 0
         return self
 
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -240,19 +240,16 @@ class StreamingCacheConfig(BaseSettings):
     seq_ttl: int = 2592000  # 30 days
     socket_timeout: int = 86400  # 1 day
     socket_connect_timeout: int = 10
-    # Interval (seconds) between health-check PINGs on idle connections. Lets
-    # redis-py detect a stalled connection (e.g. after a Sentinel failover) and
-    # reconnect + re-subscribe instead of blocking on the dead primary.
+    # Interval (seconds) between health-check PINGs on idle connections, so
+    # redis-py detects a stalled connection after a Sentinel failover and
+    # reconnects instead of blocking on the dead primary.
     health_check_interval: int = 30
-    # Redis WAIT write-concern for streaming publishes. After each publish, block
-    # until this many replicas ack the write (up to ``wait_timeout`` ms) so an
-    # in-flight write survives a Sentinel failover. ``None`` auto-selects: 1 when
-    # a Sentinel cluster is configured, else 0 (disabled). In other words it is
-    # on by default under HA (opt-out) -- set to 0 to disable -- while 0 is a
-    # strict no-op that keeps the standalone path unchanged. Shortfalls are
-    # logged + counted, never failing the client write (best-effort end-to-end).
+    # Redis WAIT write-concern: after each streaming publish, block until this
+    # many replicas ack (up to ``wait_timeout`` ms) so an in-flight write
+    # survives a failover. ``None`` auto-selects 1 under HA (Sentinel) else 0.
+    # Best-effort: a shortfall is logged + counted, never failing the write.
     wait_num_replicas: Optional[int] = None
-    wait_timeout: int = 1000  # ms
+    wait_timeout: Optional[int] = None  # ms; only applies when WAIT is active
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)
@@ -273,6 +270,10 @@ class StreamingCacheConfig(BaseSettings):
         # configured, off for a single standalone node.
         if self.wait_num_replicas is None:
             self.wait_num_replicas = 1 if self.sentinels else 0
+        # ``wait_timeout`` only applies when WAIT is active; give it a concrete
+        # default in that case and leave it unset (not applicable) otherwise.
+        if self.wait_num_replicas > 0 and self.wait_timeout is None:
+            self.wait_timeout = 1000
         return self
 
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -246,20 +246,39 @@ class StreamingCacheConfig(BaseSettings):
     socket_connect_timeout: int = 10
     # Interval (seconds) between health-check PINGs on idle connections, so
     # redis-py detects a stalled connection after a Sentinel failover and
-    # reconnects instead of blocking on the dead primary.
-    health_check_interval: int = 30
+    # reconnects instead of blocking on the dead primary. Kept low because
+    # socket_timeout is long: on a silent primary death (no TCP reset) this
+    # PING is the client's main timely signal, so it bounds failover detection.
+    health_check_interval: int = 10
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)
 
     @model_validator(mode="after")
     def check_source(self) -> "StreamingCacheConfig":
+        # 'uri' and 'sentinels' are mutually exclusive; setting both is
+        # ambiguous (which one wins?), so reject it rather than silently
+        # ignoring one.
+        if self.uri and self.sentinels:
+            raise ValueError(
+                "streaming_cache: set only one of 'uri' or 'sentinels', not both."
+            )
         if self.sentinels:
             if not self.service_name:
                 raise ValueError(
                     "streaming_cache: 'service_name' is required when "
                     "'sentinels' is set."
                 )
+            # Each Sentinel entry must be 'host:port' (parsed the same way as
+            # the client, via rpartition), else the client fails cryptically at
+            # connect time on int('') / a missing host.
+            for entry in self.sentinels:
+                host, sep, port = entry.rpartition(":")
+                if not (sep and host and port.isdigit()):
+                    raise ValueError(
+                        f"streaming_cache: sentinel entry {entry!r} must be "
+                        "'host:port'."
+                    )
         elif not self.uri:
             raise ValueError(
                 "streaming_cache: set either 'uri' or 'sentinels' + 'service_name'."

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -247,7 +247,8 @@ class StreamingCacheConfig(BaseSettings):
     # Redis WAIT write-concern: after each streaming publish, block until this
     # many replicas ack (up to ``wait_timeout`` ms) so an in-flight write
     # survives a failover. ``None`` auto-selects 1 under HA (Sentinel) else 0.
-    # Best-effort: a shortfall is logged + counted, never failing the write.
+    # On shortfall (fewer acks than requested within the timeout) the publish
+    # raises, surfacing as an error to the client, as any Redis write error does.
     wait_num_replicas: Optional[int] = None
     wait_timeout: Optional[int] = None  # ms; only applies when WAIT is active
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -228,7 +228,14 @@ class ValidationSpec(BaseSettings):
 
 
 class StreamingCacheConfig(BaseSettings):
-    uri: str
+    # A single standalone node: ``redis://`` / ``rediss://`` / ``memory``.
+    uri: Optional[str] = None
+    # Or a Redis Sentinel cluster: a list of ``"host:port"`` Sentinels plus
+    # the ``service_name`` of the monitored primary. The client follows
+    # failover to the current primary.
+    sentinels: Optional[list[str]] = None
+    service_name: Optional[str] = None
+    password: Optional[str] = None
     data_ttl: int = 3600  # 1 hr
     seq_ttl: int = 2592000  # 30 days
     socket_timeout: int = 86400  # 1 day
@@ -236,6 +243,20 @@ class StreamingCacheConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)
+
+    @model_validator(mode="after")
+    def check_source(self) -> "StreamingCacheConfig":
+        if self.sentinels:
+            if not self.service_name:
+                raise ValueError(
+                    "streaming_cache: 'service_name' is required when "
+                    "'sentinels' is set."
+                )
+        elif not self.uri:
+            raise ValueError(
+                "streaming_cache: set either 'uri' or 'sentinels' + 'service_name'."
+            )
+        return self
 
 
 class WebhooksConfig(BaseSettings):

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -248,13 +248,6 @@ class StreamingCacheConfig(BaseSettings):
     # redis-py detects a stalled connection after a Sentinel failover and
     # reconnects instead of blocking on the dead primary.
     health_check_interval: int = 30
-    # Redis WAIT write-concern: after each streaming publish, block until this
-    # many replicas ack (up to ``wait_timeout`` ms) so an in-flight write
-    # survives a failover. ``None`` auto-selects 1 under HA (Sentinel) else 0.
-    # On shortfall (fewer acks than requested within the timeout) the publish
-    # raises, surfacing as an error to the client, as any Redis write error does.
-    wait_num_replicas: Optional[int] = None
-    wait_timeout: Optional[int] = None  # ms; only applies when WAIT is active
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)
@@ -271,14 +264,6 @@ class StreamingCacheConfig(BaseSettings):
             raise ValueError(
                 "streaming_cache: set either 'uri' or 'sentinels' + 'service_name'."
             )
-        # HA-only activation: default WAIT on when a Sentinel cluster is
-        # configured, off for a single standalone node.
-        if self.wait_num_replicas is None:
-            self.wait_num_replicas = 1 if self.sentinels else 0
-        # ``wait_timeout`` only applies when WAIT is active; give it a concrete
-        # default in that case and leave it unset (not applicable) otherwise.
-        if self.wait_num_replicas > 0 and self.wait_timeout is None:
-            self.wait_timeout = 1000
         return self
 
 

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -279,7 +279,21 @@ class StreamingCacheConfig(BaseSettings):
                         f"streaming_cache: sentinel entry {entry!r} must be "
                         "'host:port'."
                     )
-        elif not self.uri:
+        elif self.uri:
+            # 'ssl' and 'service_name' apply only to the Sentinel path and are
+            # ignored with a 'uri'. Reject them so a misconfiguration fails loud
+            # -- especially 'ssl', where silently ignoring it would leave a
+            # connection the operator believes is encrypted running in plaintext.
+            if self.ssl:
+                raise ValueError(
+                    "streaming_cache: 'ssl' applies to the 'sentinels' path; for "
+                    "a single-node 'uri' use the rediss:// scheme instead."
+                )
+            if self.service_name:
+                raise ValueError(
+                    "streaming_cache: 'service_name' is only used with 'sentinels'."
+                )
+        else:
             raise ValueError(
                 "streaming_cache: set either 'uri' or 'sentinels' + 'service_name'."
             )

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -280,10 +280,11 @@ class StreamingCacheConfig(BaseSettings):
                         "'host:port'."
                     )
         elif self.uri:
-            # 'ssl' and 'service_name' apply only to the Sentinel path and are
-            # ignored with a 'uri'. Reject them so a misconfiguration fails loud
-            # -- especially 'ssl', where silently ignoring it would leave a
-            # connection the operator believes is encrypted running in plaintext.
+            # 'ssl', 'service_name', and 'password' apply only to the Sentinel
+            # path and are ignored with a 'uri'. Reject them so a misconfiguration
+            # fails loud -- especially 'ssl', where silently ignoring it would
+            # leave a connection the operator believes is encrypted running in
+            # plaintext.
             if self.ssl:
                 raise ValueError(
                     "streaming_cache: 'ssl' applies to the 'sentinels' path; for "
@@ -292,6 +293,11 @@ class StreamingCacheConfig(BaseSettings):
             if self.service_name:
                 raise ValueError(
                     "streaming_cache: 'service_name' is only used with 'sentinels'."
+                )
+            if self.password:
+                raise ValueError(
+                    "streaming_cache: 'password' is only used with 'sentinels'; "
+                    "for a single-node 'uri' include the password in the uri."
                 )
         else:
             raise ValueError(

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -236,6 +236,10 @@ class StreamingCacheConfig(BaseSettings):
     sentinels: Optional[list[str]] = None
     service_name: Optional[str] = None
     password: Optional[str] = None
+    # TLS for the Sentinel path (the standalone ``uri`` path uses ``rediss://``
+    # instead). Applies to both Sentinel discovery and data-node connections;
+    # verification uses redis-py's default, matching ``rediss://``.
+    ssl: bool = False
     data_ttl: int = 3600  # 1 hr
     seq_ttl: int = 2592000  # 30 days
     socket_timeout: int = 86400  # 1 day

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -240,6 +240,10 @@ class StreamingCacheConfig(BaseSettings):
     seq_ttl: int = 2592000  # 30 days
     socket_timeout: int = 86400  # 1 day
     socket_connect_timeout: int = 10
+    # Interval (seconds) between health-check PINGs on idle connections. Lets
+    # redis-py detect a stalled connection (e.g. after a Sentinel failover) and
+    # reconnect + re-subscribe instead of blocking on the dead primary.
+    health_check_interval: int = 30
 
     model_config = SettingsConfigDict(env_prefix="TILED_STREAMING_CACHE_")
     settings_customise_sources = classmethod(settings_customise_sources)

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -100,6 +100,7 @@ properties:
           - "redis-sentinel-3:26379"
         service_name: "mymaster"
         password: "password"
+        ssl: true
       ```
     type: object
     additionalProperties: false
@@ -128,6 +129,15 @@ properties:
         description: |
           Password for the Redis data nodes, used with `sentinels`. (For a
           single-node deployment, include the password in `uri` instead.)
+      ssl:
+        type: boolean
+        description: |
+          Enable TLS for the `sentinels` path, securing both the Sentinel
+          discovery connections and the data-node (primary/replica) connections
+          the client follows failover across. Certificate verification uses the
+          same default as the standalone `rediss://` path. Defaults to `false`.
+          (For a single-node deployment, use the `rediss://` scheme in `uri`
+          instead.)
       data_ttl:
         type: number
         description: Max retention time for streaming data (seconds)

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -98,7 +98,7 @@ properties:
           - "redis-sentinel-1:26379"
           - "redis-sentinel-2:26379"
           - "redis-sentinel-3:26379"
-        service_name: "mymaster"
+        service_name: "tiled-streaming-cache"
         password: "password"
         ssl: true
       ```
@@ -122,8 +122,11 @@ properties:
       service_name:
         type: string
         description: |
-          The name of the Sentinel-monitored primary (e.g. `mymaster`).
-          Required when `sentinels` is set.
+          The name of the Sentinel-monitored replica set (Redis calls it the
+          "master name"): an arbitrary label for the primary-plus-replicas group,
+          which stays fixed across a failover and always resolves to the current
+          primary. Must match the name the Sentinels are configured with (e.g.
+          `tiled-streaming-cache`). Required when `sentinels` is set.
       password:
         type: string
         description: |

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -75,13 +75,59 @@ properties:
             ```
   streaming_cache:
     description: |
-      Streaming cache database
+      Redis-backed cache for live data streaming.
+
+      Provide **either** a single-node `uri` **or**, for a highly-available
+      deployment fronted by Redis Sentinel, a list of `sentinels` together with
+      a `service_name`.
+
+      A single, standalone Redis node:
+
+      ```yaml
+      streaming_cache:
+        uri: "redis://:password@redis-host:6379"
+      ```
+
+      A highly-available cluster managed by Redis Sentinel. Tiled connects to
+      the Sentinels, discovers the current primary for `service_name`, and
+      automatically follows failover when the primary changes:
+
+      ```yaml
+      streaming_cache:
+        sentinels:
+          - "redis-sentinel-1:26379"
+          - "redis-sentinel-2:26379"
+          - "redis-sentinel-3:26379"
+        service_name: "mymaster"
+        password: "password"
+      ```
     type: object
     additionalProperties: false
     properties:
       uri:
         type: string
-        description: Connection string, e.g. `redis://:password@host:port`
+        description: |
+          Connection string for a single, standalone Redis node, e.g.
+          `redis://:password@host:port`. Mutually exclusive with `sentinels`.
+      sentinels:
+        type: array
+        items:
+          type: string
+        description: |
+          For a highly-available deployment, a list of `"host:port"` Redis
+          Sentinel addresses used instead of `uri`. The client discovers the
+          current primary through the Sentinels and follows failover
+          automatically. Requires `service_name`.
+      service_name:
+        type: string
+        description: |
+          The name of the Sentinel-monitored primary (e.g. `mymaster`).
+          Required when `sentinels` is set.
+      password:
+        type: string
+        description: |
+          Password for the Redis data nodes, used with `sentinels`. (For a
+          single-node deployment, include the password in `uri` instead.)
       data_ttl:
         type: number
         description: Max retention time for streaming data (seconds)
@@ -100,8 +146,14 @@ properties:
         description: |
           Configure Redis client. The default is 10 (seconds).
 
-    required:
-      - uri
+      health_check_interval:
+        type: number
+        description: |
+          Interval, in seconds, between health-check PINGs on idle Redis
+          connections. Lets the client detect a stalled connection (e.g. after
+          a Sentinel failover) and reconnect and re-subscribe rather than
+          blocking on the old primary. The default is 30 (seconds).
+
   media_types:
     type: object
     additionalProperties: true

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -165,7 +165,8 @@ properties:
           Interval, in seconds, between health-check PINGs on idle Redis
           connections. Lets the client detect a stalled connection (e.g. after
           a Sentinel failover) and reconnect and re-subscribe rather than
-          blocking on the old primary. The default is 30 (seconds).
+          blocking on the old primary. The default is 10 (seconds); it bounds
+          how quickly the client notices a silently-dead primary.
 
   media_types:
     type: object

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -154,6 +154,24 @@ properties:
           a Sentinel failover) and reconnect and re-subscribe rather than
           blocking on the old primary. The default is 30 (seconds).
 
+      wait_num_replicas:
+        type: number
+        description: |
+          Redis WAIT write-concern for streaming publishes. After each publish,
+          block until this many replicas acknowledge the write (up to
+          `wait_timeout` milliseconds) so an in-flight write survives a Sentinel
+          failover. If unset, this defaults to 1 when a Sentinel cluster
+          (`sentinels`) is configured and 0 (disabled) otherwise. A value of 0
+          is a strict no-op. Replication shortfalls are logged and counted via
+          the `tiled_streaming_replication_shortfall_total` metric but never fail
+          the client write (best-effort end-to-end).
+
+      wait_timeout:
+        type: number
+        description: |
+          Timeout, in milliseconds, for the Redis WAIT write-concern (see
+          `wait_num_replicas`). The default is 1000 (1 second).
+
   media_types:
     type: object
     additionalProperties: true

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -109,7 +109,11 @@ properties:
         type: string
         description: |
           Connection string for a single, standalone Redis node, e.g.
-          `redis://:password@host:port`. Mutually exclusive with `sentinels`.
+          `redis://:password@host:port`. The username is optional: omit it
+          (`redis://:password@host:port`) to authenticate as the default user
+          with `requirepass`, or include it (`redis://user:password@host:port`)
+          for a Redis 6+ ACL user. Use the `rediss://` scheme for TLS. Mutually
+          exclusive with `sentinels`.
       sentinels:
         type: array
         items:

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -162,9 +162,9 @@ properties:
           `wait_timeout` milliseconds) so an in-flight write survives a Sentinel
           failover. If unset, this defaults to 1 when a Sentinel cluster
           (`sentinels`) is configured and 0 (disabled) otherwise. A value of 0
-          is a strict no-op. Replication shortfalls are logged and counted via
-          the `tiled_streaming_replication_shortfall_total` metric but never fail
-          the client write (best-effort end-to-end).
+          is a strict no-op. On a shortfall (fewer replicas acknowledge than
+          requested within `wait_timeout`), the publish raises and the client's
+          write fails, as it does for any other Redis write error.
 
       wait_timeout:
         type: number

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -170,7 +170,9 @@ properties:
         type: number
         description: |
           Timeout, in milliseconds, for the Redis WAIT write-concern (see
-          `wait_num_replicas`). The default is 1000 (1 second).
+          `wait_num_replicas`). Only applies when WAIT is active
+          (`wait_num_replicas` > 0); it defaults to 1000 (1 second) in that
+          case and is otherwise unset.
 
   media_types:
     type: object

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -167,10 +167,10 @@ properties:
         type: number
         description: |
           Interval, in seconds, between health-check PINGs on idle Redis
-          connections. Lets the client detect a stalled connection (e.g. after
-          a Sentinel failover) and reconnect and re-subscribe rather than
-          blocking on the old primary. The default is 10 (seconds); it bounds
-          how quickly the client notices a silently-dead primary.
+          connections. Applies to the Sentinel (HA) path only, where it lets the
+          client detect a stalled connection after a failover and reconnect
+          rather than blocking on the old primary. The default is 10 (seconds);
+          it bounds how quickly the client notices a silently-dead primary.
 
   media_types:
     type: object

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -164,26 +164,6 @@ properties:
           a Sentinel failover) and reconnect and re-subscribe rather than
           blocking on the old primary. The default is 30 (seconds).
 
-      wait_num_replicas:
-        type: number
-        description: |
-          Redis WAIT write-concern for streaming publishes. After each publish,
-          block until this many replicas acknowledge the write (up to
-          `wait_timeout` milliseconds) so an in-flight write survives a Sentinel
-          failover. If unset, this defaults to 1 when a Sentinel cluster
-          (`sentinels`) is configured and 0 (disabled) otherwise. A value of 0
-          is a strict no-op. On a shortfall (fewer replicas acknowledge than
-          requested within `wait_timeout`), the publish raises and the client's
-          write fails, as it does for any other Redis write error.
-
-      wait_timeout:
-        type: number
-        description: |
-          Timeout, in milliseconds, for the Redis WAIT write-concern (see
-          `wait_num_replicas`). Only applies when WAIT is active
-          (`wait_num_replicas` > 0); it defaults to 1000 (1 second) in that
-          case and is otherwise unset.
-
   media_types:
     type: object
     additionalProperties: true

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -176,7 +176,7 @@ def build_app(
 
     if scalable:
         streaming_cache = server_settings.get("streaming_cache", None)
-        if streaming_cache and streaming_cache["uri"].startswith("memory"):
+        if streaming_cache and (streaming_cache.get("uri") or "").startswith("memory"):
             raise UnscalableConfig(
                 dedent(
                     """

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -116,13 +116,6 @@ DB_POOL_AT_MAX_TOTAL = Counter(
     ["uri"],
 )
 
-STREAMING_REPLICATION_SHORTFALL_TOTAL = Counter(
-    "tiled_streaming_replication_shortfall_total",
-    "Number of streaming publishes where the Redis WAIT write-concern was not "
-    "satisfied (fewer replicas acknowledged than requested, or the write was "
-    "rejected). Best-effort: these do not fail the client write.",
-)
-
 # Initialize labels in advance so that the metrics exist (and can be used in
 # dashboards and alerts) even if they have not yet occurred.
 for code in ["200", "304", "500"]:

--- a/tiled/server/metrics.py
+++ b/tiled/server/metrics.py
@@ -116,6 +116,13 @@ DB_POOL_AT_MAX_TOTAL = Counter(
     ["uri"],
 )
 
+STREAMING_REPLICATION_SHORTFALL_TOTAL = Counter(
+    "tiled_streaming_replication_shortfall_total",
+    "Number of streaming publishes where the Redis WAIT write-concern was not "
+    "satisfied (fewer replicas acknowledged than requested, or the write was "
+    "rejected). Best-effort: these do not fail the client write.",
+)
+
 # Initialize labels in advance so that the metrics exist (and can be used in
 # dashboards and alerts) even if they have not yet occurred.
 for code in ["200", "304", "500"]:

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -11,7 +11,6 @@ import orjson
 from fastapi import WebSocketDisconnect
 from redis import asyncio as redis
 from redis.asyncio.sentinel import Sentinel
-from redis.exceptions import ConnectionError as RedisConnectionError
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
@@ -194,6 +193,12 @@ class PubSub:
         return gen()
 
 
+# Sentinel pushed onto the live-event buffer when the live subscription drops
+# (e.g. a Redis failover). It signals the handler to close the socket abnormally
+# so the client reconnects and replays any sequences missed during the outage.
+_LIVE_SUBSCRIPTION_LOST = object()
+
+
 def _make_ws_handler_common(
     *,
     websocket,
@@ -302,6 +307,9 @@ def _make_ws_handler_common(
                 logger.exception(
                     f"Live subscription error for node {node_id}: {e}",
                 )
+                # Signal the handler to close the socket abnormally so the client
+                # reconnects and replays any sequences missed during the outage.
+                await stream_buffer.put(_LIVE_SUBSCRIPTION_LOST)
             finally:
                 if live_cleanup is not None:
                     await live_cleanup()
@@ -319,6 +327,13 @@ def _make_ws_handler_common(
         try:
             while not end_stream.is_set():
                 live_seq = await stream_buffer.get()
+
+                if live_seq is _LIVE_SUBSCRIPTION_LOST:
+                    # Close abnormally (1012) so the client's reconnect loop
+                    # resumes from its last received sequence and replays any
+                    # events missed while the subscription was down.
+                    await websocket.close(code=1012, reason="Live subscription lost")
+                    return
 
                 # Skip duplicates or already replayed messages
                 if live_seq <= last_sent:
@@ -522,28 +537,12 @@ class RedisStreamingDatastore(StreamingDatastore):
             await pubsub.subscribe(f"notify:{node_id}")
 
             async def live_iter():
-                nonlocal pubsub
-                while True:
-                    try:
-                        async for message in pubsub.listen():
-                            if message.get("type") == "message":
-                                try:
-                                    yield int(message["data"])
-                                except Exception as e:
-                                    logger.exception(f"Error parsing live message: {e}")
-                    except RedisConnectionError:
-                        # A Sentinel failover closes the pub/sub link; re-create
-                        # it (re-resolving the current primary) and resubscribe.
-                        logger.warning(
-                            "Streaming pub/sub connection lost; resubscribing."
-                        )
+                async for message in pubsub.listen():
+                    if message.get("type") == "message":
                         try:
-                            await pubsub.aclose()
-                        except Exception:
-                            pass
-                        await asyncio.sleep(0.5)
-                        pubsub = self.client.pubsub()
-                        await pubsub.subscribe(f"notify:{node_id}")
+                            yield int(message["data"])
+                        except Exception as e:
+                            logger.exception(f"Error parsing live message: {e}")
 
             async def cleanup():
                 await pubsub.unsubscribe(f"notify:{node_id}")

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -32,7 +32,9 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
     kwargs = dict(
         socket_timeout=settings["socket_timeout"],
         socket_connect_timeout=settings["socket_connect_timeout"],
-        health_check_interval=settings["health_check_interval"],
+        # Default mirrors StreamingCacheConfig; tolerate a partial cache_config
+        # (e.g. from a direct from_uri call) as the memory datastore does.
+        health_check_interval=settings.get("health_check_interval", 30),
     )
     sentinels = settings.get("sentinels")
     if sentinels:
@@ -490,28 +492,10 @@ class RedisStreamingDatastore(StreamingDatastore):
         self._client = _build_redis_client(settings)
         self.data_ttl = self._settings["data_ttl"]
         self.seq_ttl = self._settings["seq_ttl"]
-        self.wait_num_replicas = self._settings["wait_num_replicas"]
-        self.wait_timeout = self._settings["wait_timeout"]
 
     @property
     def client(self) -> redis.Redis:
         return self._client
-
-    async def _wait_for_replicas(self, node_id: str) -> None:
-        """Block until ``wait_num_replicas`` acknowledge the latest write.
-
-        Raises ``redis.RedisError`` if fewer than the requested number of
-        replicas ack within ``wait_timeout`` ms, so the client's write fails
-        rather than silently going unreplicated.
-        """
-        if not self.wait_num_replicas:
-            return
-        acked = await self.client.wait(self.wait_num_replicas, self.wait_timeout)
-        if acked < self.wait_num_replicas:
-            raise redis.RedisError(
-                f"Streaming write for {node_id} replicated to {acked} of "
-                f"{self.wait_num_replicas} required replicas."
-            )
 
     async def incr_seq(self, node_id: str) -> int:
         return await self.client.incr(f"sequence:{node_id}")
@@ -530,7 +514,6 @@ class RedisStreamingDatastore(StreamingDatastore):
         # Extend the lifetime of the sequence counter.
         pipeline.expire(f"sequence:{node_id}", self.seq_ttl)
         await pipeline.execute()
-        await self._wait_for_replicas(node_id)
 
     async def close(self, node_id):
         # Increment the counter for this node.
@@ -557,7 +540,6 @@ class RedisStreamingDatastore(StreamingDatastore):
         pipeline.expire(f"sequence:{node_id}", 1 + self.data_ttl)
         pipeline.publish(f"notify:{node_id}", sequence)
         await pipeline.execute()
-        await self._wait_for_replicas(node_id)
 
     async def get(self, key, *fields):
         return await self.client.hmget(key, *fields)

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -11,6 +11,7 @@ import orjson
 from fastapi import WebSocketDisconnect
 from redis import asyncio as redis
 from redis.asyncio.sentinel import Sentinel
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
@@ -29,6 +30,7 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
     kwargs = dict(
         socket_timeout=settings["socket_timeout"],
         socket_connect_timeout=settings["socket_connect_timeout"],
+        health_check_interval=settings["health_check_interval"],
     )
     sentinels = settings.get("sentinels")
     if sentinels:
@@ -520,12 +522,28 @@ class RedisStreamingDatastore(StreamingDatastore):
             await pubsub.subscribe(f"notify:{node_id}")
 
             async def live_iter():
-                async for message in pubsub.listen():
-                    if message.get("type") == "message":
+                nonlocal pubsub
+                while True:
+                    try:
+                        async for message in pubsub.listen():
+                            if message.get("type") == "message":
+                                try:
+                                    yield int(message["data"])
+                                except Exception as e:
+                                    logger.exception(f"Error parsing live message: {e}")
+                    except RedisConnectionError:
+                        # A Sentinel failover closes the pub/sub link; re-create
+                        # it (re-resolving the current primary) and resubscribe.
+                        logger.warning(
+                            "Streaming pub/sub connection lost; resubscribing."
+                        )
                         try:
-                            yield int(message["data"])
-                        except Exception as e:
-                            logger.exception(f"Error parsing live message: {e}")
+                            await pubsub.aclose()
+                        except Exception:
+                            pass
+                        await asyncio.sleep(0.5)
+                        pubsub = self.client.pubsub()
+                        await pubsub.subscribe(f"notify:{node_id}")
 
             async def cleanup():
                 await pubsub.unsubscribe(f"notify:{node_id}")

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -14,6 +14,7 @@ from redis.asyncio.sentinel import Sentinel
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
+from .metrics import STREAMING_REPLICATION_SHORTFALL_TOTAL
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,31 @@ class StreamingCache:
 
     async def set(self, node_id, sequence, metadata, payload=None):
         await self._datastore.set(node_id, sequence, metadata, payload)
+
+    async def publish_update(self, node_id, build_metadata, payload=None):
+        """Best-effort streaming publish: incr sequence, build metadata, set.
+
+        The catalog (Postgres) commit is the source of truth and has already
+        succeeded by the time this is called. Redis errors here — a connection
+        failure mid-failover, or a ``NOREPLICAS`` rejection from a
+        ``min-replicas-to-write`` write-concern gate — are logged and counted
+        but never raised, so a streaming hiccup cannot fail a client write.
+
+        ``build_metadata`` is a callable taking the freshly incremented
+        ``sequence`` and returning the metadata dict to publish.
+        """
+        try:
+            sequence = await self._datastore.incr_seq(node_id)
+            metadata = build_metadata(sequence)
+            await self._datastore.set(node_id, sequence, metadata, payload)
+        except redis.RedisError:
+            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
+            logger.warning(
+                "Streaming publish to node %s failed; live subscribers will "
+                "not receive this update (catalog commit already persisted).",
+                node_id,
+                exc_info=True,
+            )
 
     @property
     def client(self):
@@ -476,10 +502,46 @@ class RedisStreamingDatastore(StreamingDatastore):
         self._client = _build_redis_client(settings)
         self.data_ttl = self._settings["data_ttl"]
         self.seq_ttl = self._settings["seq_ttl"]
+        self.wait_num_replicas = self._settings.get("wait_num_replicas") or 0
+        self.wait_timeout = self._settings.get("wait_timeout", 1000)
 
     @property
     def client(self) -> redis.Redis:
         return self._client
+
+    async def _wait_for_replicas(self, node_id) -> None:
+        """Best-effort Redis WAIT write-concern for a just-published write.
+
+        Block until ``wait_num_replicas`` replicas acknowledge the write, up to
+        ``wait_timeout`` ms, so an in-flight write survives a Sentinel failover.
+        A shortfall (or any Redis error) is logged and counted but never raised:
+        the client write has already succeeded against the primary.
+        """
+        if self.wait_num_replicas <= 0:
+            return
+        try:
+            acked = await self.client.execute_command(
+                "WAIT", self.wait_num_replicas, self.wait_timeout
+            )
+        except redis.RedisError:
+            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
+            logger.warning(
+                "Redis WAIT failed for node %s; streamed write may not be "
+                "replicated.",
+                node_id,
+                exc_info=True,
+            )
+            return
+        if acked < self.wait_num_replicas:
+            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
+            logger.warning(
+                "Redis WAIT for node %s: %d of %d replicas acknowledged within "
+                "%d ms; streamed write may be lost on failover.",
+                node_id,
+                acked,
+                self.wait_num_replicas,
+                self.wait_timeout,
+            )
 
     async def incr_seq(self, node_id: str) -> int:
         return await self.client.incr(f"sequence:{node_id}")
@@ -498,6 +560,7 @@ class RedisStreamingDatastore(StreamingDatastore):
         # Extend the lifetime of the sequence counter.
         pipeline.expire(f"sequence:{node_id}", self.seq_ttl)
         await pipeline.execute()
+        await self._wait_for_replicas(node_id)
 
     async def close(self, node_id):
         # Increment the counter for this node.
@@ -524,6 +587,7 @@ class RedisStreamingDatastore(StreamingDatastore):
         pipeline.expire(f"sequence:{node_id}", 1 + self.data_ttl)
         pipeline.publish(f"notify:{node_id}", sequence)
         await pipeline.execute()
+        await self._wait_for_replicas(node_id)
 
     async def get(self, key, *fields):
         return await self.client.hmget(key, *fields)

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -34,7 +34,7 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
         socket_connect_timeout=settings["socket_connect_timeout"],
         # Default mirrors StreamingCacheConfig; tolerate a partial cache_config
         # (e.g. from a direct from_uri call) as the memory datastore does.
-        health_check_interval=settings.get("health_check_interval", 30),
+        health_check_interval=settings.get("health_check_interval", 10),
     )
     sentinels = settings.get("sentinels")
     if sentinels:

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -111,31 +111,6 @@ class StreamingCache:
     async def set(self, node_id, sequence, metadata, payload=None):
         await self._datastore.set(node_id, sequence, metadata, payload)
 
-    async def publish_update(self, node_id, build_metadata, payload=None):
-        """Best-effort streaming publish: incr sequence, build metadata, set.
-
-        The catalog (Postgres) commit is the source of truth and has already
-        succeeded by the time this is called. Redis errors here — a connection
-        failure mid-failover, or a ``NOREPLICAS`` rejection from a
-        ``min-replicas-to-write`` write-concern gate — are logged and counted
-        but never raised, so a streaming hiccup cannot fail a client write.
-
-        ``build_metadata`` is a callable taking the freshly incremented
-        ``sequence`` and returning the metadata dict to publish.
-        """
-        try:
-            sequence = await self._datastore.incr_seq(node_id)
-            metadata = build_metadata(sequence)
-            await self._datastore.set(node_id, sequence, metadata, payload)
-        except redis.RedisError:
-            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
-            logger.warning(
-                "Streaming publish to node %s failed; live subscribers will "
-                "not receive this update (catalog commit already persisted).",
-                node_id,
-                exc_info=True,
-            )
-
     @property
     def client(self):
         return self._datastore.client

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -14,7 +14,6 @@ from redis.asyncio.sentinel import Sentinel
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
-from .metrics import STREAMING_REPLICATION_SHORTFALL_TOTAL
 
 logger = logging.getLogger(__name__)
 
@@ -477,45 +476,27 @@ class RedisStreamingDatastore(StreamingDatastore):
         self._client = _build_redis_client(settings)
         self.data_ttl = self._settings["data_ttl"]
         self.seq_ttl = self._settings["seq_ttl"]
-        self.wait_num_replicas = self._settings.get("wait_num_replicas") or 0
-        self.wait_timeout = self._settings.get("wait_timeout", 1000)
+        self.wait_num_replicas = self._settings["wait_num_replicas"]
+        self.wait_timeout = self._settings["wait_timeout"]
 
     @property
     def client(self) -> redis.Redis:
         return self._client
 
-    async def _wait_for_replicas(self, node_id) -> None:
-        """Best-effort Redis WAIT write-concern for a just-published write.
+    async def _wait_for_replicas(self, node_id: str) -> None:
+        """Block until ``wait_num_replicas`` acknowledge the latest write.
 
-        Block until ``wait_num_replicas`` replicas acknowledge the write, up to
-        ``wait_timeout`` ms, so an in-flight write survives a Sentinel failover.
-        A shortfall (or any Redis error) is logged and counted but never raised:
-        the client write has already succeeded against the primary.
+        Raises ``redis.RedisError`` if fewer than the requested number of
+        replicas ack within ``wait_timeout`` ms, so the client's write fails
+        rather than silently going unreplicated.
         """
-        if self.wait_num_replicas <= 0:
+        if not self.wait_num_replicas:
             return
-        try:
-            acked = await self.client.execute_command(
-                "WAIT", self.wait_num_replicas, self.wait_timeout
-            )
-        except redis.RedisError:
-            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
-            logger.warning(
-                "Redis WAIT failed for node %s; streamed write may not be "
-                "replicated.",
-                node_id,
-                exc_info=True,
-            )
-            return
+        acked = await self.client.wait(self.wait_num_replicas, self.wait_timeout)
         if acked < self.wait_num_replicas:
-            STREAMING_REPLICATION_SHORTFALL_TOTAL.inc()
-            logger.warning(
-                "Redis WAIT for node %s: %d of %d replicas acknowledged within "
-                "%d ms; streamed write may be lost on failover.",
-                node_id,
-                acked,
-                self.wait_num_replicas,
-                self.wait_timeout,
+            raise redis.RedisError(
+                f"Streaming write for {node_id} replicated to {acked} of "
+                f"{self.wait_num_replicas} required replicas."
             )
 
     async def incr_seq(self, node_id: str) -> int:

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -10,11 +10,35 @@ import cachetools
 import orjson
 from fastapi import WebSocketDisconnect
 from redis import asyncio as redis
+from redis.asyncio.sentinel import Sentinel
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
 
 logger = logging.getLogger(__name__)
+
+
+def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
+    """Build the async Redis client for the streaming datastore.
+
+    - ``uri`` (``redis://`` / ``rediss://``) — a single standalone node.
+    - ``sentinels`` (a list of ``"host:port"``) plus ``service_name`` — a
+      Sentinel-managed cluster; the client follows failover to the current
+      primary.
+    """
+    kwargs = dict(
+        socket_timeout=settings["socket_timeout"],
+        socket_connect_timeout=settings["socket_connect_timeout"],
+    )
+    sentinels = settings.get("sentinels")
+    if sentinels:
+        hosts = [
+            (host, int(port))
+            for host, _, port in (s.rpartition(":") for s in sentinels)
+        ]
+        sentinel = Sentinel(hosts, password=settings.get("password"), **kwargs)
+        return sentinel.master_for(settings["service_name"])
+    return redis.from_url(settings["uri"], **kwargs)
 
 
 def safe_json_dump(content):
@@ -431,13 +455,7 @@ class TTLCacheDatastore(StreamingDatastore):
 class RedisStreamingDatastore(StreamingDatastore):
     def __init__(self, settings: Dict[str, Any]):
         self._settings = settings
-        socket_timeout = self._settings["socket_timeout"]
-        socket_connect_timeout = self._settings["socket_connect_timeout"]
-        self._client = redis.from_url(
-            self._settings["uri"],
-            socket_timeout=socket_timeout,
-            socket_connect_timeout=socket_connect_timeout,
-        )
+        self._client = _build_redis_client(settings)
         self.data_ttl = self._settings["data_ttl"]
         self.seq_ttl = self._settings["seq_ttl"]
 

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -307,8 +307,8 @@ def _make_ws_handler_common(
                 logger.exception(
                     f"Live subscription error for node {node_id}: {e}",
                 )
-                # Signal the handler to close the socket abnormally so the client
-                # reconnects and replays any sequences missed during the outage.
+                # Enqueue a sentinel to wake the main loop, which is otherwise
+                # blocked forever on an empty buffer now that this task has died.
                 await stream_buffer.put(_LIVE_SUBSCRIPTION_LOST)
             finally:
                 if live_cleanup is not None:
@@ -329,9 +329,10 @@ def _make_ws_handler_common(
                 live_seq = await stream_buffer.get()
 
                 if live_seq is _LIVE_SUBSCRIPTION_LOST:
-                    # Close abnormally (1012) so the client's reconnect loop
-                    # resumes from its last received sequence and replays any
-                    # events missed while the subscription was down.
+                    # Must be an *abnormal* close: a graceful 1000 reads as
+                    # ConnectionClosedOK on the client and would not reconnect.
+                    # 1012 yields ConnectionClosedError, so the client reconnects
+                    # and resumes from its last received sequence.
                     await websocket.close(code=1012, reason="Live subscription lost")
                     return
 

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -32,9 +32,6 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
     kwargs = dict(
         socket_timeout=settings["socket_timeout"],
         socket_connect_timeout=settings["socket_connect_timeout"],
-        # Default mirrors StreamingCacheConfig; tolerate a partial cache_config
-        # (e.g. from a direct from_uri call) as the memory datastore does.
-        health_check_interval=settings.get("health_check_interval", 10),
     )
     sentinels = settings.get("sentinels")
     if sentinels:
@@ -42,6 +39,12 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
             (host, int(port))
             for host, _, port in (s.rpartition(":") for s in sentinels)
         ]
+        # health_check_interval only matters for Sentinel failover detection, so
+        # it is applied on the HA path only -- the standalone from_url call below
+        # stays identical to the pre-HA behavior. Default mirrors
+        # StreamingCacheConfig; tolerate a partial cache_config (e.g. from a
+        # direct from_uri call) as the memory datastore does.
+        kwargs["health_check_interval"] = settings.get("health_check_interval", 10)
         sentinel_kwargs = None
         if settings.get("ssl"):
             # TLS for both Sentinel discovery and data-node connections.

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -25,6 +25,9 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
     - ``sentinels`` (a list of ``"host:port"``) plus ``service_name`` — a
       Sentinel-managed cluster; the client follows failover to the current
       primary.
+
+    When ``ssl`` is set (Sentinel path), TLS is applied to both the Sentinel
+    discovery and the data-node connections.
     """
     kwargs = dict(
         socket_timeout=settings["socket_timeout"],
@@ -37,7 +40,18 @@ def _build_redis_client(settings: Dict[str, Any]) -> redis.Redis:
             (host, int(port))
             for host, _, port in (s.rpartition(":") for s in sentinels)
         ]
-        sentinel = Sentinel(hosts, password=settings.get("password"), **kwargs)
+        sentinel_kwargs = None
+        if settings.get("ssl"):
+            # TLS for both Sentinel discovery and data-node connections.
+            tls_kwargs = {"ssl": True}
+            kwargs.update(tls_kwargs)
+            sentinel_kwargs = tls_kwargs
+        sentinel = Sentinel(
+            hosts,
+            password=settings.get("password"),
+            sentinel_kwargs=sentinel_kwargs,
+            **kwargs,
+        )
         return sentinel.master_for(settings["service_name"])
     return redis.from_url(settings["uri"], **kwargs)
 


### PR DESCRIPTION
Updates to support Redis high availability (Sentinel) for the streaming cache.

This PR only changes Tiled behavior when a Redis HA configuration is set in the Tiled config file; the standalone `uri` path is unchanged.

## Configuration

The `streaming_cache` section gains a Sentinel-based alternative to a single `uri` because the Sentinal-based Redis client does not support a `uri`.

- `sentinels` — a list of `"host:port"` Sentinel addresses.
- `service_name` — the monitored primary's name (e.g. `mymaster`).
- `password` — password for the Redis data nodes.
- `ssl` — enable TLS for the Sentinel path (Sentinel discovery **and** the data-node connections the client follows failover across). The standalone path expresses TLS via the `rediss://` scheme instead.
- `health_check_interval` — seconds between health-check PINGs on idle connections, so redis-py detects a stalled connection after a failover and reconnects instead of blocking on the dead primary.

When `sentinels` is set the datastore uses `Sentinel(...).master_for(service_name)`, which auto-detects failover and reconnects to the current primary.

## Notes

- `redis.asyncio.from_url()` and `redis.asyncio.Sentinel.master_for()` return the exact same class (`redis.asyncio.client.Redis`), and every method Tiled calls (`incr`, `pipeline`, `hset`, `expire`, `publish`, `get`, `hmget`, `pubsub`) is literally the same function. The only difference is the connection pool: `SentinelConnectionPool` vs a plain `ConnectionPool`.
- `Sentinel(...).master_for(service_name)` auto-detects failover and reconnects to the new primary (and doesn't support a URI connection string): https://redis.readthedocs.io/en/stable/connections.html#id1

## Handling a dropped subscription

In redis-py's asyncio client, the server's pinned pub/sub connection drops on **both** a hard crash of the primary **and** a graceful `sentinel failover`. In the graceful case this is because redis-py's Sentinel connection pool detects on its next health check that the node it is connected to was demoted from primary, and disconnects to re-resolve the new primary. Either way the drop surfaces as a `ConnectionError` that terminates `pubsub.listen()`.

Rather than resubscribing in place server-side — which would duplicate Tiled's existing client reconnect + sequence-replay — the server unblocks its send loop and closes the websocket abnormally (`1012`). The client's existing reconnect loop resumes from `_last_received_sequence` (tiled-client state) and the server replays from the new primary's current state. Tiled server doesn't keep track of `_last_received_sequence` this adds to the argument that the tiled-client is where the reconnect logic belongs.

Without this, the send loop blocks forever on an empty buffer, the socket stays open, and the subscriber silently stops receiving events permanently; with it, the subscriber reconnects and re-syncs. This keeps the diff minimal and leaves the non-HA path unchanged.

## Delivery semantics

Live streaming is **best-effort** — the durable record is the SQL catalog, which is committed before the streaming publish. According to the Redis docs, Redis Pub/Sub is at-most-once:

> Redis' Pub/Sub exhibits at-most-once message delivery semantics. As the name suggests, it means that a message will be delivered once if at all. Once the message is sent by the Redis server, there's no chance of it being sent again. If the subscriber is unable to handle the message (for example, due to an error or a network disconnect) the message is forever lost. (https://redis.io/docs/latest/develop/pubsub/, "Delivery semantics")

An **ordinary connection drop is lossless**: the client reconnects and resumes from `_last_received_sequence + 1`, and the server replays anything after that (skipping sequences `<= last_sent`), so a normal reconnect neither loses nor duplicates updates.

The **residual risk is a failover to a replica that had not yet caught up**. Redis replication is asynchronous and there is no per-write replication confirmation, so:

- a write the old primary acknowledged but had not replicated is **lost**; and
- because the promoted replica's `INCR` sequence counter is behind, it can re-issue already-used sequence numbers for new data, **re-delivering** them (the client does not filter incoming messages by its own last-received).

Server-side `min-replicas-to-write` / `min-replicas-max-lag` on the Redis primary narrow this window (reject writes when replicas are absent or lagging) but cannot guarantee a given write was replicated. That is the guard this PR relies on. A client-issued Redis `WAIT` write-concern would bound the window further; it is **deferred** — see below for why, and as a reference if we add it later.

## Deferred: client-issued `WAIT` write-concern (kept for reference)

An earlier revision of this PR added a Redis `WAIT` write-concern on streaming publishes, controlled by two `streaming_cache` settings (`wait_num_replicas`, `wait_timeout`): after each publish, block until `wait_num_replicas` replicas acknowledge the write, and on a shortfall (fewer acks than requested within `wait_timeout`) raise so the client's write fails — the same path any Redis write error already takes (the publish runs after the Postgres commit, so a failure propagates to the client). This section records the rationale so we understand the trade-offs.

### Why `WAIT` requires a non-transactional pipeline

Redis `WAIT` is a **per-connection** guarantee: it blocks the calling connection until writes previously issued *on that same connection* are acknowledged by the requested number of replicas (https://redis.io/docs/latest/commands/wait/). Two consequences follow.

First, `WAIT` must run on the **same connection** as the writes. The datastore uses a single shared, pool-backed async client (both the standalone `from_url` path and the Sentinel `master_for` path draw from one pool shared across concurrent requests). Running `pipeline.execute()` and then a separate `client.wait(...)` does not guarantee both land on the same connection — under concurrency the pool can hand `WAIT` a *different* connection than the one that did the writes, making the check meaningless. (Serial tests pass only because the pool is LIFO and returns the just-released connection — luck, not a guarantee.) Appending `WAIT` to the **same pipeline** forces redis-py to acquire one connection, run the writes and `WAIT` on it, then release it.

Second, `WAIT` **does not block inside a `MULTI`/`EXEC` transaction pipeline** — there it returns immediately, reporting the replica count at enqueue time instead of waiting for acknowledgements. redis-py's default `pipeline()` is transactional, so a `WAIT` appended to it would return instantly and guarantee nothing. To make `WAIT` block, the publish pipeline must be **non-transactional** when the write-concern is active (`self.client.pipeline(transaction=not self.wait_num_replicas)`), reading the trailing result from `results[-1]`.

Dropping `MULTI`/`EXEC` atomicity (transaction=false) on that path may not be safe, it would change the current proven write behavior and would require a decent amount of investigation to prove that we can drop the atomicity of the write pipeline.

**Why it is client-driven and not a server setting.** Redis replication is asynchronous by design and there is no `redis.conf` directive that makes an individual write block until it is replicated; the docs state that *"synchronous replication of certain data can be requested by the clients using the `WAIT` command"* (https://redis.io/docs/latest/operate/oss_and_stack/management/replication/). The one server-side knob, `min-replicas-to-write` / `min-replicas-max-lag`, is explicitly *best-effort* — it gates writes on how many replicas are connected and within a lag bound, but *"it is not possible to ensure the replica actually received a given write."* It therefore complements `WAIT` but cannot replace the per-write acknowledgement check, which must be issued and verified by the client. (Both MongoDB and Kafka fold the replication check into the write itself and enforce it server-side, rather than exposing it as a separate command the client has to issue on the right connection.)

## Integration testing

Because this path can't be exercised by the in-process `TestClient`, it was validated manually against a live Redis Sentinel replica set in podman (3 Redis nodes + 3 Sentinels, Tiled running in-network, pointed at the Sentinels via structured config), in both plaintext and full-TLS mode.

The test reproduces a Redis node failure:

1. A subscriber attaches to a node and records every sequence number it receives.
2. A background writer appends a new frame every 0.4s, continuously, before/during/after the outage.
3. After a steady-state phase, the primary Redis node the server's pub/sub is pinned to is crashed (`podman stop`), and Sentinel elects a new primary.
4. The writer keeps appending straight through the failover and reconnect window.

We verify that:

- the received sequence is **contiguous with no gaps** (for the caught-up subscriber);
- the stream **kept growing** after the crash;
- the server logs a **non-zero `start=` reconnect handshake** for that node — the unambiguous fingerprint of drop → reconnect → resume (the initial connect is always `start=0`);
- the **array read back** at the end equals the full range that was written (end-to-end data integrity).

**Result:** with the primary killed mid-stream, Sentinel promoted a replica and the client reconnected. The caught-up subscriber's stream stayed contiguous across the failover (it had already received everything the old primary acked); the reconnect resynced it to the new primary rather than hanging. A subsequent graceful `sentinel failover` likewise dropped the pinned connection, triggered a resume, and resynced. Without this change the same scenario hangs the socket open and the subscriber silently stops receiving events.

This is exactly the behavior we want: a primary crash or failover is transparent to subscribers instead of a silent permanent stall.
