### PR TITLE
If refresh yields 400, clear tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Fix precedence of scope check for `ProxiedOIDCAuthenticator`.
+- If refreshing access tokens yields `400 Bad Request`, clear the cached tokens
+  and prompt for login.
 
 ## v0.2.15 (2026-08-11)
 

--- a/tiled/client/auth.py
+++ b/tiled/client/auth.py
@@ -130,7 +130,10 @@ class TiledAuth(httpx.Auth):
                 self.scopes,
             )
             token_response = yield token_request
-            if token_response.status_code == httpx.codes.UNAUTHORIZED:
+            if token_response.status_code in {
+                httpx.codes.UNAUTHORIZED,
+                httpx.codes.BAD_REQUEST,
+            }:
                 # Refreshing the token failed.
                 # Discard the expired (or otherwise invalid) refresh_token.
                 self.sync_clear_token("refresh_token")


### PR DESCRIPTION
When we switch authentication providers from Tiled's internal OAuth2 to Entra OIDC, any user session with cached refresh tokens may try to present Tiled's internal refresh tokens to Entra. Entra rejects them with a `400 Bad Request` response, raising this error in the Python client:

```
ClientError: 400: Bad Request https://login.microsoftonline.com/89561e60-dc75-4c28-a1c9-2e8d8870196b/oauth2/v2.0/token
```

This PR catches the error, as it already would catch other failed attempts to refresh, and prompts for user login. I tested this interactively several times.


### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
