### PR TITLE
Fix scope extraction precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Fixed
+
+- Fix precedence of scope check for `ProxiedOIDCAuthenticator`.
+
+## v0.2.15 (2026-08-11)
+
 ### Added
 
 - Support clustered Redis for high availability.

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -346,16 +346,16 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
         if client_secret:
             self._client_secret = Secret(client_secret)
 
-        @property
-        def scopes(self):
-            mapped = set()
-            for tiled_scopes in self.scopes_map.values():
-                mapped.update(tiled_scopes)
-            return list(mapped)
+    @property
+    def scopes(self):
+        mapped = set()
+        for tiled_scopes in self.scopes_map.values():
+            mapped.update(tiled_scopes)
+        return list(mapped)
 
-        @scopes.setter
-        def scopes(self, value):
-            pass  # ignored; scopes are derived from scopes_map
+    @scopes.setter
+    def scopes(self, value):
+        pass  # ignored; scopes are derived from scopes_map
 
     def decode_token(
         self, id_token: str, access_token: Optional[str] = None

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -391,11 +391,11 @@ def _extract_scopes(
     OIDC-provider tokens (device code flow) store them as a space-separated
     string under "scope".  Handle both.
     """
+    if "scope" in decoded_access_token:
+        return set(decoded_access_token["scope"].split(" "))
     if "scp" in decoded_access_token:
         scp = decoded_access_token["scp"]
         return set(scp) if isinstance(scp, list) else set(scp.split(" "))
-    if "scope" in decoded_access_token:
-        return set(decoded_access_token["scope"].split(" "))
     return set()
 
 


### PR DESCRIPTION
Entra gives us a list of scopes in the JWT's `scp` claim. We map these onto Tiled application scopes like "read:metadata read:data".

We do this by inserting a `"scopes"` key next to the `"scp"` key during the token decoding step.

https://github.com/bluesky/tiled/blob/f4eb100884fc2a338d91bc8224266897b5eb0125/tiled/authenticators.py#L413-L431


But for that to work, we need to give `"scopes"` higher precedence than `"scp"`. That is what this PR fixes.

In a follow-up PR, I think we should refactor this more aggressively. It might be better to avoid combining this "translation" with the token-decoding step. Rather, this scope mapping could perhaps more cleanly be done further downstream.

I consider this small PR a hotfix.

- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
