### PR TITLE
Improve Performance of Reading Datasets with Many Assets

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -286,7 +286,7 @@ async def test_lazy_reshaped_sequence_selects_correct_assets(tmpdir, slice_input
     slice needs, and reads back data identical to the eager reference.
 
     Files are stored MxN but the structure declares (P, Q, R, M, N); this
-    exercises the reshape branch of `stack_indices_for_slice`/`read` for
+    exercises the reshape branch of `file_indices_for_slice`/`read` for
     complex slices (strides, ellipsis, integer index reduction).
     """
     P, Q, R, M, N = _RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,6 +3,7 @@ import random
 import string
 from contextlib import closing
 from dataclasses import asdict
+from pathlib import Path
 from typing import cast
 
 import dask.array
@@ -35,6 +36,7 @@ from tiled.queries import Eq, Key
 from tiled.server.app import build_app, build_app_from_config
 from tiled.server.schemas import Asset, DataSource, Management
 from tiled.storage import SQLStorage, get_storage, parse_storage, sanitize_uri
+from tiled.structures.array import ArrayStructure, BuiltinDtype
 from tiled.structures.core import StructureFamily
 from tiled.utils import Conflicts, ensure_specified_sql_driver, ensure_uri
 
@@ -255,7 +257,192 @@ async def test_write_array_external(a, tmpdir):
     )
     x = await a.lookup_adapter(["x"])
     assert numpy.array_equal(await x.read(), arr)
-    assert x.data_sources[0].properties == {"chunks": [[5], [3]]}
+    assert (await x.data_sources())[0].properties == {"chunks": [[5], [3]]}
+
+
+# A reshaped file sequence: K = P*Q*R files, each an M x N image, whose data
+# source structure declares the logical shape (P, Q, R, M, N). The catalog's
+# lazy per-frame path must map an arbitrary (possibly strided, ellipsis-bearing)
+# slice on that 5-D shape back to exactly the file indices it touches.
+_RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N = 2, 3, 4, 5, 7
+
+
+@pytest.mark.parametrize(
+    "slice_input",
+    [
+        Ellipsis,  # full read -> every file
+        1,  # single leftmost index
+        (slice(0, 2), 1, slice(0, 4, 2)),  # strided along the R (stacking) axis
+        (slice(None), slice(1, 3), slice(0, 4, 2), Ellipsis, slice(0, 4)),
+        (Ellipsis, 0, 0, 0),
+        (0, Ellipsis, slice(0, 3)),
+        (slice(0, 2), slice(0, 3), slice(1, 4, 2)),
+        (slice(0, 1), slice(0, 2), slice(0, 2), slice(0, 2), slice(0, 3)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_lazy_reshaped_sequence_selects_correct_assets(tmpdir, slice_input):
+    """The lazy per-frame path resolves exactly the assets a reshaped-sequence
+    slice needs, and reads back data identical to the eager reference.
+
+    Files are stored MxN but the structure declares (P, Q, R, M, N); this
+    exercises the reshape branch of `stack_indices_for_slice`/`read` for
+    complex slices (strides, ellipsis, integer index reduction).
+    """
+    P, Q, R, M, N = _RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N
+    K = P * Q * R
+
+    # Distinct data per file so any mis-selection surfaces as a value mismatch.
+    rng = numpy.random.default_rng(0)
+    frames = [rng.integers(0, 255, size=(M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    for i, frame in enumerate(frames):
+        filepath = Path(tmpdir) / f"frame{i:05}.tif"
+        tifffile.imwrite(str(filepath), frame)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # Eager references, computed independently of the adapter's own logic.
+    full = numpy.stack(frames).reshape(P, Q, R, M, N)
+    # A cube whose value at (p, q, r, :, :) is the flat file index; slicing it
+    # the same way tells us exactly which files a given slice depends on.
+    idx_cube = numpy.broadcast_to(
+        numpy.arange(K).reshape(P, Q, R, 1, 1), (P, Q, R, M, N)
+    )
+
+    struct = ArrayStructure(
+        shape=(P, Q, R, M, N),
+        chunks=((1,) * P, (1,) * Q, (1,) * R, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    # `properties["chunks"]` carries the *pre-reshape* (stacked) chunk layout:
+    # K single-file chunks along the stacking axis, then the per-file M, N dims.
+    pre_reshape_chunks = [[1] * K, [M], [N]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="seq",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="multipart/related;type=image/tiff",
+                    structure=asdict(struct),
+                    parameters={},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["seq"])
+
+        reference = full[slice_input]
+        expected_indices = set(numpy.unique(idx_cube[slice_input]).tolist())
+
+        # The lazy adapter must be used (not a fallback) and must resolve
+        # exactly the files this slice touches -- no more, no fewer.
+        lazy = await x._get_lazy_adapter(slice=slice_input)
+        assert lazy is not None
+        resolved_indices = {
+            i for i, uri in enumerate(lazy.filepaths._data_uris) if uri is not None
+        }
+        assert resolved_indices == expected_indices
+
+        # And a full read through the catalog returns the correct data.
+        result = await x.read(slice=slice_input)
+        numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.parametrize("num_offset", [1, 5])
+@pytest.mark.asyncio
+async def test_lazy_sequence_tolerates_num_offset(tmpdir, num_offset):
+    """The lazy path maps stacking rank to `num - offset`, so a contiguous run of
+    `num`s starting at any offset (e.g. 1-based numbering) resolves the same
+    files as 0-based numbering. Only the offset shifts; the dense stacking order
+    (and thus the eager reference) is unchanged.
+    """
+    P, Q, R, M, N = _RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N
+    K = P * Q * R
+
+    rng = numpy.random.default_rng(1)
+    frames = [rng.integers(0, 255, size=(M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    for i, frame in enumerate(frames):
+        filepath = Path(tmpdir) / f"frame{i:05}.tif"
+        tifffile.imwrite(str(filepath), frame)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    full = numpy.stack(frames).reshape(P, Q, R, M, N)
+    idx_cube = numpy.broadcast_to(
+        numpy.arange(K).reshape(P, Q, R, 1, 1), (P, Q, R, M, N)
+    )
+    struct = ArrayStructure(
+        shape=(P, Q, R, M, N),
+        chunks=((1,) * P, (1,) * Q, (1,) * R, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    pre_reshape_chunks = [[1] * K, [M], [N]]
+    slice_input = (slice(0, 2), 1, slice(0, 4, 2))
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="seq",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="multipart/related;type=image/tiff",
+                    structure=asdict(struct),
+                    parameters={},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        # `num` starts at `num_offset` (e.g. 1-based), but the
+                        # assets are still in dense stacking order.
+                        Asset(
+                            parameter="data_uris",
+                            num=i + num_offset,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["seq"])
+
+        reference = full[slice_input]
+        # Expected 0-based stacking ranks (offset already accounted for).
+        expected_indices = set(numpy.unique(idx_cube[slice_input]).tolist())
+
+        lazy = await x._get_lazy_adapter(slice=slice_input)
+        assert lazy is not None
+        resolved_indices = {
+            i for i, uri in enumerate(lazy.filepaths._data_uris) if uri is not None
+        }
+        assert resolved_indices == expected_indices
+
+        result = await x.read(slice=slice_input)
+        numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -680,7 +680,9 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_b = client["a"]["b"]
     assert arr_b.shape == (4 * num_files, 5, 6)
-    assert arr_b.chunks == ((1, 1, 1, 1) * num_files, (2, 2, 1), (3, 3))
+    # Native HDF5 chunks are coalesced into whole per-file blocks (bounded by
+    # READ_BATCH_BYTES) to avoid a task/open per tiny native chunk.
+    assert arr_b.chunks == ((4,) * num_files, (5,), (6,))
     assert arr_b.dtype == "int64"
     arr_true_b = numpy.concatenate(
         [
@@ -693,7 +695,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_c = client["a"]["c"]
     assert arr_c.shape == (10 * num_files, 1)
-    assert arr_c.chunks == ((2, 2, 2, 2, 2) * num_files, (1,))
+    assert arr_c.chunks == ((10,) * num_files, (1,))
     assert arr_c.dtype == "int64"
     arr_true_c = numpy.concatenate(
         [
@@ -706,7 +708,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_d = client["a"]["d"]
     assert arr_d.shape == (10 * num_files,)
-    assert arr_d.chunks == ((3, 3, 3, 1) * num_files,)
+    assert arr_d.chunks == ((10,) * num_files,)
     assert arr_d.dtype == "int64"
     arr_true_d = numpy.concatenate(
         [
@@ -782,7 +784,7 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
     h5py = pytest.importorskip("h5py")
 
     # Use the example with two files chunked along a single dimension;
-    # total chunks across the two files: ((3, 3, 3, 1)*2, )
+    # native chunks are coalesced into one block per file: ((10,) * 2, )
     file_uris = example_files_with_chunked_arrays[:2]
     file_paths = [path_from_uri(uri) for uri in file_uris]
     with patch(
@@ -816,21 +818,22 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         mock_h5open.reset_mock()
         arr = client["a"]["d"]
         assert arr.structure().shape == (20,)
-        assert arr.structure().chunks == ((3, 3, 3, 1) * 2,)
+        assert arr.structure().chunks == ((10,) * 2,)
         assert arr.metadata is not None
         mock_h5open.assert_not_called()
 
-        # Read the entire array: files are opened once to get the specs and then again,
-        # four times each, to fetch each chunk separately. Additionally, the first file is opened once
-        # adain when initialized from catalog to get the metadata
+        # Read the entire array: files are opened once to get the specs and then
+        # once more each to fetch the single coalesced chunk. Additionally, the
+        # first file is opened once again when initialized from catalog to get
+        # the metadata
         assert arr.read() is not None
-        # 2 for specs, 4*2 for chunks, 1 for metadata
-        assert mock_h5open.call_count == 2 + 4 * 2 + 1
+        # 2 for specs, 1*2 for chunks (one block per file), 1 for metadata
+        assert mock_h5open.call_count == 2 + 1 * 2 + 1
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
-        # First file: 1 for specs, 4 for chunks, 1 for metadata
-        assert files_opened.count(file_paths[0].name) == 4 + 1 + 1
-        # Second file: 1 for specs, 4 for chunks
-        assert files_opened.count(file_paths[1].name) == 4 + 1
+        # First file: 1 for specs, 1 for chunk, 1 for metadata
+        assert files_opened.count(file_paths[0].name) == 1 + 1 + 1
+        # Second file: 1 for specs, 1 for chunk
+        assert files_opened.count(file_paths[1].name) == 1 + 1
 
         # Read a slice that only touches one file: only the relevant file should be opened
         mock_h5open.reset_mock()
@@ -843,12 +846,12 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         # Read everything from the second file
         mock_h5open.reset_mock()
         assert arr[-10:] is not None
-        assert mock_h5open.call_count == 7
+        assert mock_h5open.call_count == 2 + 1 + 1  # 2 specs, 1 chunk, 1 metadata
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
         # First file: 1 for specs, 1 for metadata
         assert files_opened.count(file_paths[0].name) == 1 + 1
-        # Second file: 4 for chunks, 1 for specs
-        assert files_opened.count(file_paths[1].name) == 4 + 1
+        # Second file: 1 for chunk, 1 for specs
+        assert files_opened.count(file_paths[1].name) == 1 + 1
 
         # Read a slice that has one value from each of the files
         mock_h5open.reset_mock()

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -670,9 +670,44 @@ def test_adapter_from_catalog(example_file, shape, error):
         assert adp.read().shape == shape
 
 
+# The fixture datasets are int64 (8 bytes) with per-file native chunks
+#   a/b: shape (4, 5, 6),  native chunk (1, 2, 3) -> one row is 5*6*8 = 240 bytes
+#   a/c: shape (10, 1),    native chunk (2, 1)    -> one row is 1*8   =   8 bytes
+#   a/d: shape (10,),      native chunk (3,)      -> one row is        =   8 bytes
+# The coalescing groups whole rows (full trailing dims) into blocks along the
+# leading axis up to READ_BATCH_BYTES, never smaller than the native chunk along
+# that axis; if a single row already exceeds the limit it falls back to the
+# files' native tiling in every dimension. Each expected chunk pattern below is
+# per-file (repeated once per file, since all files are identical).
+@pytest.mark.parametrize(
+    "read_batch_bytes, b_dim0, b_rest, c_dim0, c_rest, d_dim0",
+    [
+        # Default (1 GiB): everything coalesces to a single block per file.
+        (1 << 30, (4,), ((5,), (6,)), (10,), ((1,),), (10,)),
+        # 480 bytes = 2 rows of `b`: `b` coalesces to 2 blocks per file; `c`/`d`
+        # (tiny rows) still fit one block per file.
+        (480, (2, 2), ((5,), (6,)), (10,), ((1,),), (10,)),
+        # 40 bytes < one row of `b` (240 B) *and* < its native chunk (48 B): `b`
+        # falls back to native tiling in every dimension; `c`/`d` coalesce to
+        # 5-row blocks (2 blocks per file).
+        (40, (1, 1, 1, 1), ((2, 2, 1), (3, 3)), (5, 5), ((1,),), (5, 5)),
+    ],
+)
 @pytest.mark.parametrize("num_files", [1, 3])
-def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
-    # Test that chunked arrays can be read and reshaped correctly
+def test_chunked_arrays_from_uris(
+    example_files_with_chunked_arrays,
+    num_files,
+    read_batch_bytes,
+    b_dim0,
+    b_rest,
+    c_dim0,
+    c_rest,
+    d_dim0,
+    monkeypatch,
+):
+    # Test that chunked arrays can be read and reshaped correctly, and that the
+    # native HDF5 chunks are coalesced according to READ_BATCH_BYTES.
+    monkeypatch.setattr("tiled.adapters.hdf5.READ_BATCH_BYTES", read_batch_bytes)
     fpaths = example_files_with_chunked_arrays[:num_files]
     tree = HDF5Adapter.from_uris(*fpaths)
     with Context.from_app(build_app(tree)) as context:
@@ -680,9 +715,9 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_b = client["a"]["b"]
     assert arr_b.shape == (4 * num_files, 5, 6)
-    # Native HDF5 chunks are coalesced into whole per-file blocks (bounded by
-    # READ_BATCH_BYTES) to avoid a task/open per tiny native chunk.
-    assert arr_b.chunks == ((4,) * num_files, (5,), (6,))
+    # Native HDF5 chunks are coalesced into blocks (bounded by READ_BATCH_BYTES)
+    # to avoid a task/open per tiny native chunk.
+    assert arr_b.chunks == (b_dim0 * num_files, *b_rest)
     assert arr_b.dtype == "int64"
     arr_true_b = numpy.concatenate(
         [
@@ -695,7 +730,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_c = client["a"]["c"]
     assert arr_c.shape == (10 * num_files, 1)
-    assert arr_c.chunks == ((10,) * num_files, (1,))
+    assert arr_c.chunks == (c_dim0 * num_files, *c_rest)
     assert arr_c.dtype == "int64"
     arr_true_c = numpy.concatenate(
         [
@@ -708,7 +743,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_d = client["a"]["d"]
     assert arr_d.shape == (10 * num_files,)
-    assert arr_d.chunks == ((10,) * num_files,)
+    assert arr_d.chunks == (d_dim0 * num_files,)
     assert arr_d.dtype == "int64"
     arr_true_d = numpy.concatenate(
         [

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -329,6 +329,42 @@ def test_compose_slices(shape, data):
     np.testing.assert_array_equal(arr[slc1][slc2], arr[slc1[slc2]])
 
 
+@given(
+    shape=st.lists(st.integers(1, 6), min_size=1, max_size=4),
+    data=st.data(),
+)
+def test_flat_indices(shape, data):
+    """`flat_indices` returns the C-order positions a slice selects.
+
+    Ground truth: label every cell with its flat position and apply the same
+    slice with NumPy.
+    """
+    shape = tuple(shape)
+    grid = np.arange(np.prod(shape)).reshape(shape)
+    ndslice = NDSlice(data.draw(ndslice_strategy(shape)))
+
+    result = ndslice.flat_indices(shape)
+    expected = tuple(np.atleast_1d(grid[ndslice].ravel()).tolist())
+
+    assert result == expected
+    # Result is a plain tuple of ints labeling valid, unique flat positions.
+    assert isinstance(result, tuple)
+    assert set(result) <= set(range(grid.size))
+    assert len(set(result)) == len(result)
+
+
+def test_flat_indices_examples():
+    # Empty/':'/'...' select everything, in C order.
+    assert NDSlice().flat_indices((2, 3)) == tuple(range(6))
+    assert NDSlice(Ellipsis).flat_indices((2, 3)) == tuple(range(6))
+    # An integer drops the leading dimension.
+    assert NDSlice(1).flat_indices((3, 4)) == (4, 5, 6, 7)
+    # Strides are honored exactly (no contiguous over-selection).
+    assert NDSlice(slice(0, 4, 2)).flat_indices((4,)) == (0, 2)
+    # Selecting only stacking (leading) dimensions of a larger grid.
+    assert NDSlice(slice(0, 2), 1).flat_indices((2, 3)) == (1, 4)
+
+
 def chunks_strategy(shape):
     """Generate valid chunking schemes for a given shape."""
 

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -278,6 +278,88 @@ a,b,c
         assert client["other_file2"].columns == ["a", "b", "c"]
 
 
+@pytest.mark.asyncio
+async def test_tiff_sequence_client_data_sources_assets(tmpdir):
+    """A file-sequence node exposes ALL its assets to the client via
+    `c.data_sources()[0].assets`, even though the server loads assets
+    lazily (asset-free `data_sources` property + on-demand per-frame reads).
+
+    Also confirms single-frame reads return correct data, exercising the lazy
+    per-frame resolution path end-to-end through the catalog.
+    """
+    num_frames = 10
+    base = numpy.random.default_rng(0).integers(0, 255, size=(3, 5), dtype="uint8")
+    frames = []
+    for i in range(num_frames):
+        arr = (base + i).astype("uint8")
+        tf.imwrite(Path(tmpdir / f"image{i:05}.tif"), arr)
+        frames.append(arr)
+    adapter = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(adapter)) as context:
+        client = from_context(context)
+        await register(client, tmpdir)
+        seq = client["image"]
+        assert seq.shape == (num_frames, 3, 5)
+
+        # Client-facing data_sources() must still expose every asset.
+        data_sources = seq.data_sources()
+        assert data_sources is not None
+        assert len(data_sources) == 1
+        assets = data_sources[0].assets
+        assert len(assets) == num_frames
+        assert all(asset.data_uri for asset in assets)
+
+        # Single-frame reads via the lazy path return the correct frame.
+        for i in (0, 3, num_frames - 1):
+            numpy.testing.assert_array_equal(seq[i], frames[i])
+        # A multi-frame slice also resolves correctly.
+        numpy.testing.assert_array_equal(seq[2:5], numpy.stack(frames[2:5]))
+
+
+@pytest.mark.asyncio
+async def test_tiff_sequence_lazy_http_block_and_slice_reads(tmpdir):
+    """End-to-end HTTP exercise of the lazy per-frame path.
+
+    Reads reach the server via the `/array/full` (slice) and `/array/block`
+    routes, which dispatch to the catalog's lazy resolver. Confirms both give
+    data identical to the eager reference for whole-array, sliced, strided, and
+    single-block reads.
+    """
+    num_frames = 6
+    base = numpy.random.default_rng(1).integers(0, 255, size=(3, 5), dtype="uint8")
+    frames = []
+    for i in range(num_frames):
+        arr = (base + i).astype("uint8")
+        tf.imwrite(Path(tmpdir / f"image{i:05}.tif"), arr)
+        frames.append(arr)
+    stacked = numpy.stack(frames)
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    with Context.from_app(build_app(adapter)) as context:
+        client = from_context(context)
+        await register(client, tmpdir)
+        seq = client["image"]
+        assert seq.shape == (num_frames, 3, 5)
+
+        # Full read over HTTP (/array/full).
+        numpy.testing.assert_array_equal(seq.read(), stacked)
+        # Contiguous and strided slice reads over HTTP.
+        numpy.testing.assert_array_equal(seq.read(slice=(slice(1, 4),)), stacked[1:4])
+        numpy.testing.assert_array_equal(
+            seq.read(slice=(slice(0, num_frames, 2),)), stacked[0:num_frames:2]
+        )
+        # Per-block reads over HTTP (/array/block): each file is one block on axis 0.
+        for i in (0, 2, num_frames - 1):
+            block = seq.read_block((i, 0, 0))
+            numpy.testing.assert_array_equal(block, frames[i][numpy.newaxis])
+        # Block read with a within-block slice (/array/block?slice=...): the block
+        # selects the file(s) to resolve; the within-block slice is applied to the
+        # already-loaded block data and must never change which files are read.
+        for i in (0, 3, num_frames - 1):
+            block = seq.read_block((i, 0, 0), slice=(0, slice(1, 3)))
+            numpy.testing.assert_array_equal(block, frames[i][1:3])
+
+
 def test_rgb(client):
     "Test an RGB TIFF."
     arr = client["color"].read()

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -185,6 +185,41 @@ def test_tiff_sequence_block(client, block_input, correct_shape):
     assert arr.shape == correct_shape
 
 
+@pytest.mark.parametrize(
+    "slice_input, correct_shape",
+    [
+        ((slice(None), slice(None), 0, 0, 0), (3, 4)),
+        ((..., 0, 0, 0, 0), (3,)),
+        ((slice(None), slice(None), slice(None), 0, 0), (3, 4, 5)),
+        ((slice(0, 2), slice(None), 1, 2, 3), (2, 4)),
+        ((slice(None),) * 5, (3, 4, 5, 7, 4)),
+    ],
+)
+def test_reshaped_sequence_reducing_slice_is_batch_invariant(
+    client, monkeypatch, slice_input, correct_shape
+):
+    """A slice that touches many files but keeps only part of each frame must be
+    read in memory-bounded batches without changing the result. Force a tiny
+    per-batch budget so every file lands in its own batch, and check the result
+    matches both numpy ground truth and a single-batch read.
+    """
+    import tiled.adapters.sequence as sequence_module
+
+    true_arr = tiff_data.reshape(3, 4, 5, 7, 4)[slice_input]
+
+    # Single batch (generous budget).
+    monkeypatch.setattr(sequence_module, "READ_BATCH_BYTES", 1 << 30)
+    single = client["5d_sequence_first_and_second_dim"].read(slice=slice_input)
+    assert single.shape == correct_shape
+    numpy.testing.assert_equal(single, true_arr)
+
+    # Force one file per batch; result must be identical.
+    monkeypatch.setattr(sequence_module, "READ_BATCH_BYTES", 1)
+    batched = client["5d_sequence_first_and_second_dim"].read(slice=slice_input)
+    assert batched.shape == correct_shape
+    numpy.testing.assert_equal(batched, true_arr)
+
+
 @pytest.mark.asyncio
 async def test_tiff_sequence_order(tmpdir):
     """

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -1,9 +1,11 @@
 import builtins
 import copy
 import itertools
+import math
 import os
 import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
@@ -29,6 +31,8 @@ from ..structures.data_source import DataSource
 from ..type_aliases import JSON
 from ..utils import BrokenLink, Sentinel, node_repr, path_from_uri
 from .array import ArrayAdapter
+from .resource_cache import with_resource_cache
+from .sequence import IO_WORKERS, READ_BATCH_BYTES
 from .utils import split_chunks
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
@@ -182,8 +186,16 @@ class HDF5ArrayAdapter(ArrayAdapter):
                 result = ds.shape, ds.chunks or ds.shape, ds.dtype
             return result
 
-        # Need to know shapes/dtypes of constituent arrays to load them lazily
-        shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
+        # Need to know shapes/dtypes of constituent arrays to load them lazily.
+        # Reading specs opens every file (twice, for external links), so for
+        # many-file datasets do this in parallel while preserving order.
+        if len(file_paths) > 1:
+            with ThreadPoolExecutor(
+                max_workers=min(IO_WORKERS, len(file_paths))
+            ) as executor:
+                shapes_chunks_dtypes = list(executor.map(_get_hdf5_specs, file_paths))
+        else:
+            shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
         dtype = shapes_chunks_dtypes[0][2]
         if dtype == numpy.dtype("O"):
             # h5py uses NumPy's object dtype to represent variable-length
@@ -239,18 +251,40 @@ class HDF5ArrayAdapter(ArrayAdapter):
 
         else:
             # Use delayed loading to read and conactenate arrays from multiple files
-            # First, find chunks along the left axis (split per file),
-            # and chunks in the rest of the dimensions (same for each file)
-            file_chunks = tuple(
-                split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
-                for shp, chk, _ in shapes_chunks_dtypes
-            )
-            # Shape of the rest of dimensions
+            # Determine chunks along the leftmost (concatenation) axis, split
+            # per file, and chunks in the rest of the dimensions (shared by all
+            # files). The constituent files' native HDF5 chunks are often tiny
+            # (e.g. a single frame per chunk, with thousands of frames per
+            # file), which explodes the number of Dask tasks -- and every task
+            # re-opens the file. To avoid that, coalesce native chunks into
+            # blocks of whole rows (full rest dimensions) up to READ_BATCH_BYTES,
+            # so each file is read in as few tasks as possible.
             rest_shape = shapes_chunks_dtypes[0][0][1:]
-            rest_chunks = tuple(
-                split_chunks(shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes))
-                for i, shp in enumerate(rest_shape)
-            )
+            rest_row_bytes = math.prod(rest_shape) * dtype.itemsize
+            rest_chunks: Tuple[Tuple[int, ...], ...]
+            if not rest_shape or 0 < rest_row_bytes <= READ_BATCH_BYTES:
+                # Read whole rows (full rest dimensions) in blocks along axis 0,
+                # sized up to the batch limit but never smaller than the native
+                # chunk along axis 0.
+                rows_per_block = max(1, READ_BATCH_BYTES // (rest_row_bytes or 1))
+                file_chunks = tuple(
+                    split_chunks(shp[0], max(chk[0], rows_per_block))
+                    for shp, chk, _ in shapes_chunks_dtypes
+                )
+                rest_chunks = tuple((shp,) for shp in rest_shape)
+            else:
+                # A single row already exceeds the batch limit: fall back to the
+                # files' native tiling in every dimension.
+                file_chunks = tuple(
+                    split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
+                    for shp, chk, _ in shapes_chunks_dtypes
+                )
+                rest_chunks = tuple(
+                    split_chunks(
+                        shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes)
+                    )
+                    for i, shp in enumerate(rest_shape)
+                )
             dim0_chunks = tuple(size for fc in file_chunks for size in fc)
             chunks_final = (dim0_chunks, *[tuple(d) for d in rest_chunks])
 
@@ -327,8 +361,26 @@ class HDF5ArrayAdapter(ArrayAdapter):
         ] or [assets[0].data_uri]
         file_paths = [path_from_uri(uri) for uri in data_uris]
 
-        array = cls.lazy_load_hdf5_array(
-            *file_paths, dataset=dataset, swmr=swmr, libver=libver, locking=locking
+        # Building the lazy Dask array opens every constituent file to read its
+        # specs. Cache the array so repeated reads of the same dataset reuse the
+        # graph instead of re-opening all files. Slicing the cached array below
+        # returns a new array, leaving the cached one unmodified.
+        cache_key = (
+            HDF5ArrayAdapter.lazy_load_hdf5_array,
+            dataset,
+            tuple(file_paths),
+            swmr,
+            libver,
+            locking,
+        )
+        array = with_resource_cache(
+            cache_key,
+            cls.lazy_load_hdf5_array,
+            *file_paths,
+            dataset=dataset,
+            swmr=swmr,
+            libver=libver,
+            locking=locking,
         )
 
         if slice:

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -262,11 +262,12 @@ class HDF5ArrayAdapter(ArrayAdapter):
             rest_shape = shapes_chunks_dtypes[0][0][1:]
             rest_row_bytes = math.prod(rest_shape) * dtype.itemsize
             rest_chunks: Tuple[Tuple[int, ...], ...]
-            if not rest_shape or 0 < rest_row_bytes <= READ_BATCH_BYTES:
+            read_batch_bytes = READ_BATCH_BYTES
+            if not rest_shape or 0 < rest_row_bytes <= read_batch_bytes:
                 # Read whole rows (full rest dimensions) in blocks along axis 0,
                 # sized up to the batch limit but never smaller than the native
                 # chunk along axis 0.
-                rows_per_block = max(1, READ_BATCH_BYTES // (rest_row_bytes or 1))
+                rows_per_block = max(1, read_batch_bytes // (rest_row_bytes or 1))
                 file_chunks = tuple(
                     split_chunks(shp[0], max(chk[0], rows_per_block))
                     for shp, chk, _ in shapes_chunks_dtypes

--- a/tiled/adapters/jpeg.py
+++ b/tiled/adapters/jpeg.py
@@ -108,13 +108,16 @@ class JPEGSequenceAdapter(FileSequenceAdapter):
     def _load_from_files(
         self, slice: Union[builtins.slice, int, Iterable[int]] = slice(None)
     ) -> NDArray[Any]:
-        from PIL import Image
-
         if isinstance(slice, int):
-            return np.asarray(Image.open(self.filepaths[slice]))[None, ...]
+            return self._read_one(self.filepaths[slice])[None, ...]
         else:
             if isinstance(slice, Iterable):
                 selected = [self.filepaths[i] for i in slice]
             else:
                 selected = self.filepaths[slice]
-            return np.asarray([np.asarray(Image.open(file)) for file in selected])
+            return np.asarray(self._map_read(selected))
+
+    def _read_one(self, filepath: str) -> NDArray[Any]:
+        from PIL import Image
+
+        return np.asarray(Image.open(filepath))

--- a/tiled/adapters/npy.py
+++ b/tiled/adapters/npy.py
@@ -113,4 +113,7 @@ class NPYSequenceAdapter(FileSequenceAdapter):
                 selected = [self.filepaths[i] for i in slice]
             else:
                 selected = self.filepaths[slice]
-            return numpy.asarray([numpy.load(file) for file in selected])
+            return numpy.asarray(self._map_read(selected))
+
+    def _read_one(self, filepath: str) -> NDArray[Any]:
+        return numpy.load(filepath)

--- a/tiled/adapters/resource_cache.py
+++ b/tiled/adapters/resource_cache.py
@@ -63,7 +63,7 @@ def default_resource_cache() -> cachetools.TLRUCache[Any, Any]:
 
 
 def with_resource_cache(
-    cache_key: Tuple[Any, Path],
+    cache_key: Tuple[Any, ...],
     factory: Callable[..., Any],
     *args: Any,
     _resource_cache: Optional[AnyCache] = None,

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -1,6 +1,8 @@
 import builtins
 import math
+import os
 from abc import abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Iterable, List, Optional, Union
 
 import numpy as np
@@ -17,6 +19,24 @@ from ..structures.data_source import DataSource
 from ..type_aliases import JSON, EllipsisType
 from ..utils import path_from_uri
 from .utils import force_reshape
+
+# Concurrency and memory knobs for reads that span many files of a sequence.
+#
+# IO_WORKERS: how many files to read concurrently. Reading a file is I/O-bound
+#   (open + read + decode, releasing the GIL in the C codecs), so a worker count
+#   somewhat above the CPU count keeps the storage busy. Override with
+#   TILED_SEQUENCE_IO_WORKERS.
+# READ_BATCH_BYTES: soft cap on the *full-frame* bytes held in memory at once
+#   while a multi-file read is in flight. A read that touches many files but
+#   keeps only a few pixels of each (e.g. one pixel from every file of a large
+#   stack) reads each file on a worker, reduces the frame, and drops it before
+#   the next, so peak memory stays near `min(IO_WORKERS, READ_BATCH_BYTES /
+#   frame_bytes)` full frames plus the (reduced) result, never the whole stack.
+#   Override with TILED_SEQUENCE_READ_BATCH_BYTES.
+IO_WORKERS = int(
+    os.environ.get("TILED_SEQUENCE_IO_WORKERS") or min(32, (os.cpu_count() or 4) + 4)
+)
+READ_BATCH_BYTES = int(os.environ.get("TILED_SEQUENCE_READ_BATCH_BYTES") or (1 << 30))
 
 
 class _LazyFilepaths:
@@ -183,6 +203,86 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
 
         pass
 
+    def _read_one(self, filepath: str) -> NDArray[Any]:
+        """Read a single file into an array of its stored (per-file) shape.
+
+        The per-file primitive used by the concurrent readers below. Subclasses
+        implement the format-specific single-file read (e.g. `numpy.load`,
+        `tifffile.imread`, `PIL.Image.open`).
+        """
+        raise NotImplementedError
+
+    def _map_read(self, filepaths: Iterable[str]) -> List[NDArray[Any]]:
+        """Read files concurrently via `_read_one`, preserving input order.
+
+        Overlaps the (I/O-bound) per-file reads across `IO_WORKERS` threads.
+        Falls back to a serial map for a single file or when `IO_WORKERS == 1`.
+        """
+        filepaths = list(filepaths)
+        if IO_WORKERS <= 1 or len(filepaths) <= 1:
+            return [self._read_one(fp) for fp in filepaths]
+        with ThreadPoolExecutor(max_workers=min(IO_WORKERS, len(filepaths))) as ex:
+            return list(ex.map(self._read_one, filepaths))
+
+    def _read_selected(
+        self,
+        file_indices: tuple[int, ...],
+        frame_slice: tuple[Any, ...],
+        frame_shape: tuple[int, ...],
+    ) -> NDArray[Any]:
+        """Read the selected files and reduce each frame, with bounded memory.
+
+        `file_indices` are flat stacking-grid indices (in read order);
+        `frame_slice` is the trailing part of the selection that applies within
+        each file, expressed in *structure* coordinates; `frame_shape` is the
+        per-file structure shape (the structure dims after the stacking grid) --
+        i.e. what each loaded frame is reshaped to before `frame_slice` applies.
+
+        Each file is read on a worker, reshaped to `frame_shape`, reduced by
+        `frame_slice`, and written straight into the preallocated output; the
+        full frame is then dropped. Reducing *before* stacking is what keeps a
+        read that touches many files but keeps only a few pixels of each from
+        materializing the whole stack -- peak extra memory is about
+        `min(IO_WORKERS, READ_BATCH_BYTES / frame_bytes)` full frames in flight,
+        not `n_files x full_frame`. A single persistent pool reads all files
+        (no per-batch spin-up/idle-tail), keeping storage continuously busy.
+        Returns the reduced frames stacked along a new leading axis: shape
+        `(len(file_indices), *frame_slice applied to frame_shape)`.
+        """
+        dtype = self.structure().data_type.to_numpy_dtype()
+        key = tuple(frame_slice)
+        reduced_frame_shape = (
+            ndindex(key).newshape(tuple(frame_shape)) if key else tuple(frame_shape)
+        )
+        out = np.empty((len(file_indices), *reduced_frame_shape), dtype=dtype)
+        if len(file_indices) == 0:
+            return out
+
+        frame_nbytes = max(1, math.prod(frame_shape) * dtype.itemsize)
+        # Cap concurrent in-flight full frames so peak memory stays near
+        # READ_BATCH_BYTES regardless of how many files the read touches.
+        max_workers = max(1, min(IO_WORKERS, READ_BATCH_BYTES // frame_nbytes))
+
+        def fill(pos: int) -> None:
+            frame = self._read_one(self.filepaths[file_indices[pos]])
+            # Reshape the stored frame to the per-file structure shape so the
+            # (structure-space) `frame_slice` applies; `prod(frame_shape)` equals
+            # the stored size, so this never crosses a file boundary. The reduced
+            # frame is copied into `out[pos]`, so the full frame can be freed.
+            frame = force_reshape(frame, tuple(frame_shape))
+            out[pos] = frame[key] if key else frame
+
+        if max_workers <= 1 or len(file_indices) <= 1:
+            for pos in range(len(file_indices)):
+                fill(pos)
+        else:
+            with ThreadPoolExecutor(
+                max_workers=min(max_workers, len(file_indices))
+            ) as ex:
+                # Consume to propagate any worker exception and wait for all.
+                list(ex.map(fill, range(len(file_indices))))
+        return out
+
     def metadata(self) -> JSON:
         # TODO How to deal with the many headers?
         return super().metadata()
@@ -238,19 +338,20 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
             # Map the leading (stacking) part of the selection onto flat file indices.
             file_indx_list = NDSlice(file_indx_slice).flat_indices(stacking_grid_shape)
 
-            # The remaining slice to be applied after loading the data from files and stacking;
-            # expand to include any non-degenerate leading dimensions along the file axis
-            tail_dims_slice = expanded[len(stacking_grid_shape) :]  # noqa: E203
-            for slc in file_indx_slice:
-                if not isinstance(slc, int):
-                    tail_dims_slice = NDSlice(builtins.slice(None), *tail_dims_slice)
-
-            arr = self._load_from_files(slice=file_indx_list)
-            stacked_shape = ndindex(file_indx_slice).newshape(struct_shape)
-            arr = force_reshape(arr, stacked_shape)
-            arr = np.atleast_1d(arr[tail_dims_slice])
-
-            return force_reshape(arr, ndindex(expanded).newshape(struct_shape))
+            # The trailing part of the selection applies within each file (frame).
+            # Push it into the batched loader so each frame is reduced *before*
+            # frames are stacked -- this keeps a read that touches many files but
+            # keeps only a few pixels of each from materializing the whole stack.
+            # `frame_slice` and the per-file structure shape are both in structure
+            # coordinates; `_read_selected` reshapes each stored frame to that
+            # shape before applying `frame_slice`. Reducing per-file and reshaping
+            # the file axis afterward commute, so the result matches a full read.
+            frame_slice = expanded[len(stacking_grid_shape) :]  # noqa: E203
+            struct_frame_shape = struct_shape[len(stacking_grid_shape) :]  # noqa: E203
+            reduced = self._read_selected(
+                file_indx_list, frame_slice, struct_frame_shape
+            )
+            return force_reshape(reduced, ndindex(expanded).newshape(struct_shape))
 
         # Load the data from files, applying the slice along the left-most dimension if possible
         if slice is Ellipsis:

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -406,7 +406,7 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         """The shape of the file-stacking dimensions, or None if not partially-loadable.
 
         Pure function of the structure shape and the true (stored) shape -- no
-        adapter state, no I/O -- so both `read` and the `stack_indices_for_slice`
+        adapter state, no I/O -- so both `read` and the `file_indices_for_slice`
         classmethod (used by the catalog before any adapter is built) can share it.
 
         Each file contributes one element along the left-most stored axis, so a
@@ -440,7 +440,7 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         return None
 
     @classmethod
-    def stack_indices_for_slice(
+    def file_indices_for_slice(
         cls,
         structure: ArrayStructure,
         chunks: Optional[tuple[tuple[int, ...], ...]],

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -106,7 +106,7 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
 
     # When True, the catalog may build this adapter with a partially-populated
     # list of `data_uris` and resolve only the URIs needed for a given read
-    supports_lazy_filepaths = True
+    supports_lazy_assets = True
 
     structure_family = StructureFamily.array
 

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -16,7 +16,44 @@ from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
 from ..type_aliases import JSON, EllipsisType
 from ..utils import path_from_uri
-from .utils import force_reshape, init_adapter_from_catalog
+from .utils import force_reshape
+
+
+class _LazyFilepaths:
+    """A sequence of filepaths derived lazily from a sequence of data URIs.
+
+    Wraps the `data_uris` given to :class:`FileSequenceAdapter` and converts
+    each URI to a local filesystem path (via :func:`path_from_uri`) only when
+    that entry is accessed. Deferring the conversion lets the catalog supply a
+    fixed-length list in which only the entries a given read needs are populated
+    (the rest left as `None`), so a single-frame read out of a large file
+    sequence never materializes all N paths. Indexing and slicing mirror a plain
+    `list` of paths, so subclasses can treat `self.filepaths` uniformly
+    whether the underlying URIs were fully or only partially resolved.
+    """
+
+    __slots__ = ("_data_uris",)
+
+    def __init__(self, data_uris: Any) -> None:
+        # Stored by reference (not copied) so a caller may populate entries
+        # after construction -- as the catalog's lazy per-frame path does once
+        # it knows which stack indices the read touches.
+        self._data_uris = data_uris
+
+    def __len__(self) -> int:
+        return len(self._data_uris)
+
+    def __getitem__(self, key: Union[int, builtins.slice]) -> Any:
+        item = self._data_uris[key]
+        if isinstance(key, builtins.slice):
+            return [path_from_uri(uri) for uri in item]
+        return path_from_uri(item)
+
+    def __repr__(self) -> str:
+        resolved = sum(uri is not None for uri in self._data_uris)
+        return (
+            f"<{type(self).__name__} length={len(self._data_uris)} resolved={resolved}>"
+        )
 
 
 class FileSequenceAdapter(Adapter[ArrayStructure]):
@@ -47,18 +84,26 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         from data source parameters) they take precedence over the chunks derived from the files.
     """
 
+    # When True, the catalog may build this adapter with a partially-populated
+    # list of `data_uris` and resolve only the URIs needed for a given read
+    supports_lazy_filepaths = True
+
     structure_family = StructureFamily.array
 
     def __init__(
         self,
-        data_uris: Iterable[str],
+        data_uris: Optional[Iterable[str]] = None,
         structure: Optional[ArrayStructure] = None,
         *,
         metadata: Optional[JSON] = None,
         specs: Optional[List[Spec]] = None,
         chunks: Optional[tuple[tuple[int, ...], ...]] = None,
     ) -> None:
-        self.filepaths = [path_from_uri(data_uri) for data_uri in data_uris]
+        # `self.filepaths` is a lazy view over the URIs: each is converted to a
+        # local path (path_from_uri) only when accessed. `data_uris` is a
+        # fixed-length list; the eager case fills every slot, while the catalog's
+        # lazy per-frame case leaves the slots it does not need as `None`.
+        self.filepaths = _LazyFilepaths(data_uris if data_uris is not None else [])
         self._chunks = chunks  # "True" chunks in the files before reshaping
         if structure is None:
             dat0 = self._load_from_files(0)
@@ -86,9 +131,37 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         /,
         **kwargs: Optional[Any],
     ) -> "FileSequenceAdapter":
+        # One entry point for both the eager and lazy paths. The eager path
+        # derives `data_uris` from the data source's assets (dense 0-based
+        # stacking rank -> uri); the catalog's lazy path passes a sparse
+        # `{stack_index: uri}` mapping directly as the `data_uris` kwarg,
+        # holding only the frames a given read touches. Uses the `chunks`
+        # recorded in the data source properties (set when the stored files are
+        # reshaped to the structure shape).
+        if "data_uris" not in kwargs:
+            kwargs["data_uris"] = cls._stacking_uris_from_assets(data_source)
         kwargs["chunks"] = data_source.properties.get("chunks")
+        kwargs["metadata"] = node.metadata_
+        kwargs["specs"] = node.specs
+        return cls(structure=data_source.structure, **kwargs)
 
-        return init_adapter_from_catalog(cls, data_source, node, **kwargs)
+    @staticmethod
+    def _stacking_uris_from_assets(
+        data_source: DataSource[ArrayStructure],
+    ) -> list[str]:
+        """Return the list-valued assets' URIs in dense stacking-rank order.
+
+        The data source's assets arrive ordered by `(parameter, num)`, so the
+        list-valued ones are already in the stacking order eager reads use. This
+        is the sequence-specific analogue of `asset_parameters_to_adapter_kwargs`
+        (which the single-file and columnar adapters still use), specialized to
+        the one list parameter a file sequence carries.
+        """
+        return [
+            asset.data_uri
+            for asset in data_source.assets
+            if (asset.num is not None) or (asset.parameter == "data_uris")
+        ]
 
     @abstractmethod
     def _load_from_files(
@@ -143,45 +216,41 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         # files are stacking dimensions, and they define which files need to be read.
         # Finally, the resulting array is reshaped to match the desired structure shape and slice.
         struct_shape = self.structure().shape
-        if self._chunks:
-            true_shape = tuple(map(sum, self._chunks))
-            if true_shape != struct_shape:
-                # The trailing dimensions must match (can be generalized in the future)
-                if math.prod(true_shape) != math.prod(struct_shape):
-                    raise RuntimeError(
-                        f"Array with shape {true_shape} derived from storage can not be reshaped "
-                        f"to match the desired structure, {struct_shape}."
-                    )
+        true_shape = tuple(map(sum, self._chunks)) if self._chunks else struct_shape
+        is_reshaped = true_shape != struct_shape
+        stacking_grid_shape = self._stacking_grid_shape(struct_shape, true_shape)
 
-                # The leading dimensions define stacking and the indices of files we need to read
-                stack_shape = (
-                    struct_shape[: -len(true_shape[1:])]
-                    if len(true_shape) > 1
-                    else struct_shape
-                )
-                slice = NDSlice(slice).expand_for_shape(struct_shape)  # typing: ignore
-                file_indx_slice = slice[: len(stack_shape)]
-                file_indx_list = (
-                    np.arange(true_shape[0])
-                    .reshape(stack_shape)[file_indx_slice]
-                    .ravel()
-                )
-
-                # The remaining slice to be applied after loading the data from files and stacking;
-                # expand to include any non-degenerate leading dimensions along the file axis
-                tail_dims_slice = slice[len(stack_shape) :]  # noqa: E203
-                for slc in file_indx_slice:
-                    if not isinstance(slc, int):
-                        tail_dims_slice = NDSlice(
-                            builtins.slice(None), *tail_dims_slice
-                        )
-
-                arr = self._load_from_files(slice=file_indx_list)
-                stacked_shape = ndindex(file_indx_slice).newshape(struct_shape)
-                arr = force_reshape(arr, stacked_shape)
-                arr = np.atleast_1d(arr[tail_dims_slice])
-
+        if is_reshaped:
+            if stacking_grid_shape is None:
+                # The reshape interleaves file contents: the per-file boundary
+                # falls *inside* a structure dimension, so no subset of whole
+                # files can satisfy the read. Load every file, stack, reshape to
+                # the structure shape, then apply the requested slice. Correct
+                # (row-major order is preserved) but with no partial-load benefit.
+                arr = force_reshape(self._load_from_files(), struct_shape)
+                arr = np.atleast_1d(arr[slice])
                 return force_reshape(arr, ndindex(slice).newshape(struct_shape))
+
+            # The reshape is file-boundary-aligned, so a subset of whole files can
+            # satisfy the read (`stacking_grid_shape` is now known non-None).
+            expanded = NDSlice(slice).expand_for_shape(struct_shape)
+            file_indx_slice = expanded[: len(stacking_grid_shape)]
+            # Map the leading (stacking) part of the selection onto flat file indices.
+            file_indx_list = NDSlice(file_indx_slice).flat_indices(stacking_grid_shape)
+
+            # The remaining slice to be applied after loading the data from files and stacking;
+            # expand to include any non-degenerate leading dimensions along the file axis
+            tail_dims_slice = expanded[len(stacking_grid_shape) :]  # noqa: E203
+            for slc in file_indx_slice:
+                if not isinstance(slc, int):
+                    tail_dims_slice = NDSlice(builtins.slice(None), *tail_dims_slice)
+
+            arr = self._load_from_files(slice=file_indx_list)
+            stacked_shape = ndindex(file_indx_slice).newshape(struct_shape)
+            arr = force_reshape(arr, stacked_shape)
+            arr = np.atleast_1d(arr[tail_dims_slice])
+
+            return force_reshape(arr, ndindex(expanded).newshape(struct_shape))
 
         # Load the data from files, applying the slice along the left-most dimension if possible
         if slice is Ellipsis:
@@ -227,3 +296,74 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         block_slice = block.slice_from_chunks(self._structure.chunks)
         arr = self.read(block_slice[0])
         return arr[slice] if slice else arr
+
+    @staticmethod
+    def _stacking_grid_shape(
+        struct_shape: tuple[int, ...],
+        true_shape: tuple[int, ...],
+    ) -> Optional[tuple[int, ...]]:
+        """The shape of the file-stacking dimensions, or None if not partially-loadable.
+
+        Pure function of the structure shape and the true (stored) shape -- no
+        adapter state, no I/O -- so both `read` and the `stack_indices_for_slice`
+        classmethod (used by the catalog before any adapter is built) can share it.
+
+        Each file contributes one element along the left-most stored axis, so a
+        file spans `P = prod(true_shape[1:])` contiguous elements of the row-major
+        flat array. Whole-file (partial) loading is possible only when the file
+        boundary aligns with a structure dimension boundary -- i.e. there is a
+        split `j` with `prod(struct_shape[:j]) == n_files` -- in which case the
+        leading `j` structure dimensions map onto the files and this returns
+        `struct_shape[:j]`. When no such split exists the reshape interleaves file
+        contents across the file boundary (every file must be loaded) and this
+        returns `None`. The caller derives `partial_loadable` as `result is not
+        None` and `reshaped` as `true_shape != struct_shape`.
+        """
+        if math.prod(true_shape) != math.prod(struct_shape):
+            raise RuntimeError(
+                f"Array with shape {true_shape} derived from storage can not be reshaped "
+                f"to match the desired structure, {struct_shape}."
+            )
+        # Locate the file boundary within the structure shape: the smallest split
+        # `j` whose leading dimensions multiply to the file count. Products grow
+        # monotonically (dimensions >= 1), so once the running product passes
+        # `n_files` without landing on it, no aligned split exists.
+        n_files = true_shape[0]
+        product = 1
+        for j, dim in enumerate(struct_shape, start=1):
+            product *= dim
+            if product == n_files:
+                return struct_shape[:j]
+            if product > n_files:
+                break
+        return None
+
+    @classmethod
+    def stack_indices_for_slice(
+        cls,
+        structure: ArrayStructure,
+        chunks: Optional[tuple[tuple[int, ...], ...]],
+        slice: Any = ...,
+    ) -> Optional[tuple[int, ...]]:
+        """Return the global file (stack) indices needed to satisfy `slice`.
+
+        Pure classmethod of the structure and chunks only -- performs no file or
+        database I/O and needs no adapter instance -- so the catalog can prefetch
+        exactly the assets a read will touch before building any adapter (a
+        `read_block` is handled by first converting the block to the equivalent
+        slice). The leading `stacking_grid_shape` dimensions of the structure map onto
+        the files, so the files touched are the flat positions the slice selects
+        within them. Mirrors the file selection in `read()`.
+
+        Returns `None` when the reshape is not file-boundary-aligned (every file
+        may need to be loaded), signalling the catalog to skip the lazy loading path.
+        """
+        struct_shape = structure.shape
+        true_shape = tuple(map(sum, chunks)) if chunks else struct_shape
+        stacking_grid_shape = cls._stacking_grid_shape(struct_shape, true_shape)
+        if stacking_grid_shape is None:
+            return None
+        file_indx_slice = NDSlice(slice).expand_for_shape(struct_shape)[
+            : len(stacking_grid_shape)
+        ]
+        return NDSlice(file_indx_slice).flat_indices(stacking_grid_shape)

--- a/tiled/adapters/tiff.py
+++ b/tiled/adapters/tiff.py
@@ -14,7 +14,7 @@ from ..structures.data_source import DataSource
 from ..type_aliases import JSON
 from ..utils import path_from_uri
 from .resource_cache import with_resource_cache
-from .sequence import FileSequenceAdapter
+from .sequence import IO_WORKERS, FileSequenceAdapter
 from .utils import force_reshape, init_adapter_from_catalog
 
 
@@ -111,4 +111,9 @@ class TiffSequenceAdapter(FileSequenceAdapter):
             if isinstance(slice, Iterable)
             else self.filepaths[slice]
         )
-        return tifffile.TiffSequence(selected).asarray()
+        # `ioworkers` lets tifffile read the selected files concurrently (I/O is
+        # the bottleneck for a large stack); default is serial (ioworkers=1).
+        return tifffile.TiffSequence(selected).asarray(ioworkers=IO_WORKERS)
+
+    def _read_one(self, filepath: str) -> NDArray[Any]:
+        return tifffile.imread(filepath)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -726,7 +726,7 @@ class CatalogNodeAdapter:
             if any(block[1:]):
                 raise IndexError(block)
             slice = block.slice_from_chunks(structure.chunks)[0]
-        indices = adapter_cls.stack_indices_for_slice(structure, chunks, slice)
+        indices = adapter_cls.file_indices_for_slice(structure, chunks, slice)
         if indices is None:
             # The reshape interleaves file contents (not file-boundary-aligned),
             # so every file must be loaded: the lazy path offers no benefit. Fall

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -669,7 +669,7 @@ class CatalogNodeAdapter:
         Returns `None` (so the caller falls back to :meth:`get_adapter`) unless
         every precondition for lazy per-frame resolution holds:
         a single file-scheme data source whose adapter class opts in via
-        `supports_lazy_filepaths` and whose `properties` carry `chunks`, and
+        `supports_lazy_assets` and whose `properties` carry `chunks`, and
         whose asset `num`s form a contiguous run of length n (any starting
         offset -- 0-based, 1-based, etc. -- so stacking rank == num - offset).
 
@@ -705,7 +705,7 @@ class CatalogNodeAdapter:
             adapter_cls = self.context.adapters_by_mimetype[ds.mimetype]
         except KeyError:
             return None
-        if not getattr(adapter_cls, "supports_lazy_filepaths", False):
+        if not getattr(adapter_cls, "supports_lazy_assets", False):
             return None
 
         n = sum(int(c) for c in chunks[0])  # stack length == number of files

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -13,7 +13,17 @@ from contextlib import closing
 from datetime import datetime, timezone
 from functools import partial, reduce
 from pathlib import Path
-from typing import Callable, Dict, List, Literal, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 import anyio
@@ -110,6 +120,10 @@ from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
 from .utils import compute_structure_id
+
+if TYPE_CHECKING:
+    from ..adapters.protocols import AnyAdapter
+    from ..ndslice import NDBlock
 
 logger = logging.getLogger(__name__)
 
@@ -405,9 +419,39 @@ class CatalogNodeAdapter:
         async with self.context.session() as db:
             return (await db.execute(statement)).scalar().all()
 
-    @property
-    def data_sources(self):
-        return [DataSource.from_orm(ds) for ds in (self.node.data_sources or [])]
+    async def data_sources(self, include_assets: bool = False):
+        """Return this node's data source(s) as pydantic `DataSource` objects.
+
+        With `include_assets=False` (the default), the assets are NOT
+        loaded: this uses the data source ORM objects already selectin-loaded
+        by `lookup_adapter` and issues no query. `asset_associations` is
+        `lazy="raise"`, so materializing all assets of a large file sequence
+        is avoided on the common metadata/structure/truthiness paths.
+
+        With `include_assets=True`, an explicit query eagerly loads each data
+        source's `asset_associations` (and their `asset`). Only the paths
+        that genuinely need assets -- the full `get_adapter()` build and the
+        opt-in `?include_data_sources=true` metadata response -- should ask
+        for them.
+        """
+        if not include_assets:
+            return [
+                DataSource.from_orm(ds, include_assets=False)
+                for ds in (self.node.data_sources or [])
+            ]
+        statement = (
+            select(orm.DataSource)
+            .where(orm.DataSource.node_id == self.node.id)
+            .options(
+                selectinload(orm.DataSource.structure),
+                selectinload(orm.DataSource.asset_associations).selectinload(
+                    orm.DataSourceAssetAssociation.asset
+                ),
+            )
+        )
+        async with self.context.session() as db:
+            ds_orms = (await db.execute(statement)).scalars().all()
+        return [DataSource.from_orm(ds, include_assets=True) for ds in ds_orms]
 
     async def asset_by_id(self, asset_id):
         statement = (
@@ -430,9 +474,10 @@ class CatalogNodeAdapter:
         return Asset.from_orm(asset)
 
     def structure(self):
-        if self.data_sources:
-            assert len(self.data_sources) == 1  # more not yet implemented
-            return self.data_sources[0].structure
+        data_sources = self.node.data_sources or []
+        if data_sources:
+            assert len(data_sources) == 1  # more not yet implemented
+            return DataSource.from_orm(data_sources[0], include_assets=False).structure
         return None
 
     def apply_conditions(self, statement):
@@ -556,7 +601,7 @@ class CatalogNodeAdapter:
 
             for i in range(len(segments)):
                 catalog_adapter = await self.lookup_adapter(segments[:i])
-                if catalog_adapter.data_sources:
+                if catalog_adapter.node.data_sources:
                     adapter = await catalog_adapter.get_adapter()
                     for segment in segments[i:]:
                         adapter = await anyio.to_thread.run_sync(adapter.get, segment)
@@ -567,8 +612,29 @@ class CatalogNodeAdapter:
 
         return STRUCTURES[node.structure_family](self.context, node)
 
+    def _ensure_uri_within_readable_storage(self, data_uri):
+        """Raise if a `file://` data URI lies outside every readable storage area.
+
+        Protects against misbehaving clients (or registrations) that would read
+        from unintended parts of the filesystem: a ``file`` URI is served only
+        when it resolves under one of the server's readable `FileStorage` roots.
+        Non-`file` schemes are not path-scoped and pass through unchecked.
+        """
+        if urlparse(data_uri).scheme != "file":
+            return
+        asset_path = path_from_uri(data_uri)
+        for storage in self.context.readable_storage.values():
+            if not isinstance(storage, FileStorage):
+                continue
+            if Path(os.path.commonpath([storage.path, asset_path])) == storage.path:
+                return
+        raise RuntimeError(
+            f"Refusing to serve {data_uri} because it is outside "
+            "the readable storage area for this server."
+        )
+
     async def get_adapter(self):
-        (data_source,) = self.data_sources
+        (data_source,) = await self.data_sources(include_assets=True)
         try:
             adapter_cls = self.context.adapters_by_mimetype[data_source.mimetype]
         except KeyError:
@@ -578,25 +644,7 @@ class CatalogNodeAdapter:
         for asset in data_source.assets:
             if asset.parameter is None:
                 continue
-            scheme = urlparse(asset.data_uri).scheme
-            if scheme == "file":
-                # Protect against misbehaving clients reading from unintended parts of the filesystem.
-                asset_path = path_from_uri(asset.data_uri)
-                for readable_storage in {
-                    item
-                    for item in self.context.readable_storage.values()
-                    if isinstance(item, FileStorage)
-                }:
-                    if (
-                        Path(os.path.commonpath([readable_storage.path, asset_path]))
-                        == readable_storage.path
-                    ):
-                        break
-                else:
-                    raise RuntimeError(
-                        f"Refusing to serve {asset.data_uri} because it is outside "
-                        "the readable storage area for this server."
-                    )
+            self._ensure_uri_within_readable_storage(asset.data_uri)
         adapter = await anyio.to_thread.run_sync(
             partial(
                 adapter_cls.from_catalog,
@@ -609,6 +657,143 @@ class CatalogNodeAdapter:
             if hasattr(adapter, "search"):
                 adapter = adapter.search(query)
         return adapter
+
+    async def _get_lazy_adapter(
+        self,
+        *,
+        block: Optional["NDBlock"] = None,
+        slice: Any = ...,
+    ) -> Optional["AnyAdapter"]:
+        """Build an I/O adapter that resolves only the assets a read will touch.
+
+        Returns `None` (so the caller falls back to :meth:`get_adapter`) unless
+        every precondition for lazy per-frame resolution holds:
+        a single file-scheme data source whose adapter class opts in via
+        `supports_lazy_filepaths` and whose `properties` carry `chunks`, and
+        whose asset `num`s form a contiguous run of length n (any starting
+        offset -- 0-based, 1-based, etc. -- so stacking rank == num - offset).
+
+        Instead of materializing all N asset rows, this reads only the data
+        source's structure/chunks (no assets), asks the adapter class which
+        stack indices (== stacking ranks) the given `block`/`slice` needs, and
+        fetches just those URIs. Keeps all DB access in the async layer; the
+        adapter (built through its normal `from_catalog` entry point with a
+        partially-populated URI list) resolves each URI to a filepath lazily,
+        only for the indices actually read.
+        """
+        if self.queries:
+            # Standing queries expect a fully-built adapter to search.
+            return None
+
+        # Read the data source's meta (id, mimetype, properties, structure)
+        # straight from the in-memory ORM object. `Node.data_sources` and each
+        # data source's `structure` are already selectin-loaded by
+        # `lookup_adapter`, so this avoids an extra DB round-trip. Assets are
+        # deliberately NOT touched here (asset_associations is lazy="raise").
+        data_source_orms = self.node.data_sources or []
+        if len(data_source_orms) != 1:
+            # Zero or multiple data sources: not supported by the lazy path.
+            return None
+        ds = data_source_orms[0]
+        if (chunks := (ds.properties or {}).get("chunks")) is None:
+            return None
+        if ds.structure is None:
+            return None
+
+        # The adapter class must opt in to lazy URI resolution
+        try:
+            adapter_cls = self.context.adapters_by_mimetype[ds.mimetype]
+        except KeyError:
+            return None
+        if not getattr(adapter_cls, "supports_lazy_filepaths", False):
+            return None
+
+        n = sum(int(c) for c in chunks[0])  # stack length == number of files
+
+        # Data source meta only (no assets); the structure/chunks are enough to
+        # compute the file geometry.
+        data_source = DataSource.from_orm(ds, include_assets=False)
+        structure = data_source.structure
+
+        # Which stack indices does this read need? Pure geometry -- a classmethod
+        # of the structure and chunks, needing no adapter instance or I/O.
+        #
+        # File selection for a block read depends ONLY on the block:
+        # FileSequenceAdapter.read_block loads the whole block along the stacking
+        # axis (`self.read(block.slice_from_chunks(...)[0])`) and applies any
+        # within-block slice AFTER, to the already-loaded data.
+        if block is not None:
+            if any(block[1:]):
+                raise IndexError(block)
+            slice = block.slice_from_chunks(structure.chunks)[0]
+        indices = adapter_cls.stack_indices_for_slice(structure, chunks, slice)
+        if indices is None:
+            # The reshape interleaves file contents (not file-boundary-aligned),
+            # so every file must be loaded: the lazy path offers no benefit. Fall
+            # back to the full adapter build.
+            return None
+
+        # Contiguity precheck: the lazy path maps each 0-based stacking rank to
+        # an asset `num`. That mapping is well-defined only when the `num`s form
+        # a contiguous run of length n with no gaps -- then rank == num - offset,
+        # where offset is the smallest num (0 for 0-based numbering, 1 for
+        # 1-based, and so on). Verify cheaply with an aggregate query (no asset
+        # rows materialized): count == n AND max - min == n - 1 holds iff the n
+        # distinct `num`s are exactly {offset .. offset + n - 1}. A set-equality
+        # check on only the requested `num`s is insufficient: a present-but-
+        # mis-ranked `num` (e.g. a silent gap elsewhere shifting ranks) would
+        # pass yet map to the wrong file. On any mismatch, fall back to the full
+        # build, whose asset-ordering logic does not rely on this assumption.
+        # TODO: It might be worth ensuring zero-based contiguous `num`s when writing
+        # assets; then this check can be dropped.
+        count_stmt = (
+            select(
+                func.count(orm.DataSourceAssetAssociation.num),
+                func.min(orm.DataSourceAssetAssociation.num),
+                func.max(orm.DataSourceAssetAssociation.num),
+            )
+            .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+            .where(orm.DataSourceAssetAssociation.num.isnot(None))
+        )
+
+        async with self.context.session() as db:
+            count, min_num, max_num = (await db.execute(count_stmt)).one()
+            if count != n or (n and max_num - min_num != n - 1):
+                return None
+            offset = min_num or 0  # `num`s run [offset, offset + n - 1]
+
+            # Fetch only the needed assets' URIs (indexed by
+            # (data_source_id, parameter, num)). The read's 0-based stack indices
+            # map to `num`s by adding the offset.
+            uri_stmt = (
+                select(
+                    orm.DataSourceAssetAssociation.num,
+                    orm.Asset.data_uri,
+                )
+                .join(
+                    orm.Asset,
+                    orm.Asset.id == orm.DataSourceAssetAssociation.asset_id,
+                )
+                .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+                .where(
+                    orm.DataSourceAssetAssociation.num.in_(
+                        [offset + i for i in indices]
+                    )
+                )
+            )
+            uri_rows = (await db.execute(uri_stmt)).all()
+
+        # Build a fixed-length URI list populated with only the frames this read needs
+        # (the rest left as None). Stacking rank == num - offset (contiguous run,
+        # guaranteed by the precheck above), so it indexes directly into the list.
+        data_uris = [None] * n
+        for num, data_uri in uri_rows:
+            self._ensure_uri_within_readable_storage(data_uri)
+            data_uris[num - offset] = data_uri
+
+        # One entry point for both eager and lazy: pass the partially-populated
+        # URI list as the `data_uris` kwarg. `from_catalog` derives chunks/metadata/specs.
+        return adapter_cls.from_catalog(data_source, self.node, data_uris=data_uris)
 
     def new_variation(
         self,
@@ -634,7 +819,7 @@ class CatalogNodeAdapter:
         )
 
     def search(self, query):
-        if self.data_sources:
+        if self.node.data_sources:
             # Stand queries, which will be passed down to the adapter
             # when / if get_adapter() is called.
             self.queries.append(query)
@@ -645,7 +830,7 @@ class CatalogNodeAdapter:
         return self.new_variation(sorting=sorting)
 
     async def get_distinct(self, metadata, structure_families, specs, counts):
-        if self.data_sources:
+        if self.node.data_sources:
             return (await self.get_adapter()).get_disinct(
                 metadata, structure_families, specs, counts
             )
@@ -1441,7 +1626,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
             )
 
         # Case 1: Node has external data sources -- delegate to the associated adapter
-        if self.data_sources:
+        if self.node.data_sources:
             keys = (await self.get_adapter()).keys()
             if self.default_sorting_direction == -1:
                 keys = reversed(keys)
@@ -1474,7 +1659,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
 
         The server uses `keys_page()` internally for cursor-based pagination.
         """
-        if self.data_sources:
+        if self.node.data_sources:
             keys = (await self.get_adapter()).keys()
             if self.default_sorting_direction == -1:
                 keys = reversed(keys)
@@ -1520,7 +1705,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
             )
 
         # Case 1: Node has external data sources -- delegate to the associated adapter
-        if self.data_sources:
+        if self.node.data_sources:
             items = (await self.get_adapter()).items()
             if self.default_sorting_direction == -1:
                 items = reversed(items)
@@ -1561,7 +1746,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
 
         The server uses `items_page()` internally for cursor-based pagination.
         """
-        if self.data_sources:
+        if self.node.data_sources:
             items = (await self.get_adapter()).items()
             if self.default_sorting_direction == -1:
                 items = reversed(items)
@@ -1596,7 +1781,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
         if offset == 0 or not self._is_default_sort:
             return None
 
-        if self.data_sources:
+        if self.node.data_sources:
             # For nodes with external data sources the adapter manages its own
             # iteration order and conditions are not applied at the DB level
             # (see keys_page/items_page data_sources path). The offset is
@@ -1614,7 +1799,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
         return row[0] if row is not None else None
 
     async def read(self, *args, **kwargs):
-        if not self.data_sources:
+        if not self.node.data_sources:
             fields = kwargs.get("fields")
             if fields:
                 return self.search(KeysFilter(fields))
@@ -1627,14 +1812,26 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
 
 class CatalogArrayAdapter(CatalogNodeAdapter):
     async def read(self, *args, **kwargs):
-        if not self.data_sources:
+        if not self.node.data_sources:
             fields = kwargs.get("fields")
             if fields:
                 return self.search(KeysFilter(fields))
             return self
+        # Try lazy per-frame resolution for a plain slice read (no field
+        # selection). Falls back to the full adapter build if not applicable.
+        if "fields" not in kwargs:
+            slice_ = args[0] if args else kwargs.get("slice", ...)
+            adapter = await self._get_lazy_adapter(slice=slice_)
+            if adapter is not None:
+                return await ensure_awaitable(adapter.read, *args, **kwargs)
         return await ensure_awaitable((await self.get_adapter()).read, *args, **kwargs)
 
     async def read_block(self, *args, **kwargs):
+        block = args[0] if args else kwargs.get("block")
+        if block is not None:
+            adapter = await self._get_lazy_adapter(block=block)
+            if adapter is not None:
+                return await ensure_awaitable(adapter.read_block, *args, **kwargs)
         return await ensure_awaitable(
             (await self.get_adapter()).read_block, *args, **kwargs
         )

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -490,13 +490,13 @@ class DataSource(Timestamped, Base):
         secondary="data_source_asset_association",
         back_populates="data_sources",
         cascade="all, delete",
-        lazy="selectin",
+        lazy="raise",
         viewonly=True,
     )
     # association between Asset -> Association -> DataSource
     asset_associations: Mapped[List["DataSourceAssetAssociation"]] = relationship(
         back_populates="data_source",
-        lazy="selectin",
+        lazy="raise",
         order_by=[DataSourceAssetAssociation.parameter, DataSourceAssetAssociation.num],
     )
 

--- a/tiled/ndslice.py
+++ b/tiled/ndslice.py
@@ -579,6 +579,31 @@ class NDSlice(tuple):
         "Calculate the shape after applying NDSlice to an array of the given shape"
         return ndindex(self).newshape(shape) if self else shape
 
+    def flat_indices(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        """Return the flat (C-order) positions selected by this slice.
+
+        Conceptually `numpy.arange(prod(shape)).reshape(shape)[self]` flattened
+        to 1-D: it labels each cell of an array of `shape` with its C-order
+        position and reports the positions this slice keeps. Integer entries drop
+        a dimension; slices (including strided and negative) and Ellipsis are
+        honored exactly as in NumPy indexing.
+
+        This is the inverse-mapping companion to :meth:`shape_after_slice` (which
+        gives the *shape* of a selection); here we get the flat *identities* of
+        the selected cells. It is useful for mapping an N-dimensional selection
+        back onto a flat, C-ordered collection -- e.g. finding which files of a
+        stacked file-sequence a given slice touches, where each file occupies one
+        cell of the stacking grid.
+
+        Returns a `tuple` of Python ints (empty if the slice selects nothing).
+        The selection order matches NumPy's, so the result also serves as the
+        read order for the underlying elements.
+        """
+        import numpy
+
+        grid = numpy.arange(math.prod(shape)).reshape(shape)
+        return tuple(grid[self.expand_for_shape(shape)].ravel().tolist())
+
     def unsqueeze(self) -> "NDSlice":
         "Convert all integer dims to slices of length 1 to preserve the dimensionality"
         return self.__class__(

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -481,7 +481,13 @@ async def construct_resource(
     id_ = path_parts[-1] if path_parts else ""
     attributes = {"ancestors": path_parts[:-1]}
     if include_data_sources and hasattr(entry, "data_sources"):
-        attributes["data_sources"] = entry.data_sources
+        if callable(getattr(entry, "data_sources")):
+            # Catalog adapters expose `data_sources(include_assets=...)`; the
+            # assets are loaded only when the client asked to include data
+            # sources (they are otherwise omitted for large file sequences).
+            attributes["data_sources"] = await entry.data_sources(include_assets=True)
+        else:
+            attributes["data_sources"] = entry.data_sources
     if schemas.EntryFields.metadata in fields:
         if select_metadata is not None:
             attributes["metadata"] = {

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -1912,7 +1912,9 @@ def get_router(
         links = links_for_node(
             structure_family, structure, get_base_url(request), path + f"/{node.key}"
         )
-        data_sources_dump = [ds.model_dump() for ds in node.data_sources]
+        data_sources_dump = [
+            ds.model_dump() for ds in await node.data_sources(include_assets=True)
+        ]
         strip_asset_fields_for_client(
             data_sources_dump, parse_python_tiled_client_version(request)
         )

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -181,12 +181,22 @@ class DataSource(pydantic.BaseModel, Generic[StructureT]):
     model_config = pydantic.ConfigDict(extra="forbid")
 
     @classmethod
-    def from_orm(cls, orm: tiled.catalog.orm.DataSource) -> DataSource:
+    def from_orm(
+        cls, orm: tiled.catalog.orm.DataSource, include_assets: bool = True
+    ) -> DataSource:
         if hasattr(orm.structure, "structure"):
             structure_cls = STRUCTURE_TYPES[orm.structure_family]
             structure = structure_cls.from_json(orm.structure.structure)
         else:
             structure = None
+        # `asset_associations` is not eagerly loaded (lazy="raise"); only touch it
+        # when the caller explicitly needs assets and has loaded them. This keeps
+        # the common metadata/structure/truthiness paths from materializing all
+        # assets of a large file-sequence data source.
+        if include_assets:
+            assets = [Asset.from_assoc_orm(assoc) for assoc in orm.asset_associations]
+        else:
+            assets = []
         return cls(
             id=orm.id,
             structure_family=orm.structure_family,
@@ -194,7 +204,7 @@ class DataSource(pydantic.BaseModel, Generic[StructureT]):
             mimetype=orm.mimetype,
             parameters=orm.parameters,
             properties=orm.properties,
-            assets=[Asset.from_assoc_orm(assoc) for assoc in orm.asset_associations],
+            assets=assets,
             management=orm.management,
         )
 


### PR DESCRIPTION
## Summary

Reading slices or blocks from array datasets backed by **many files** (e.g. multipart TIFF stacks with thousands of frames, or HDF5 datasets spread across many `.h5` files) was slow and memory-hungry in several independent ways. This PR addresses them.

### 1. Lazy asset resolution

Previously, serving *any* slice/block of a file-sequence array materialized **every** asset row just to build the adapter — ~560–650 ms per read regardless of how little data was requested.

Now assets are resolved lazily: read only the data source's structure/chunks, compute which stack indices the slice/block touches purely from geometry, and fetch just those asset URIs. The adapter is built through its normal `from_catalog` entry point with a partially-populated URI list, so only the frames actually read are resolved to filepaths.

- `catalog/orm.py`: `DataSource` asset relationships switch to `lazy="raise"` — assets are never loaded implicitly; every access is explicit.
- `server/schemas.py`: `DataSource.from_orm` gains `include_assets` to skip `asset_associations` on common metadata/structure paths.
- `server/core.py`, `server/router.py`: request assets (`data_sources(include_assets=True)`) only when genuinely needed.
- `catalog/adapter.py`: `_get_lazy_adapter` prechecks contiguity of asset `num`s, fetches only the needed URIs, validates each is within readable storage, and falls back to the full build when preconditions don't hold.
- `adapters/sequence.py`: `stack_indices_for_slice`/`_stacking_grid_shape` map a slice/block onto file-boundary-aligned stack indices, with a full-load fallback for reshapes that interleave file contents.
- `ndslice.py`: `NDSlice.flat_indices` reports the C-order positions a slice selects.

**Result** (CHX node, 8190-frame TIFF stack), warm:

| stage | baseline (was) | lazy (now) |
|---|---|---|
| `lookup_adapter` walk | ~190–350 ms | **6–7 ms** |
| adapter build | ~220–415 ms | **~5 ms** |
| assets materialized (build) | 8190 | **1** (only those touched) |
| E2E stateless walk + 1-frame read | ~600 ms | **~160 ms** |

Values match the full read.

### 2. Parallel, memory-bounded reads

A slice that touches many/all files but keeps only a few pixels of each frame (e.g. `arr[:, :, 0, 0]` over thousands of TIFFs) previously read every file **serially** and materialized the **entire stack** in memory before slicing it down — cold reads exceeded the client read timeout and peak memory scaled with the full stack.

- **Parallel I/O:** new sequence-adapter knobs `IO_WORKERS` (`TILED_SEQUENCE_IO_WORKERS`) and `READ_BATCH_BYTES` (`TILED_SEQUENCE_READ_BATCH_BYTES`), a per-file `_read_one` primitive, and a concurrent `_map_read`. TIFF reads via `asarray(ioworkers=IO_WORKERS)`; NPY/JPEG via `_map_read`.
- **Memory-bounded read+reduce:** in the reshaped-aligned branch of `read()`, `_read_selected` reads each file on a persistent worker pool, reshapes it to the per-file structure shape, reduces it by the trailing (frame) slice, and writes straight into a preallocated output — dropping the full frame immediately. Reducing per-file before stacking commutes with reshaping the file axis, so results match a full read. Concurrency is capped so in-flight full frames stay near `READ_BATCH_BYTES`, bounding peak memory independent of file count.
- Adds a batch-invariance regression test.

**Scope:** only the reshaped-aligned branch uses the reduce path; the misaligned fallback and non-reshaped branch are unchanged (they still benefit from parallel I/O).

**Result** (CHX node, 8190-frame / 41 GB TIFF stack), warm:

| slice | files touched | peak extra RSS before | peak extra RSS after | time |
|---|---|---|---|---|
| `arr[:, :, 0, 0]` | 8190 (all) | ~41 GB (full stack) | **+0.04 GB** | 5.9 s |
| `arr[:300, :, :, 0]` | 1500 | ~7.76 GB | **+0.01 GB** | 1.1 s |

Peak memory is bounded regardless of how many files the slice touches.

### 3. Faster many-file HDF5 datasets

HDF5 datasets spanning many `.h5` files (e.g. detector streams with one file per acquisition segment) were slow for a different set of reasons than the sequence adapters above:

1. **Every read rebuilt the graph.** `get_adapter` → `from_catalog` → `lazy_load_hdf5_array` opened **every** constituent file (twice, for external links) on each request just to re-derive shape/chunks/dtype that are already known — the HDF5 adapter did not use the resource cache that TIFF/NPY/JPEG do.
2. **Spec reads were serial** — N files opened one at a time.
3. **Tiny native chunks exploded the task/open count.** Constituent datasets often use a single-frame native HDF5 chunk (e.g. `(1, 8, 4096)`) with thousands of frames per file. Concatenated along the leading axis, this yields a Dask array with one size-1 chunk per frame; the server reshapes the flat stack back to the logical shape, so reading a *single* logical row of one file expanded into hundreds of Dask tasks, **each re-opening the file**.

This PR fixes all three in `adapters/hdf5.py`:

- **Cache the lazy graph.** `from_catalog` wraps `lazy_load_hdf5_array` in `with_resource_cache` (keyed on dataset + file paths + open options), so repeated reads reuse the graph instead of re-opening all files. Slicing the cached array returns a new array, leaving the cached one unmodified; open h5py handles are still opened/closed per task, so nothing leaks.
- **Read specs in parallel.** For multi-file datasets, `_get_hdf5_specs` runs over the files on a `ThreadPoolExecutor` (`min(IO_WORKERS, n_files)`), order-preserving.
- **Coalesce native chunks.** Instead of tiling by the files' tiny native chunks, read whole rows (full trailing dimensions) in blocks along the concatenation axis, sized up to `READ_BATCH_BYTES` but never smaller than the native chunk. Typical detector frames collapse to **one read task per file**. Falls back to native tiling only when a single row already exceeds the batch limit.
  - *Trade-off:* a single inner-frame read now pulls that file's whole per-file block (bounded by `READ_BATCH_BYTES`, default 1 GiB). Bulk/many-file reads — the reported problem — win dramatically; incidental single-frame reads of a huge dataset read a bit more.

**Result** (SRX-style dataset, warm), per read after the change:

| dataset | read | baseline (was) | now |
|---|---|---|---|
| `enc1` (153 files, `(153, 223)`) | `arr[0:1]` | 805 ms | **33 ms / 4 opens** |
| `fluor` (153 files, `(153, 223, 8, 4096)` f8) | `arr[0:1]` | 9842 ms / 446 opens | **785 ms / 4 opens** |

The first build still reads specs from all files once (now parallel, ~900 ms for 153 files); the resource cache means subsequent reads reuse the graph and touch only the files a read needs.

**Follow-up (not in this PR):** a lazy-asset fast path for HDF5 (open specs only for the files a slice touches, skipping the full first build) was investigated and deferred. Unlike the sequence adapters, HDF5 files each contribute a *variable-length block* along the stacking axis, so the catalog's `1 file = 1 row` geometry does not apply; it would need per-file block boundaries stored in `properties["chunks"]` and an HDF5-aware branch in `_get_lazy_adapter`. Worth doing mainly for datasets scaling into the thousands of files.

### Notes / follow-ups

- The lazy change makes server-side `CatalogNodeAdapter.data_sources` an `async def data_sources(include_assets=False)`; callers needing assets must `await ...(include_assets=True)`. (Downstream `bluesky-tiled-plugins` server-side sites need the matching update.)
- Cold reads of very large stacks remain fundamentally I/O-bound and can still exceed the hardcoded 30 s client read timeout; a configurable client read timeout is a planned follow-up.

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section

