### PR TITLE
Refactor and Generalize Lazy Asset Resolution Paths

### DIFF
--- a/tiled/adapters/sequence.py
+++ b/tiled/adapters/sequence.py
@@ -3,7 +3,7 @@ import math
 import os
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import numpy as np
 from ndindex import ndindex
@@ -18,7 +18,7 @@ from ..structures.core import Spec, StructureFamily
 from ..structures.data_source import DataSource
 from ..type_aliases import JSON, EllipsisType
 from ..utils import path_from_uri
-from .utils import force_reshape
+from .utils import force_reshape, grid_shape_for_files
 
 # Concurrency and memory knobs for reads that span many files of a sequence.
 #
@@ -409,62 +409,43 @@ class FileSequenceAdapter(Adapter[ArrayStructure]):
         adapter state, no I/O -- so both `read` and the `file_indices_for_slice`
         classmethod (used by the catalog before any adapter is built) can share it.
 
-        Each file contributes one element along the left-most stored axis, so a
-        file spans `P = prod(true_shape[1:])` contiguous elements of the row-major
-        flat array. Whole-file (partial) loading is possible only when the file
-        boundary aligns with a structure dimension boundary -- i.e. there is a
-        split `j` with `prod(struct_shape[:j]) == n_files` -- in which case the
-        leading `j` structure dimensions map onto the files and this returns
-        `struct_shape[:j]`. When no such split exists the reshape interleaves file
-        contents across the file boundary (every file must be loaded) and this
-        returns `None`. The caller derives `partial_loadable` as `result is not
-        None` and `reshaped` as `true_shape != struct_shape`.
+        Each file contributes one element along the left-most stored axis, so
+        `n_files == true_shape[0]`, and the shared `grid_shape_for_files` helper
+        computes the file-alignment geometry. The caller derives
+        `partial_loadable` as `result is not None` and `reshaped` as
+        `true_shape != struct_shape`.
         """
         if math.prod(true_shape) != math.prod(struct_shape):
             raise RuntimeError(
                 f"Array with shape {true_shape} derived from storage can not be reshaped "
                 f"to match the desired structure, {struct_shape}."
             )
-        # Locate the file boundary within the structure shape: the smallest split
-        # `j` whose leading dimensions multiply to the file count. Products grow
-        # monotonically (dimensions >= 1), so once the running product passes
-        # `n_files` without landing on it, no aligned split exists.
-        n_files = true_shape[0]
-        product = 1
-        for j, dim in enumerate(struct_shape, start=1):
-            product *= dim
-            if product == n_files:
-                return struct_shape[:j]
-            if product > n_files:
-                break
-        return None
+        return grid_shape_for_files(struct_shape, true_shape[0])
 
     @classmethod
     def file_indices_for_slice(
         cls,
         structure: ArrayStructure,
-        chunks: Optional[tuple[tuple[int, ...], ...]],
+        n_files: int,
         slice: Any = ...,
+        properties: Optional[Dict[str, Any]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[tuple[int, ...]]:
         """Return the global file (stack) indices needed to satisfy `slice`.
 
-        Pure classmethod of the structure and chunks only -- performs no file or
-        database I/O and needs no adapter instance -- so the catalog can prefetch
-        exactly the assets a read will touch before building any adapter (a
-        `read_block` is handled by first converting the block to the equivalent
-        slice). The leading `stacking_grid_shape` dimensions of the structure map onto
-        the files, so the files touched are the flat positions the slice selects
-        within them. Mirrors the file selection in `read()`.
+        The leading `grid_shape_for_files` dimensions map onto the `n_files` files,
+        so the touched files are the flat positions the slice selects within
+        them. `properties`/`parameters` are accepted for interface parity with
+        adapters that need them (e.g. HDF5) and ignored here.
 
         Returns `None` when the reshape is not file-boundary-aligned (every file
-        may need to be loaded), signalling the catalog to skip the lazy loading path.
+        may need to be loaded), signalling the catalog to skip the lazy path.
         """
         struct_shape = structure.shape
-        true_shape = tuple(map(sum, chunks)) if chunks else struct_shape
-        stacking_grid_shape = cls._stacking_grid_shape(struct_shape, true_shape)
-        if stacking_grid_shape is None:
+        grid_shape = grid_shape_for_files(struct_shape, n_files)
+        if grid_shape is None:
             return None
         file_indx_slice = NDSlice(slice).expand_for_shape(struct_shape)[
-            : len(stacking_grid_shape)
+            : len(grid_shape)
         ]
-        return NDSlice(file_indx_slice).flat_indices(stacking_grid_shape)
+        return NDSlice(file_indx_slice).flat_indices(grid_shape)

--- a/tiled/adapters/utils.py
+++ b/tiled/adapters/utils.py
@@ -113,3 +113,38 @@ def split_chunks(total: int, chunk: int) -> tuple[int, ...]:
     "Split total into repeated chunks of size `chunk`, with a remainder at the end."
     num_full_chunks, remainder = divmod(total, chunk)
     return tuple([chunk] * num_full_chunks + ([remainder] if remainder else []))
+
+
+def grid_shape_for_files(
+    struct_shape: Tuple[int, ...], n_files: int
+) -> Optional[Tuple[int, ...]]:
+    """For multi-asset datasets, return the leading axes of `struct_shape` that
+    enumerate the files, one grid cell per file, or `None` when no clean split exists.
+
+    Context: `n_files` files were each read as one fixed-shape frame, stacked
+    into a new leading axis of length `n_files`, and that axis was then reshaped
+    into one or more leading dimensions of `struct_shape` (the trailing
+    dimensions are the shared per-frame shape). This recovers the grid of those
+    leading dimensions so a caller can map a grid cell back to its one file.
+
+    The split is clean only when a prefix of `struct_shape` multiplies to exactly
+    `n_files`: the smallest `j` with `prod(struct_shape[:j]) == n_files`. Then the
+    leading `j` dimensions index the files and this returns `struct_shape[:j]`.
+
+    For example, 12 files reshaped to `(3, 4, H, W)` returns `(3, 4)` -- the file
+    at grid cell `(i, j)` supplies the `H x W` frame at `[i, j]`. But `(5, ...)`
+    with 12 files returns `None`: no prefix hits 12, so a single file's frame
+    would straddle a dimension boundary and the leading indices no longer
+    correspond one-to-one with files.
+
+    The running product only grows (every dimension is `>= 1`), so once it passes
+    `n_files` without landing on it, no aligned split can exist and this stops.
+    """
+    product = 1
+    for j, dim in enumerate(struct_shape, start=1):
+        product *= dim
+        if product == n_files:
+            return struct_shape[:j]
+        if product > n_files:
+            break
+    return None

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -670,14 +670,16 @@ class CatalogNodeAdapter:
         Returns `None` (so the caller falls back to :meth:`get_adapter`) unless
         every precondition for lazy per-frame resolution holds:
         a single file-scheme data source whose adapter class opts in via
-        `supports_lazy_assets` and whose `properties` carry `chunks`, and
-        whose asset `num`s form a contiguous run of length n (any starting
-        offset -- 0-based, 1-based, etc. -- so stacking rank == num - offset).
+        `supports_lazy_assets`, whose `parameter == "data_uris"` asset `num`s
+        form a contiguous run of length n (any starting offset -- 0-based,
+        1-based, etc. -- so stacking rank == num - offset), and whose adapter
+        can determine, from the structure and the data source `properties`,
+        which files a slice touches.
 
         Instead of materializing all N asset rows, this reads only the data
-        source's structure/chunks (no assets), asks the adapter class which
-        stack indices (== stacking ranks) the given `block`/`slice` needs, and
-        fetches just those URIs. Keeps all DB access in the async layer; the
+        source's structure and properties (no assets), asks the adapter class
+        which stack indices (== stacking ranks) the given `block`/`slice` needs,
+        and fetches just those URIs. Keeps all DB access in the async layer; the
         adapter (built through its normal `from_catalog` entry point with a
         partially-populated URI list) resolves each URI to a filepath lazily,
         only for the indices actually read.
@@ -696,8 +698,6 @@ class CatalogNodeAdapter:
             # Zero or multiple data sources: not supported by the lazy path.
             return None
         ds = data_source_orms[0]
-        if (chunks := (ds.properties or {}).get("chunks")) is None:
-            return None
         if ds.structure is None:
             return None
 
@@ -709,44 +709,30 @@ class CatalogNodeAdapter:
         if not getattr(adapter_cls, "supports_lazy_assets", False):
             return None
 
-        n = sum(int(c) for c in chunks[0])  # stack length == number of files
-
-        # Data source meta only (no assets); the structure/chunks are enough to
-        # compute the file geometry.
+        # Data source meta only (no assets); the structure is enough (with the
+        # file count) to compute the file geometry.
         data_source = DataSource.from_orm(ds, include_assets=False)
         structure = data_source.structure
 
-        # Which stack indices does this read need? Pure geometry -- a classmethod
-        # of the structure and chunks, needing no adapter instance or I/O.
-        #
-        # File selection for a block read depends ONLY on the block:
-        # FileSequenceAdapter.read_block loads the whole block along the stacking
-        # axis (`self.read(block.slice_from_chunks(...)[0])`) and applies any
-        # within-block slice AFTER, to the already-loaded data.
+        # A block read's file selection depends ONLY on the block: read_block
+        # loads the whole block along the stacking axis and applies any
+        # within-block slice AFTER, to the already-loaded data. Convert the block
+        # to the equivalent leading-axis slice here (pure; uses structure.chunks).
         if block is not None:
             if any(block[1:]):
                 raise IndexError(block)
             slice = block.slice_from_chunks(structure.chunks)[0]
-        indices = adapter_cls.file_indices_for_slice(structure, chunks, slice)
-        if indices is None:
-            # The reshape interleaves file contents (not file-boundary-aligned),
-            # so every file must be loaded: the lazy path offers no benefit. Fall
-            # back to the full adapter build.
-            return None
 
-        # Contiguity precheck: the lazy path maps each 0-based stacking rank to
-        # an asset `num`. That mapping is well-defined only when the `num`s form
-        # a contiguous run of length n with no gaps -- then rank == num - offset,
-        # where offset is the smallest num (0 for 0-based numbering, 1 for
-        # 1-based, and so on). Verify cheaply with an aggregate query (no asset
-        # rows materialized): count == n AND max - min == n - 1 holds iff the n
-        # distinct `num`s are exactly {offset .. offset + n - 1}. A set-equality
-        # check on only the requested `num`s is insufficient: a present-but-
-        # mis-ranked `num` (e.g. a silent gap elsewhere shifting ranks) would
-        # pass yet map to the wrong file. On any mismatch, fall back to the full
-        # build, whose asset-ordering logic does not rely on this assumption.
+        # File count = number of numbered "data_uris" assets, NOT len(chunks[0]):
+        # one file may span several native chunks along the concatenation axis.
+        # The lazy path maps each 0-based stacking rank to an asset `num` via
+        # rank == num - offset, valid only when the `num`s are a contiguous run
+        # (offset is the smallest num: 0 for 0-based, 1 for 1-based, etc.). One
+        # aggregate query yields count/min/max without materializing asset rows:
+        # `count == n AND max - min == n - 1` holds iff the `num`s are exactly
+        # {offset .. offset + n - 1}. On any mismatch, fall back to the full build.
         # TODO: It might be worth ensuring zero-based contiguous `num`s when writing
-        # assets; then this check can be dropped.
+        # assets; then the contiguity check can be dropped.
         count_stmt = (
             select(
                 func.count(orm.DataSourceAssetAssociation.num),
@@ -754,18 +740,33 @@ class CatalogNodeAdapter:
                 func.max(orm.DataSourceAssetAssociation.num),
             )
             .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+            .where(orm.DataSourceAssetAssociation.parameter == "data_uris")
             .where(orm.DataSourceAssetAssociation.num.isnot(None))
         )
 
         async with self.context.session() as db:
-            count, min_num, max_num = (await db.execute(count_stmt)).one()
-            if count != n or (n and max_num - min_num != n - 1):
-                return None
+            n, min_num, max_num = (await db.execute(count_stmt)).one()
             offset = min_num or 0  # `num`s run [offset, offset + n - 1]
 
-            # Fetch only the needed assets' URIs (indexed by
-            # (data_source_id, parameter, num)). The read's 0-based stack indices
-            # map to `num`s by adding the offset.
+            if not n or max_num - min_num != n - 1:
+                return None
+            if n < 2:
+                # A single backing file -- fall back to the full adapter.
+                return None
+
+            # Determine which files / assets this read needs purely from geometry.
+            indices = adapter_cls.file_indices_for_slice(
+                structure,
+                n,
+                slice,
+                properties=ds.properties or {},
+                parameters=ds.parameters or {},
+            )
+            if indices is None:
+                return None
+
+            # Fetch only the needed assets' URIs (indexed by (data_source_id, parameter, num)).
+            # The read's 0-based stack indices map to `num`s by adding the offset.
             uri_stmt = (
                 select(
                     orm.DataSourceAssetAssociation.num,
@@ -776,6 +777,7 @@ class CatalogNodeAdapter:
                     orm.Asset.id == orm.DataSourceAssetAssociation.asset_id,
                 )
                 .where(orm.DataSourceAssetAssociation.data_source_id == ds.id)
+                .where(orm.DataSourceAssetAssociation.parameter == "data_uris")
                 .where(
                     orm.DataSourceAssetAssociation.num.in_(
                         [offset + i for i in indices]
@@ -784,7 +786,7 @@ class CatalogNodeAdapter:
             )
             uri_rows = (await db.execute(uri_stmt)).all()
 
-        # Build a fixed-length URI list populated with only the frames this read needs
+        # Build a fixed-length URI list populated with only the assets this read needs
         # (the rest left as None). Stacking rank == num - offset (contiguous run,
         # guaranteed by the precheck above), so it indexes directly into the list.
         data_uris = [None] * n
@@ -793,8 +795,10 @@ class CatalogNodeAdapter:
             data_uris[num - offset] = data_uri
 
         # One entry point for both eager and lazy: pass the partially-populated
-        # URI list as the `data_uris` kwarg. `from_catalog` derives chunks/metadata/specs.
-        return adapter_cls.from_catalog(data_source, self.node, data_uris=data_uris)
+        # URI list as the `data_uris` kwarg. `from_catalog` derives metadata/specs.
+        return adapter_cls.from_catalog(
+            data_source, self.node, data_uris=data_uris, **data_source.parameters
+        )
 
     def new_variation(
         self,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -748,10 +748,12 @@ class CatalogNodeAdapter:
             n, min_num, max_num = (await db.execute(count_stmt)).one()
             offset = min_num or 0  # `num`s run [offset, offset + n - 1]
 
-            if not n or max_num - min_num != n - 1:
-                return None
+            # A single backing file -- fall back to the full adapter.
             if n < 2:
-                # A single backing file -- fall back to the full adapter.
+                return None
+
+            # The asset nums are not a contiguous run -- fall back to the full adapter.
+            if not n or max_num - min_num != n - 1:
                 return None
 
             # Determine which files / assets this read needs purely from geometry.
@@ -797,7 +799,7 @@ class CatalogNodeAdapter:
         # One entry point for both eager and lazy: pass the partially-populated
         # URI list as the `data_uris` kwarg. `from_catalog` derives metadata/specs.
         return adapter_cls.from_catalog(
-            data_source, self.node, data_uris=data_uris, **data_source.parameters
+            data_source, self.node, **{**data_source.parameters, "data_uris": data_uris}
         )
 
     def new_variation(


### PR DESCRIPTION
Extract the file-alignment geometry from FileSequenceAdapter._stacking_grid_shape into a shared tiled.adapters.utils.grid_shape_for_files helper, and generalize the catalog's lazy asset-resolution path to compute the file count from numbered "data_uris" assets rather than the structure chunks. file_indices_for_slice now takes n_files (plus optional properties/parameters for adapter parity) instead of chunks. No user-facing behavior change for file-sequence datasets; this prepares the lazy path for multi-file HDF5 support.

Relared #1465 , #1463 

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
