### PR TITLE
Fix check_scopes for scope-restricted API keys under ProxiedOIDCAutenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix `check_scopes` incorrectly requiring every request under a
+  `ProxiedOIDCAuthenticator` (e.g. `EntraAuthenticator`) to carry the full set
+  of scopes known to the authenticator (the union of all scopes in
+  `scopes_map`). This broke scope-restricted API keys, which legitimately hold
+  only a subset of scopes. Authorization is now enforced solely against the
+  scopes each endpoint requires.
+
 ## v0.2.16 (2026-08-21)
 
 ### Changed

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -371,6 +371,42 @@ async def test_ProxiedOIDCAuthenticator_requires_scopes(mock_oidc_server, well_k
     assert exception.value.status_code == HTTP_401_UNAUTHORIZED
 
 
+async def test_ProxiedOIDCAuthenticator_scoped_api_key_passes(mock_oidc_server, well_known_url):
+    # Regression test: a request (e.g. from a scope-restricted API key) that
+    # carries only a *subset* of the authenticator's full scope universe must
+    # succeed as long as it holds the scopes the endpoint actually requires.
+    # Previously check_scopes required the request to carry *all* of the
+    # authenticator's scopes (the union of every scope in scopes_map), which
+    # broke scoped API keys under a ProxiedOIDC/Entra authenticator.
+    authenticator = ProxiedOIDCAuthenticator(
+        "tiled", "tiled", well_known_url, device_flow_client_id="tiled-cli",
+        scopes_map={"access_as_user": [
+            "read:metadata", "read:data", "create:node", "write:metadata",
+            "write:data", "delete:revision", "delete:node", "create:apikeys",
+            "revoke:apikeys",
+        ]},
+    )
+
+    test_request = Request(scope={"type": "http", "scheme": "http", "headers": [(b"host", b"testserver")]}, )
+    settings = Settings(authenticator=authenticator)
+
+    # The /metadata/ write endpoint requires these scopes; the restricted key
+    # has exactly these (and not the full universe, e.g. no read:data).
+    request_scopes = ["write:data", "create:node", "read:metadata", "write:metadata"]
+    security_scopes = SecurityScopes(scopes=["write:metadata", "create:node"])
+
+    # Should NOT raise.
+    await check_scopes(request=test_request, settings=settings, scopes=request_scopes,
+                       security_scopes=security_scopes)
+
+    # Sanity check: missing a required endpoint scope still fails.
+    security_scopes = SecurityScopes(scopes=["read:data"])
+    with pytest.raises(HTTPException) as exception:
+        await check_scopes(request=test_request, settings=settings, scopes=request_scopes,
+                           security_scopes=security_scopes)
+    assert exception.value.status_code == HTTP_401_UNAUTHORIZED
+
+
 def test_ProxiedOIDCAuthenticator_scopes_explicit(mock_oidc_server, well_known_url):
     # With no scopes_map, explicit scopes are returned as-is.
     authenticator = ProxiedOIDCAuthenticator(

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -545,19 +545,8 @@ async def check_scopes(
     scopes: set[str] = Depends(get_current_scopes),
     settings: Settings = Depends(get_settings),
 ) -> None:
-    if isinstance(settings.authenticator, ProxiedOIDCAuthenticator):
-        if settings.authenticator.scopes and not set(
-            settings.authenticator.scopes
-        ).issubset(scopes):
-            raise HTTPException(
-                status_code=HTTP_401_UNAUTHORIZED,
-                detail=(
-                    "Authenticator has scopes that the request does not have. "
-                    f"Authenticator has scopes {settings.authenticator.scopes}. "
-                    f"Request had scopes {list(scopes)}"
-                ),
-                headers=headers_for_401(request, security_scopes),
-            )
+    # Authorization is enforced per-endpoint: the request must carry the scopes
+    # that this specific endpoint requires (`security_scopes`).
     if not set(security_scopes.scopes).issubset(scopes):
         raise HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
check_scopes required every request under a ProxiedOIDCAuthenticator (e.g. EntraAuthenticator) to carry the full set of scopes known to the authenticator (the union of all scopes in scopes_map). This broke scope-restricted API keys, which legitimately hold only a subset of scopes. Authorization is now enforced solely against the scopes each endpoint requires.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
