### PR TITLE
Honor proxy env vars in client's custom httpx transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix the client ignoring the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+  environment variables. Because Tiled supplies a custom `httpx` transport (to
+  enable client-side response caching), httpx's built-in proxy resolution was
+  bypassed, so proxied requests (e.g. to an external OIDC provider) never went
+  through the configured proxy. The transport now honors these environment
+  variables. This can be disabled via the new `trust_env=False` parameter on
+  `from_uri`. As part of this fix, the client's `verify` setting is now applied
+  to the underlying transport (previously it was silently ignored when the
+  custom transport was in use).
+
 - Fix `check_scopes` incorrectly requiring every request under a
   `ProxiedOIDCAuthenticator` (e.g. `EntraAuthenticator`) to carry the full set
   of scopes known to the authenticator (the union of all scopes in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix the client showing a spurious "Retrying…" indicator (and a misleading
+  "Retry scheduled" debug log) when a request failed with a *non-retryable*
+  error, such as a 4xx response or `CannotRefreshAuthentication` during a normal
+  first-time login. The underlying retry context manager captures every
+  exception before deciding whether to retry, so the indicator was being driven
+  off exception capture rather than an actual retry. The indicator now appears
+  only when a retry genuinely occurs.
+
 - Fix the client ignoring the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
   environment variables. Because Tiled supplies a custom `httpx` transport (to
   enable client-side response caching), httpx's built-in proxy resolution was

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -586,6 +586,44 @@ def test_retry_context_signals_retry_indicator():
                 stamina.set_active(False)
 
 
+def test_retry_context_no_indicator_on_non_retryable_error():
+    """A non-retryable error must not trigger the retry indicator.
+
+    Regression test: the attempt context manager "captures" every exception
+    (including non-retryable ones that are about to be re-raised), so the
+    indicator must not be driven off that. It should fire only when a retry
+    genuinely occurs.
+    """
+    from unittest.mock import patch
+
+    import stamina
+
+    from tiled.client.auth import CannotRefreshAuthentication
+    from tiled.client.utils import retry_context
+
+    tree = MapAdapter({"data": ArrayAdapter.from_array(numpy.zeros((10,)))})
+    app = build_app(tree)
+
+    with Context.from_app(app, show_progress=True) as context:
+        with patch.object(context, "signal_retry") as mock_signal:
+            stamina.set_active(True)
+            try:
+                call_count = 0
+                with pytest.raises(CannotRefreshAuthentication):
+                    for attempt in retry_context(context):
+                        with attempt:
+                            call_count += 1
+                            # Non-retryable: mimics first-login with no cached
+                            # refresh token.
+                            raise CannotRefreshAuthentication("no token")
+                # The body ran exactly once (no retry) and the indicator was
+                # never signaled.
+                assert call_count == 1
+                assert mock_signal.call_count == 0
+            finally:
+                stamina.set_active(False)
+
+
 # --- 429 Too Many Requests tests ---
 
 
@@ -731,7 +769,7 @@ def test_retry_context_logs_429_retry(caplog):
 
         tiled_messages = [r for r in caplog.records if r.name == "tiled.client"]
         assert len(tiled_messages) >= 1
-        assert "Retry" in tiled_messages[0].message
+        assert any("Retrying" in r.message for r in tiled_messages)
     finally:
         stamina.set_active(False)
         hide_logs()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,83 @@
+"""Tests for the client's custom httpx Transport, focusing on proxy handling.
+
+Because Tiled supplies a custom transport to httpx.Client (to enable
+client-side response caching), httpx's built-in resolution of the
+HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment variables is bypassed.
+The Transport replicates that behavior so proxy env vars are honored.
+"""
+import httpx
+import pytest
+
+from tiled.client.transport import Transport
+
+
+@pytest.fixture
+def clear_proxy_env(monkeypatch):
+    for var in (
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_no_proxy_env_means_no_mounts(clear_proxy_env):
+    transport = Transport()
+    assert transport._mounts == {}
+
+
+def test_https_proxy_env_is_honored(clear_proxy_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9999")
+    transport = Transport()
+    # A request to an https URL should route through the proxy transport,
+    # not the direct transport.
+    selected = transport._transport_for_url(httpx.URL("https://example.com/path"))
+    assert selected is not transport.transport
+    assert selected._pool._proxy_url.host == b"127.0.0.1"
+    assert selected._pool._proxy_url.port == 9999
+    # A request to an http URL (no HTTP_PROXY set) should go direct.
+    selected_http = transport._transport_for_url(httpx.URL("http://example.com/path"))
+    assert selected_http is transport.transport
+
+
+def test_no_proxy_bypass_is_honored(clear_proxy_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9999")
+    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    transport = Transport()
+    # Host on the NO_PROXY list connects directly.
+    direct = transport._transport_for_url(
+        httpx.URL("https://internal.example.com/path")
+    )
+    assert direct is transport.transport
+    # Other hosts still go through the proxy.
+    proxied = transport._transport_for_url(httpx.URL("https://external.example.com/"))
+    assert proxied is not transport.transport
+
+
+def test_trust_env_false_ignores_proxy_env(clear_proxy_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9999")
+    transport = Transport(trust_env=False)
+    assert transport._mounts == {}
+    selected = transport._transport_for_url(httpx.URL("https://example.com/"))
+    assert selected is transport.transport
+
+
+def test_explicit_transport_skips_proxy_handling(clear_proxy_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9999")
+    inner = httpx.HTTPTransport()
+    transport = Transport(transport=inner)
+    # When an explicit transport is provided (e.g. ASGI), no proxy mounts.
+    assert transport._mounts == {}
+    assert transport.transport is inner
+
+
+def test_verify_is_honored_on_inner_transport(clear_proxy_env):
+    transport = Transport(verify=False)
+    import ssl
+
+    assert transport.transport._pool._ssl_context.verify_mode == ssl.CERT_NONE

--- a/tiled/client/constructors.py
+++ b/tiled/client/constructors.py
@@ -31,6 +31,7 @@ def from_uri(
     auth: Optional[httpx.Auth] = None,
     max_connections: int = MAX_CONCURRENT_CONNECTIONS,
     show_progress=None,
+    trust_env=True,
 ):
     """
     Connect to a Node on a local or remote server.
@@ -70,6 +71,10 @@ def from_uri(
     max_connections : int, optional
         If provided, use this value for the maximum number of concurrent
         connections in the HTTP client.
+    trust_env : bool, optional
+        Whether to honor environment variables such as HTTP_PROXY, HTTPS_PROXY,
+        and NO_PROXY. True by default. Set False to ignore proxy configuration
+        in the environment.
     """
     EXPLAIN_LOGIN = """
 
@@ -98,6 +103,7 @@ For non-interactive authentication, use an API key or add custom auth
         verify=verify,
         max_connections=max_connections,
         show_progress=show_progress,
+        trust_env=trust_env,
     )
     if auth is not None:
         if isinstance(auth, httpx.Auth):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -182,6 +182,7 @@ class Context:
         raise_server_exceptions=True,
         max_connections=MAX_CONCURRENT_CONNECTIONS,
         show_progress=None,
+        trust_env=True,
     ):
         # The uri is expected to reach the root API route.
         uri = httpx.URL(uri)
@@ -239,7 +240,9 @@ class Context:
         )
         if app is None:
             client = httpx.Client(
-                transport=Transport(cache=cache, limits=limits),
+                transport=Transport(
+                    cache=cache, limits=limits, verify=verify, trust_env=trust_env
+                ),
                 verify=verify,
                 timeout=timeout,
                 follow_redirects=True,
@@ -287,6 +290,7 @@ class Context:
 
         self.http_client = client
         self._verify = verify
+        self._trust_env = trust_env
         self._cache = cache
         self._token_cache = Path(TILED_CACHE_DIR / "tokens")
         # Semaphore that caps the number of concurrent data-fetch requests
@@ -401,6 +405,7 @@ class Context:
             self.server_info,
             self.cache,
             self._concurrent_request_semaphore._value,
+            self._trust_env,
         )
 
     def __setstate__(self, state):
@@ -416,6 +421,7 @@ class Context:
             server_info,
             cache,
             max_connections,
+            trust_env,
         ) = state
         if state_tiled_version != tiled_version:
             raise TypeError(
@@ -435,7 +441,9 @@ class Context:
         )
         self.http_client = httpx.Client(
             verify=verify,
-            transport=Transport(cache=cache, limits=limits),
+            transport=Transport(
+                cache=cache, limits=limits, verify=verify, trust_env=trust_env
+            ),
             cookies=cookies,
             timeout=timeout,
             headers=headers,
@@ -445,6 +453,7 @@ class Context:
         self._token_cache = token_cache
         self._cache = cache
         self._verify = verify
+        self._trust_env = trust_env
         self.server_info = server_info
         self._max_connections = max_connections
         self._concurrent_request_semaphore = threading.Semaphore(max_connections)
@@ -691,6 +700,7 @@ class Context:
         app=None,
         max_connections=MAX_CONCURRENT_CONNECTIONS,
         show_progress=None,
+        trust_env=True,
     ):
         """
         Accept a URI to a specific node.
@@ -746,6 +756,7 @@ class Context:
             app=app,
             max_connections=max_connections,
             show_progress=show_progress,
+            trust_env=trust_env,
         )
         return context, node_path_parts
 

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -12,6 +12,32 @@ from .logger import collect_request, collect_response, log_request, log_response
 from .utils import TiledResponse
 
 
+def _proxy_mounts_from_env(
+    transport_kwargs: tp.Dict[str, tp.Any],
+) -> tp.Dict[tp.Any, tp.Optional[httpx.BaseTransport]]:
+    """Build proxy transports from the standard proxy environment variables.
+
+    Reads HTTP_PROXY / HTTPS_PROXY / ALL_PROXY / NO_PROXY (via httpx's own
+    resolution helper) and returns a mapping of URLPattern -> transport,
+    sorted by pattern priority so the most specific match wins. A value of
+    None indicates a NO_PROXY entry (connect directly).
+
+    This reproduces the behavior httpx.Client applies to the transport it
+    builds itself, which is otherwise skipped when a custom transport is
+    supplied.
+    """
+    from httpx._utils import URLPattern, get_environment_proxies
+
+    mounts: tp.Dict[tp.Any, tp.Optional[httpx.BaseTransport]] = {}
+    for key, value in get_environment_proxies().items():
+        mounts[URLPattern(key)] = (
+            None
+            if value is None
+            else httpx.HTTPTransport(proxy=value, **transport_kwargs)
+        )
+    return dict(sorted(mounts.items(), key=lambda item: item[0].priority))
+
+
 class Transport(httpx.BaseTransport):
     """Custom transport, implementing caching and custom compression encodings.
 
@@ -31,6 +57,8 @@ class Transport(httpx.BaseTransport):
         transport: tp.Optional[httpx.BaseTransport] = None,
         cache: tp.Optional[Cache] = None,
         limits: tp.Optional[httpx.Limits] = None,
+        verify: tp.Union[bool, str] = True,
+        trust_env: bool = True,
         cacheable_methods: tp.Tuple[str, ...] = ("GET",),
         cacheable_status_codes: tp.Tuple[int, ...] = (
             httpx.codes.OK,
@@ -46,16 +74,44 @@ class Transport(httpx.BaseTransport):
             cacheable_status_codes=cacheable_status_codes,
             always_cache=always_cache,
         )
+        # Mapping of URLPattern -> transport for requests that must be routed
+        # through a proxy (or, when the value is None, connected to directly).
+        self._mounts: tp.Dict[tp.Any, tp.Optional[httpx.BaseTransport]] = {}
         if transport is not None:
+            # An explicit transport was provided (e.g. the in-process ASGI
+            # transport used for TestClient). Use it as-is; proxy/verify
+            # handling does not apply.
             self.transport = transport
-        elif limits is not None:
-            self.transport = httpx.HTTPTransport(limits=limits)
         else:
-            self.transport = httpx.HTTPTransport()
+            transport_kwargs: tp.Dict[str, tp.Any] = {"verify": verify}
+            if limits is not None:
+                transport_kwargs["limits"] = limits
+            self.transport = httpx.HTTPTransport(**transport_kwargs)
+            if trust_env:
+                # httpx.Client honors HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars,
+                # but only for the transport it builds itself. Because Tiled
+                # supplies a custom transport (to enable response caching),
+                # that logic is bypassed. Replicate it here so proxy env vars
+                # are respected.
+                self._mounts = _proxy_mounts_from_env(transport_kwargs)
         self.cache = cache
+
+    def _transport_for_url(self, url: httpx.URL) -> httpx.BaseTransport:
+        """Select the transport for a URL, honoring proxy mounts.
+
+        Mirrors httpx.Client._transport_for_url: the most specific matching
+        pattern wins; a value of None means "connect directly" (e.g. NO_PROXY).
+        """
+        for pattern, transport in self._mounts.items():
+            if pattern.matches(url):
+                return transport or self.transport
+        return self.transport
 
     def close(self) -> None:
         self.transport.close()
+        for transport in self._mounts.values():
+            if transport is not None:
+                transport.close()
         if self.cache is not None:
             self.cache.close()
 
@@ -94,7 +150,7 @@ class Transport(httpx.BaseTransport):
         if __debug__:
             log_request(request)
             collect_request(request)
-        response = self.transport.handle_request(request)
+        response = self._transport_for_url(request.url).handle_request(request)
         response.__class__ = TiledResponse
         response.request = request
         if __debug__:

--- a/tiled/client/utils.py
+++ b/tiled/client/utils.py
@@ -181,19 +181,19 @@ class _LoggingAttempt:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         result = self._attempt.__exit__(exc_type, exc_val, exc_tb)
-        # stamina returns True from __exit__ when it suppresses the exception
-        # and schedules a retry.  That is the moment we want to log.
+        # stamina returns True from __exit__ when it captures the exception.
+        # Note that this happens for *every* captured exception, including
+        # non-retryable ones that will be re-raised on the next iteration; it
+        # does not by itself mean a retry has been scheduled.  We therefore only
+        # log the failure here (for debugging) and leave the decision of whether
+        # to show a retry indicator to retry_context, which knows -- by reaching
+        # a later attempt -- that a retry genuinely occurred.
         if exc_val is not None and result:
             _retry_logger.debug(
-                "Retry %d scheduled in %.2fs due to %r",
+                "Attempt %d failed with %r",
                 self._attempt.num,
-                self._attempt.next_wait,
                 exc_val,
             )
-            if self._context is not None:
-                self._context.signal_retry()
-            elif self._standalone is not None:
-                self._standalone.show()
         return result
 
 
@@ -219,6 +219,19 @@ def retry_context(context=None):
                 # would normally be swallowed by tenacity.  Re-raise it here so
                 # that Ctrl-C cancels all remaining retries immediately.
                 raise
+            if attempt.num > 1:
+                # We only reach a second (or later) attempt when the previous
+                # attempt failed with a *retryable* error and stamina scheduled
+                # this retry.  Show the indicator here so it appears only when a
+                # retry genuinely happens -- not for terminal, non-retryable
+                # exceptions (e.g. a 404 or CannotRefreshAuthentication on first
+                # login), which the attempt context manager also "captures"
+                # before re-raising.
+                _retry_logger.debug("Retrying (attempt %d)…", attempt.num)
+                if context is not None:
+                    context.signal_retry()
+                elif standalone is not None:
+                    standalone.show()
             yield _LoggingAttempt(attempt, context=context, standalone=standalone)
     finally:
         # Always clean up the retry indicator, whether the loop completed


### PR DESCRIPTION
Tiled supplies a custom httpx transport (to enable client-side response caching), which causes httpx.Client to skip its built-in resolution of the HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables. As a result, proxied requests (e.g. to an external OIDC provider) never went through the configured proxy.

Replicate httpx's env-proxy routing in the custom Transport: build per-pattern proxy transports (honoring NO_PROXY) and select the transport per request URL. Add a trust_env parameter (default True) to from_uri to opt out.

Also apply the client's verify setting to the underlying transport, which was previously silently ignored when the custom transport was in use.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
