### PR TITLE
Implement Lazy Loading of HDF5 Assets -- ON HOLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   optional per-asset `extents` property records each file's length along that
   axis, so a read opens only the files its slice touches; the adapter also
   infers the layout from the structure chunks or grid shape when the property
-  is absent. (#1465)
+  is absent. Datasets served through a `slice`/`squeeze` adapter transform fall
+  back to a full build, since the transform reshapes each file and breaks the
+  mapping from the served axis to whole files. (#1465)
 - Add a new feature that stores a graph of links into the catalog database. Adds strawberry
   as a dependency. Import/search/export of graph links is accomplished through graphql.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   read fetches. The budget is now a modest 16 MiB, keeping small reads cheap
   while full reads still coalesce sensibly. Override with
   `TILED_HDF5_READ_CHUNK_BYTES`. (#1465)
+- Route single-file HDF5 array datasets through the eager (non-lazy) adapter.
+  The lazy path culls no assets when there is only one file and would otherwise
+  turn the whole file into a single coalesced read block. (#1465)
 - Fix the `raw_export` download progress bar, which showed a wrong total (e.g.
   `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar
   now seeds each task's total from the known asset size, and raw-asset downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Route single-file HDF5 array datasets through the eager (non-lazy) adapter.
-  The lazy path culls no assets when there is only one file and would read the
-  whole file as one task even for a small slice; the eager adapter honors the
-  file's native HDF5 chunking and reads only the touched chunks. (#1465)
+  With only one file the lazy path can cull nothing, so it offers no benefit
+  over the eager adapter, which already honors the file's native HDF5 chunking
+  and reads only the touched chunks. (#1465)
 - Fix the `raw_export` download progress bar, which showed a wrong total (e.g.
   `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar
   now seeds each task's total from the known asset size, and raw-asset downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Bound the bytes a single HDF5 read task pulls from disk. Coalescing tiny
+  native chunks previously used a 1 GiB budget, so reading one frame of a large
+  dataset fetched up to a gigabyte because a block is also the minimum a partial
+  read fetches. The budget is now a modest 16 MiB, keeping small reads cheap
+  while full reads still coalesce sensibly. Override with
+  `TILED_HDF5_READ_CHUNK_BYTES`. (#1465)
 - Fix the `raw_export` download progress bar, which showed a wrong total (e.g.
   `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar
   now seeds each task's total from the known asset size, and raw-asset downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
   axis, so a read opens only the files its slice touches; the adapter also
   infers the layout from the structure chunks or grid shape when the property
   is absent. Datasets served through a `slice`/`squeeze` adapter transform fall
-  back to a full build, since the transform reshapes each file and breaks the
-  mapping from the served axis to whole files. (#1465)
+  back to a full build, since the lazy read reshapes each whole file into its
+  slab of the served structure and that transform can make the served per-file
+  shape differ from the raw file. (#1465)
 - Add a new feature that stores a graph of links into the catalog database. Adds strawberry
   as a dependency. Import/search/export of graph links is accomplished through graphql.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,18 @@ Write the date in place of the "Unreleased" in the case a new version is release
   `TILED_SEQUENCE_IO_WORKERS` and `TILED_SEQUENCE_READ_BATCH_BYTES` environment
   variables. (#1463)
 - Faster reads of HDF5 datasets spanning many files: the lazy Dask graph is
-  cached through the resource cache, per-file specs are read in parallel, and
-  tiny native chunks are coalesced into whole-file read tasks. (#1463)
+  cached through the resource cache and per-file specs are read in parallel.
+  (#1463)
 - Lazy asset resolution for multi-file HDF5 array datasets, extending the lazy
   path above to datasets that concatenate files along the leading axis. An
   optional per-asset `extents` property records each file's length along that
   axis, so a read opens only the files its slice touches; the adapter also
   infers the layout from the structure chunks or grid shape when the property
-  is absent. Datasets served through a `slice`/`squeeze` adapter transform fall
-  back to a full build, since the lazy read reshapes each whole file into its
-  slab of the served structure and that transform can make the served per-file
-  shape differ from the raw file. (#1465)
+  is absent. The lazy read is tiled by native HDF5 chunks (mirroring the eager
+  path), so a partial read fetches only the native chunks it overlaps -- the
+  minimum HDF5 can serve -- with no coalescing. Datasets served through a
+  `slice`/`squeeze` adapter transform fall back to a full build, since that
+  transform can make the served per-file shape differ from the raw file. (#1465)
 - Add a new feature that stores a graph of links into the catalog database. Adds strawberry
   as a dependency. Import/search/export of graph links is accomplished through graphql.
 
@@ -44,15 +45,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
-- Bound the bytes a single HDF5 read task pulls from disk. Coalescing tiny
-  native chunks previously used a 1 GiB budget, so reading one frame of a large
-  dataset fetched up to a gigabyte because a block is also the minimum a partial
-  read fetches. The budget is now a modest 16 MiB, keeping small reads cheap
-  while full reads still coalesce sensibly. Override with
-  `TILED_HDF5_READ_CHUNK_BYTES`. (#1465)
 - Route single-file HDF5 array datasets through the eager (non-lazy) adapter.
-  The lazy path culls no assets when there is only one file and would otherwise
-  turn the whole file into a single coalesced read block. (#1465)
+  The lazy path culls no assets when there is only one file and would read the
+  whole file as one task even for a small slice; the eager adapter honors the
+  file's native HDF5 chunking and reads only the touched chunks. (#1465)
 - Fix the `raw_export` download progress bar, which showed a wrong total (e.g.
   `1,257,333,024/100 bytes`) and did not advance during the transfer. The bar
   now seeds each task's total from the known asset size, and raw-asset downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Support clustered Redis for high availability.
 - Add client_secret,redirect_on_success,redirect_on_failure to
   ProxiedOIDCAuthenticator. This is to allow login using Tiled-UI
-- Allow configuration of user_id_claim for OIDCAuthenticator
+- Allow configuration of user_id_claim for OIDCAuthenticator.
 - Lazy asset resolution for array datasets backed by many files: reading a
   slice or block now resolves only the assets (files) the read touches,
   computed purely from the structure geometry, instead of materializing every
@@ -20,6 +20,15 @@ Write the date in place of the "Unreleased" in the case a new version is release
   bounded regardless of how many files a slice spans. Tunable via the
   `TILED_SEQUENCE_IO_WORKERS` and `TILED_SEQUENCE_READ_BATCH_BYTES` environment
   variables. (#1463)
+- Faster reads of HDF5 datasets spanning many files: the lazy Dask graph is
+  cached through the resource cache, per-file specs are read in parallel, and
+  tiny native chunks are coalesced into whole-file read tasks. (#1463)
+- Lazy asset resolution for multi-file HDF5 array datasets, extending the lazy
+  path above to datasets that concatenate files along the leading axis. An
+  optional per-asset `extents` property records each file's length along that
+  axis, so a read opens only the files its slice touches; the adapter also
+  infers the layout from the structure chunks or grid shape when the property
+  is absent. (#1465)
 - Add a new feature that stores a graph of links into the catalog database. Adds strawberry
   as a dependency. Import/search/export of graph links is accomplished through graphql.
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -998,6 +998,112 @@ async def test_lazy_hdf5_nonuniform_requires_extents(tmpdir):
         await adapter.shutdown()
 
 
+@pytest.mark.parametrize("transform", [{"slice": ":,0,:"}, {"squeeze": True}])
+def test_file_indices_for_slice_declines_under_transform(transform):
+    """A `slice`/`squeeze` adapter parameter reshapes each file when the served
+    array is built, so the served axis 0 no longer maps to whole backing files.
+    `file_indices_for_slice` must decline (return None) so the catalog skips the
+    lazy path -- even when the structure alone (one leading chunk per file) would
+    otherwise let the files be located from `chunks[0]`.
+    """
+    from tiled.adapters.hdf5 import HDF5ArrayAdapter
+
+    # One leading chunk per file: without a transform the files ARE locatable.
+    struct = ArrayStructure(
+        shape=(3, 2, 3),
+        chunks=((1, 1, 1), (2,), (3,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    sl = (slice(0, 2),)
+
+    # Baseline: no transform -> the lazy path can locate the touched files.
+    assert HDF5ArrayAdapter.file_indices_for_slice(struct, 3, sl) == (0, 1)
+    assert HDF5ArrayAdapter.file_indices_for_slice(struct, 3, sl, parameters={}) == (
+        0,
+        1,
+    )
+    # A slice/squeeze transform is present -> decline regardless of the layout.
+    assert (
+        HDF5ArrayAdapter.file_indices_for_slice(struct, 3, sl, parameters=transform)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_lazy_hdf5_declines_under_slice_squeeze(tmpdir):
+    """A data source carrying a `slice`/`squeeze` parameter must not take the lazy
+    path even when its structure would otherwise locate files: those transforms
+    reshape each file on read, breaking the served-axis-0 -> file mapping. The
+    catalog threads the data source `parameters` to the adapter, which declines,
+    and the eager build still reads correctly.
+    """
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    # Uniform files, one leading chunk each: the structure alone locates files
+    # (len(chunks[0]) == n_files), so only the transform can hold back the lazy path.
+    K, M, N = 4, 2, 3
+    rng = numpy.random.default_rng(11)
+    files = [rng.integers(0, 255, size=(1, M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    for i, file_data in enumerate(files):
+        filepath = Path(tmpdir) / f"file{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=file_data, chunks=(1, M, N))
+        data_uris.append(ensure_uri(str(filepath)))
+
+    full = numpy.concatenate(files, axis=0)  # (K, M, N)
+    struct = ArrayStructure(
+        shape=(K, M, N),
+        chunks=((1,) * K, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+
+    async def _make_node(adapter, key, parameters):
+        await adapter.create_node(
+            key=key,
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters=parameters,
+                    properties={"chunks": [[M] * K, [M], [N]]},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        # Control: no transform -> the structure lets the lazy path engage.
+        await _make_node(adapter, "plain", {"dataset": "a/b"})
+        ctrl = await adapter.lookup_adapter(["plain"])
+        assert await ctrl._get_lazy_adapter(slice=(slice(0, 2),)) is not None
+
+        # A squeeze parameter (a no-op on this non-singleton array) is enough to
+        # hold back the lazy path; the eager read still returns the whole array.
+        await _make_node(adapter, "squeezed", {"dataset": "a/b", "squeeze": True})
+        x = await adapter.lookup_adapter(["squeezed"])
+        assert await x._get_lazy_adapter(slice=(slice(0, 2),)) is None
+        result = await x.read(slice=NDSlice((slice(0, 2),)))
+        numpy.testing.assert_array_equal(result, full[0:2])
+    finally:
+        await adapter.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_write_table_external_direct(a, tmpdir):
     df = pandas.DataFrame(numpy.ones((5, 3)), columns=list("abc"))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1000,11 +1000,13 @@ async def test_lazy_hdf5_nonuniform_requires_extents(tmpdir):
 
 @pytest.mark.parametrize("transform", [{"slice": ":,0,:"}, {"squeeze": True}])
 def test_file_indices_for_slice_declines_under_transform(transform):
-    """A `slice`/`squeeze` adapter parameter reshapes each file when the served
-    array is built, so the served axis 0 no longer maps to whole backing files.
-    `file_indices_for_slice` must decline (return None) so the catalog skips the
-    lazy path -- even when the structure alone (one leading chunk per file) would
-    otherwise let the files be located from `chunks[0]`.
+    """A `slice`/`squeeze` adapter parameter makes each file's served shape
+    differ from its raw contents, so the lazy read (which builds a block by
+    reading a whole file and reshaping it to that file's slab of the served
+    structure) can not form the stack. `file_indices_for_slice` must decline
+    (return None) so the catalog skips the lazy path -- even when the structure
+    alone (one leading chunk per file) would otherwise let the files be located
+    from `chunks[0]`.
     """
     from tiled.adapters.hdf5 import HDF5ArrayAdapter
 
@@ -1032,10 +1034,11 @@ def test_file_indices_for_slice_declines_under_transform(transform):
 @pytest.mark.asyncio
 async def test_lazy_hdf5_declines_under_slice_squeeze(tmpdir):
     """A data source carrying a `slice`/`squeeze` parameter must not take the lazy
-    path even when its structure would otherwise locate files: those transforms
-    reshape each file on read, breaking the served-axis-0 -> file mapping. The
-    catalog threads the data source `parameters` to the adapter, which declines,
-    and the eager build still reads correctly.
+    path even when its structure would otherwise locate files: the lazy read
+    reads each whole file and reshapes it to that file's slab of the served
+    structure, which fails once the transform makes the served per-file shape
+    differ from the raw file. The catalog threads the data source `parameters` to
+    the adapter, which declines, and the eager build still reads correctly.
     """
     from tiled.ndslice import NDSlice
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -445,6 +445,559 @@ async def test_lazy_sequence_tolerates_num_offset(tmpdir, num_offset):
         await adapter.shutdown()
 
 
+@pytest.mark.parametrize(
+    "slice_input",
+    [
+        Ellipsis,  # full read -> every file
+        1,  # single leftmost index
+        (slice(0, 2), 1, slice(0, 4, 2)),  # strided along the R (stacking) axis
+        (slice(None), slice(1, 3), slice(0, 4, 2), Ellipsis, slice(0, 4)),
+        (Ellipsis, 0, 0, 0),
+        (0, Ellipsis, slice(0, 3)),
+        (slice(0, 2), slice(0, 3), slice(1, 4, 2)),
+        (slice(0, 1), slice(0, 2), slice(0, 2), slice(0, 2), slice(0, 3)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_lazy_reshaped_hdf5_opens_only_touched_files(tmpdir, slice_input):
+    """The lazy per-frame path opens exactly the HDF5 files that a reshaped
+    slice needs -- no specs pass, no metadata open -- and reads back data
+    identical to the eager reference.
+
+    Each file stores one M x N dataset; the true concatenated shape is (K*M, N)
+    but the structure declares (P, Q, R, M, N). The file count is the number of
+    assets (K), and the leading (P, Q, R) structure dimensions map onto them.
+    """
+    from unittest.mock import patch
+
+    import tiled.adapters.hdf5
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    P, Q, R, M, N = _RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N
+    K = P * Q * R
+
+    # Distinct data per file so any mis-selection surfaces as a value mismatch.
+    rng = numpy.random.default_rng(2)
+    frames = [rng.integers(0, 255, size=(M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    filepaths = []
+    for i, frame in enumerate(frames):
+        filepath = Path(tmpdir) / f"frame{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=frame)
+        filepaths.append(filepath)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # Eager references, computed independently of the adapter's own logic.
+    full = numpy.stack(frames).reshape(P, Q, R, M, N)
+    idx_cube = numpy.broadcast_to(
+        numpy.arange(K).reshape(P, Q, R, 1, 1), (P, Q, R, M, N)
+    )
+
+    struct = ArrayStructure(
+        shape=(P, Q, R, M, N),
+        chunks=((1,) * P, (1,) * Q, (1,) * R, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    # `properties["chunks"]` carries the *pre-reshape* (stacked) chunk layout:
+    # one whole-file chunk of M rows per file along the concatenation axis, then
+    # the shared trailing N dim. len(chunks[0]) == K files; sum == K*M rows.
+    pre_reshape_chunks = [[M] * K, [N]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        reference = full[slice_input]
+        expected_indices = set(numpy.unique(idx_cube[slice_input]).tolist())
+        expected_names = {filepaths[i].name for i in expected_indices}
+
+        # The lazy adapter must be used (not a fallback).
+        lazy = await x._get_lazy_adapter(slice=slice_input)
+        assert lazy is not None
+
+        # Reading through the catalog opens exactly the files that this slice
+        # touches, each exactly once: no specs pass and no metadata open. (The
+        # server always presents a slice as an NDSlice.)
+        with patch(
+            "tiled.adapters.hdf5.h5open", wraps=tiled.adapters.hdf5.h5open
+        ) as mock_h5open:
+            result = await x.read(slice=NDSlice(slice_input))
+            opened = [Path(call.args[0]).name for call in mock_h5open.call_args_list]
+
+        assert set(opened) == expected_names
+        assert len(opened) == len(expected_names)
+        numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lazy_reshaped_hdf5_read_block(tmpdir):
+    """`read_block` takes the same lazy path. The catalog resolves the whole
+    leading-axis slab a block sits in, but a block addresses a single grid cell
+    (one file), and Dask culls the rest -- so exactly that one file is opened and
+    the data matches the eager reference.
+    """
+    from unittest.mock import patch
+
+    import tiled.adapters.hdf5
+    from tiled.ndslice import NDBlock
+
+    h5py = pytest.importorskip("h5py")
+    P, Q, R, M, N = _RESHAPE_P, _RESHAPE_Q, _RESHAPE_R, _RESHAPE_M, _RESHAPE_N
+    K = P * Q * R
+
+    rng = numpy.random.default_rng(3)
+    frames = [rng.integers(0, 255, size=(M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    filepaths = []
+    for i, frame in enumerate(frames):
+        filepath = Path(tmpdir) / f"frame{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=frame)
+        filepaths.append(filepath)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    full = numpy.stack(frames).reshape(P, Q, R, M, N)
+    struct = ArrayStructure(
+        shape=(P, Q, R, M, N),
+        chunks=((1,) * P, (1,) * Q, (1,) * R, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    pre_reshape_chunks = [[M] * K, [N]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        # `read_block` only accepts blocks whose non-leading indices are 0; such a
+        # block addresses grid cell (p, 0, 0), i.e. file index p * Q * R.
+        for p in range(P):
+            block = NDBlock(p, 0, 0, 0, 0)
+            reference = full[p : p + 1, 0:1, 0:1]  # noqa: E203
+            expected_name = filepaths[p * Q * R].name
+
+            lazy = await x._get_lazy_adapter(block=block)
+            assert lazy is not None
+            with patch(
+                "tiled.adapters.hdf5.h5open", wraps=tiled.adapters.hdf5.h5open
+            ) as mock_h5open:
+                result = await x.read_block(block)
+                opened = [
+                    Path(call.args[0]).name for call in mock_h5open.call_args_list
+                ]
+            # Over-resolved to the leading slab, but Dask culls to the one cell.
+            assert opened == [expected_name]
+            numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.parametrize(
+    "slice_input",
+    [
+        0,  # single event -> one file
+        2,  # single event -> one file
+        (1, slice(0, 2)),  # event 1, first two frames -> still one file
+        (slice(1, 3),),  # two events -> two files
+    ],
+)
+@pytest.mark.asyncio
+async def test_lazy_reshaped_hdf5_multichunk_files(tmpdir, slice_input):
+    """A file that holds many native chunks along the concatenation axis still
+    takes the lazy path.
+
+    Each file stores an (F, H, W) dataset chunked one frame at a time, so its
+    native tiling is (1, H, W): `properties["chunks"][0]` has K*F ones, far more
+    than the K files. The structure declares (K, F, H, W). The file count is the
+    number of assets (K), NOT `len(chunks[0])` (== K*F), and the leading axis
+    maps onto the files -- so reading one event opens exactly one file. (This is
+    the shape of a per-frame-chunked detector stream.)
+    """
+    from unittest.mock import patch
+
+    import tiled.adapters.hdf5
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    K, F, H, W = 3, 4, 2, 3
+
+    rng = numpy.random.default_rng(5)
+    files = [rng.integers(0, 255, size=(F, H, W), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    filepaths = []
+    for i, file_data in enumerate(files):
+        filepath = Path(tmpdir) / f"file{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            # One frame per native chunk: many native chunks per file.
+            f.create_dataset("a/b", data=file_data, chunks=(1, H, W))
+        filepaths.append(filepath)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # Eager reference and a cube labelling every element by its source file.
+    full = numpy.stack(files)  # (K, F, H, W)
+    idx_cube = numpy.broadcast_to(numpy.arange(K).reshape(K, 1, 1, 1), (K, F, H, W))
+
+    struct = ArrayStructure(
+        shape=(K, F, H, W),
+        chunks=((1,) * K, (F,), (H,), (W,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    # Pre-reshape (native) tiling: one frame per chunk over the K*F concatenated
+    # frames, then the shared trailing H, W dims. len(chunks[0]) == K*F != K.
+    pre_reshape_chunks = [[1] * (K * F), [H], [W]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        reference = full[slice_input]
+        expected_indices = set(numpy.unique(idx_cube[slice_input]).tolist())
+        expected_names = {filepaths[i].name for i in expected_indices}
+
+        # The lazy adapter must be used (not a fallback).
+        lazy = await x._get_lazy_adapter(slice=slice_input)
+        assert lazy is not None
+
+        with patch(
+            "tiled.adapters.hdf5.h5open", wraps=tiled.adapters.hdf5.h5open
+        ) as mock_h5open:
+            result = await x.read(slice=NDSlice(slice_input))
+            opened = [Path(call.args[0]).name for call in mock_h5open.call_args_list]
+
+        assert set(opened) == expected_names
+        assert len(opened) == len(expected_names)
+        numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lazy_hdf5_falls_back_when_not_file_aligned(tmpdir):
+    """When the reshape is not file-boundary-aligned the lazy path bows out
+    (`_get_lazy_adapter` returns None) and the eager build still reads correctly.
+    """
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    # K files of M rows each; a structure whose leading dims never multiply to
+    # the file count K, so no whole-file split exists.
+    K, M, N = 6, 5, 3
+    rng = numpy.random.default_rng(4)
+    frames = [rng.integers(0, 255, size=(M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    for i, frame in enumerate(frames):
+        filepath = Path(tmpdir) / f"frame{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=frame)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # true concatenated shape (K*M, N) == (30, 3); reshape to (10, 3, 3) splits
+    # the file boundary (10 > K at the first axis), so it is not file-aligned.
+    full = numpy.concatenate(frames, axis=0).reshape(10, 3, N)
+    struct = ArrayStructure(
+        shape=(10, 3, N),
+        chunks=((1,) * 10, (3,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    pre_reshape_chunks = [[M] * K, [N]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        # Not file-aligned -> lazy path declines, eager path still correct.
+        assert await x._get_lazy_adapter(slice=(slice(0, 2),)) is None
+        result = await x.read(slice=NDSlice((slice(0, 2),)))
+        numpy.testing.assert_array_equal(result, full[0:2])
+    finally:
+        await adapter.shutdown()
+
+
+# Genuinely non-uniform files: K files hold DIFFERENT numbers of frames, stored
+# flat-concatenated along axis 0. The native tiling (one frame per chunk) can not
+# reveal the file boundaries -- only the optional per-asset `properties["extents"]`
+# does. `extents[i]` is file i's extent along axis 0; `sum(extents) == shape[0]`.
+_NONUNIFORM_EXTENTS = [2, 5, 3]
+
+
+@pytest.mark.parametrize(
+    "slice_input,expected_indices",
+    [
+        (0, {0}),  # first row -> first file
+        (6, {1}),  # a row deep inside the second file
+        ((slice(0, 2),), {0}),  # exactly the first file's rows
+        ((slice(1, 4),), {0, 1}),  # straddles the first boundary
+        ((slice(6, 10),), {1, 2}),  # straddles the second boundary
+        (Ellipsis, {0, 1, 2}),  # full read -> every file
+    ],
+)
+@pytest.mark.asyncio
+async def test_lazy_hdf5_nonuniform_extents_property(
+    tmpdir, slice_input, expected_indices
+):
+    """`properties["extents"]` enables the lazy path for non-uniform files stored
+    flat, mapping an axis-0 slice to exactly the files it touches via a cumulative
+    sum of the per-file extents.
+
+    Each file holds a different frame count and is chunked one frame at a time, so
+    the native tiling (`len(chunks[0]) == sum(extents)`) can not delimit the files;
+    `extents` supplies the boundaries the catalog can not otherwise infer.
+    """
+    from unittest.mock import patch
+
+    import tiled.adapters.hdf5
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    extents = _NONUNIFORM_EXTENTS
+    K, H, W = len(extents), 2, 3
+    total = sum(extents)
+
+    rng = numpy.random.default_rng(6)
+    files = [rng.integers(0, 255, size=(f, H, W), dtype="uint8") for f in extents]
+    data_uris = []
+    filepaths = []
+    for i, file_data in enumerate(files):
+        filepath = Path(tmpdir) / f"file{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=file_data, chunks=(1, H, W))
+        filepaths.append(filepath)
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # Flat concatenation along axis 0; a cube labelling each row by its file.
+    full = numpy.concatenate(files, axis=0)  # (total, H, W)
+    idx_cube = numpy.broadcast_to(
+        numpy.repeat(numpy.arange(K), extents).reshape(total, 1, 1), (total, H, W)
+    )
+
+    struct = ArrayStructure(
+        shape=(total, H, W),
+        chunks=((1,) * total, (H,), (W,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    # Native (per-frame) tiling can not delimit files; `extents` supplies it.
+    pre_reshape_chunks = [[1] * total, [H], [W]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks, "extents": extents},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        reference = full[slice_input]
+        assert set(numpy.unique(idx_cube[slice_input]).tolist()) == expected_indices
+        expected_names = {filepaths[i].name for i in expected_indices}
+
+        # The lazy adapter is used (not a fallback).
+        lazy = await x._get_lazy_adapter(slice=slice_input)
+        assert lazy is not None
+
+        with patch(
+            "tiled.adapters.hdf5.h5open", wraps=tiled.adapters.hdf5.h5open
+        ) as mock_h5open:
+            result = await x.read(slice=NDSlice(slice_input))
+            opened = [Path(call.args[0]).name for call in mock_h5open.call_args_list]
+
+        assert set(opened) == expected_names
+        assert len(opened) == len(expected_names)
+        numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lazy_hdf5_nonuniform_requires_extents(tmpdir):
+    """Without `properties["extents"]` the same non-uniform flat layout has no way
+    to locate file boundaries, so the lazy path bows out and the eager build
+    still reads correctly.
+    """
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    extents = _NONUNIFORM_EXTENTS
+    H, W = 2, 3
+    total = sum(extents)
+
+    rng = numpy.random.default_rng(7)
+    files = [rng.integers(0, 255, size=(f, H, W), dtype="uint8") for f in extents]
+    data_uris = []
+    for i, file_data in enumerate(files):
+        filepath = Path(tmpdir) / f"file{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=file_data, chunks=(1, H, W))
+        data_uris.append(ensure_uri(str(filepath)))
+
+    full = numpy.concatenate(files, axis=0)
+    struct = ArrayStructure(
+        shape=(total, H, W),
+        chunks=((1,) * total, (H,), (W,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+    # No `extents`, and the native tiling can not delimit the K files.
+    pre_reshape_chunks = [[1] * total, [H], [W]]
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": pre_reshape_chunks},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=i,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                        for i, data_uri in enumerate(data_uris)
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        assert await x._get_lazy_adapter(slice=(slice(0, 2),)) is None
+        result = await x.read(slice=NDSlice((slice(0, 2),)))
+        numpy.testing.assert_array_equal(result, full[0:2])
+    finally:
+        await adapter.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_write_table_external_direct(a, tmpdir):
     df = pandas.DataFrame(numpy.ones((5, 3)), columns=list("abc"))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -820,11 +820,9 @@ async def test_lazy_hdf5_falls_back_when_not_file_aligned(tmpdir):
 @pytest.mark.asyncio
 async def test_lazy_hdf5_declines_single_file(tmpdir):
     """A dataset backed by a single file must not take the lazy path. With one
-    file there is nothing to cull, and the lazy build reads the whole file as one
-    block (`ds[...]`) rather than letting the normal adapter do a native chunked,
-    partial read -- so a large single-file dataset would read entirely just to
-    serve one element. `_get_lazy_adapter` declines (returns None) and the normal
-    adapter still reads correctly.
+    file there is nothing to cull, so the lazy path has no upside; the standard
+    adapter already serves a native chunked, partial read. `_get_lazy_adapter`
+    declines (returns None) and the normal adapter still reads correctly.
     """
     from tiled.ndslice import NDBlock, NDSlice
 
@@ -1069,12 +1067,11 @@ async def test_lazy_hdf5_nonuniform_requires_extents(tmpdir):
 @pytest.mark.parametrize("transform", [{"slice": ":,0,:"}, {"squeeze": True}])
 def test_file_indices_for_slice_declines_under_transform(transform):
     """A `slice`/`squeeze` adapter parameter makes each file's served shape
-    differ from its raw contents, so the lazy read (which builds a block by
-    reading a whole file and reshaping it to that file's slab of the served
-    structure) can not form the stack. `file_indices_for_slice` must decline
-    (return None) so the catalog skips the lazy path -- even when the structure
-    alone (one leading chunk per file) would otherwise let the files be located
-    from `chunks[0]`.
+    differ from its raw contents, so the lazy read (which maps the served
+    structure's native chunks back onto the raw files) can not form the stack.
+    `file_indices_for_slice` must decline (return None) so the catalog skips the
+    lazy path -- even when the structure alone (one leading chunk per file) would
+    otherwise let the files be located from `chunks[0]`.
     """
     from tiled.adapters.hdf5 import HDF5ArrayAdapter
 
@@ -1102,11 +1099,11 @@ def test_file_indices_for_slice_declines_under_transform(transform):
 @pytest.mark.asyncio
 async def test_lazy_hdf5_declines_under_slice_squeeze(tmpdir):
     """A data source carrying a `slice`/`squeeze` parameter must not take the lazy
-    path even when its structure would otherwise locate files: the lazy read
-    reads each whole file and reshapes it to that file's slab of the served
-    structure, which fails once the transform makes the served per-file shape
-    differ from the raw file. The catalog threads the data source `parameters` to
-    the adapter, which declines, and the eager build still reads correctly.
+    path even when its structure would otherwise locate files: the lazy read maps
+    the served structure's native chunks back onto the raw files, which breaks
+    once the transform makes the served per-file shape differ from the raw file.
+    The catalog threads the data source `parameters` to the adapter, which
+    declines, and the eager build still reads correctly.
     """
     from tiled.ndslice import NDSlice
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -646,16 +646,16 @@ async def test_lazy_reshaped_hdf5_read_block(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "slice_input",
+    "slice_input,expected_opens",
     [
-        0,  # single event -> one file
-        2,  # single event -> one file
-        (1, slice(0, 2)),  # event 1, first two frames -> still one file
-        (slice(1, 3),),  # two events -> two files
+        (0, 4),  # event 0 -> file 0's 4 native frame-chunks
+        (2, 4),  # event 2 -> file 2's 4 native frame-chunks
+        ((1, slice(0, 2)), 2),  # event 1, first two frames -> 2 native chunks
+        ((slice(1, 3),), 8),  # events 1, 2 -> both files' 4 frame-chunks each
     ],
 )
 @pytest.mark.asyncio
-async def test_lazy_reshaped_hdf5_multichunk_files(tmpdir, slice_input):
+async def test_lazy_reshaped_hdf5_multichunk_files(tmpdir, slice_input, expected_opens):
     """A file that holds many native chunks along the concatenation axis still
     takes the lazy path.
 
@@ -663,8 +663,9 @@ async def test_lazy_reshaped_hdf5_multichunk_files(tmpdir, slice_input):
     native tiling is (1, H, W): `properties["chunks"][0]` has K*F ones, far more
     than the K files. The structure declares (K, F, H, W). The file count is the
     number of assets (K), NOT `len(chunks[0])` (== K*F), and the leading axis
-    maps onto the files -- so reading one event opens exactly one file. (This is
-    the shape of a per-frame-chunked detector stream.)
+    maps onto the files. The read fetches only the native frame-chunks it
+    overlaps -- so it opens one file once per touched frame, not the whole file.
+    (This is the shape of a per-frame-chunked detector stream.)
     """
     from unittest.mock import patch
 
@@ -743,7 +744,7 @@ async def test_lazy_reshaped_hdf5_multichunk_files(tmpdir, slice_input):
             opened = [Path(call.args[0]).name for call in mock_h5open.call_args_list]
 
         assert set(opened) == expected_names
-        assert len(opened) == len(expected_names)
+        assert len(opened) == expected_opens
         numpy.testing.assert_array_equal(result, reference)
     finally:
         await adapter.shutdown()
@@ -891,19 +892,19 @@ _NONUNIFORM_EXTENTS = [2, 5, 3]
 
 
 @pytest.mark.parametrize(
-    "slice_input,expected_indices",
+    "slice_input,expected_indices,expected_opens",
     [
-        (0, {0}),  # first row -> first file
-        (6, {1}),  # a row deep inside the second file
-        ((slice(0, 2),), {0}),  # exactly the first file's rows
-        ((slice(1, 4),), {0, 1}),  # straddles the first boundary
-        ((slice(6, 10),), {1, 2}),  # straddles the second boundary
-        (Ellipsis, {0, 1, 2}),  # full read -> every file
+        (0, {0}, 1),  # first row -> first file's first frame-chunk
+        (6, {1}, 1),  # a row deep inside the second file -> one frame-chunk
+        ((slice(0, 2),), {0}, 2),  # exactly the first file's rows -> 2 chunks
+        ((slice(1, 4),), {0, 1}, 3),  # straddles the first boundary -> 3 chunks
+        ((slice(6, 10),), {1, 2}, 4),  # straddles the second boundary -> 4 chunks
+        (Ellipsis, {0, 1, 2}, 10),  # full read -> every frame-chunk
     ],
 )
 @pytest.mark.asyncio
 async def test_lazy_hdf5_nonuniform_extents_property(
-    tmpdir, slice_input, expected_indices
+    tmpdir, slice_input, expected_indices, expected_opens
 ):
     """`properties["extents"]` enables the lazy path for non-uniform files stored
     flat, mapping an axis-0 slice to exactly the files it touches via a cumulative
@@ -992,7 +993,7 @@ async def test_lazy_hdf5_nonuniform_extents_property(
             opened = [Path(call.args[0]).name for call in mock_h5open.call_args_list]
 
         assert set(opened) == expected_names
-        assert len(opened) == len(expected_names)
+        assert len(opened) == expected_opens
         numpy.testing.assert_array_equal(result, reference)
     finally:
         await adapter.shutdown()
@@ -1170,6 +1171,101 @@ async def test_lazy_hdf5_declines_under_slice_squeeze(tmpdir):
         assert await x._get_lazy_adapter(slice=(slice(0, 2),)) is None
         result = await x.read(slice=NDSlice((slice(0, 2),)))
         numpy.testing.assert_array_equal(result, full[0:2])
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lazy_hdf5_ignores_secondary_numbered_parameter(tmpdir):
+    """A data source may carry a second numbered asset parameter alongside
+    `data_uris` (e.g. a per-frame mask series). Only the `data_uris` assets
+    describe the stacking axis, so the lazy path must filter on
+    `parameter == "data_uris"` when counting files and fetching URIs. Without
+    that filter the extra rows can pass the contiguity check (count and
+    max-min-num line up) and either inflate the file count or leak wrong URIs
+    into stacking-rank slots.
+    """
+    from tiled.ndslice import NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    # Uniform files, one leading chunk each: structure alone locates files.
+    K, M, N = 3, 2, 3
+    rng = numpy.random.default_rng(13)
+    files = [rng.integers(0, 255, size=(1, M, N), dtype="uint8") for _ in range(K)]
+    data_uris = []
+    for i, file_data in enumerate(files):
+        filepath = Path(tmpdir) / f"file{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("a/b", data=file_data, chunks=(1, M, N))
+        data_uris.append(ensure_uri(str(filepath)))
+
+    # A parallel numbered parameter (`masks`) whose `num`s continue the run
+    # from `data_uris` (0..K-1 then K..2K-1). Without a `parameter` filter the
+    # count is 2K and `max - min == 2K - 1 == count - 1`, so the contiguity
+    # precheck passes and the lazy build proceeds with wrong metadata.
+    mask_uris = []
+    for i in range(K):
+        filepath = Path(tmpdir) / f"mask{i:05}.h5"
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("mask", data=numpy.zeros((1,), dtype="uint8"))
+        mask_uris.append(ensure_uri(str(filepath)))
+
+    full = numpy.concatenate(files, axis=0)  # (K, M, N)
+    struct = ArrayStructure(
+        shape=(K, M, N),
+        chunks=((1,) * K, (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": [[1] * K, [M], [N]]},
+                    management="external",
+                    assets=(
+                        [
+                            Asset(
+                                parameter="data_uris",
+                                num=i,
+                                data_uri=data_uri,
+                                is_directory=False,
+                            )
+                            for i, data_uri in enumerate(data_uris)
+                        ]
+                        + [
+                            Asset(
+                                parameter="masks",
+                                num=K + i,
+                                data_uri=mask_uri,
+                                is_directory=False,
+                            )
+                            for i, mask_uri in enumerate(mask_uris)
+                        ]
+                    ),
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        # The lazy path counts only `data_uris` (n == K), so the URI list has
+        # length K and holds only the touched files; a full read returns the
+        # correct stack without the extra `masks` URIs leaking in.
+        lazy = await x._get_lazy_adapter(slice=(slice(0, 2),))
+        assert lazy is not None
+        result = await x.read(slice=NDSlice((slice(0, 2),)))
+        numpy.testing.assert_array_equal(result, full[0:2])
+        full_result = await x.read()
+        numpy.testing.assert_array_equal(full_result, full)
     finally:
         await adapter.shutdown()
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -816,6 +816,73 @@ async def test_lazy_hdf5_falls_back_when_not_file_aligned(tmpdir):
         await adapter.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_lazy_hdf5_declines_single_file(tmpdir):
+    """A dataset backed by a single file must not take the lazy path. With one
+    file there is nothing to cull, and the lazy build reads the whole file as one
+    block (`ds[...]`) rather than letting the normal adapter do a native chunked,
+    partial read -- so a large single-file dataset would read entirely just to
+    serve one element. `_get_lazy_adapter` declines (returns None) and the normal
+    adapter still reads correctly.
+    """
+    from tiled.ndslice import NDBlock, NDSlice
+
+    h5py = pytest.importorskip("h5py")
+    # One file of shape (R, N) reshaped to (P, M, N) with R == P * M -- the
+    # frame-per-point layout: a single file whose leading axis is split.
+    P, M, N = 4, 2, 3
+    R = P * M
+    rng = numpy.random.default_rng(7)
+    raw = rng.integers(0, 255, size=(R, N), dtype="uint8")
+    filepath = Path(tmpdir) / "single.h5"
+    with h5py.File(filepath, "w") as f:
+        f.create_dataset("a/b", data=raw)
+    data_uri = ensure_uri(str(filepath))
+
+    full = raw.reshape(P, M, N)
+    struct = ArrayStructure(
+        shape=(P, M, N),
+        chunks=((P,), (M,), (N,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("uint8")),
+    )
+
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await adapter.create_node(
+            key="ds",
+            structure_family="array",
+            metadata={},
+            data_sources=[
+                DataSource(
+                    structure_family="array",
+                    mimetype="application/x-hdf5",
+                    structure=asdict(struct),
+                    parameters={"dataset": "a/b"},
+                    properties={"chunks": [[R], [N]]},
+                    management="external",
+                    assets=[
+                        Asset(
+                            parameter="data_uris",
+                            num=0,
+                            data_uri=data_uri,
+                            is_directory=False,
+                        )
+                    ],
+                )
+            ],
+        )
+        x = await adapter.lookup_adapter(["ds"])
+
+        # Single file -> lazy path declines; normal adapter still reads correctly.
+        assert await x._get_lazy_adapter(slice=(0,)) is None
+        assert await x._get_lazy_adapter(block=NDBlock(0, 0, 0)) is None
+        result = await x.read(slice=NDSlice((0,)))
+        numpy.testing.assert_array_equal(result, full[0])
+    finally:
+        await adapter.shutdown()
+
+
 # Genuinely non-uniform files: K files hold DIFFERENT numbers of frames, stored
 # flat-concatenated along axis 0. The native tiling (one frame per chunk) can not
 # reveal the file boundaries -- only the optional per-asset `properties["extents"]`

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -670,9 +670,44 @@ def test_adapter_from_catalog(example_file, shape, error):
         assert adp.read().shape == shape
 
 
+# The fixture datasets are int64 (8 bytes) with per-file native chunks
+#   a/b: shape (4, 5, 6),  native chunk (1, 2, 3) -> one row is 5*6*8 = 240 bytes
+#   a/c: shape (10, 1),    native chunk (2, 1)    -> one row is 1*8   =   8 bytes
+#   a/d: shape (10,),      native chunk (3,)      -> one row is        =   8 bytes
+# The coalescing groups whole rows (full trailing dims) into blocks along the
+# leading axis up to READ_CHUNK_BYTES, never smaller than the native chunk along
+# that axis; if a single row already exceeds the limit it falls back to the
+# files' native tiling in every dimension. Each expected chunk pattern below is
+# per-file (repeated once per file, since all files are identical).
+@pytest.mark.parametrize(
+    "read_chunk_bytes, b_dim0, b_rest, c_dim0, c_rest, d_dim0",
+    [
+        # Large (1 GiB): everything coalesces to a single block per file.
+        (1 << 30, (4,), ((5,), (6,)), (10,), ((1,),), (10,)),
+        # 480 bytes = 2 rows of `b`: `b` coalesces to 2 blocks per file; `c`/`d`
+        # (tiny rows) still fit one block per file.
+        (480, (2, 2), ((5,), (6,)), (10,), ((1,),), (10,)),
+        # 40 bytes < one row of `b` (240 B) *and* < its native chunk (48 B): `b`
+        # falls back to native tiling in every dimension; `c`/`d` coalesce to
+        # 5-row blocks (2 blocks per file).
+        (40, (1, 1, 1, 1), ((2, 2, 1), (3, 3)), (5, 5), ((1,),), (5, 5)),
+    ],
+)
 @pytest.mark.parametrize("num_files", [1, 3])
-def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
-    # Test that chunked arrays can be read and reshaped correctly
+def test_chunked_arrays_from_uris(
+    example_files_with_chunked_arrays,
+    num_files,
+    read_chunk_bytes,
+    b_dim0,
+    b_rest,
+    c_dim0,
+    c_rest,
+    d_dim0,
+    monkeypatch,
+):
+    # Test that chunked arrays can be read and reshaped correctly, and that the
+    # native HDF5 chunks are coalesced according to READ_CHUNK_BYTES.
+    monkeypatch.setattr("tiled.adapters.hdf5.READ_CHUNK_BYTES", read_chunk_bytes)
     fpaths = example_files_with_chunked_arrays[:num_files]
     tree = HDF5Adapter.from_uris(*fpaths)
     with Context.from_app(build_app(tree)) as context:
@@ -680,7 +715,9 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_b = client["a"]["b"]
     assert arr_b.shape == (4 * num_files, 5, 6)
-    assert arr_b.chunks == ((1, 1, 1, 1) * num_files, (2, 2, 1), (3, 3))
+    # Native HDF5 chunks are coalesced into blocks (bounded by READ_CHUNK_BYTES)
+    # to avoid a task/open per tiny native chunk.
+    assert arr_b.chunks == (b_dim0 * num_files, *b_rest)
     assert arr_b.dtype == "int64"
     arr_true_b = numpy.concatenate(
         [
@@ -693,7 +730,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_c = client["a"]["c"]
     assert arr_c.shape == (10 * num_files, 1)
-    assert arr_c.chunks == ((2, 2, 2, 2, 2) * num_files, (1,))
+    assert arr_c.chunks == (c_dim0 * num_files, *c_rest)
     assert arr_c.dtype == "int64"
     arr_true_c = numpy.concatenate(
         [
@@ -706,7 +743,7 @@ def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
 
     arr_d = client["a"]["d"]
     assert arr_d.shape == (10 * num_files,)
-    assert arr_d.chunks == ((3, 3, 3, 1) * num_files,)
+    assert arr_d.chunks == (d_dim0 * num_files,)
     assert arr_d.dtype == "int64"
     arr_true_d = numpy.concatenate(
         [
@@ -782,7 +819,7 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
     h5py = pytest.importorskip("h5py")
 
     # Use the example with two files chunked along a single dimension;
-    # total chunks across the two files: ((3, 3, 3, 1)*2, )
+    # native chunks are coalesced into one block per file: ((10,) * 2, )
     file_uris = example_files_with_chunked_arrays[:2]
     file_paths = [path_from_uri(uri) for uri in file_uris]
     with patch(
@@ -816,21 +853,22 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         mock_h5open.reset_mock()
         arr = client["a"]["d"]
         assert arr.structure().shape == (20,)
-        assert arr.structure().chunks == ((3, 3, 3, 1) * 2,)
+        assert arr.structure().chunks == ((10,) * 2,)
         assert arr.metadata is not None
         mock_h5open.assert_not_called()
 
-        # Read the entire array: files are opened once to get the specs and then again,
-        # four times each, to fetch each chunk separately. Additionally, the first file is opened once
-        # adain when initialized from catalog to get the metadata
+        # Read the entire array: files are opened once to get the specs and then
+        # once more each to fetch the single coalesced chunk. Additionally, the
+        # first file is opened once again when initialized from catalog to get
+        # the metadata
         assert arr.read() is not None
-        # 2 for specs, 4*2 for chunks, 1 for metadata
-        assert mock_h5open.call_count == 2 + 4 * 2 + 1
+        # 2 for specs, 1*2 for chunks (one block per file), 1 for metadata
+        assert mock_h5open.call_count == 2 + 1 * 2 + 1
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
-        # First file: 1 for specs, 4 for chunks, 1 for metadata
-        assert files_opened.count(file_paths[0].name) == 4 + 1 + 1
-        # Second file: 1 for specs, 4 for chunks
-        assert files_opened.count(file_paths[1].name) == 4 + 1
+        # First file: 1 for specs, 1 for chunk, 1 for metadata
+        assert files_opened.count(file_paths[0].name) == 1 + 1 + 1
+        # Second file: 1 for specs, 1 for chunk
+        assert files_opened.count(file_paths[1].name) == 1 + 1
 
         # Read a slice that only touches one file: only the relevant file should be opened
         mock_h5open.reset_mock()
@@ -843,12 +881,12 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         # Read everything from the second file
         mock_h5open.reset_mock()
         assert arr[-10:] is not None
-        assert mock_h5open.call_count == 7
+        assert mock_h5open.call_count == 2 + 1 + 1  # 2 specs, 1 chunk, 1 metadata
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
         # First file: 1 for specs, 1 for metadata
         assert files_opened.count(file_paths[0].name) == 1 + 1
-        # Second file: 4 for chunks, 1 for specs
-        assert files_opened.count(file_paths[1].name) == 4 + 1
+        # Second file: 1 for chunk, 1 for specs
+        assert files_opened.count(file_paths[1].name) == 1 + 1
 
         # Read a slice that has one value from each of the files
         mock_h5open.reset_mock()
@@ -865,3 +903,49 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
 
     h5py.File(file_paths[0], "r", swmr=not swmr).close()
     h5py.File(file_paths[1], "r", swmr=not swmr).close()
+
+
+@pytest.mark.parametrize(
+    "read_chunk_bytes, expected_dim0",
+    [
+        # Modest budget: the per-frame file splits into bounded blocks along axis
+        # 0, so a single-frame read touches only its small block -- not the whole
+        # file. 8 frames x 400 B/frame = 3200 B/frame; 1600 B budget -> 4 frames
+        # per block -> blocks of 4.
+        (1600, (4, 4)),
+        # Huge budget (the pre-fix behavior): everything coalesces into one block,
+        # so a single-frame read would read the entire file.
+        (1 << 30, (8,)),
+    ],
+)
+def test_partial_read_does_not_coalesce_whole_file(
+    tmp_path, read_chunk_bytes, expected_dim0, monkeypatch
+):
+    """A single-frame read of a per-frame-chunked file must not read the whole
+    file. The read-chunk budget bounds the axis-0 block size, so a modest budget
+    splits a big file into several blocks and a one-frame read touches only one
+    block; an over-large budget coalesces the file into a single block (the
+    regression this guards against).
+    """
+    h5py = pytest.importorskip("h5py")
+    monkeypatch.setattr("tiled.adapters.hdf5.READ_CHUNK_BYTES", read_chunk_bytes)
+
+    # 8 frames of 10x20 int16 (400 bytes each), stored one frame per native chunk.
+    frames, rows, cols = 8, 10, 20
+    rng = numpy.random.default_rng(0)
+    raw = rng.integers(-1000, 1000, size=(frames, rows, cols), dtype="int16")
+    file_path = tmp_path / "frames.h5"
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("a/b", data=raw, chunks=(1, rows, cols))
+    file_uri = ensure_uri(str(file_path))
+
+    tree = HDF5Adapter.from_uris(file_uri)
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        arr = client["a"]["b"]
+        # Axis-0 blocks are bounded by the budget (or the whole file when huge).
+        assert arr.chunks[0] == expected_dim0
+        # A single-frame read is correct regardless of coalescing.
+        numpy.testing.assert_array_equal(arr[0], raw[0])
+        numpy.testing.assert_array_equal(arr[frames - 1], raw[frames - 1])
+        numpy.testing.assert_array_equal(arr.read(), raw)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -671,43 +671,16 @@ def test_adapter_from_catalog(example_file, shape, error):
 
 
 # The fixture datasets are int64 (8 bytes) with per-file native chunks
-#   a/b: shape (4, 5, 6),  native chunk (1, 2, 3) -> one row is 5*6*8 = 240 bytes
-#   a/c: shape (10, 1),    native chunk (2, 1)    -> one row is 1*8   =   8 bytes
-#   a/d: shape (10,),      native chunk (3,)      -> one row is        =   8 bytes
-# The coalescing groups whole rows (full trailing dims) into blocks along the
-# leading axis up to READ_CHUNK_BYTES, never smaller than the native chunk along
-# that axis; if a single row already exceeds the limit it falls back to the
-# files' native tiling in every dimension. Each expected chunk pattern below is
-# per-file (repeated once per file, since all files are identical).
-@pytest.mark.parametrize(
-    "read_chunk_bytes, b_dim0, b_rest, c_dim0, c_rest, d_dim0",
-    [
-        # Large (1 GiB): everything coalesces to a single block per file.
-        (1 << 30, (4,), ((5,), (6,)), (10,), ((1,),), (10,)),
-        # 480 bytes = 2 rows of `b`: `b` coalesces to 2 blocks per file; `c`/`d`
-        # (tiny rows) still fit one block per file.
-        (480, (2, 2), ((5,), (6,)), (10,), ((1,),), (10,)),
-        # 40 bytes < one row of `b` (240 B) *and* < its native chunk (48 B): `b`
-        # falls back to native tiling in every dimension; `c`/`d` coalesce to
-        # 5-row blocks (2 blocks per file).
-        (40, (1, 1, 1, 1), ((2, 2, 1), (3, 3)), (5, 5), ((1,),), (5, 5)),
-    ],
-)
+#   a/b: shape (4, 5, 6),  native chunk (1, 2, 3)
+#   a/c: shape (10, 1),    native chunk (2, 1)
+#   a/d: shape (10,),      native chunk (3,)
+# The Dask graph honors each file's native HDF5 tiling: axis 0 uses each file's
+# own leading chunk size, and the remaining dimensions use the smallest native
+# chunk across files (so every file's chunk boundaries align with the Dask grid).
 @pytest.mark.parametrize("num_files", [1, 3])
-def test_chunked_arrays_from_uris(
-    example_files_with_chunked_arrays,
-    num_files,
-    read_chunk_bytes,
-    b_dim0,
-    b_rest,
-    c_dim0,
-    c_rest,
-    d_dim0,
-    monkeypatch,
-):
+def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
     # Test that chunked arrays can be read and reshaped correctly, and that the
-    # native HDF5 chunks are coalesced according to READ_CHUNK_BYTES.
-    monkeypatch.setattr("tiled.adapters.hdf5.READ_CHUNK_BYTES", read_chunk_bytes)
+    # Dask chunk layout follows the native HDF5 chunking.
     fpaths = example_files_with_chunked_arrays[:num_files]
     tree = HDF5Adapter.from_uris(*fpaths)
     with Context.from_app(build_app(tree)) as context:
@@ -715,9 +688,7 @@ def test_chunked_arrays_from_uris(
 
     arr_b = client["a"]["b"]
     assert arr_b.shape == (4 * num_files, 5, 6)
-    # Native HDF5 chunks are coalesced into blocks (bounded by READ_CHUNK_BYTES)
-    # to avoid a task/open per tiny native chunk.
-    assert arr_b.chunks == (b_dim0 * num_files, *b_rest)
+    assert arr_b.chunks == ((1, 1, 1, 1) * num_files, (2, 2, 1), (3, 3))
     assert arr_b.dtype == "int64"
     arr_true_b = numpy.concatenate(
         [
@@ -730,7 +701,7 @@ def test_chunked_arrays_from_uris(
 
     arr_c = client["a"]["c"]
     assert arr_c.shape == (10 * num_files, 1)
-    assert arr_c.chunks == (c_dim0 * num_files, *c_rest)
+    assert arr_c.chunks == ((2, 2, 2, 2, 2) * num_files, (1,))
     assert arr_c.dtype == "int64"
     arr_true_c = numpy.concatenate(
         [
@@ -743,7 +714,7 @@ def test_chunked_arrays_from_uris(
 
     arr_d = client["a"]["d"]
     assert arr_d.shape == (10 * num_files,)
-    assert arr_d.chunks == (d_dim0 * num_files,)
+    assert arr_d.chunks == ((3, 3, 3, 1) * num_files,)
     assert arr_d.dtype == "int64"
     arr_true_d = numpy.concatenate(
         [
@@ -819,7 +790,7 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
     h5py = pytest.importorskip("h5py")
 
     # Use the example with two files chunked along a single dimension;
-    # native chunks are coalesced into one block per file: ((10,) * 2, )
+    # total chunks across the two files: ((3, 3, 3, 1)*2, )
     file_uris = example_files_with_chunked_arrays[:2]
     file_paths = [path_from_uri(uri) for uri in file_uris]
     with patch(
@@ -853,22 +824,21 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         mock_h5open.reset_mock()
         arr = client["a"]["d"]
         assert arr.structure().shape == (20,)
-        assert arr.structure().chunks == ((10,) * 2,)
+        assert arr.structure().chunks == ((3, 3, 3, 1) * 2,)
         assert arr.metadata is not None
         mock_h5open.assert_not_called()
 
-        # Read the entire array: files are opened once to get the specs and then
-        # once more each to fetch the single coalesced chunk. Additionally, the
-        # first file is opened once again when initialized from catalog to get
-        # the metadata
+        # Read the entire array: files are opened once to get the specs and then again,
+        # four times each, to fetch each native chunk separately. Additionally, the first
+        # file is opened once again when initialized from catalog to get the metadata
         assert arr.read() is not None
-        # 2 for specs, 1*2 for chunks (one block per file), 1 for metadata
-        assert mock_h5open.call_count == 2 + 1 * 2 + 1
+        # 2 for specs, 4*2 for chunks, 1 for metadata
+        assert mock_h5open.call_count == 2 + 4 * 2 + 1
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
-        # First file: 1 for specs, 1 for chunk, 1 for metadata
-        assert files_opened.count(file_paths[0].name) == 1 + 1 + 1
-        # Second file: 1 for specs, 1 for chunk
-        assert files_opened.count(file_paths[1].name) == 1 + 1
+        # First file: 1 for specs, 4 for chunks, 1 for metadata
+        assert files_opened.count(file_paths[0].name) == 4 + 1 + 1
+        # Second file: 1 for specs, 4 for chunks
+        assert files_opened.count(file_paths[1].name) == 4 + 1
 
         # Read a slice that only touches one file: only the relevant file should be opened
         mock_h5open.reset_mock()
@@ -881,12 +851,12 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         # Read everything from the second file
         mock_h5open.reset_mock()
         assert arr[-10:] is not None
-        assert mock_h5open.call_count == 2 + 1 + 1  # 2 specs, 1 chunk, 1 metadata
+        assert mock_h5open.call_count == 7
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
         # First file: 1 for specs, 1 for metadata
         assert files_opened.count(file_paths[0].name) == 1 + 1
-        # Second file: 1 for chunk, 1 for specs
-        assert files_opened.count(file_paths[1].name) == 1 + 1
+        # Second file: 4 for chunks, 1 for specs
+        assert files_opened.count(file_paths[1].name) == 4 + 1
 
         # Read a slice that has one value from each of the files
         mock_h5open.reset_mock()
@@ -903,49 +873,3 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
 
     h5py.File(file_paths[0], "r", swmr=not swmr).close()
     h5py.File(file_paths[1], "r", swmr=not swmr).close()
-
-
-@pytest.mark.parametrize(
-    "read_chunk_bytes, expected_dim0",
-    [
-        # Modest budget: the per-frame file splits into bounded blocks along axis
-        # 0, so a single-frame read touches only its small block -- not the whole
-        # file. 8 frames x 400 B/frame = 3200 B/frame; 1600 B budget -> 4 frames
-        # per block -> blocks of 4.
-        (1600, (4, 4)),
-        # Huge budget (the pre-fix behavior): everything coalesces into one block,
-        # so a single-frame read would read the entire file.
-        (1 << 30, (8,)),
-    ],
-)
-def test_partial_read_does_not_coalesce_whole_file(
-    tmp_path, read_chunk_bytes, expected_dim0, monkeypatch
-):
-    """A single-frame read of a per-frame-chunked file must not read the whole
-    file. The read-chunk budget bounds the axis-0 block size, so a modest budget
-    splits a big file into several blocks and a one-frame read touches only one
-    block; an over-large budget coalesces the file into a single block (the
-    regression this guards against).
-    """
-    h5py = pytest.importorskip("h5py")
-    monkeypatch.setattr("tiled.adapters.hdf5.READ_CHUNK_BYTES", read_chunk_bytes)
-
-    # 8 frames of 10x20 int16 (400 bytes each), stored one frame per native chunk.
-    frames, rows, cols = 8, 10, 20
-    rng = numpy.random.default_rng(0)
-    raw = rng.integers(-1000, 1000, size=(frames, rows, cols), dtype="int16")
-    file_path = tmp_path / "frames.h5"
-    with h5py.File(file_path, "w") as f:
-        f.create_dataset("a/b", data=raw, chunks=(1, rows, cols))
-    file_uri = ensure_uri(str(file_path))
-
-    tree = HDF5Adapter.from_uris(file_uri)
-    with Context.from_app(build_app(tree)) as context:
-        client = from_context(context)
-        arr = client["a"]["b"]
-        # Axis-0 blocks are bounded by the budget (or the whole file when huge).
-        assert arr.chunks[0] == expected_dim0
-        # A single-frame read is correct regardless of coalescing.
-        numpy.testing.assert_array_equal(arr[0], raw[0])
-        numpy.testing.assert_array_equal(arr[frames - 1], raw[frames - 1])
-        numpy.testing.assert_array_equal(arr.read(), raw)

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -2,7 +2,6 @@ import bisect
 import builtins
 import copy
 import itertools
-import math
 import os
 import sys
 import warnings
@@ -42,18 +41,6 @@ INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 HDF5_DATASET = Sentinel("HDF5_DATASET")
 HDF5_BROKEN_LINK = Sentinel("HDF5_BROKEN_LINK")
 MIN_CHUNK_SIZE = 1  # Minimum chunk size along the concatenation axis
-
-# Soft cap on the bytes a single Dask chunk reads from an HDF5 dataset. Native
-# HDF5 chunks are often tiny (e.g. one frame each), and one Dask task per native
-# chunk both explodes the task count and re-opens the file each time; coalescing
-# native chunks into blocks up to this many bytes keeps the task/open count low.
-# But the block size is also the MINIMUM a partial read fetches -- reading a
-# single frame still reads its whole block -- so an over-large cap makes small
-# reads pull far more than they need. This is deliberately modest (16 MiB) so a
-# one-element read stays cheap while a full read still coalesces sensibly; the
-# residual per-block open cost is negligible against the actual I/O. Override
-# with TILED_HDF5_READ_CHUNK_BYTES.
-READ_CHUNK_BYTES = int(os.environ.get("TILED_HDF5_READ_CHUNK_BYTES") or (16 << 20))
 
 
 def _lazy_placeholder_block(
@@ -255,15 +242,15 @@ class HDF5ArrayAdapter(ArrayAdapter):
         Returns `None` when the files can not be located -- so a slice may need
         every file -- to tell the catalog to skip the lazy path. This includes
         the case of a `slice`/`squeeze` adapter parameter: the lazy read builds
-        each block by reading a whole backing file and reshaping it to that
-        file's slab of the SERVED structure (see `_lazy_stack_from_structure`).
-        A `slice`/`squeeze` makes the served per-file shape differ from the raw
-        file contents (it drops or collapses elements along one or more axes), so
-        that reshape is invalid and the file-stacked build can not be formed from
-        whole files. The transform is applied only after a full (non-lazy) stack,
-        so it is caught here from the data source `parameters`; `_file_layout`
-        alone can not detect it (`structure.chunks[0]` may still look
-        one-per-file).
+        each block by reading a native chunk of a backing file and reshaping it
+        to that file's slab of the SERVED structure (see
+        `_lazy_stack_from_structure`). A `slice`/`squeeze` makes the served
+        per-file shape differ from the raw file contents (it drops or collapses
+        elements along one or more axes), so that reshape is invalid and the
+        file-stacked build can not be formed from the raw files. The transform is
+        applied only after a full (non-lazy) stack, so it is caught here from the
+        data source `parameters`; `_file_layout` alone can not detect it
+        (`structure.chunks[0]` may still look one-per-file).
         """
         parameters = parameters or {}
         if parameters.get("slice") is not None or parameters.get("squeeze"):
@@ -289,6 +276,40 @@ class HDF5ArrayAdapter(ArrayAdapter):
         return tuple(sorted({bisect.bisect_right(ends, p) for p in positions}))
 
     @staticmethod
+    def _flat_file_extents(
+        layout: Tuple[str, Tuple[int, ...]],
+        flat_leading: int,
+        n_files: int,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[int, ...]:
+        """Per-file element counts along the FLAT concatenation axis.
+
+        The lazy build stacks the files into their flat (pre-reshape)
+        concatenation along axis 0; these extents give the file boundaries there
+        (their cumulative sums), so each native chunk can be mapped to its file.
+
+        `properties["extents"]` (the writer's authoritative per-asset row counts)
+        is used when present. Otherwise, when the structure IS the flat
+        concatenation (an "extents" layout whose per-file counts already sum to
+        the flat leading length), those counts are the flat extents. Failing
+        both, the stack is uniform (a grid or an evenly reshaped stack) and the
+        flat leading axis divides evenly among the files.
+        """
+        raw_extents = (properties or {}).get("extents")
+        if raw_extents is not None:
+            return tuple(int(e) for e in raw_extents)
+        kind, data = layout
+        if kind == "extents" and sum(data) == flat_leading:
+            return tuple(int(e) for e in data)
+        quotient, remainder = divmod(flat_leading, n_files)
+        if remainder:
+            raise ValueError(
+                f"Cannot evenly divide flat leading axis {flat_leading} among "
+                f"{n_files} files."
+            )
+        return (quotient,) * n_files
+
+    @staticmethod
     def _lazy_stack_from_structure(
         data_uris: Tuple[Optional[str], ...],
         structure: ArrayStructure,
@@ -306,21 +327,35 @@ class HDF5ArrayAdapter(ArrayAdapter):
         length is the file count), populated only for the files that this read
         touches and left `None` elsewhere. Each present URI is converted to a
         local path (via `path_from_uri`) lazily, inside its read task, so an
-        untouched file is never resolved. `_file_layout` gives each file's
-        extent along a single leading axis; the remaining dimensions are that
-        file's own shape. The array is built one whole file per block along that
-        axis, then reshaped to the structure by the caller's `read` (via
-        `force_reshape`), so Dask culls every untouched file's block before
-        computing.
+        untouched file is never resolved.
 
-        A present entry reads its whole file in one task (reshaping it to the
-        block's shape, which absorbs a stacking axis or a per-file row count
-        equally); a `None` entry gets a placeholder that raises if ever computed
-        (it should always be culled).
+        This mirrors the eager `lazy_load_hdf5_array`: it builds the FLAT
+        concatenation of the files (stacked along axis 0) tiled by native HDF5
+        chunks -- axis 0 by `chunks[0]` (additionally split at the file
+        boundaries so no block straddles two files), the trailing axes by
+        `chunks[1:]` -- where the native chunking comes from
+        `properties["chunks"]` (the pre-reshape chunking recorded when the stored
+        files are reshaped to the structure) or, absent that, from the structure
+        itself (which is then the flat concatenation). Each block is one native
+        chunk (no coalescing). The caller's `read` reshapes this flat array to
+        the structure (via `force_reshape`) -- the reshape preserves the native
+        chunk granularity -- and slices it, so Dask culls every chunk outside the
+        read (and every untouched file's placeholder) before computing. A partial
+        read therefore fetches only the native chunks it overlaps, the minimum
+        HDF5 can serve.
+
+        When the structure is a reshaped grid but no native chunking is recorded,
+        the flat chunking is unknown, so each file is served as one whole block (a
+        grid cell): the file is then the minimal read unit.
+
+        A present entry reads its native chunk in one task (reshaping to the
+        block's shape); every block of an untouched file gets a placeholder that
+        raises if ever computed (it should always be culled).
         """
         n_files = len(data_uris)
         dtype = structure.data_type.to_numpy_dtype()
         struct_shape = tuple(structure.shape)
+        properties = properties or {}
         layout = HDF5ArrayAdapter._file_layout(structure, n_files, properties)
         if layout is None:
             # The catalog only takes the lazy path when the files can be located,
@@ -329,37 +364,114 @@ class HDF5ArrayAdapter(ArrayAdapter):
                 f"Structure shape {struct_shape} does not locate {n_files} files."
             )
         kind, data = layout
-        if kind == "extents":
-            # File i is `data[i]` elements along axis 0; the rest is its own shape.
-            leading_extents = data
-            per_file_rest = struct_shape[1:]
-        else:  # "grid": each file is one element on a flattened leading axis.
-            leading_extents = (1,) * n_files
-            per_file_rest = struct_shape[len(data) :]  # noqa: E203
 
-        def _read_hdf5_file(uri: str, block_shape: Tuple[int, ...]) -> NDArray:
-            # Resolve the URI to a local path only now, when this file is read.
+        def _read_hdf5_chunk(
+            uri: str, selection: Any, block_shape: Tuple[int, ...]
+        ) -> NDArray:
+            # Resolve the URI to a local path only now, when this chunk is read.
             with h5open(
                 path_from_uri(uri), dataset, swmr=swmr, libver=libver, locking=locking
             ) as ds:
-                # Read the whole file; reshape it into this file's block (adds a
-                # stacking axis when the extent is 1, or is a no-op for a concat).
-                return numpy.asarray(ds[...]).reshape(block_shape)
+                data = ds[...] if selection is Ellipsis else ds[selection]
+                return numpy.asarray(data).reshape(block_shape)
+
+        pre_chunks = properties.get("chunks")
+        if pre_chunks is None and kind == "grid":
+            # A reshaped grid with no recorded native chunking: the flat
+            # concatenation's chunking is unknown, so serve one whole file per
+            # grid cell (the file is the minimal read unit).
+            per_file_rest = struct_shape[len(data) :]  # noqa: E203
+            name = "hdf5-lazy-grid-" + str(
+                hash((dataset, data_uris, struct_shape, str(dtype)))
+            )
+            dsk: dict[Any, Any] = {}
+            rest_key = tuple(0 for _ in per_file_rest)
+            block_shape = (1, *per_file_rest)
+            for file_indx, uri in enumerate(data_uris):
+                key = (name, file_indx, *rest_key)
+                if uri is None:
+                    dsk[key] = (_lazy_placeholder_block, block_shape, dtype)
+                else:
+                    dsk[key] = (_read_hdf5_chunk, uri, Ellipsis, block_shape)
+            chunks_final = ((1,) * n_files, *[(s,) for s in per_file_rest])
+            hlg = HighLevelGraph.from_collections(name, dsk, dependencies=[])
+            return dask.array.Array(hlg, name, chunks=chunks_final, dtype=dtype)
+
+        # Native (pre-reshape) chunking of the FLAT concatenation.
+        raw_chunks = pre_chunks if pre_chunks is not None else structure.chunks
+        flat_chunks = tuple(tuple(int(c) for c in dim) for dim in raw_chunks)
+        flat_shape = tuple(sum(dim) for dim in flat_chunks)
+        flat_rest = flat_shape[1:]
+
+        # File boundaries along the flat leading axis, so each native chunk maps
+        # to exactly one file.
+        flat_extents = HDF5ArrayAdapter._flat_file_extents(
+            layout, flat_shape[0], n_files, properties
+        )
+        file_ends = tuple(itertools.accumulate(flat_extents))  # exclusive per file
+        file_starts = (0, *file_ends[:-1])
+
+        # Leading-axis block boundaries: the native chunk boundaries, split also
+        # at the file boundaries so no block straddles two files (normally the
+        # file boundaries already fall on native-chunk boundaries; the union just
+        # guards the pathological straddle).
+        chunk_ends = itertools.accumulate(flat_chunks[0])
+        boundaries = sorted({0, flat_shape[0], *file_ends, *chunk_ends})
+
+        # Trailing native-chunk grid; the same grid applies to every leading
+        # block. `key_rest` is the trailing chunk index tuple, `slc_rest` its
+        # (file-local) slice, and `size_rest` its shape.
+        rest_chunks = flat_chunks[1:]
+        if not rest_chunks or max((len(dim) for dim in rest_chunks), default=1) == 1:
+            key_rest: Tuple[Tuple[int, ...], ...] = (tuple(0 for _ in rest_chunks),)
+            slc_rest: Tuple[Tuple[builtins.slice, ...], ...] = (
+                tuple(builtins.slice(None) for _ in rest_chunks),
+            )
+            size_rest: Tuple[Tuple[int, ...], ...] = (tuple(flat_rest),)
+        else:
+            key_rest = tuple(
+                itertools.product(*(range(len(dim)) for dim in rest_chunks))
+            )
+            rest_bounds = tuple(
+                numpy.cumsum((0,) + dim).tolist() for dim in rest_chunks
+            )
+            rest_starts = itertools.product(*(bounds[:-1] for bounds in rest_bounds))
+            rest_stops = itertools.product(*(bounds[1:] for bounds in rest_bounds))
+            slc_rest = tuple(
+                tuple(
+                    builtins.slice(start, stop)
+                    for start, stop in zip(dim_starts, dim_stops)
+                )
+                for dim_starts, dim_stops in zip(rest_starts, rest_stops)
+            )
+            size_rest = tuple(itertools.product(*rest_chunks))
 
         name = "hdf5-lazy-stack-" + str(
-            hash((dataset, data_uris, struct_shape, str(dtype)))
+            hash((dataset, data_uris, flat_shape, str(dtype)))
         )
-        dsk: dict[Any, Any] = {}
-        rest_key = tuple(0 for _ in per_file_rest)
-        for file_indx, (uri, extent) in enumerate(zip(data_uris, leading_extents)):
-            block_shape = (extent, *per_file_rest)
-            key = (name, file_indx, *rest_key)
-            if uri is None:
-                dsk[key] = (_lazy_placeholder_block, block_shape, dtype)
-            else:
-                dsk[key] = (_read_hdf5_file, uri, block_shape)
+        dsk = {}
+        axis0_sizes: List[int] = []
+        for blk_indx, (seg_start, seg_stop) in enumerate(
+            zip(boundaries, boundaries[1:])
+        ):
+            axis0_sizes.append(seg_stop - seg_start)
+            # Every block is inside one file (boundaries include the file ends).
+            file_indx = bisect.bisect_right(file_ends, seg_start)
+            uri = data_uris[file_indx]
+            axis0_local = builtins.slice(
+                seg_start - file_starts[file_indx], seg_stop - file_starts[file_indx]
+            )
+            for kr, sr, size in zip(key_rest, slc_rest, size_rest):
+                key = (name, blk_indx, *kr)
+                block_shape = (seg_stop - seg_start, *size)
+                if uri is None:
+                    # An untouched file (should have been culled): a placeholder
+                    # that raises if ever computed.
+                    dsk[key] = (_lazy_placeholder_block, block_shape, dtype)
+                else:
+                    dsk[key] = (_read_hdf5_chunk, uri, (axis0_local, *sr), block_shape)
 
-        chunks_final = (tuple(leading_extents), *[(s,) for s in per_file_rest])
+        chunks_final = (tuple(axis0_sizes), *rest_chunks)
         hlg = HighLevelGraph.from_collections(name, dsk, dependencies=[])
         return dask.array.Array(hlg, name, chunks=chunks_final, dtype=dtype)
 
@@ -476,45 +588,24 @@ class HDF5ArrayAdapter(ArrayAdapter):
             array = dask.array.stack([_read_hdf5_array(fp, ()) for fp in file_paths])
 
         else:
-            # Use delayed loading to read and conactenate arrays from multiple files
-            # Determine chunks along the leftmost (concatenation) axis, split
-            # per file, and chunks in the rest of the dimensions (shared by all
-            # files). The constituent files' native HDF5 chunks are often tiny
-            # (e.g. a single frame per chunk, with thousands of frames per
-            # file), which explodes the number of Dask tasks -- and every task
-            # re-opens the file. To avoid that, coalesce native chunks into
-            # blocks of whole rows (full rest dimensions) up to READ_CHUNK_BYTES,
-            # so each file is read in a reasonable number of tasks. The block is
-            # also the granularity of a partial read (a single-frame read still
-            # reads its whole block), so READ_CHUNK_BYTES stays modest rather than
-            # coalescing whole files -- keeping small reads cheap.
+            # Use delayed loading to read and concatenate arrays from multiple
+            # files. Honor each file's native HDF5 chunking: the leftmost
+            # (concatenation) axis is split per file by that file's native
+            # chunk, and the remaining dimensions are split by the smallest
+            # native chunk across files (so every file's chunk boundaries land
+            # on the Dask grid). A partial read then fetches only the native
+            # chunks it touches -- the minimum HDF5 can serve -- so small reads
+            # stay cheap without any coalescing heuristic.
+            file_chunks = tuple(
+                split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
+                for shp, chk, _ in shapes_chunks_dtypes
+            )
+            # Shape of the rest of dimensions
             rest_shape = shapes_chunks_dtypes[0][0][1:]
-            rest_row_bytes = math.prod(rest_shape) * dtype.itemsize
-            rest_chunks: Tuple[Tuple[int, ...], ...]
-            read_chunk_bytes = READ_CHUNK_BYTES
-            if not rest_shape or 0 < rest_row_bytes <= read_chunk_bytes:
-                # Read whole rows (full rest dimensions) in blocks along axis 0,
-                # sized up to the chunk-byte limit but never smaller than the
-                # native chunk along axis 0.
-                rows_per_block = max(1, read_chunk_bytes // (rest_row_bytes or 1))
-                file_chunks = tuple(
-                    split_chunks(shp[0], max(chk[0], rows_per_block))
-                    for shp, chk, _ in shapes_chunks_dtypes
-                )
-                rest_chunks = tuple((shp,) for shp in rest_shape)
-            else:
-                # A single row already exceeds the chunk-byte limit: fall back to
-                # the files' native tiling in every dimension.
-                file_chunks = tuple(
-                    split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
-                    for shp, chk, _ in shapes_chunks_dtypes
-                )
-                rest_chunks = tuple(
-                    split_chunks(
-                        shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes)
-                    )
-                    for i, shp in enumerate(rest_shape)
-                )
+            rest_chunks = tuple(
+                split_chunks(shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes))
+                for i, shp in enumerate(rest_shape)
+            )
             dim0_chunks = tuple(size for fc in file_chunks for size in fc)
             chunks_final = (dim0_chunks, *[tuple(d) for d in rest_chunks])
 
@@ -592,10 +683,11 @@ class HDF5ArrayAdapter(ArrayAdapter):
             # (leaving the rest as None) and passes them here. The structure is
             # known, so build the file-stacked array without opening any file for
             # specs; placeholders stand in for the untouched files' blocks, which
-            # Dask culls once the read slices the reshaped array. Each URI is
-            # converted to a local path lazily, inside its read task, so untouched
-            # files stay closed. Metadata comes from the node alone (no attribute
-            # read).
+            # Dask culls once the read slices the reshaped array. Each touched file
+            # is tiled by its native HDF5 chunks, so a partial read pulls only the
+            # native chunks it overlaps. Each URI is converted to a local path
+            # lazily, inside its read task, so untouched files stay closed. Metadata
+            # comes from the node alone (no attribute read).
             array = cls._lazy_stack_from_structure(
                 tuple(data_uris),
                 structure,

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -241,13 +241,16 @@ class HDF5ArrayAdapter(ArrayAdapter):
 
         Returns `None` when the files can not be located -- so a slice may need
         every file -- to tell the catalog to skip the lazy path. This includes
-        the case of a `slice`/`squeeze` adapter parameter: those transforms
-        reshape each file when building the served array (see `from_catalog`), so
-        the served axis 0 is no longer a plain concatenation of whole files and
-        the requested slice (in served coordinates) can not be mapped back onto
-        the stored per-file boundaries. `_file_layout` alone can not detect this
-        -- `structure.chunks[0]` may still look one-per-file -- so it is caught
-        here from the data source `parameters`.
+        the case of a `slice`/`squeeze` adapter parameter: the lazy read builds
+        each block by reading a whole backing file and reshaping it to that
+        file's slab of the SERVED structure (see `_lazy_stack_from_structure`).
+        A `slice`/`squeeze` makes the served per-file shape differ from the raw
+        file contents (it drops or collapses elements along one or more axes), so
+        that reshape is invalid and the file-stacked build can not be formed from
+        whole files. The transform is applied only after a full (non-lazy) stack,
+        so it is caught here from the data source `parameters`; `_file_layout`
+        alone can not detect it (`structure.chunks[0]` may still look
+        one-per-file).
         """
         parameters = parameters or {}
         if parameters.get("slice") is not None or parameters.get("squeeze"):

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -62,6 +62,51 @@ def _lazy_placeholder_block(
     )
 
 
+def _trailing_chunk_grid(
+    rest_chunks: Tuple[Tuple[int, ...], ...]
+) -> Tuple[
+    Tuple[Tuple[int, ...], ...],
+    Tuple[Tuple[builtins.slice, ...], ...],
+    Tuple[Tuple[int, ...], ...],
+]:
+    """Enumerate the trailing (non-concatenation) native-chunk grid.
+
+    The same grid applies to every leading (axis-0) block, so it is computed
+    once and reused. Returns three parallel tuples, one entry per grid cell.
+
+    Parameters
+    ----------
+    rest_chunks : tuple of tuple of int
+        Native chunk sizes for each trailing dimension.
+
+    Returns
+    -------
+    key_rest : tuple of tuple of int
+        Trailing chunk-index tuples.
+    slc_rest : tuple of tuple of slice
+        File-local slices selecting each cell.
+    size_rest : tuple of tuple of int
+        Shape of each cell.
+    """
+    if not rest_chunks or max((len(dim) for dim in rest_chunks), default=1) == 1:
+        # A single chunk in every trailing dimension: one cell, full slices.
+        return (
+            (tuple(0 for _ in rest_chunks),),
+            (tuple(builtins.slice(None) for _ in rest_chunks),),
+            (tuple(dim[0] for dim in rest_chunks),),
+        )
+    key_rest = tuple(itertools.product(*(range(len(dim)) for dim in rest_chunks)))
+    rest_bounds = tuple(numpy.cumsum((0,) + dim).tolist() for dim in rest_chunks)
+    rest_starts = itertools.product(*(bounds[:-1] for bounds in rest_bounds))
+    rest_stops = itertools.product(*(bounds[1:] for bounds in rest_bounds))
+    slc_rest = tuple(
+        tuple(builtins.slice(start, stop) for start, stop in zip(dim_starts, dim_stops))
+        for dim_starts, dim_stops in zip(rest_starts, rest_stops)
+    )
+    size_rest = tuple(itertools.product(*rest_chunks))
+    return key_rest, slc_rest, size_rest
+
+
 def parse_hdf5_tree(
     tree: Union[h5py.File, h5py.Group, h5py.Dataset]
 ) -> Union[dict[str, Union[Any, Sentinel]], Sentinel]:
@@ -157,14 +202,13 @@ class h5open(h5py.File):  # type: ignore
 class HDF5ArrayAdapter(ArrayAdapter):
     """Adapter for array-type data stored in HDF5 files
 
-    This adapter lazily loads array data from HDF5 files using Dask. Supports reading from datasets spanning
-    multiple files.
+    This adapter lazily loads array data from HDF5 files using Dask. Supports reading
+    from datasets spanning multiple files.
     """
 
     # When True, the catalog may build this adapter with a partially-populated
     # list of `data_uris`: it resolves only the files that a given read touches
-    # and leaves the rest as None, then resolves the untouched files' blocks
-    # lazily.
+    # and leaves the rest as None, then resolves the untouched files' blocks lazily.
     supports_lazy_assets = True
 
     @staticmethod
@@ -173,7 +217,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
         n_files: int,
         properties: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[str, Tuple[int, ...]]]:
-        """Describe how the `n_files` backing files tile the array's leading axes.
+        """Describe how the `n_files` backing files/assets tile the array's leading axes.
 
         HDF5 files are CONCATENATED along the array's leading (axis-0) stored
         dimension, and each file may contribute a DIFFERENT number of elements
@@ -223,34 +267,38 @@ class HDF5ArrayAdapter(ArrayAdapter):
         properties: Optional[Dict[str, Any]] = None,
         parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[int, ...]]:
-        """Return the global file indices needed to satisfy `slice`.
+        """Return the global file indices a `slice` touches, or `None`.
 
-        A pure classmethod of the structure, the file count and the data source
-        `properties`/`parameters` -- it touches no file or database and needs no
-        adapter instance -- so the catalog can prefetch exactly the assets that a
-        read will touch before building any adapter (for a `read_block`, the
-        catalog first converts the block to the equivalent slice). It mirrors the
-        file selection in the lazy `read()`.
+        A pure classmethod (no I/O, no adapter instance) so the catalog can
+        prefetch just the assets a read touches before building any adapter.
+        `_file_layout` locates the files in the structure and this maps the slice
+        onto them: for `("extents", extents)`, the axis-0 selection is mapped
+        through the cumulative file boundaries; for `("grid", grid_shape)`, the
+        leading grid dimensions index the files directly.
 
-        `n_files` is the number of backing files (the catalog passes the asset
-        count). `_file_layout` locates the files within the structure; this
-        maps the slice onto them: for `("extents", extents)`, the slice's axis-0
-        selection is mapped through the cumulative file boundaries; for
-        `("grid", grid_shape)`, the leading grid dimensions index the files
-        directly.
+        Returns `None` (so the catalog skips the lazy path and loads every file)
+        when the files can not be located, or under a `slice`/`squeeze` adapter
+        parameter -- that transform makes the served per-file shape differ from
+        the raw file, so the native-chunk reshape in `_assemble_partial`
+        would be invalid, and `_file_layout` alone can not detect it.
 
-        Returns `None` when the files can not be located -- so a slice may need
-        every file -- to tell the catalog to skip the lazy path. This includes
-        the case of a `slice`/`squeeze` adapter parameter: the lazy read builds
-        each block by reading a native chunk of a backing file and reshaping it
-        to that file's slab of the SERVED structure (see
-        `_lazy_stack_from_structure`). A `slice`/`squeeze` makes the served
-        per-file shape differ from the raw file contents (it drops or collapses
-        elements along one or more axes), so that reshape is invalid and the
-        file-stacked build can not be formed from the raw files. The transform is
-        applied only after a full (non-lazy) stack, so it is caught here from the
-        data source `parameters`; `_file_layout` alone can not detect it
-        (`structure.chunks[0]` may still look one-per-file).
+        Parameters
+        ----------
+        structure : ArrayStructure
+            The served array structure.
+        n_files : int
+            The number of backing files (the catalog passes the asset count).
+        slice : Any
+            The requested slice (or `read_block`'s equivalent leading slice).
+        properties : dict, optional
+            Data source properties (e.g. per-asset `extents`).
+        parameters : dict, optional
+            Data source parameters (e.g. `slice`/`squeeze`).
+
+        Returns
+        -------
+        tuple of int or None
+            The touched file indices, or `None` to skip the lazy path.
         """
         parameters = parameters or {}
         if parameters.get("slice") is not None or parameters.get("squeeze"):
@@ -285,15 +333,26 @@ class HDF5ArrayAdapter(ArrayAdapter):
         """Per-file element counts along the FLAT concatenation axis.
 
         The lazy build stacks the files into their flat (pre-reshape)
-        concatenation along axis 0; these extents give the file boundaries there
-        (their cumulative sums), so each native chunk can be mapped to its file.
+        concatenation along axis 0; the cumulative sums of these extents give the
+        file boundaries, so each native chunk maps to its file. Uses
+        `properties["extents"]` when present, else the `"extents"` layout's
+        per-file counts when they sum to `flat_leading`, else an even split.
 
-        `properties["extents"]` (the writer's authoritative per-asset row counts)
-        is used when present. Otherwise, when the structure IS the flat
-        concatenation (an "extents" layout whose per-file counts already sum to
-        the flat leading length), those counts are the flat extents. Failing
-        both, the stack is uniform (a grid or an evenly reshaped stack) and the
-        flat leading axis divides evenly among the files.
+        Parameters
+        ----------
+        layout : tuple
+            The `_file_layout` result, `(kind, data)`.
+        flat_leading : int
+            Length of the flat concatenation axis.
+        n_files : int
+            The number of backing files.
+        properties : dict, optional
+            Data source properties (e.g. per-asset `extents`).
+
+        Returns
+        -------
+        tuple of int
+            Per-file element counts along the flat axis.
         """
         raw_extents = (properties or {}).get("extents")
         if raw_extents is not None:
@@ -310,7 +369,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
         return (quotient,) * n_files
 
     @staticmethod
-    def _lazy_stack_from_structure(
+    def _assemble_partial(
         data_uris: Tuple[Optional[str], ...],
         structure: ArrayStructure,
         dataset: Optional[str] = None,
@@ -319,38 +378,39 @@ class HDF5ArrayAdapter(ArrayAdapter):
         locking: Optional[Union[bool, str]] = None,
         properties: Optional[Dict[str, Any]] = None,
     ) -> dask.array.Array:
-        """Build the file-stacked Dask array from the known structure, opening no
-        file for specs.
+        """Build the file-stacked Dask array from the known structure.
 
-        The catalog knows the structure, so a read need not open any file to
-        discover shapes: `data_uris` carries one entry per backing file (its
-        length is the file count), populated only for the files that this read
-        touches and left `None` elsewhere. Each present URI is converted to a
-        local path (via `path_from_uri`) lazily, inside its read task, so an
-        untouched file is never resolved.
+        `data_uris` carries one entry per backing file, populated only for the
+        files this read touches and left `None` elsewhere; each present URI is
+        resolved to a local path lazily inside its read task, so untouched files
+        stay closed. Mirrors the eager `lazy_load_hdf5_array`: it builds the flat
+        (pre-reshape) concatenation along axis 0 tiled by native HDF5 chunks --
+        axis 0 by `chunks[0]` (also split at file boundaries so no block straddles
+        two files), the trailing axes by `chunks[1:]` -- with the native chunking
+        taken from `properties["chunks"]` or, absent that, from the structure. The
+        caller's `read` reshapes this flat array (preserving chunk granularity)
+        and slices it, so Dask culls every chunk outside the read (and every
+        untouched file's placeholder), fetching only the native chunks it
+        overlaps. A reshaped grid with no recorded native chunking instead serves
+        one whole file per grid cell (the file is then the minimal read unit).
 
-        This mirrors the eager `lazy_load_hdf5_array`: it builds the FLAT
-        concatenation of the files (stacked along axis 0) tiled by native HDF5
-        chunks -- axis 0 by `chunks[0]` (additionally split at the file
-        boundaries so no block straddles two files), the trailing axes by
-        `chunks[1:]` -- where the native chunking comes from
-        `properties["chunks"]` (the pre-reshape chunking recorded when the stored
-        files are reshaped to the structure) or, absent that, from the structure
-        itself (which is then the flat concatenation). Each block is one native
-        chunk (no coalescing). The caller's `read` reshapes this flat array to
-        the structure (via `force_reshape`) -- the reshape preserves the native
-        chunk granularity -- and slices it, so Dask culls every chunk outside the
-        read (and every untouched file's placeholder) before computing. A partial
-        read therefore fetches only the native chunks it overlaps, the minimum
-        HDF5 can serve.
+        Parameters
+        ----------
+        data_uris : tuple of (str or None)
+            One entry per backing file; only touched files are populated.
+        structure : ArrayStructure
+            The served array structure.
+        dataset : str, optional
+            The dataset path within each file.
+        swmr, libver, locking
+            HDF5 open options.
+        properties : dict, optional
+            Data source properties (e.g. pre-reshape `chunks`, `extents`).
 
-        When the structure is a reshaped grid but no native chunking is recorded,
-        the flat chunking is unknown, so each file is served as one whole block (a
-        grid cell): the file is then the minimal read unit.
-
-        A present entry reads its native chunk in one task (reshaping to the
-        block's shape); every block of an untouched file gets a placeholder that
-        raises if ever computed (it should always be culled).
+        Returns
+        -------
+        dask.array.Array
+            The flat file-stacked array (reshaped to the structure by `read`).
         """
         n_files = len(data_uris)
         dtype = structure.data_type.to_numpy_dtype()
@@ -401,7 +461,6 @@ class HDF5ArrayAdapter(ArrayAdapter):
         raw_chunks = pre_chunks if pre_chunks is not None else structure.chunks
         flat_chunks = tuple(tuple(int(c) for c in dim) for dim in raw_chunks)
         flat_shape = tuple(sum(dim) for dim in flat_chunks)
-        flat_rest = flat_shape[1:]
 
         # File boundaries along the flat leading axis, so each native chunk maps
         # to exactly one file.
@@ -419,32 +478,9 @@ class HDF5ArrayAdapter(ArrayAdapter):
         boundaries = sorted({0, flat_shape[0], *file_ends, *chunk_ends})
 
         # Trailing native-chunk grid; the same grid applies to every leading
-        # block. `key_rest` is the trailing chunk index tuple, `slc_rest` its
-        # (file-local) slice, and `size_rest` its shape.
+        # block.
         rest_chunks = flat_chunks[1:]
-        if not rest_chunks or max((len(dim) for dim in rest_chunks), default=1) == 1:
-            key_rest: Tuple[Tuple[int, ...], ...] = (tuple(0 for _ in rest_chunks),)
-            slc_rest: Tuple[Tuple[builtins.slice, ...], ...] = (
-                tuple(builtins.slice(None) for _ in rest_chunks),
-            )
-            size_rest: Tuple[Tuple[int, ...], ...] = (tuple(flat_rest),)
-        else:
-            key_rest = tuple(
-                itertools.product(*(range(len(dim)) for dim in rest_chunks))
-            )
-            rest_bounds = tuple(
-                numpy.cumsum((0,) + dim).tolist() for dim in rest_chunks
-            )
-            rest_starts = itertools.product(*(bounds[:-1] for bounds in rest_bounds))
-            rest_stops = itertools.product(*(bounds[1:] for bounds in rest_bounds))
-            slc_rest = tuple(
-                tuple(
-                    builtins.slice(start, stop)
-                    for start, stop in zip(dim_starts, dim_stops)
-                )
-                for dim_starts, dim_stops in zip(rest_starts, rest_stops)
-            )
-            size_rest = tuple(itertools.product(*rest_chunks))
+        key_rest, slc_rest, size_rest = _trailing_chunk_grid(rest_chunks)
 
         name = "hdf5-lazy-stack-" + str(
             hash((dataset, data_uris, flat_shape, str(dtype)))
@@ -489,12 +525,11 @@ class HDF5ArrayAdapter(ArrayAdapter):
 
         Every file is opened to read its specs (shapes/chunks/dtype). When the
         structure is already known (a catalog read), prefer
-        `_lazy_stack_from_structure`, which opens no file for specs and can leave
-        untouched files unresolved.
+        `_assemble_partial`, which opens no file for specs and can load only necessary files.
 
         Parameters
         ----------
-        file_paths : list
+        file_paths : list of str or Path
             A list of file paths pointing to the HDF5 files
         dataset : str
             The dataset to read from the files, for example, "/path/to/dataset" within the file
@@ -502,7 +537,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
             Whether to open the files in single-writer multiple-reader mode
         libver : str
             The HDF5 library version to use
-        locking : bool
+        locking : bool or str, optional
             Whether to use file locking when accessing the files
         """
 
@@ -594,8 +629,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
             # chunk, and the remaining dimensions are split by the smallest
             # native chunk across files (so every file's chunk boundaries land
             # on the Dask grid). A partial read then fetches only the native
-            # chunks it touches -- the minimum HDF5 can serve -- so small reads
-            # stay cheap without any coalescing heuristic.
+            # chunks it touches -- the minimum HDF5 can serve.
             file_chunks = tuple(
                 split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
                 for shp, chk, _ in shapes_chunks_dtypes
@@ -609,33 +643,9 @@ class HDF5ArrayAdapter(ArrayAdapter):
             dim0_chunks = tuple(size for fc in file_chunks for size in fc)
             chunks_final = (dim0_chunks, *[tuple(d) for d in rest_chunks])
 
-            # Prepare slice tuples and indices for the rightmost dimensions (same for each file)
-            key_rest: Tuple[Tuple[int, ...], ...]
-            slc_rest: Tuple[Tuple[builtins.slice, ...], ...]
-            if not rest_chunks or (max(len(dim) for dim in rest_chunks) == 1):
-                # All dimensions have only one chunk per each: use full slices
-                key_rest = (tuple(0 for _ in rest_chunks),)
-                slc_rest = (tuple(builtins.slice(None) for _ in rest_chunks),)
-            else:
-                # Multiple chunks in at least one of the dimensions:
-                # build full product of indices and corresponding slices
-                key_rest = tuple(
-                    itertools.product(*(range(len(dim)) for dim in rest_chunks))
-                )
-                rest_bounds = tuple(
-                    numpy.cumsum((0,) + dim).tolist() for dim in rest_chunks
-                )
-                rest_starts = itertools.product(
-                    *(bounds[:-1] for bounds in rest_bounds)
-                )
-                rest_stops = itertools.product(*(bounds[1:] for bounds in rest_bounds))
-                slc_rest = tuple(
-                    tuple(
-                        builtins.slice(start, stop)
-                        for start, stop in zip(dim_starts, dim_stops)
-                    )
-                    for dim_starts, dim_stops in zip(rest_starts, rest_stops)
-                )
+            # Prepare slice tuples and indices for the rightmost dimensions
+            # (same for each file).
+            key_rest, slc_rest, _ = _trailing_chunk_grid(rest_chunks)
 
             # Define the Dask tasks for loading each chunk from the files
             name = "hdf5-stack-" + str(hash(tuple([dataset, *file_paths])))
@@ -688,7 +698,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
             # native chunks it overlaps. Each URI is converted to a local path
             # lazily, inside its read task, so untouched files stay closed. Metadata
             # comes from the node alone (no attribute read).
-            array = cls._lazy_stack_from_structure(
+            array = cls._assemble_partial(
                 tuple(data_uris),
                 structure,
                 dataset=dataset,

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -2,6 +2,7 @@ import bisect
 import builtins
 import copy
 import itertools
+import math
 import os
 import sys
 import warnings
@@ -32,7 +33,7 @@ from ..type_aliases import JSON
 from ..utils import BrokenLink, Sentinel, node_repr, path_from_uri
 from .array import ArrayAdapter
 from .resource_cache import with_resource_cache
-from .sequence import IO_WORKERS, READ_BATCH_BYTES
+from .sequence import IO_WORKERS
 from .utils import grid_shape_for_files, split_chunks
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
@@ -41,6 +42,18 @@ INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 HDF5_DATASET = Sentinel("HDF5_DATASET")
 HDF5_BROKEN_LINK = Sentinel("HDF5_BROKEN_LINK")
 MIN_CHUNK_SIZE = 1  # Minimum chunk size along the concatenation axis
+
+# Soft cap on the bytes a single Dask chunk reads from an HDF5 dataset. Native
+# HDF5 chunks are often tiny (e.g. one frame each), and one Dask task per native
+# chunk both explodes the task count and re-opens the file each time; coalescing
+# native chunks into blocks up to this many bytes keeps the task/open count low.
+# But the block size is also the MINIMUM a partial read fetches -- reading a
+# single frame still reads its whole block -- so an over-large cap makes small
+# reads pull far more than they need. This is deliberately modest (16 MiB) so a
+# one-element read stays cheap while a full read still coalesces sensibly; the
+# residual per-block open cost is negligible against the actual I/O. Override
+# with TILED_HDF5_READ_CHUNK_BYTES.
+READ_CHUNK_BYTES = int(os.environ.get("TILED_HDF5_READ_CHUNK_BYTES") or (16 << 20))
 
 
 def _lazy_placeholder_block(
@@ -464,18 +477,44 @@ class HDF5ArrayAdapter(ArrayAdapter):
 
         else:
             # Use delayed loading to read and conactenate arrays from multiple files
-            # First, find chunks along the left axis (split per file),
-            # and chunks in the rest of the dimensions (same for each file)
-            file_chunks = tuple(
-                split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
-                for shp, chk, _ in shapes_chunks_dtypes
-            )
-            # Shape of the rest of dimensions
+            # Determine chunks along the leftmost (concatenation) axis, split
+            # per file, and chunks in the rest of the dimensions (shared by all
+            # files). The constituent files' native HDF5 chunks are often tiny
+            # (e.g. a single frame per chunk, with thousands of frames per
+            # file), which explodes the number of Dask tasks -- and every task
+            # re-opens the file. To avoid that, coalesce native chunks into
+            # blocks of whole rows (full rest dimensions) up to READ_CHUNK_BYTES,
+            # so each file is read in a reasonable number of tasks. The block is
+            # also the granularity of a partial read (a single-frame read still
+            # reads its whole block), so READ_CHUNK_BYTES stays modest rather than
+            # coalescing whole files -- keeping small reads cheap.
             rest_shape = shapes_chunks_dtypes[0][0][1:]
-            rest_chunks = tuple(
-                split_chunks(shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes))
-                for i, shp in enumerate(rest_shape)
-            )
+            rest_row_bytes = math.prod(rest_shape) * dtype.itemsize
+            rest_chunks: Tuple[Tuple[int, ...], ...]
+            read_chunk_bytes = READ_CHUNK_BYTES
+            if not rest_shape or 0 < rest_row_bytes <= read_chunk_bytes:
+                # Read whole rows (full rest dimensions) in blocks along axis 0,
+                # sized up to the chunk-byte limit but never smaller than the
+                # native chunk along axis 0.
+                rows_per_block = max(1, read_chunk_bytes // (rest_row_bytes or 1))
+                file_chunks = tuple(
+                    split_chunks(shp[0], max(chk[0], rows_per_block))
+                    for shp, chk, _ in shapes_chunks_dtypes
+                )
+                rest_chunks = tuple((shp,) for shp in rest_shape)
+            else:
+                # A single row already exceeds the chunk-byte limit: fall back to
+                # the files' native tiling in every dimension.
+                file_chunks = tuple(
+                    split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
+                    for shp, chk, _ in shapes_chunks_dtypes
+                )
+                rest_chunks = tuple(
+                    split_chunks(
+                        shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes)
+                    )
+                    for i, shp in enumerate(rest_shape)
+                )
             dim0_chunks = tuple(size for fc in file_chunks for size in fc)
             chunks_final = (dim0_chunks, *[tuple(d) for d in rest_chunks])
 

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -1,11 +1,13 @@
+import bisect
 import builtins
 import copy
 import itertools
 import os
 import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import dask
 import dask.array
@@ -29,7 +31,9 @@ from ..structures.data_source import DataSource
 from ..type_aliases import JSON
 from ..utils import BrokenLink, Sentinel, node_repr, path_from_uri
 from .array import ArrayAdapter
-from .utils import split_chunks
+from .resource_cache import with_resource_cache
+from .sequence import IO_WORKERS, READ_BATCH_BYTES
+from .utils import grid_shape_for_files, split_chunks
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
 INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
@@ -37,6 +41,25 @@ INLINED_DEPTH = int(os.getenv("TILED_HDF5_INLINED_CONTENTS_MAX_DEPTH", "7"))
 HDF5_DATASET = Sentinel("HDF5_DATASET")
 HDF5_BROKEN_LINK = Sentinel("HDF5_BROKEN_LINK")
 MIN_CHUNK_SIZE = 1  # Minimum chunk size along the concatenation axis
+
+
+def _lazy_placeholder_block(
+    block_shape: Tuple[int, ...], dtype: numpy.dtype
+) -> NDArray:
+    """Dask task body for a file that the current read does not touch.
+
+    The catalog's lazy path resolves only the URIs a read needs; the other
+    files' blocks carry this placeholder. The read reshapes the full-shape Dask
+    array and slices it, so Dask culls every block outside the requested slice
+    before computing and never runs these placeholder tasks. If one does run,
+    the predicted file geometry (`file_indices_for_slice`) disagreed with the
+    blocks that the slice touches, so raise loudly rather than serve wrong data.
+    """
+    raise RuntimeError(
+        "Lazy HDF5 placeholder block was computed: the file geometry predicted "
+        "by file_indices_for_slice does not match the blocks the read touches. "
+        f"(block_shape={block_shape}, dtype={dtype})"
+    )
 
 
 def parse_hdf5_tree(
@@ -138,6 +161,181 @@ class HDF5ArrayAdapter(ArrayAdapter):
     multiple files.
     """
 
+    # When True, the catalog may build this adapter with a partially-populated
+    # list of `data_uris`: it resolves only the files that a given read touches
+    # and leaves the rest as None, then resolves the untouched files' blocks
+    # lazily.
+    supports_lazy_assets = True
+
+    @staticmethod
+    def _file_layout(
+        structure: ArrayStructure,
+        n_files: int,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Tuple[str, Tuple[int, ...]]]:
+        """Describe how the `n_files` backing files tile the array's leading axes.
+
+        HDF5 files are CONCATENATED along the array's leading (axis-0) stored
+        dimension, and each file may contribute a DIFFERENT number of elements
+        there (unlike a TIFF stack, where every file adds exactly one frame on a
+        new axis). The combined leading chunking is then non-uniform, and file
+        boundaries can NOT be recovered from `structure.chunks` alone. This
+        returns one of:
+
+        - `("extents", extents)` -- file `i` is a contiguous slab of `extents[i]`
+          elements along structure axis 0; `sum(extents) == shape[0]`. Cumulative
+          sums give the file boundaries, so any per-file extents (uniform or not)
+          are supported. Sourced from the optional `properties["extents"]` (the
+          authoritative per-asset row counts the writer stored) or, absent that,
+          from `structure.chunks[0]` when it has exactly one chunk per file (each
+          file is then one leading chunk).
+        - `("grid", grid_shape)` -- the leading `grid_shape` dimensions (product
+          `== n_files`) each index one file (a uniform stack whose leading axis
+          was reshaped across several structure dimensions). Used only when the
+          per-file extents can not be determined as above.
+        - `None` -- files can not be located from the structure, so the caller
+          must skip the lazy path and open every file.
+        """
+        struct_shape = tuple(structure.shape)
+        raw_extents = (properties or {}).get("extents")
+        if raw_extents is not None:
+            extents = tuple(int(e) for e in raw_extents)
+            if len(extents) != n_files or sum(extents) != struct_shape[0]:
+                # Inconsistent with the structure: don't trust it for selection.
+                return None
+            return ("extents", extents)
+        chunks0 = tuple(int(c) for c in structure.chunks[0])
+        if len(chunks0) == n_files:
+            # One leading chunk per file: the chunk sizes ARE the per-file extents
+            # (holds when each file was written as a single leading chunk).
+            return ("extents", chunks0)
+        grid_shape = grid_shape_for_files(struct_shape, n_files)
+        if grid_shape is not None:
+            return ("grid", grid_shape)
+        return None
+
+    @classmethod
+    def file_indices_for_slice(
+        cls,
+        structure: ArrayStructure,
+        n_files: int,
+        slice: Any = ...,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Tuple[int, ...]]:
+        """Return the global file indices needed to satisfy `slice`.
+
+        A pure classmethod of the structure, the file count and the data source
+        `properties` -- it touches no file or database and needs no adapter
+        instance -- so the catalog can prefetch exactly the assets that a read
+        will touch before building any adapter (for a `read_block`, the catalog
+        first converts the block to the equivalent slice). It mirrors the file
+        selection in the lazy `read()`.
+
+        `n_files` is the number of backing files (the catalog passes the asset
+        count). `_file_layout` locates the files within the structure; this
+        maps the slice onto them: for `("extents", extents)`, the slice's axis-0
+        selection is mapped through the cumulative file boundaries; for
+        `("grid", grid_shape)`, the leading grid dimensions index the files
+        directly.
+
+        Returns `None` when the files can not be located from the structure -- a
+        slice may then need every file -- to tell the catalog to skip the lazy path.
+        """
+        layout = cls._file_layout(structure, n_files, properties)
+        if layout is None:
+            return None
+        struct_shape = tuple(structure.shape)
+        expanded = NDSlice(slice).expand_for_shape(struct_shape)
+        kind, data = layout
+        if kind == "grid":
+            file_indx_slice = expanded[: len(data)]
+            return NDSlice(file_indx_slice).flat_indices(data)
+        # kind == "extents": map the axis-0 selection through the file boundaries.
+        ends = tuple(itertools.accumulate(data))  # exclusive end position per file
+        axis0 = expanded[0]
+        if isinstance(axis0, builtins.slice):
+            positions: Iterable[int] = range(*axis0.indices(struct_shape[0]))
+        else:
+            positions = (int(axis0),)
+        # bisect_right(ends, p) is the index of the file whose half-open
+        # [start, end) range contains flat position p.
+        return tuple(sorted({bisect.bisect_right(ends, p) for p in positions}))
+
+    @staticmethod
+    def _lazy_stack_from_structure(
+        data_uris: Tuple[Optional[str], ...],
+        structure: ArrayStructure,
+        dataset: Optional[str] = None,
+        swmr: bool = SWMR_DEFAULT,
+        libver: str = "latest",
+        locking: Optional[Union[bool, str]] = None,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> dask.array.Array:
+        """Build the file-stacked Dask array from the known structure, opening no
+        file for specs.
+
+        The catalog knows the structure, so a read need not open any file to
+        discover shapes: `data_uris` carries one entry per backing file (its
+        length is the file count), populated only for the files that this read
+        touches and left `None` elsewhere. Each present URI is converted to a
+        local path (via `path_from_uri`) lazily, inside its read task, so an
+        untouched file is never resolved. `_file_layout` gives each file's
+        extent along a single leading axis; the remaining dimensions are that
+        file's own shape. The array is built one whole file per block along that
+        axis, then reshaped to the structure by the caller's `read` (via
+        `force_reshape`), so Dask culls every untouched file's block before
+        computing.
+
+        A present entry reads its whole file in one task (reshaping it to the
+        block's shape, which absorbs a stacking axis or a per-file row count
+        equally); a `None` entry gets a placeholder that raises if ever computed
+        (it should always be culled).
+        """
+        n_files = len(data_uris)
+        dtype = structure.data_type.to_numpy_dtype()
+        struct_shape = tuple(structure.shape)
+        layout = HDF5ArrayAdapter._file_layout(structure, n_files, properties)
+        if layout is None:
+            # The catalog only takes the lazy path when the files can be located,
+            # so this should not happen; guard rather than build a wrong graph.
+            raise ValueError(
+                f"Structure shape {struct_shape} does not locate {n_files} files."
+            )
+        kind, data = layout
+        if kind == "extents":
+            # File i is `data[i]` elements along axis 0; the rest is its own shape.
+            leading_extents = data
+            per_file_rest = struct_shape[1:]
+        else:  # "grid": each file is one element on a flattened leading axis.
+            leading_extents = (1,) * n_files
+            per_file_rest = struct_shape[len(data) :]  # noqa: E203
+
+        def _read_hdf5_file(uri: str, block_shape: Tuple[int, ...]) -> NDArray:
+            # Resolve the URI to a local path only now, when this file is read.
+            with h5open(
+                path_from_uri(uri), dataset, swmr=swmr, libver=libver, locking=locking
+            ) as ds:
+                # Read the whole file; reshape it into this file's block (adds a
+                # stacking axis when the extent is 1, or is a no-op for a concat).
+                return numpy.asarray(ds[...]).reshape(block_shape)
+
+        name = "hdf5-lazy-stack-" + str(
+            hash((dataset, data_uris, struct_shape, str(dtype)))
+        )
+        dsk: dict[Any, Any] = {}
+        rest_key = tuple(0 for _ in per_file_rest)
+        for file_indx, (uri, extent) in enumerate(zip(data_uris, leading_extents)):
+            block_shape = (extent, *per_file_rest)
+            key = (name, file_indx, *rest_key)
+            if uri is None:
+                dsk[key] = (_lazy_placeholder_block, block_shape, dtype)
+            else:
+                dsk[key] = (_read_hdf5_file, uri, block_shape)
+
+        chunks_final = (tuple(leading_extents), *[(s,) for s in per_file_rest])
+        hlg = HighLevelGraph.from_collections(name, dsk, dependencies=[])
+        return dask.array.Array(hlg, name, chunks=chunks_final, dtype=dtype)
+
     @staticmethod
     def lazy_load_hdf5_array(
         *file_paths: Union[str, Path],
@@ -149,6 +347,11 @@ class HDF5ArrayAdapter(ArrayAdapter):
         """Lazily load arrays from possibly multiple HDF5 files and concatenate them along the first axis
 
         The chunks of the resulting Dask array are determined by the chunks of the constituent arrays.
+
+        Every file is opened to read its specs (shapes/chunks/dtype). When the
+        structure is already known (a catalog read), prefer
+        `_lazy_stack_from_structure`, which opens no file for specs and can leave
+        untouched files unresolved.
 
         Parameters
         ----------
@@ -182,8 +385,16 @@ class HDF5ArrayAdapter(ArrayAdapter):
                 result = ds.shape, ds.chunks or ds.shape, ds.dtype
             return result
 
-        # Need to know shapes/dtypes of constituent arrays to load them lazily
-        shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
+        # Need to know shapes/dtypes of constituent arrays to load them lazily.
+        # Reading specs opens every file (twice, for external links), so for
+        # many-file datasets do this in parallel while preserving order.
+        if len(file_paths) > 1:
+            with ThreadPoolExecutor(
+                max_workers=min(IO_WORKERS, len(file_paths))
+            ) as executor:
+                shapes_chunks_dtypes = list(executor.map(_get_hdf5_specs, file_paths))
+        else:
+            shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
         dtype = shapes_chunks_dtypes[0][2]
         if dtype == numpy.dtype("O"):
             # h5py uses NumPy's object dtype to represent variable-length
@@ -319,16 +530,67 @@ class HDF5ArrayAdapter(ArrayAdapter):
         swmr: bool = SWMR_DEFAULT,
         libver: str = "latest",
         locking: Optional[Union[bool, str]] = None,
+        data_uris: Optional[List[Optional[str]]] = None,
     ) -> "HDF5ArrayAdapter":
         structure = data_source.structure
+
+        if data_uris is not None:
+            # Lazy path: the catalog resolved only the files that this read touches
+            # (leaving the rest as None) and passes them here. The structure is
+            # known, so build the file-stacked array without opening any file for
+            # specs; placeholders stand in for the untouched files' blocks, which
+            # Dask culls once the read slices the reshaped array. Each URI is
+            # converted to a local path lazily, inside its read task, so untouched
+            # files stay closed. Metadata comes from the node alone (no attribute
+            # read).
+            array = cls._lazy_stack_from_structure(
+                tuple(data_uris),
+                structure,
+                dataset=dataset,
+                swmr=swmr,
+                libver=libver,
+                locking=locking,
+                properties=data_source.properties,
+            )
+            if slice:
+                if isinstance(slice, str):
+                    slice = NDSlice.from_numpy_str(slice)
+                array = array[slice]
+            if squeeze:
+                array = array.squeeze()
+            return cls(
+                array,
+                structure,
+                metadata=copy.deepcopy(node.metadata_),
+                specs=node.specs,
+            )
+
         assets = data_source.assets
-        data_uris = [
+        asset_uris = [
             ast.data_uri for ast in assets if ast.parameter == "data_uris"
         ] or [assets[0].data_uri]
-        file_paths = [path_from_uri(uri) for uri in data_uris]
+        file_paths = [path_from_uri(uri) for uri in asset_uris]
 
-        array = cls.lazy_load_hdf5_array(
-            *file_paths, dataset=dataset, swmr=swmr, libver=libver, locking=locking
+        # Building the lazy Dask array opens every constituent file to read its
+        # specs. Cache the array so repeated reads of the same dataset reuse the
+        # graph instead of re-opening all files. Slicing the cached array below
+        # returns a new array, leaving the cached one unmodified.
+        cache_key = (
+            HDF5ArrayAdapter.lazy_load_hdf5_array,
+            dataset,
+            tuple(file_paths),
+            swmr,
+            libver,
+            locking,
+        )
+        array = with_resource_cache(
+            cache_key,
+            cls.lazy_load_hdf5_array,
+            *file_paths,
+            dataset=dataset,
+            swmr=swmr,
+            libver=libver,
+            locking=locking,
         )
 
         if slice:
@@ -351,7 +613,7 @@ class HDF5ArrayAdapter(ArrayAdapter):
         metadata = copy.deepcopy(node.metadata_)
         metadata.update(
             get_hdf5_attrs(
-                data_uris[0], dataset, swmr=swmr, libver=libver, locking=locking
+                asset_uris[0], dataset, swmr=swmr, libver=libver, locking=locking
             )
         )
 
@@ -431,6 +693,25 @@ class HDF5Adapter(
     >>> HDF5Adapter.from_uri("file://localhost/path/to/file.h5")
 
     """
+
+    # The catalog serves an HDF5 array node through this container adapter (the
+    # mimetype-registered class), which dispatches array data sources to
+    # HDF5ArrayAdapter. Opt in to the catalog's lazy per-frame path here and
+    # delegate the file-selection geometry to the array adapter; the catalog
+    # consults both only when reading an array data source.
+    supports_lazy_assets = True
+
+    @classmethod
+    def file_indices_for_slice(
+        cls,
+        structure: ArrayStructure,
+        n_files: int,
+        slice: Any = ...,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Tuple[int, ...]]:
+        return HDF5ArrayAdapter.file_indices_for_slice(
+            structure, n_files, slice, properties
+        )
 
     def __init__(
         self,

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -221,15 +221,16 @@ class HDF5ArrayAdapter(ArrayAdapter):
         n_files: int,
         slice: Any = ...,
         properties: Optional[Dict[str, Any]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[int, ...]]:
         """Return the global file indices needed to satisfy `slice`.
 
         A pure classmethod of the structure, the file count and the data source
-        `properties` -- it touches no file or database and needs no adapter
-        instance -- so the catalog can prefetch exactly the assets that a read
-        will touch before building any adapter (for a `read_block`, the catalog
-        first converts the block to the equivalent slice). It mirrors the file
-        selection in the lazy `read()`.
+        `properties`/`parameters` -- it touches no file or database and needs no
+        adapter instance -- so the catalog can prefetch exactly the assets that a
+        read will touch before building any adapter (for a `read_block`, the
+        catalog first converts the block to the equivalent slice). It mirrors the
+        file selection in the lazy `read()`.
 
         `n_files` is the number of backing files (the catalog passes the asset
         count). `_file_layout` locates the files within the structure; this
@@ -238,9 +239,19 @@ class HDF5ArrayAdapter(ArrayAdapter):
         `("grid", grid_shape)`, the leading grid dimensions index the files
         directly.
 
-        Returns `None` when the files can not be located from the structure -- a
-        slice may then need every file -- to tell the catalog to skip the lazy path.
+        Returns `None` when the files can not be located -- so a slice may need
+        every file -- to tell the catalog to skip the lazy path. This includes
+        the case of a `slice`/`squeeze` adapter parameter: those transforms
+        reshape each file when building the served array (see `from_catalog`), so
+        the served axis 0 is no longer a plain concatenation of whole files and
+        the requested slice (in served coordinates) can not be mapped back onto
+        the stored per-file boundaries. `_file_layout` alone can not detect this
+        -- `structure.chunks[0]` may still look one-per-file -- so it is caught
+        here from the data source `parameters`.
         """
+        parameters = parameters or {}
+        if parameters.get("slice") is not None or parameters.get("squeeze"):
+            return None
         layout = cls._file_layout(structure, n_files, properties)
         if layout is None:
             return None
@@ -708,9 +719,10 @@ class HDF5Adapter(
         n_files: int,
         slice: Any = ...,
         properties: Optional[Dict[str, Any]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[Tuple[int, ...]]:
         return HDF5ArrayAdapter.file_indices_for_slice(
-            structure, n_files, slice, properties
+            structure, n_files, slice, properties, parameters
         )
 
     def __init__(

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -3,7 +3,7 @@ import math
 import os
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import numpy as np
 from ndindex import ndindex
@@ -18,7 +18,7 @@ from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
 from ..type_aliases import JSON, EllipsisType
 from ..utils import path_from_uri
-from .utils import force_reshape
+from .utils import force_reshape, grid_shape_for_files
 
 # Concurrency and memory knobs for reads that span many files of a sequence.
 #
@@ -409,62 +409,51 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         adapter state, no I/O -- so both `read` and the `file_indices_for_slice`
         classmethod (used by the catalog before any adapter is built) can share it.
 
-        Each file contributes one element along the left-most stored axis, so a
-        file spans `P = prod(true_shape[1:])` contiguous elements of the row-major
-        flat array. Whole-file (partial) loading is possible only when the file
-        boundary aligns with a structure dimension boundary -- i.e. there is a
-        split `j` with `prod(struct_shape[:j]) == n_files` -- in which case the
-        leading `j` structure dimensions map onto the files and this returns
-        `struct_shape[:j]`. When no such split exists the reshape interleaves file
-        contents across the file boundary (every file must be loaded) and this
-        returns `None`. The caller derives `partial_loadable` as `result is not
-        None` and `reshaped` as `true_shape != struct_shape`.
+        Each file contributes one element along the left-most stored axis, so
+        `n_files == true_shape[0]`, and the shared `grid_shape_for_files` helper
+        computes the file-alignment geometry. The caller derives
+        `partial_loadable` as `result is not None` and `reshaped` as
+        `true_shape != struct_shape`.
         """
         if math.prod(true_shape) != math.prod(struct_shape):
             raise RuntimeError(
                 f"Array with shape {true_shape} derived from storage can not be reshaped "
                 f"to match the desired structure, {struct_shape}."
             )
-        # Locate the file boundary within the structure shape: the smallest split
-        # `j` whose leading dimensions multiply to the file count. Products grow
-        # monotonically (dimensions >= 1), so once the running product passes
-        # `n_files` without landing on it, no aligned split exists.
-        n_files = true_shape[0]
-        product = 1
-        for j, dim in enumerate(struct_shape, start=1):
-            product *= dim
-            if product == n_files:
-                return struct_shape[:j]
-            if product > n_files:
-                break
-        return None
+        return grid_shape_for_files(struct_shape, true_shape[0])
 
     @classmethod
     def file_indices_for_slice(
         cls,
         structure: ArrayStructure,
-        chunks: Optional[tuple[tuple[int, ...], ...]],
+        n_files: int,
         slice: Any = ...,
+        properties: Optional[Dict[str, Any]] = None,
     ) -> Optional[tuple[int, ...]]:
         """Return the global file (stack) indices needed to satisfy `slice`.
 
-        Pure classmethod of the structure and chunks only -- performs no file or
-        database I/O and needs no adapter instance -- so the catalog can prefetch
-        exactly the assets a read will touch before building any adapter (a
-        `read_block` is handled by first converting the block to the equivalent
-        slice). The leading `stacking_grid_shape` dimensions of the structure map onto
-        the files, so the files touched are the flat positions the slice selects
-        within them. Mirrors the file selection in `read()`.
+        Pure classmethod of the structure and the file count -- performs no file
+        or database I/O and needs no adapter instance -- so the catalog can
+        prefetch exactly the assets that a read will touch before building any
+        adapter (a `read_block` is handled by first converting the block to the
+        equivalent slice). The leading `grid_shape_for_files` dimensions of the
+        structure map onto the `n_files` files (the catalog passes the asset
+        count), so the files touched are the flat positions that the slice
+        selects within them. Mirrors the file selection in `read()`.
+
+        A sequence stacks uniform files (each adds one frame on a new leading
+        axis), so the geometry follows from the structure alone; `properties`
+        is accepted for interface parity with adapters that need it (e.g. HDF5)
+        and ignored here.
 
         Returns `None` when the reshape is not file-boundary-aligned (every file
         may need to be loaded), signalling the catalog to skip the lazy loading path.
         """
         struct_shape = structure.shape
-        true_shape = tuple(map(sum, chunks)) if chunks else struct_shape
-        stacking_grid_shape = cls._stacking_grid_shape(struct_shape, true_shape)
-        if stacking_grid_shape is None:
+        grid_shape = grid_shape_for_files(struct_shape, n_files)
+        if grid_shape is None:
             return None
         file_indx_slice = NDSlice(slice).expand_for_shape(struct_shape)[
-            : len(stacking_grid_shape)
+            : len(grid_shape)
         ]
-        return NDSlice(file_indx_slice).flat_indices(stacking_grid_shape)
+        return NDSlice(file_indx_slice).flat_indices(grid_shape)

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -433,22 +433,13 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
     ) -> Optional[tuple[int, ...]]:
         """Return the global file (stack) indices needed to satisfy `slice`.
 
-        Pure classmethod of the structure and the file count -- performs no file
-        or database I/O and needs no adapter instance -- so the catalog can
-        prefetch exactly the assets that a read will touch before building any
-        adapter (a `read_block` is handled by first converting the block to the
-        equivalent slice). The leading `grid_shape_for_files` dimensions of the
-        structure map onto the `n_files` files (the catalog passes the asset
-        count), so the files touched are the flat positions that the slice
-        selects within them. Mirrors the file selection in `read()`.
-
-        A sequence stacks uniform files (each adds one frame on a new leading
-        axis), so the geometry follows from the structure alone; `properties`
-        and `parameters` are accepted for interface parity with adapters that
-        need them (e.g. HDF5) and ignored here.
+        The leading `grid_shape_for_files` dimensions map onto the `n_files` files,
+        so the touched files are the flat positions the slice selects within
+        them. `properties`/`parameters` are accepted for interface parity with
+        adapters that need them (e.g. HDF5) and ignored here.
 
         Returns `None` when the reshape is not file-boundary-aligned (every file
-        may need to be loaded), signalling the catalog to skip the lazy loading path.
+        may need to be loaded), signalling the catalog to skip the lazy path.
         """
         struct_shape = structure.shape
         grid_shape = grid_shape_for_files(struct_shape, n_files)

--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -429,6 +429,7 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         n_files: int,
         slice: Any = ...,
         properties: Optional[Dict[str, Any]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[tuple[int, ...]]:
         """Return the global file (stack) indices needed to satisfy `slice`.
 
@@ -443,8 +444,8 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
 
         A sequence stacks uniform files (each adds one frame on a new leading
         axis), so the geometry follows from the structure alone; `properties`
-        is accepted for interface parity with adapters that need it (e.g. HDF5)
-        and ignored here.
+        and `parameters` are accepted for interface parity with adapters that
+        need them (e.g. HDF5) and ignored here.
 
         Returns `None` when the reshape is not file-boundary-aligned (every file
         may need to be loaded), signalling the catalog to skip the lazy loading path.

--- a/tiled/adapters/utils.py
+++ b/tiled/adapters/utils.py
@@ -118,8 +118,8 @@ def split_chunks(total: int, chunk: int) -> tuple[int, ...]:
 def grid_shape_for_files(
     struct_shape: Tuple[int, ...], n_files: int
 ) -> Optional[Tuple[int, ...]]:
-    """Return the leading axes of `struct_shape` that enumerate the files, one
-    grid cell per file, or `None` when no such clean split exists.
+    """For multi-asset datasets, return the leading axes of `struct_shape` that
+    enumerate the files, one grid cell per file, or `None` when no clean split exists.
 
     Context: `n_files` files were each read as one fixed-shape frame, stacked
     into a new leading axis of length `n_files`, and that axis was then reshaped
@@ -136,10 +136,6 @@ def grid_shape_for_files(
     with 12 files returns `None`: no prefix hits 12, so a single file's frame
     would straddle a dimension boundary and the leading indices no longer
     correspond one-to-one with files.
-
-    This is a pure function of the shape and the file count -- no array, no I/O --
-    so a running adapter's `read` and the catalog's `file_indices_for_slice`
-    (which runs before any adapter exists) share one file-selection geometry.
 
     The running product only grows (every dimension is `>= 1`), so once it passes
     `n_files` without landing on it, no aligned split can exist and this stops.

--- a/tiled/adapters/utils.py
+++ b/tiled/adapters/utils.py
@@ -113,3 +113,42 @@ def split_chunks(total: int, chunk: int) -> tuple[int, ...]:
     "Split total into repeated chunks of size `chunk`, with a remainder at the end."
     num_full_chunks, remainder = divmod(total, chunk)
     return tuple([chunk] * num_full_chunks + ([remainder] if remainder else []))
+
+
+def grid_shape_for_files(
+    struct_shape: Tuple[int, ...], n_files: int
+) -> Optional[Tuple[int, ...]]:
+    """Return the leading axes of `struct_shape` that enumerate the files, one
+    grid cell per file, or `None` when no such clean split exists.
+
+    Context: `n_files` files were each read as one fixed-shape frame, stacked
+    into a new leading axis of length `n_files`, and that axis was then reshaped
+    into one or more leading dimensions of `struct_shape` (the trailing
+    dimensions are the shared per-frame shape). This recovers the grid of those
+    leading dimensions so a caller can map a grid cell back to its one file.
+
+    The split is clean only when a prefix of `struct_shape` multiplies to exactly
+    `n_files`: the smallest `j` with `prod(struct_shape[:j]) == n_files`. Then the
+    leading `j` dimensions index the files and this returns `struct_shape[:j]`.
+
+    For example, 12 files reshaped to `(3, 4, H, W)` returns `(3, 4)` -- the file
+    at grid cell `(i, j)` supplies the `H x W` frame at `[i, j]`. But `(5, ...)`
+    with 12 files returns `None`: no prefix hits 12, so a single file's frame
+    would straddle a dimension boundary and the leading indices no longer
+    correspond one-to-one with files.
+
+    This is a pure function of the shape and the file count -- no array, no I/O --
+    so a running adapter's `read` and the catalog's `file_indices_for_slice`
+    (which runs before any adapter exists) share one file-selection geometry.
+
+    The running product only grows (every dimension is `>= 1`), so once it passes
+    `n_files` without landing on it, no aligned split can exist and this stops.
+    """
+    product = 1
+    for j, dim in enumerate(struct_shape, start=1):
+        product *= dim
+        if product == n_files:
+            return struct_shape[:j]
+        if product > n_files:
+            break
+    return None

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -670,10 +670,11 @@ class CatalogNodeAdapter:
         Returns `None` (so the caller falls back to :meth:`get_adapter`) unless
         every precondition for lazy per-frame resolution holds:
         a single file-scheme data source whose adapter class opts in via
-        `supports_lazy_assets`, whose asset `num`s form a contiguous run of
-        length n (any starting offset -- 0-based, 1-based, etc. -- so stacking
-        rank == num - offset), and whose adapter can determine, from the
-        structure and the data source `properties`, which files a slice touches.
+        `supports_lazy_assets`, whose `parameter == "data_uris"` asset `num`s
+        form a contiguous run of length n (any starting offset -- 0-based,
+        1-based, etc. -- so stacking rank == num - offset), and whose adapter
+        can determine, from the structure and the data source `properties`,
+        which files a slice touches.
 
         Instead of materializing all N asset rows, this reads only the data
         source's structure and properties (no assets), asks the adapter class
@@ -739,6 +740,11 @@ class CatalogNodeAdapter:
         # logic does not rely on this assumption.
         # TODO: It might be worth ensuring zero-based contiguous `num`s when writing
         # assets; then the contiguity check can be dropped.
+        # Filter on `parameter == "data_uris"` (the convention both opted-in
+        # adapters use in their eager paths) so a data source carrying a second
+        # numbered parameter alongside `data_uris` (e.g. a numbered per-frame
+        # mask series) does not inflate the count or leak URIs from the wrong
+        # parameter into the stacking-rank slot assignment below.
         count_stmt = (
             select(
                 func.count(orm.DataSourceAssetAssociation.num),
@@ -746,6 +752,7 @@ class CatalogNodeAdapter:
                 func.max(orm.DataSourceAssetAssociation.num),
             )
             .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+            .where(orm.DataSourceAssetAssociation.parameter == "data_uris")
             .where(orm.DataSourceAssetAssociation.num.isnot(None))
         )
 
@@ -794,6 +801,7 @@ class CatalogNodeAdapter:
                     orm.Asset.id == orm.DataSourceAssetAssociation.asset_id,
                 )
                 .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+                .where(orm.DataSourceAssetAssociation.parameter == "data_uris")
                 .where(
                     orm.DataSourceAssetAssociation.num.in_(
                         [offset + i for i in indices]

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -723,28 +723,16 @@ class CatalogNodeAdapter:
                 raise IndexError(block)
             slice = block.slice_from_chunks(structure.chunks)[0]
 
-        # The file count is the number of backing files == the number of numbered
-        # assets, NOT len(chunks[0]): a file may hold several chunks along the
-        # concatenation axis (e.g. one frame per native chunk, many frames per
-        # file), so the native-chunk count overcounts files. The lazy path maps
-        # each 0-based stacking rank to an asset `num`; that mapping is
-        # well-defined only when the `num`s form a contiguous run of length n with
-        # no gaps -- then rank == num - offset, where offset is the smallest num
-        # (0 for 0-based numbering, 1 for 1-based, and so on). One aggregate query
-        # (no asset rows materialized) yields both the count and the contiguity
-        # check: count == n AND max - min == n - 1 holds iff the n distinct `num`s
-        # are exactly {offset .. offset + n - 1}. A set-equality check on only the
-        # requested `num`s is insufficient: a present-but-mis-ranked `num` (e.g. a
-        # silent gap elsewhere shifting ranks) would pass yet map to the wrong
-        # file. On any mismatch, fall back to the full build, whose asset-ordering
-        # logic does not rely on this assumption.
+        # File count = number of numbered "data_uris" assets, NOT len(chunks[0]):
+        # one file may span several native chunks along the concatenation axis.
+        # The lazy path maps each 0-based stacking rank to an asset `num` via
+        # rank == num - offset, valid only when the `num`s are a contiguous run
+        # (offset is the smallest num: 0 for 0-based, 1 for 1-based, etc.). One
+        # aggregate query yields count/min/max without materializing asset rows:
+        # `count == n AND max - min == n - 1` holds iff the `num`s are exactly
+        # {offset .. offset + n - 1}. On any mismatch, fall back to the full build.
         # TODO: It might be worth ensuring zero-based contiguous `num`s when writing
         # assets; then the contiguity check can be dropped.
-        # Filter on `parameter == "data_uris"` (the convention both opted-in
-        # adapters use in their eager paths) so a data source carrying a second
-        # numbered parameter alongside `data_uris` (e.g. a numbered per-frame
-        # mask series) does not inflate the count or leak URIs from the wrong
-        # parameter into the stacking-rank slot assignment below.
         count_stmt = (
             select(
                 func.count(orm.DataSourceAssetAssociation.num),
@@ -758,26 +746,15 @@ class CatalogNodeAdapter:
 
         async with self.context.session() as db:
             n, min_num, max_num = (await db.execute(count_stmt)).one()
+            offset = min_num or 0  # `num`s run [offset, offset + n - 1]
+
             if not n or max_num - min_num != n - 1:
                 return None
             if n < 2:
-                # A single backing file: the lazy path can cull nothing (there
-                # are no other files to skip), yet it would read the whole file
-                # as one block instead of letting the normal adapter do a native
-                # chunked, partial read. It is therefore strictly slower here --
-                # a large single-file dataset would read entirely just to serve
-                # one element -- so fall back to the full adapter.
+                # A single backing file -- fall back to the full adapter.
                 return None
-            offset = min_num or 0  # `num`s run [offset, offset + n - 1]
 
-            # Which stack indices does this read need? Pure geometry -- a
-            # classmethod of the structure, the file count and the data source
-            # `properties`/`parameters`, needing no adapter instance or I/O. The
-            # adapter alone interprets these (e.g. HDF5's per-asset `extents`, or
-            # a `slice`/`squeeze` transform that precludes file selection); the
-            # catalog stays ignorant of the internals. Returns None when the files
-            # can not be located from the structure (a slice may then need every
-            # file).
+            # Determine which files / assets this read needs purely from geometry.
             indices = adapter_cls.file_indices_for_slice(
                 structure,
                 n,
@@ -788,9 +765,8 @@ class CatalogNodeAdapter:
             if indices is None:
                 return None
 
-            # Fetch only the needed assets' URIs (indexed by
-            # (data_source_id, parameter, num)). The read's 0-based stack indices
-            # map to `num`s by adding the offset.
+            # Fetch only the needed assets' URIs (indexed by (data_source_id, parameter, num)).
+            # The read's 0-based stack indices map to `num`s by adding the offset.
             uri_stmt = (
                 select(
                     orm.DataSourceAssetAssociation.num,
@@ -810,7 +786,7 @@ class CatalogNodeAdapter:
             )
             uri_rows = (await db.execute(uri_stmt)).all()
 
-        # Build a fixed-length URI list populated with only the frames this read needs
+        # Build a fixed-length URI list populated with only the assets this read needs
         # (the rest left as None). Stacking rank == num - offset (contiguous run,
         # guaranteed by the precheck above), so it indexes directly into the list.
         data_uris = [None] * n
@@ -820,8 +796,6 @@ class CatalogNodeAdapter:
 
         # One entry point for both eager and lazy: pass the partially-populated
         # URI list as the `data_uris` kwarg. `from_catalog` derives metadata/specs.
-        # Forward the data source parameters too (as the eager `get_adapter`
-        # does), so adapters needing them (e.g. HDF5's `dataset`) are configured.
         return adapter_cls.from_catalog(
             data_source, self.node, data_uris=data_uris, **data_source.parameters
         )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -670,14 +670,15 @@ class CatalogNodeAdapter:
         Returns `None` (so the caller falls back to :meth:`get_adapter`) unless
         every precondition for lazy per-frame resolution holds:
         a single file-scheme data source whose adapter class opts in via
-        `supports_lazy_assets` and whose `properties` carry `chunks`, and
-        whose asset `num`s form a contiguous run of length n (any starting
-        offset -- 0-based, 1-based, etc. -- so stacking rank == num - offset).
+        `supports_lazy_assets`, whose asset `num`s form a contiguous run of
+        length n (any starting offset -- 0-based, 1-based, etc. -- so stacking
+        rank == num - offset), and whose adapter can determine, from the
+        structure and the data source `properties`, which files a slice touches.
 
         Instead of materializing all N asset rows, this reads only the data
-        source's structure/chunks (no assets), asks the adapter class which
-        stack indices (== stacking ranks) the given `block`/`slice` needs, and
-        fetches just those URIs. Keeps all DB access in the async layer; the
+        source's structure and properties (no assets), asks the adapter class
+        which stack indices (== stacking ranks) the given `block`/`slice` needs,
+        and fetches just those URIs. Keeps all DB access in the async layer; the
         adapter (built through its normal `from_catalog` entry point with a
         partially-populated URI list) resolves each URI to a filepath lazily,
         only for the indices actually read.
@@ -696,8 +697,6 @@ class CatalogNodeAdapter:
             # Zero or multiple data sources: not supported by the lazy path.
             return None
         ds = data_source_orms[0]
-        if (chunks := (ds.properties or {}).get("chunks")) is None:
-            return None
         if ds.structure is None:
             return None
 
@@ -709,44 +708,37 @@ class CatalogNodeAdapter:
         if not getattr(adapter_cls, "supports_lazy_assets", False):
             return None
 
-        n = sum(int(c) for c in chunks[0])  # stack length == number of files
-
-        # Data source meta only (no assets); the structure/chunks are enough to
-        # compute the file geometry.
+        # Data source meta only (no assets); the structure is enough (with the
+        # file count) to compute the file geometry.
         data_source = DataSource.from_orm(ds, include_assets=False)
         structure = data_source.structure
 
-        # Which stack indices does this read need? Pure geometry -- a classmethod
-        # of the structure and chunks, needing no adapter instance or I/O.
-        #
-        # File selection for a block read depends ONLY on the block:
-        # FileSequenceAdapter.read_block loads the whole block along the stacking
-        # axis (`self.read(block.slice_from_chunks(...)[0])`) and applies any
-        # within-block slice AFTER, to the already-loaded data.
+        # A block read's file selection depends ONLY on the block: read_block
+        # loads the whole block along the stacking axis and applies any
+        # within-block slice AFTER, to the already-loaded data. Convert the block
+        # to the equivalent leading-axis slice here (pure; uses structure.chunks).
         if block is not None:
             if any(block[1:]):
                 raise IndexError(block)
             slice = block.slice_from_chunks(structure.chunks)[0]
-        indices = adapter_cls.file_indices_for_slice(structure, chunks, slice)
-        if indices is None:
-            # The reshape interleaves file contents (not file-boundary-aligned),
-            # so every file must be loaded: the lazy path offers no benefit. Fall
-            # back to the full adapter build.
-            return None
 
-        # Contiguity precheck: the lazy path maps each 0-based stacking rank to
-        # an asset `num`. That mapping is well-defined only when the `num`s form
-        # a contiguous run of length n with no gaps -- then rank == num - offset,
-        # where offset is the smallest num (0 for 0-based numbering, 1 for
-        # 1-based, and so on). Verify cheaply with an aggregate query (no asset
-        # rows materialized): count == n AND max - min == n - 1 holds iff the n
-        # distinct `num`s are exactly {offset .. offset + n - 1}. A set-equality
-        # check on only the requested `num`s is insufficient: a present-but-
-        # mis-ranked `num` (e.g. a silent gap elsewhere shifting ranks) would
-        # pass yet map to the wrong file. On any mismatch, fall back to the full
-        # build, whose asset-ordering logic does not rely on this assumption.
+        # The file count is the number of backing files == the number of numbered
+        # assets, NOT len(chunks[0]): a file may hold several chunks along the
+        # concatenation axis (e.g. one frame per native chunk, many frames per
+        # file), so the native-chunk count overcounts files. The lazy path maps
+        # each 0-based stacking rank to an asset `num`; that mapping is
+        # well-defined only when the `num`s form a contiguous run of length n with
+        # no gaps -- then rank == num - offset, where offset is the smallest num
+        # (0 for 0-based numbering, 1 for 1-based, and so on). One aggregate query
+        # (no asset rows materialized) yields both the count and the contiguity
+        # check: count == n AND max - min == n - 1 holds iff the n distinct `num`s
+        # are exactly {offset .. offset + n - 1}. A set-equality check on only the
+        # requested `num`s is insufficient: a present-but-mis-ranked `num` (e.g. a
+        # silent gap elsewhere shifting ranks) would pass yet map to the wrong
+        # file. On any mismatch, fall back to the full build, whose asset-ordering
+        # logic does not rely on this assumption.
         # TODO: It might be worth ensuring zero-based contiguous `num`s when writing
-        # assets; then this check can be dropped.
+        # assets; then the contiguity check can be dropped.
         count_stmt = (
             select(
                 func.count(orm.DataSourceAssetAssociation.num),
@@ -758,10 +750,22 @@ class CatalogNodeAdapter:
         )
 
         async with self.context.session() as db:
-            count, min_num, max_num = (await db.execute(count_stmt)).one()
-            if count != n or (n and max_num - min_num != n - 1):
+            n, min_num, max_num = (await db.execute(count_stmt)).one()
+            if not n or max_num - min_num != n - 1:
                 return None
             offset = min_num or 0  # `num`s run [offset, offset + n - 1]
+
+            # Which stack indices does this read need? Pure geometry -- a
+            # classmethod of the structure, the file count and the data source
+            # `properties`, needing no adapter instance or I/O. The adapter alone
+            # interprets `properties` (e.g. HDF5's per-asset `extents`); the catalog
+            # stays ignorant of the internals. Returns None when the files can not
+            # be located from the structure (a slice may then need every file).
+            indices = adapter_cls.file_indices_for_slice(
+                structure, n, slice, properties=ds.properties or {}
+            )
+            if indices is None:
+                return None
 
             # Fetch only the needed assets' URIs (indexed by
             # (data_source_id, parameter, num)). The read's 0-based stack indices
@@ -793,8 +797,12 @@ class CatalogNodeAdapter:
             data_uris[num - offset] = data_uri
 
         # One entry point for both eager and lazy: pass the partially-populated
-        # URI list as the `data_uris` kwarg. `from_catalog` derives chunks/metadata/specs.
-        return adapter_cls.from_catalog(data_source, self.node, data_uris=data_uris)
+        # URI list as the `data_uris` kwarg. `from_catalog` derives metadata/specs.
+        # Forward the data source parameters too (as the eager `get_adapter`
+        # does), so adapters needing them (e.g. HDF5's `dataset`) are configured.
+        return adapter_cls.from_catalog(
+            data_source, self.node, data_uris=data_uris, **data_source.parameters
+        )
 
     def new_variation(
         self,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -753,6 +753,14 @@ class CatalogNodeAdapter:
             n, min_num, max_num = (await db.execute(count_stmt)).one()
             if not n or max_num - min_num != n - 1:
                 return None
+            if n < 2:
+                # A single backing file: the lazy path can cull nothing (there
+                # are no other files to skip), yet it would read the whole file
+                # as one block instead of letting the normal adapter do a native
+                # chunked, partial read. It is therefore strictly slower here --
+                # a large single-file dataset would read entirely just to serve
+                # one element -- so fall back to the full adapter.
+                return None
             offset = min_num or 0  # `num`s run [offset, offset + n - 1]
 
             # Which stack indices does this read need? Pure geometry -- a

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -757,12 +757,18 @@ class CatalogNodeAdapter:
 
             # Which stack indices does this read need? Pure geometry -- a
             # classmethod of the structure, the file count and the data source
-            # `properties`, needing no adapter instance or I/O. The adapter alone
-            # interprets `properties` (e.g. HDF5's per-asset `extents`); the catalog
-            # stays ignorant of the internals. Returns None when the files can not
-            # be located from the structure (a slice may then need every file).
+            # `properties`/`parameters`, needing no adapter instance or I/O. The
+            # adapter alone interprets these (e.g. HDF5's per-asset `extents`, or
+            # a `slice`/`squeeze` transform that precludes file selection); the
+            # catalog stays ignorant of the internals. Returns None when the files
+            # can not be located from the structure (a slice may then need every
+            # file).
             indices = adapter_cls.file_indices_for_slice(
-                structure, n, slice, properties=ds.properties or {}
+                structure,
+                n,
+                slice,
+                properties=ds.properties or {},
+                parameters=ds.parameters or {},
             )
             if indices is None:
                 return None


### PR DESCRIPTION
## Summary

Follow-up on #1463.

#1463 made many-file HDF5 reads reuse a cached Dask graph, but the **first** read of a dataset in a fresh process still opened *every* constituent file once to discover specs before the cache could help. This PR extends the lazy asset-resolution path (introduced for file sequences in #1463) to multi-file HDF5 array datasets, so the first read opens only the native chunks its slice actually touches.

## Why HDF5 needed its own path

A file sequence stacks **uniform** frames — one file adds exactly one row on a new leading axis — so the catalog's `1 file = 1 row` geometry recovers file boundaries from the structure alone. HDF5 files instead **concatenate** along the array's leading axis, and each file may contribute a *different* number of rows, so the boundaries can not be read off `structure.chunks`.

## What changed

- **`catalog/adapter.py`** — `_get_lazy_adapter` is now adapter-agnostic. It no longer gates on a `chunks` property; it derives the file count from a single aggregate `data_uris` asset query (which also performs the existing `num` contiguity check), then asks the adapter class `file_indices_for_slice(structure, n_files, slice, properties=..., parameters=...)` which files a slice touches. Only the adapter interprets `properties`. It also forwards the data source `parameters` (as the eager path does) so adapters that need them (e.g. HDF5's `dataset`) are configured. Previously the lazy path was reachable only when the data source recorded a `chunks` property (the old file-count source); dropping that requirement lets stacks without one use it too.
- **`adapters/hdf5.py`** — `HDF5ArrayAdapter` opts in via `supports_lazy_assets` and gains `_file_layout`, which resolves each file's extent along the leading axis in priority order:
  1. an optional per-asset **`extents`** property — the authoritative per-file row counts (`sum(extents) == shape[0]`); supports genuinely **non-uniform** files,
  2. else `structure.chunks[0]` when it has exactly one chunk per file,
  3. else the **grid** geometry (a uniform stack whose leading axis was reshaped across several structure dimensions),
  4. else `None` → the catalog falls back to the full build.

  `_assemble_partial` builds the file-stacked Dask array from the known structure without opening any file for specs. It mirrors the eager `lazy_load_hdf5_array`: the flat (pre-reshape) concatenation is tiled by **native HDF5 chunks** (axis 0 by `chunks[0]`, also split at file boundaries; trailing axes by `chunks[1:]`), so the native chunk is the minimum read unit. Touched chunks resolve their URI to a path lazily *inside* the read task; untouched files carry a placeholder block that Dask culls once the read reshapes and slices the array (and that raises loudly if ever computed, so a geometry mismatch can never serve wrong data). A reshaped grid with no recorded native chunking is the one case that still serves a whole file per grid cell (the file is then the minimal read unit).
- **`adapters/utils.py`** — the file-alignment geometry shared by the sequence and HDF5 adapters is extracted into `grid_shape_for_files` (a pure function of shape + file count, no I/O).

## On the optional `extents` property

`extents` is optional and fully adapter-contained; the catalog stays ignorant of it. The dataset benchmarked below resolves *without* it — one leading chunk per file (path 2). It is needed only for genuinely non-uniform *flat* files (differing per-file row counts that are not one-chunk-per-file). A writer can populate `properties["extents"]` to unlock the lazy path there; that consolidator change is a planned follow-up (not in this PR).

## Benchmark

Synthetic xspress3-like dataset: `N` files, each `(11, 8, 4096)` `uint32` with native chunk `(1, 8, 4096)` (one frame per chunk), concatenated to `(N, 11, 8, 4096)`. The metric is the `h5open` call count (deterministic) plus median wall time over 5 reps. **Before** is the merge-base (eager HDF5, post-#1468 revert); **after** is this PR. Script at the bottom.

**`h5open` calls (before → after):**

| scenario | N=3 | N=25 | N=100 | N=300 |
|---|---|---|---|---|
| single frame `[1,5]` | 5 → **1** | 27 → **1** | 102 → **1** | 302 → **1** |
| one file, all frames `[1]` | 15 → **11** | 37 → **11** | 112 → **11** | 312 → **11** |
| two files `[0:2]` | 26 → **22** | 48 → **22** | 123 → **22** | 323 → **22** |
| one frame from every file `[:,5]` | 7 → **3** | 51 → **25** | 201 → **100** | 601 → **300** |
| whole dataset | 37 → **33** | 301 → **275** | 1201 → **1100** | 3601 → **3300** |

Before, every scenario pays an O(N) specs-reading pass across all files. After, opens equal the number of native chunks the slice actually overlaps — **independent of `N`** for targeted reads (`[1,5]`→1, `[1]`→11 frames of one file, `[0:2]`→22). Reads that genuinely span every file (`[:,5]`, whole) stay O(N) but shed the redundant specs pass.

**median wall time, ms (before → after):**

| scenario | N=3 | N=25 | N=100 | N=300 |
|---|---|---|---|---|
| single frame `[1,5]` | 4.3 → 2.6 | 8.1 → 3.1 | 21.2 → 5.6 | 56.3 → **11.3** |
| one file, all frames `[1]` | 8.0 → 6.6 | 14.5 → 7.1 | 25.8 → 9.7 | 60.5 → **16.5** |
| two files `[0:2]` | 11.9 → 10.4 | 16.2 → 11.1 | 29.4 → 14.6 | 64.3 → **19.9** |
| one frame from every file `[:,5]` | 4.9 → 3.6 | 17.8 → 13.6 | 64.6 → 48.9 | 224.2 → **191.6** |
| whole dataset | 16.0 → 15.3 | 97.6 → 100.7 | 455.5 → 428.4 | 1287.7 → 1333.7 |

Whole-dataset reads are within noise (both read every chunk); targeted reads improve ~5× at N=300 and the gap widens with `N`.

## Tests

- `pytest tests/test_catalog.py tests/test_hdf5.py tests/test_tiff.py tests/test_slicer.py` → **264 passed, 29 skipped**.
- New unit tests in `test_catalog.py` cover the grid path (opens only touched files), multi-chunk files, the non-file-aligned fallback, the `extents` property (parameterized, incl. non-uniform), the single-file decline, and the `slice`/`squeeze` transform decline.
- New tests in `test_hdf5.py` verify native-chunk reads from multi-file URIs and that only the touched files are opened and then closed.
- pre-commit (flake8 / isort / black / mypy) all pass.

## Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~

<details>
<summary>Benchmark script</summary>

```python
"""Ad-hoc benchmark for multi-file (xspress3-like) lazy HDF5 reads.

Runs against whichever tiled is importable (editable install -> current git
branch). Measures h5open() call counts and wall time for representative slice
patterns as a function of the number of assets (files).
"""
import asyncio
import statistics
import tempfile
import time
from dataclasses import asdict
from pathlib import Path
from unittest.mock import patch

import numpy

import tiled
import tiled.adapters.hdf5
from tiled.catalog import in_memory
from tiled.ndslice import NDSlice
from tiled.server.schemas import Asset, DataSource
from tiled.structures.array import ArrayStructure, BuiltinDtype
from tiled.utils import ensure_uri

# xspress3-like geometry: each file holds (F, H, W) uint32, one frame per chunk.
F, H, W = 11, 8, 4096
DTYPE = numpy.dtype("uint32")
DATASET = "/entry/data/data"


def make_files(tmpdir: Path, n_files: int):
    import h5py

    rng = numpy.random.default_rng(0)
    data_uris, filepaths, files = [], [], []
    for i in range(n_files):
        arr = rng.integers(0, 2**16, size=(F, H, W), dtype=DTYPE)
        fp = tmpdir / f"file{i:05}.h5"
        with h5py.File(fp, "w") as f:
            f.create_dataset(DATASET, data=arr, chunks=(1, H, W))
        files.append(arr)
        filepaths.append(fp)
        data_uris.append(ensure_uri(str(fp)))
    return data_uris, filepaths, files


async def build_node(tmpdir: Path, n_files: int):
    data_uris, filepaths, files = make_files(tmpdir, n_files)
    struct = ArrayStructure(
        shape=(n_files, F, H, W),
        chunks=((1,) * n_files, (F,), (H,), (W,)),
        data_type=BuiltinDtype.from_numpy_dtype(DTYPE),
    )
    pre_chunks = [[1] * (n_files * F), [H], [W]]
    adapter = in_memory(readable_storage=[str(tmpdir)])
    await adapter.startup()
    key = f"ds{n_files}"
    await adapter.create_node(
        key=key,
        structure_family="array",
        metadata={},
        data_sources=[
            DataSource(
                structure_family="array",
                mimetype="application/x-hdf5",
                structure=asdict(struct),
                parameters={"dataset": DATASET},
                properties={"chunks": pre_chunks},
                management="external",
                assets=[
                    Asset(parameter="data_uris", num=i, data_uri=u, is_directory=False)
                    for i, u in enumerate(data_uris)
                ],
            )
        ],
    )
    x = await adapter.lookup_adapter([key])
    full = numpy.stack(files)  # (N, F, H, W)
    return adapter, x, full


async def measure(x, slice_input, reps=5):
    sl = NDSlice(slice_input)
    with patch("tiled.adapters.hdf5.h5open", wraps=tiled.adapters.hdf5.h5open) as m:
        result = await x.read(slice=sl)
    opens = len(m.call_args_list)
    shape = tuple(getattr(result, "shape", ()))
    times = []
    for _ in range(reps):
        t0 = time.perf_counter()
        await x.read(slice=sl)
        times.append((time.perf_counter() - t0) * 1e3)
    return opens, statistics.median(times), shape, result


async def main():
    Ns = [3, 25, 100, 300]
    scenarios = [
        ("whole", (slice(None),)),
        ("single frame [1,5]", (1, 5)),
        ("one time full [1]", (1,)),
        ("2 files [0:2]", (slice(0, 2),)),
        ("bin across ALL files [:,5]", (slice(None), 5)),
    ]
    print(f"\n=== per-file (F,H,W)=({F},{H},{W}) {DTYPE} ===")
    header = f"{'scenario':<28}{'N':>5}{'opens':>8}{'time_ms':>10}  result_shape"
    for n in Ns:
        with tempfile.TemporaryDirectory() as td:
            adapter, x, full = await build_node(Path(td), n)
            print(header)
            for label, sl in scenarios:
                opens, ms, shape, result = await measure(x, sl)
                print(f"{label:<28}{n:>5}{opens:>8}{ms:>10.2f}  {shape}")
            print("-" * len(header))


if __name__ == "__main__":
    asyncio.run(main())
```

</details>
