### PR TITLE
Raising a 422 exception when column name is too long instead of a 500 exception

### DIFF
--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -20,6 +20,7 @@ from tiled.storage import (
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import DataSource, Management
 from tiled.structures.table import TableStructure
+from tiled.utils import UnsafeIdentifier
 
 names = ["f0", "f1", "f2", "f3"]
 data0 = [
@@ -1247,3 +1248,36 @@ def test_primary_key_invalid_type_raises(
     data_source = data_source_from_init_storage(data_uri_val, 1, schema.empty_table())
     with pytest.raises(ValueError, match="bad_col"):
         adapter_from_data_source(data_source, primary_key=["bad_col"])
+
+
+@pytest.mark.parametrize("data_uri", ["sqlite_uri", "duckdb_uri", "postgres_uri"])
+def test_column_name_too_long(data_uri: str, request: pytest.FixtureRequest) -> None:
+    # Define a table and a storage
+    data_uri = request.getfixturevalue(data_uri)
+    storage = cast(SQLStorage, parse_storage(data_uri))
+    register_storage(storage)
+
+    # Create a table with a column name that exceeds the maximum length of 63 characters
+    table = pa.Table.from_arrays(
+        [[1, 2, 3], [4, 5, 6]],
+        [
+            "column_name_that_is_way_too_long_and_should_"
+            "return_an_exception_because_it_is_over_sixty_three_characters",
+            "COLUMN_NAME",
+        ],
+    )
+    structure = TableStructure.from_arrow_table(table)
+    data_source = DataSource(
+        management=Management.writable,
+        mimetype="application/x-tiled-sql-table",
+        structure_family=StructureFamily.table,
+        structure=structure,
+        parameters={"table_name": "table_name"},
+        assets=[],
+    )
+    with pytest.raises(
+        UnsafeIdentifier,
+        match='Invalid SQL identifier "column_name_that_is_way_too_long_and_should_'
+        'return_an_exception_because_it_is_over_sixty_three_characters": max character number is 63',
+    ):
+        SQLAdapter.init_storage(data_source=data_source, storage=storage)

--- a/tests/adapters/test_sql.py
+++ b/tests/adapters/test_sql.py
@@ -394,21 +394,15 @@ def test_write_read_one_batch_many_part(
     [
         (
             "table_abcdefg12423pnjsbldfhjdfbv_hbdhfljb128w40_ndgjfsdflfnscljm",
-            pytest.raises(
-                ValueError, match=r"Invalid SQL identifier.+max character number is 63"
-            ),
+            pytest.raises(ValueError, match=r"Invalid SQL identifier.+max bytes is 63"),
         ),
         (
             "create_abcdefg12423pnjsbldfhjdfbv_hbdhfljb128w40_ndgjfsdflfnscljk_sdbf_jhvjkbefl",
-            pytest.raises(
-                ValueError, match=r"Invalid SQL identifier.+max character number is 63"
-            ),
+            pytest.raises(ValueError, match=r"Invalid SQL identifier.+max bytes is 63"),
         ),
         (
             "hello_abcdefg12423pnjsbldfhjdfbv_hbdhfljb128w40_ndgjfsdflfnscljk_sdbf_jhvjkbefl",
-            pytest.raises(
-                ValueError, match=r"Invalid SQL identifier.+max character number is 63"
-            ),
+            pytest.raises(ValueError, match=r"Invalid SQL identifier.+max bytes is 63"),
         ),
         ("my_table_here_123_", None),
         ("the_short_table12374620_hello_table23704ynnm", None),
@@ -511,9 +505,7 @@ def test_check_table_name_is_safe(table_name: str, expected: Union[None, Any]) -
         # Invalid identifiers - length
         (
             "a" * 64,
-            pytest.raises(
-                ValueError, match=r"Invalid SQL identifier.+max character number is 63"
-            ),
+            pytest.raises(ValueError, match=r"Invalid SQL identifier.+max bytes is 63"),
         ),
         # Invalid identifiers - malformed
         (
@@ -1257,7 +1249,7 @@ def test_column_name_too_long(data_uri: str, request: pytest.FixtureRequest) -> 
     storage = cast(SQLStorage, parse_storage(data_uri))
     register_storage(storage)
 
-    # Create a table with a column name that exceeds the maximum length of 63 characters
+    # Create a table with a column name that exceeds the maximum of 63 bytes
     table = pa.Table.from_arrays(
         [[1, 2, 3], [4, 5, 6]],
         [
@@ -1277,7 +1269,7 @@ def test_column_name_too_long(data_uri: str, request: pytest.FixtureRequest) -> 
     )
     with pytest.raises(
         UnsafeIdentifier,
-        match='Invalid SQL identifier "column_name_that_is_way_too_long_and_should_'
-        'return_an_exception_because_it_is_over_sixty_three_characters": max character number is 63',
+        match=r'Invalid SQL identifier "column_name_that_is_way_too_long_and_should_'
+        r'return_an_exception_because_it_is_over_sixty_three_characters": max bytes is 63+',
     ):
         SQLAdapter.init_storage(data_source=data_source, storage=storage)

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -1022,9 +1022,13 @@ def is_safe_identifier(
     pattern: re.Pattern[str],
     allow_reserved_words: bool = True,
 ) -> bool:
-    if len(identifier) > 63:
+    # According to https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS,
+    # the maximum bytes for an identifier is 63 with PostgreSQL. This is the smallest limit across supported
+    # databases (PostgreSQL, SQLite, DuckDB).
+    bytes_length = len(identifier.encode("utf-8"))
+    if bytes_length > 63:
         raise UnsafeIdentifier(
-            f'Invalid SQL identifier "{identifier}": max character number is 63'
+            f'Invalid SQL identifier "{identifier}": max bytes is 63 but identifier has {bytes_length} bytes'
         )
 
     if not allow_reserved_words and identifier.lower() in RESERVED_WORDS:

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -29,6 +29,7 @@ import adbc_driver_manager
 import numpy
 import pandas
 import pyarrow
+from fastapi import HTTPException
 from sqlalchemy.sql.compiler import RESERVED_WORDS
 
 from tiled.adapters.core import Adapter
@@ -245,9 +246,12 @@ class SQLAdapter(Adapter[TableStructure]):
         schema = schema.insert(0, pyarrow.field("_partition_id", pyarrow.int16()))
         schema = schema.insert(0, pyarrow.field("_dataset_id", pyarrow.int32()))
         table_name = cls.get_table_name(data_source)
-        create_table_statement = arrow_schema_to_create_table(
-            schema, table_name, cast(DIALECTS, storage.dialect)
-        )
+        try:
+            create_table_statement = arrow_schema_to_create_table(
+                schema, table_name, cast(DIALECTS, storage.dialect)
+            )
+        except ValueError as err:
+            raise HTTPException(status_code=422, detail=str(err))
 
         # If there is a primary_key parameter, first validate it against the table schema
         if primary_key := data_source.parameters.get("primary_key"):

--- a/tiled/adapters/sql.py
+++ b/tiled/adapters/sql.py
@@ -21,6 +21,8 @@ from typing import (
     cast,
 )
 
+from tiled.utils import UnsafeIdentifier
+
 if TYPE_CHECKING:
     from .ragged import RaggedAdapter
     from .awkward import AwkwardAdapter
@@ -29,7 +31,6 @@ import adbc_driver_manager
 import numpy
 import pandas
 import pyarrow
-from fastapi import HTTPException
 from sqlalchemy.sql.compiler import RESERVED_WORDS
 
 from tiled.adapters.core import Adapter
@@ -246,12 +247,9 @@ class SQLAdapter(Adapter[TableStructure]):
         schema = schema.insert(0, pyarrow.field("_partition_id", pyarrow.int16()))
         schema = schema.insert(0, pyarrow.field("_dataset_id", pyarrow.int32()))
         table_name = cls.get_table_name(data_source)
-        try:
-            create_table_statement = arrow_schema_to_create_table(
-                schema, table_name, cast(DIALECTS, storage.dialect)
-            )
-        except ValueError as err:
-            raise HTTPException(status_code=422, detail=str(err))
+        create_table_statement = arrow_schema_to_create_table(
+            schema, table_name, cast(DIALECTS, storage.dialect)
+        )
 
         # If there is a primary_key parameter, first validate it against the table schema
         if primary_key := data_source.parameters.get("primary_key"):
@@ -1025,7 +1023,7 @@ def is_safe_identifier(
     allow_reserved_words: bool = True,
 ) -> bool:
     if len(identifier) > 63:
-        raise ValueError(
+        raise UnsafeIdentifier(
             f'Invalid SQL identifier "{identifier}": max character number is 63'
         )
 

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -33,6 +33,7 @@ from starlette.status import (
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
     HTTP_409_CONFLICT,
+    HTTP_422_UNPROCESSABLE_CONTENT,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
@@ -56,7 +57,7 @@ from ..media_type_registration import (
 )
 from ..query_registration import QueryRegistry, default_query_registry
 from ..type_aliases import AppTask, TaskMap
-from ..utils import SHARE_TILED_PATH, Conflicts, UnsupportedQueryType
+from ..utils import SHARE_TILED_PATH, Conflicts, UnsafeIdentifier, UnsupportedQueryType
 from ..validation_registration import ValidationRegistry, default_validation_registry
 from ._backcompat import raw_python_tiled_client_version
 from .authentication import move_api_key
@@ -371,6 +372,15 @@ def build_app(
     ):
         return JSONResponse(
             status_code=HTTP_409_CONFLICT,
+            content={"detail": exc.args[0]},
+        )
+
+    @app.exception_handler(UnsafeIdentifier)
+    async def unsafe_identifier_exception_handler(
+        request: Request, exc: UnsafeIdentifier
+    ):
+        return JSONResponse(
+            status_code=HTTP_422_UNPROCESSABLE_CONTENT,
             content={"detail": exc.args[0]},
         )
 

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -649,6 +649,10 @@ class BrokenLink(Exception):
     pass
 
 
+class UnsafeIdentifier(ValueError):
+    pass
+
+
 # Arrow obtained an official MIME type 2021-06-23.
 # https://www.iana.org/assignments/media-types/application/vnd.apache.arrow.file
 APACHE_ARROW_FILE_MIME_TYPE = "application/vnd.apache.arrow.file"


### PR DESCRIPTION
This PR addresses Issue #1459. It raises an HTTPException with status code 422 when the column name is greater than 63 characters instead of 500 and 409 exceptions.

### Checklist
- [ ] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
