### PR TITLE
Revert HDF5 adapter changes from #1463

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,24 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Add client_secret,redirect_on_success,redirect_on_failure to
   ProxiedOIDCAuthenticator. This is to allow login using Tiled-UI
 - Allow configuration of user_id_claim for OIDCAuthenticator
+- Lazy asset resolution for array datasets backed by many files: reading a
+  slice or block now resolves only the assets (files) the read touches,
+  computed purely from the structure geometry, instead of materializing every
+  asset row to build the adapter. (#1463)
+- Parallel, memory-bounded reads for many-file sequence datasets: files are
+  read concurrently and reduced per file before stacking, so peak memory stays
+  bounded regardless of how many files a slice spans. Tunable via the
+  `TILED_SEQUENCE_IO_WORKERS` and `TILED_SEQUENCE_READ_BATCH_BYTES` environment
+  variables. (#1463)
 - Add a new feature that stores a graph of links into the catalog database. Adds strawberry
   as a dependency. Import/search/export of graph links is accomplished through graphql.
+
+### Changed
+
+- Server-side `CatalogNodeAdapter.data_sources` is now an async method taking
+  `include_assets` (default `False`) so common metadata and structure paths no
+  longer load asset rows; callers that need assets must
+  `await data_sources(include_assets=True)`. (#1463)
 
 ### Fixed
 

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -670,44 +670,9 @@ def test_adapter_from_catalog(example_file, shape, error):
         assert adp.read().shape == shape
 
 
-# The fixture datasets are int64 (8 bytes) with per-file native chunks
-#   a/b: shape (4, 5, 6),  native chunk (1, 2, 3) -> one row is 5*6*8 = 240 bytes
-#   a/c: shape (10, 1),    native chunk (2, 1)    -> one row is 1*8   =   8 bytes
-#   a/d: shape (10,),      native chunk (3,)      -> one row is        =   8 bytes
-# The coalescing groups whole rows (full trailing dims) into blocks along the
-# leading axis up to READ_BATCH_BYTES, never smaller than the native chunk along
-# that axis; if a single row already exceeds the limit it falls back to the
-# files' native tiling in every dimension. Each expected chunk pattern below is
-# per-file (repeated once per file, since all files are identical).
-@pytest.mark.parametrize(
-    "read_batch_bytes, b_dim0, b_rest, c_dim0, c_rest, d_dim0",
-    [
-        # Default (1 GiB): everything coalesces to a single block per file.
-        (1 << 30, (4,), ((5,), (6,)), (10,), ((1,),), (10,)),
-        # 480 bytes = 2 rows of `b`: `b` coalesces to 2 blocks per file; `c`/`d`
-        # (tiny rows) still fit one block per file.
-        (480, (2, 2), ((5,), (6,)), (10,), ((1,),), (10,)),
-        # 40 bytes < one row of `b` (240 B) *and* < its native chunk (48 B): `b`
-        # falls back to native tiling in every dimension; `c`/`d` coalesce to
-        # 5-row blocks (2 blocks per file).
-        (40, (1, 1, 1, 1), ((2, 2, 1), (3, 3)), (5, 5), ((1,),), (5, 5)),
-    ],
-)
 @pytest.mark.parametrize("num_files", [1, 3])
-def test_chunked_arrays_from_uris(
-    example_files_with_chunked_arrays,
-    num_files,
-    read_batch_bytes,
-    b_dim0,
-    b_rest,
-    c_dim0,
-    c_rest,
-    d_dim0,
-    monkeypatch,
-):
-    # Test that chunked arrays can be read and reshaped correctly, and that the
-    # native HDF5 chunks are coalesced according to READ_BATCH_BYTES.
-    monkeypatch.setattr("tiled.adapters.hdf5.READ_BATCH_BYTES", read_batch_bytes)
+def test_chunked_arrays_from_uris(example_files_with_chunked_arrays, num_files):
+    # Test that chunked arrays can be read and reshaped correctly
     fpaths = example_files_with_chunked_arrays[:num_files]
     tree = HDF5Adapter.from_uris(*fpaths)
     with Context.from_app(build_app(tree)) as context:
@@ -715,9 +680,7 @@ def test_chunked_arrays_from_uris(
 
     arr_b = client["a"]["b"]
     assert arr_b.shape == (4 * num_files, 5, 6)
-    # Native HDF5 chunks are coalesced into blocks (bounded by READ_BATCH_BYTES)
-    # to avoid a task/open per tiny native chunk.
-    assert arr_b.chunks == (b_dim0 * num_files, *b_rest)
+    assert arr_b.chunks == ((1, 1, 1, 1) * num_files, (2, 2, 1), (3, 3))
     assert arr_b.dtype == "int64"
     arr_true_b = numpy.concatenate(
         [
@@ -730,7 +693,7 @@ def test_chunked_arrays_from_uris(
 
     arr_c = client["a"]["c"]
     assert arr_c.shape == (10 * num_files, 1)
-    assert arr_c.chunks == (c_dim0 * num_files, *c_rest)
+    assert arr_c.chunks == ((2, 2, 2, 2, 2) * num_files, (1,))
     assert arr_c.dtype == "int64"
     arr_true_c = numpy.concatenate(
         [
@@ -743,7 +706,7 @@ def test_chunked_arrays_from_uris(
 
     arr_d = client["a"]["d"]
     assert arr_d.shape == (10 * num_files,)
-    assert arr_d.chunks == (d_dim0 * num_files,)
+    assert arr_d.chunks == ((3, 3, 3, 1) * num_files,)
     assert arr_d.dtype == "int64"
     arr_true_d = numpy.concatenate(
         [
@@ -819,7 +782,7 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
     h5py = pytest.importorskip("h5py")
 
     # Use the example with two files chunked along a single dimension;
-    # native chunks are coalesced into one block per file: ((10,) * 2, )
+    # total chunks across the two files: ((3, 3, 3, 1)*2, )
     file_uris = example_files_with_chunked_arrays[:2]
     file_paths = [path_from_uri(uri) for uri in file_uris]
     with patch(
@@ -853,22 +816,21 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         mock_h5open.reset_mock()
         arr = client["a"]["d"]
         assert arr.structure().shape == (20,)
-        assert arr.structure().chunks == ((10,) * 2,)
+        assert arr.structure().chunks == ((3, 3, 3, 1) * 2,)
         assert arr.metadata is not None
         mock_h5open.assert_not_called()
 
-        # Read the entire array: files are opened once to get the specs and then
-        # once more each to fetch the single coalesced chunk. Additionally, the
-        # first file is opened once again when initialized from catalog to get
-        # the metadata
+        # Read the entire array: files are opened once to get the specs and then again,
+        # four times each, to fetch each chunk separately. Additionally, the first file is opened once
+        # adain when initialized from catalog to get the metadata
         assert arr.read() is not None
-        # 2 for specs, 1*2 for chunks (one block per file), 1 for metadata
-        assert mock_h5open.call_count == 2 + 1 * 2 + 1
+        # 2 for specs, 4*2 for chunks, 1 for metadata
+        assert mock_h5open.call_count == 2 + 4 * 2 + 1
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
-        # First file: 1 for specs, 1 for chunk, 1 for metadata
-        assert files_opened.count(file_paths[0].name) == 1 + 1 + 1
-        # Second file: 1 for specs, 1 for chunk
-        assert files_opened.count(file_paths[1].name) == 1 + 1
+        # First file: 1 for specs, 4 for chunks, 1 for metadata
+        assert files_opened.count(file_paths[0].name) == 4 + 1 + 1
+        # Second file: 1 for specs, 4 for chunks
+        assert files_opened.count(file_paths[1].name) == 4 + 1
 
         # Read a slice that only touches one file: only the relevant file should be opened
         mock_h5open.reset_mock()
@@ -881,12 +843,12 @@ def test_files_opened_and_closed(example_files_with_chunked_arrays, swmr):
         # Read everything from the second file
         mock_h5open.reset_mock()
         assert arr[-10:] is not None
-        assert mock_h5open.call_count == 2 + 1 + 1  # 2 specs, 1 chunk, 1 metadata
+        assert mock_h5open.call_count == 7
         files_opened = [call.args[0].name for call in mock_h5open.call_args_list]
         # First file: 1 for specs, 1 for metadata
         assert files_opened.count(file_paths[0].name) == 1 + 1
-        # Second file: 1 for chunk, 1 for specs
-        assert files_opened.count(file_paths[1].name) == 1 + 1
+        # Second file: 4 for chunks, 1 for specs
+        assert files_opened.count(file_paths[1].name) == 4 + 1
 
         # Read a slice that has one value from each of the files
         mock_h5open.reset_mock()

--- a/tiled/adapters/hdf5.py
+++ b/tiled/adapters/hdf5.py
@@ -1,11 +1,9 @@
 import builtins
 import copy
 import itertools
-import math
 import os
 import sys
 import warnings
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
@@ -31,8 +29,6 @@ from ..structures.data_source import DataSource
 from ..type_aliases import JSON
 from ..utils import BrokenLink, Sentinel, node_repr, path_from_uri
 from .array import ArrayAdapter
-from .resource_cache import with_resource_cache
-from .sequence import IO_WORKERS, READ_BATCH_BYTES
 from .utils import split_chunks
 
 SWMR_DEFAULT = bool(int(os.getenv("TILED_HDF5_SWMR_DEFAULT", "0")))
@@ -186,16 +182,8 @@ class HDF5ArrayAdapter(ArrayAdapter):
                 result = ds.shape, ds.chunks or ds.shape, ds.dtype
             return result
 
-        # Need to know shapes/dtypes of constituent arrays to load them lazily.
-        # Reading specs opens every file (twice, for external links), so for
-        # many-file datasets do this in parallel while preserving order.
-        if len(file_paths) > 1:
-            with ThreadPoolExecutor(
-                max_workers=min(IO_WORKERS, len(file_paths))
-            ) as executor:
-                shapes_chunks_dtypes = list(executor.map(_get_hdf5_specs, file_paths))
-        else:
-            shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
+        # Need to know shapes/dtypes of constituent arrays to load them lazily
+        shapes_chunks_dtypes = [_get_hdf5_specs(fpath) for fpath in file_paths]
         dtype = shapes_chunks_dtypes[0][2]
         if dtype == numpy.dtype("O"):
             # h5py uses NumPy's object dtype to represent variable-length
@@ -251,41 +239,18 @@ class HDF5ArrayAdapter(ArrayAdapter):
 
         else:
             # Use delayed loading to read and conactenate arrays from multiple files
-            # Determine chunks along the leftmost (concatenation) axis, split
-            # per file, and chunks in the rest of the dimensions (shared by all
-            # files). The constituent files' native HDF5 chunks are often tiny
-            # (e.g. a single frame per chunk, with thousands of frames per
-            # file), which explodes the number of Dask tasks -- and every task
-            # re-opens the file. To avoid that, coalesce native chunks into
-            # blocks of whole rows (full rest dimensions) up to READ_BATCH_BYTES,
-            # so each file is read in as few tasks as possible.
+            # First, find chunks along the left axis (split per file),
+            # and chunks in the rest of the dimensions (same for each file)
+            file_chunks = tuple(
+                split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
+                for shp, chk, _ in shapes_chunks_dtypes
+            )
+            # Shape of the rest of dimensions
             rest_shape = shapes_chunks_dtypes[0][0][1:]
-            rest_row_bytes = math.prod(rest_shape) * dtype.itemsize
-            rest_chunks: Tuple[Tuple[int, ...], ...]
-            read_batch_bytes = READ_BATCH_BYTES
-            if not rest_shape or 0 < rest_row_bytes <= read_batch_bytes:
-                # Read whole rows (full rest dimensions) in blocks along axis 0,
-                # sized up to the batch limit but never smaller than the native
-                # chunk along axis 0.
-                rows_per_block = max(1, read_batch_bytes // (rest_row_bytes or 1))
-                file_chunks = tuple(
-                    split_chunks(shp[0], max(chk[0], rows_per_block))
-                    for shp, chk, _ in shapes_chunks_dtypes
-                )
-                rest_chunks = tuple((shp,) for shp in rest_shape)
-            else:
-                # A single row already exceeds the batch limit: fall back to the
-                # files' native tiling in every dimension.
-                file_chunks = tuple(
-                    split_chunks(shp[0], max(chk[0], MIN_CHUNK_SIZE))
-                    for shp, chk, _ in shapes_chunks_dtypes
-                )
-                rest_chunks = tuple(
-                    split_chunks(
-                        shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes)
-                    )
-                    for i, shp in enumerate(rest_shape)
-                )
+            rest_chunks = tuple(
+                split_chunks(shp, min(chk[i + 1] for _, chk, _ in shapes_chunks_dtypes))
+                for i, shp in enumerate(rest_shape)
+            )
             dim0_chunks = tuple(size for fc in file_chunks for size in fc)
             chunks_final = (dim0_chunks, *[tuple(d) for d in rest_chunks])
 
@@ -362,26 +327,8 @@ class HDF5ArrayAdapter(ArrayAdapter):
         ] or [assets[0].data_uri]
         file_paths = [path_from_uri(uri) for uri in data_uris]
 
-        # Building the lazy Dask array opens every constituent file to read its
-        # specs. Cache the array so repeated reads of the same dataset reuse the
-        # graph instead of re-opening all files. Slicing the cached array below
-        # returns a new array, leaving the cached one unmodified.
-        cache_key = (
-            HDF5ArrayAdapter.lazy_load_hdf5_array,
-            dataset,
-            tuple(file_paths),
-            swmr,
-            libver,
-            locking,
-        )
-        array = with_resource_cache(
-            cache_key,
-            cls.lazy_load_hdf5_array,
-            *file_paths,
-            dataset=dataset,
-            swmr=swmr,
-            libver=libver,
-            locking=locking,
+        array = cls.lazy_load_hdf5_array(
+            *file_paths, dataset=dataset, swmr=swmr, libver=libver, locking=locking
         )
 
         if slice:


### PR DESCRIPTION
Revert the coalescing of native HDF5 chunks (READ_BATCH_BYTES-bounded blocks), parallel spec reads, and resource-cache wrapping of the lazy Dask graph introduced for the HDF5 adapter in #1463, restoring tiled/adapters/hdf5.py and the coupled tests in tests/test_hdf5.py to their pre-#1463 state. The coalescing made a single-frame read pull up to a 1 GiB block, since a block is also the minimum a partial read fetches.

The TIFF and file-sequence adapter improvements from #1463 (parallel, memory-bounded reads and lazy asset resolution) are left intact.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
