### PR TITLE
Promote `scopes_map` to the Base Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Changed
+
+- `ProxiedOIDCAuthenticator` now accepts a `scopes_map` parameter (previously
+  available only on `EntraAuthenticator`) and translates identity-provider
+  scopes into Tiled scopes when decoding tokens. Its effective `scopes` are the
+  union of any explicitly-configured `scopes` and the Tiled scopes granted via
+  `scopes_map`. When `scopes_map` is omitted, behavior is unchanged (the token's
+  native scopes are used).
+
 ### Fixed
 
 - Fix precedence of scope check for `ProxiedOIDCAuthenticator`.

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -170,7 +170,7 @@ def test_entra_decoding_ignores_unmapped_scopes(caplog):
         caplog.set_level(logging.WARNING)
 
         authenticator = object.__new__(EntraAuthenticator)
-        authenticator.scopes_map = {"known.scope": ["read:metadata"]}
+        authenticator._scopes_map = {"known.scope": ["read:metadata"]}
         claims = authenticator.decode_token("id-token", "access-token")
 
         assert claims["entra_sub"] == "opaque-sub"
@@ -178,7 +178,7 @@ def test_entra_decoding_ignores_unmapped_scopes(caplog):
         assert claims["user"] == "alice"
         assert claims["scope"] == "read:metadata"
         assert any(
-            "Unmapped Entra scope in 'scp': unknown.scope" in record.message
+            "Unmapped scope in 'scp': unknown.scope" in record.message
             for record in caplog.records
         )
     finally:
@@ -369,3 +369,84 @@ async def test_ProxiedOIDCAuthenticator_requires_scopes(mock_oidc_server, well_k
         await check_scopes(request=test_request, settings=settings, scopes=["read:data"],
                            security_scopes=security_scopes)
     assert exception.value.status_code == HTTP_401_UNAUTHORIZED
+
+
+def test_ProxiedOIDCAuthenticator_scopes_explicit(mock_oidc_server, well_known_url):
+    # With no scopes_map, explicit scopes are returned as-is.
+    authenticator = ProxiedOIDCAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+        scopes=["read:data"],
+    )
+    assert authenticator.scopes == ["read:data"]
+
+
+def test_ProxiedOIDCAuthenticator_scopes_union(mock_oidc_server, well_known_url):
+    # When both are provided, scopes is the union of explicit scopes and the
+    # Tiled scopes granted via scopes_map.
+    authenticator = ProxiedOIDCAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+        scopes=["read:data"],
+        scopes_map={"provider.write": ["write:data"]},
+    )
+    assert set(authenticator.scopes) == {"read:data", "write:data"}
+
+
+def test_ProxiedOIDCAuthenticator_scopes_derived_from_scopes_map(mock_oidc_server, well_known_url):
+    # With no explicit scopes, they are derived from the values of scopes_map.
+    authenticator = ProxiedOIDCAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+        scopes_map={"provider.read": ["read:metadata", "read:data"]},
+    )
+    assert set(authenticator.scopes) == {"read:metadata", "read:data"}
+
+
+def test_ProxiedOIDCAuthenticator_scopes_default_empty(mock_oidc_server, well_known_url):
+    # With neither scopes nor scopes_map, scopes is an empty list.
+    authenticator = ProxiedOIDCAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+    )
+    assert authenticator.scopes == []
+
+
+def test_EntraAuthenticator_scopes_derived_from_scopes_map(mock_oidc_server, well_known_url):
+    # EntraAuthenticator no longer defines its own scopes property; it inherits
+    # the scopes_map-derived behavior from ProxiedOIDCAuthenticator.
+    authenticator = EntraAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+        scopes_map={"provider.read": ["read:metadata"], "provider.write": ["write:data"]},
+    )
+    assert set(authenticator.scopes) == {"read:metadata", "write:data"}
+
+
+def test_ProxiedOIDCAuthenticator_decode_token_maps_scopes():
+    # scopes_map translates provider scopes ("scp") into Tiled scopes ("scope").
+    def mock_decode_token(self, id_token, access_token=None):
+        return {"sub": "abc", "scp": "provider.read provider.unknown"}
+
+    original = OIDCAuthenticator.decode_token
+    OIDCAuthenticator.decode_token = mock_decode_token
+    try:
+        authenticator = object.__new__(ProxiedOIDCAuthenticator)
+        authenticator._scopes_map = {"provider.read": ["read:metadata"]}
+        claims = authenticator.decode_token("id-token", "access-token")
+        # Mapped scope is translated; unmapped provider scope is dropped.
+        assert claims["scope"] == "read:metadata"
+    finally:
+        OIDCAuthenticator.decode_token = original
+
+
+def test_ProxiedOIDCAuthenticator_decode_token_no_map_leaves_scopes():
+    # Without scopes_map, the token's native scopes are left untouched.
+    def mock_decode_token(self, id_token, access_token=None):
+        return {"sub": "abc", "scp": ["read:data"]}
+
+    original = OIDCAuthenticator.decode_token
+    OIDCAuthenticator.decode_token = mock_decode_token
+    try:
+        authenticator = object.__new__(ProxiedOIDCAuthenticator)
+        authenticator._scopes_map = {}
+        claims = authenticator.decode_token("id-token", "access-token")
+        assert "scope" not in claims
+        assert claims["scp"] == ["read:data"]
+    finally:
+        OIDCAuthenticator.decode_token = original

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -22,7 +22,7 @@ from tiled.authenticators import (
     OIDCAuthenticator,
     ProxiedOIDCAuthenticator,
 )
-from tiled.server.authentication import check_scopes
+from tiled.server.authentication import _extract_scopes, check_scopes
 from tiled.server.settings import Settings
 
 # Set this if there is an LDAP container running for testing.
@@ -381,14 +381,14 @@ def test_ProxiedOIDCAuthenticator_scopes_explicit(mock_oidc_server, well_known_u
 
 
 def test_ProxiedOIDCAuthenticator_scopes_union(mock_oidc_server, well_known_url):
-    # When both are provided, scopes is the union of explicit scopes and the
-    # Tiled scopes granted via scopes_map.
+    # When both are provided, scopes is the (sorted) union of explicit scopes
+    # and the Tiled scopes granted via scopes_map.
     authenticator = ProxiedOIDCAuthenticator(
         "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
         scopes=["read:data"],
         scopes_map={"provider.write": ["write:data"]},
     )
-    assert set(authenticator.scopes) == {"read:data", "write:data"}
+    assert authenticator.scopes == ["read:data", "write:data"]
 
 
 def test_ProxiedOIDCAuthenticator_scopes_derived_from_scopes_map(mock_oidc_server, well_known_url):
@@ -450,3 +450,31 @@ def test_ProxiedOIDCAuthenticator_decode_token_no_map_leaves_scopes():
         assert claims["scp"] == ["read:data"]
     finally:
         OIDCAuthenticator.decode_token = original
+
+
+def test_ProxiedOIDCAuthenticator_decode_token_all_unmapped_empty_scope():
+    # When scopes_map is configured but nothing maps, "scope" is set to an empty
+    # string (not left unset) so downstream extraction does not fall back to the
+    # raw, unmapped provider "scp" claim.
+    def mock_decode_token(self, id_token, access_token=None):
+        return {"sub": "abc", "scp": "provider.unknown"}
+
+    original = OIDCAuthenticator.decode_token
+    OIDCAuthenticator.decode_token = mock_decode_token
+    try:
+        authenticator = object.__new__(ProxiedOIDCAuthenticator)
+        authenticator._scopes_map = {"provider.read": ["read:metadata"]}
+        claims = authenticator.decode_token("id-token", "access-token")
+        assert claims["scope"] == ""
+    finally:
+        OIDCAuthenticator.decode_token = original
+
+
+def test_extract_scopes_empty_scope_is_empty_set():
+    # An empty "scope" string must yield an empty set, not {""}.
+    assert _extract_scopes({"scope": ""}, None) == set()
+    assert _extract_scopes(
+        {"scope": "read:data write:data"}, None
+    ) == {"read:data", "write:data"}
+    # "scope" (even empty) takes precedence over "scp" and is not overridden.
+    assert _extract_scopes({"scope": "", "scp": "read:data"}, None) == set()

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -281,8 +281,8 @@ properties:
     type: object
     description: |
       Optional mapping from identity-provider scopes to the list of Tiled
-      scopes they grant. When `scopes` is not provided, the effective scopes
-      are derived from the values of this mapping.
+      scopes they grant. The effective `scopes` are the union of any
+      explicitly-configured `scopes` and all Tiled scopes from this mapping.
   device_flow_client_id:
     type: string
   confirmation_message:

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -277,6 +277,12 @@ properties:
       Optional list of OAuth2 scopes to request. If provided, authorization
       should be enforced by an external policy agent (for example ExternalPolicyDecisionPoint)
       rather than by this authenticator.
+  scopes_map:
+    type: object
+    description: |
+      Optional mapping from identity-provider scopes to the list of Tiled
+      scopes they grant. When `scopes` is not provided, the effective scopes
+      are derived from the values of this mapping.
   device_flow_client_id:
     type: string
   confirmation_message:
@@ -291,6 +297,7 @@ properties:
         device_flow_client_id: str,
         client_secret: str = "",
         scopes: Optional[List[str]] = None,
+        scopes_map: Optional[Dict[str, List[str]]] = None,
         confirmation_message: str = "",
         redirect_on_success: Optional[str] = None,
         redirect_on_failure: Optional[str] = None,
@@ -306,7 +313,8 @@ properties:
             redirect_on_failure=redirect_on_failure,
             user_id_claim=user_id_claim,
         )
-        self.scopes = scopes
+        self._scopes_map = scopes_map if scopes_map is not None else {}
+        self._scopes = scopes
         self.device_flow_client_id = device_flow_client_id
         self._oidc_bearer = OAuth2AuthorizationCodeBearer(
             authorizationUrl=str(self.authorization_endpoint),
@@ -317,6 +325,46 @@ properties:
     def oauth2_schema(self) -> OAuth2:
         return self._oidc_bearer
 
+    @property
+    def scopes(self) -> List[str]:
+        # Combine explicitly-configured scopes with those granted via
+        # scopes_map (the union of its values, i.e. all Tiled scopes it grants).
+        combined: set[str] = set(self._scopes or [])
+        for tiled_scopes in self._scopes_map.values():
+            combined.update(tiled_scopes)
+        return list(combined)
+
+    def decode_token(
+        self, id_token: str, access_token: Optional[str] = None
+    ) -> dict[str, Any]:
+        claims = super().decode_token(id_token, access_token)
+        # Translate identity-provider scopes to Tiled scopes via scopes_map.
+        # The provider "scp" claim is present in access tokens but may be absent
+        # from id_tokens (e.g. during the authorization-code flow).  When absent,
+        # assume all mapped scopes were granted (the provider would not have
+        # issued the tokens if the user lacked the requested scopes).  When no
+        # scopes_map is configured, the token's native scopes are left untouched.
+        if not self._scopes_map:
+            return claims
+        scp_raw = claims.get("scp", "")
+        tiled_scope_set: set[str] = set()
+        if scp_raw:
+            provider_scopes = (
+                scp_raw.split(" ") if isinstance(scp_raw, str) else scp_raw
+            )
+            for scope in provider_scopes:
+                mapped_scopes = self._scopes_map.get(scope)
+                if mapped_scopes is None:
+                    logger.warning("Unmapped scope in 'scp': %s", scope)
+                    continue
+                tiled_scope_set.update(mapped_scopes)
+        else:
+            # No scp claim — grant all Tiled scopes from the map.
+            for mapped_scopes in self._scopes_map.values():
+                tiled_scope_set.update(mapped_scopes)
+        claims["scope"] = " ".join(tiled_scope_set)
+        return claims
+
 
 class EntraAuthenticator(ProxiedOIDCAuthenticator):
     def __init__(
@@ -326,12 +374,11 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
         well_known_uri: str,
         device_flow_client_id: str,
         extra_scopes: Optional[List[str]] = None,
+        scopes_map: Optional[Dict[str, List[str]]] = None,
         confirmation_message: str = "",
-        scopes_map: Optional[Dict[str, list[str]]] = None,
         client_secret: str = "",
         redirect_on_success: Optional[str] = None,
     ):
-        self.scopes_map = scopes_map if scopes_map is not None else {}
         self.extra_scopes = extra_scopes or []
         super().__init__(
             audience,
@@ -339,6 +386,7 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
             well_known_uri,
             device_flow_client_id,
             scopes=None,  # not used by Entra; enforcement is via scopes_map
+            scopes_map=scopes_map,
             confirmation_message=confirmation_message,
             redirect_on_success=redirect_on_success,
         )
@@ -346,20 +394,10 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
         if client_secret:
             self._client_secret = Secret(client_secret)
 
-    @property
-    def scopes(self):
-        mapped = set()
-        for tiled_scopes in self.scopes_map.values():
-            mapped.update(tiled_scopes)
-        return list(mapped)
-
-    @scopes.setter
-    def scopes(self, value):
-        pass  # ignored; scopes are derived from scopes_map
-
     def decode_token(
         self, id_token: str, access_token: Optional[str] = None
     ) -> dict[str, Any]:
+        # Handle scope translation (scp -> Tiled scopes via scopes_map) in super()
         claims = super().decode_token(id_token, access_token)
 
         # sub generated by Entra is an opaque string; generate a stable UUID
@@ -409,26 +447,6 @@ class EntraAuthenticator(ProxiedOIDCAuthenticator):
                 original_sub,
             )
         claims["user"] = user
-
-        # Translate Entra scopes to tiled scopes.
-        # The "scp" claim is present in access tokens but may be absent from
-        # id_tokens (e.g. during the authorization code flow).  When absent,
-        # assume all mapped scopes were granted (Entra would not have issued
-        # the tokens if the user lacked the requested scopes).
-        scp_raw = claims.get("scp", "")
-        tiled_scope_set = set()
-        if scp_raw:
-            for scope in scp_raw.split(" "):
-                mapped_scopes = self.scopes_map.get(scope)
-                if mapped_scopes is None:
-                    logger.warning("Unmapped Entra scope in 'scp': %s", scope)
-                    continue
-                tiled_scope_set.update(mapped_scopes)
-        else:
-            # No scp claim — grant all tiled scopes from the map.
-            for mapped_scopes in self.scopes_map.values():
-                tiled_scope_set.update(mapped_scopes)
-        claims["scope"] = " ".join(tiled_scope_set)
 
         return claims
 

--- a/tiled/authenticators.py
+++ b/tiled/authenticators.py
@@ -332,7 +332,7 @@ properties:
         combined: set[str] = set(self._scopes or [])
         for tiled_scopes in self._scopes_map.values():
             combined.update(tiled_scopes)
-        return list(combined)
+        return sorted(combined)
 
     def decode_token(
         self, id_token: str, access_token: Optional[str] = None
@@ -349,9 +349,7 @@ properties:
         scp_raw = claims.get("scp", "")
         tiled_scope_set: set[str] = set()
         if scp_raw:
-            provider_scopes = (
-                scp_raw.split(" ") if isinstance(scp_raw, str) else scp_raw
-            )
+            provider_scopes = scp_raw.split() if isinstance(scp_raw, str) else scp_raw
             for scope in provider_scopes:
                 mapped_scopes = self._scopes_map.get(scope)
                 if mapped_scopes is None:
@@ -362,7 +360,9 @@ properties:
             # No scp claim — grant all Tiled scopes from the map.
             for mapped_scopes in self._scopes_map.values():
                 tiled_scope_set.update(mapped_scopes)
-        claims["scope"] = " ".join(tiled_scope_set)
+        # Always set "scope" (even if empty) so downstream scope extraction does
+        # not fall back to the raw, unmapped provider "scp" claim.
+        claims["scope"] = " ".join(sorted(tiled_scope_set))
         return claims
 
 

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -392,10 +392,10 @@ def _extract_scopes(
     string under "scope".  Handle both.
     """
     if "scope" in decoded_access_token:
-        return set(decoded_access_token["scope"].split(" "))
+        return set(decoded_access_token["scope"].split())
     if "scp" in decoded_access_token:
         scp = decoded_access_token["scp"]
-        return set(scp) if isinstance(scp, list) else set(scp.split(" "))
+        return set(scp) if isinstance(scp, list) else set(scp.split())
     return set()
 
 


### PR DESCRIPTION
Adds `scopes_map` as an optional parameter to the base `ProxiedOIDCAuthenticator` class, further subclassed by `EntraAuthenticator`. If both, `scopes` and `scopes_map` are configured, their union is used.

Issue: #1476 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section

Closes #1476 
