### PR TITLE
BUG: fix read_partition divisions for multi-partition dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Reading of individual partitions of multi-partitioned tables.
 - Fix `check_scopes` incorrectly requiring every request under a
   `ProxiedOIDCAuthenticator` (e.g. `EntraAuthenticator`) to carry the full set
   of scopes known to the authenticator (the union of all scopes in

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -112,6 +112,22 @@ def test_dataframe_single_partition(context):
     pandas.testing.assert_frame_equal(actual, expected)
 
 
+def test_read_partition_multipartition(context):
+    # Reading one partition of a multi-partition frame must build a
+    # single-partition dask dataframe (divisions of length 2), independent of
+    # the total partition count.
+    client = from_context(context)["basic"]
+    npartitions = client.structure().npartitions
+    assert npartitions == 3
+    expected = tree["basic"].read()
+    for partition in range(npartitions):
+        actual = client.read_partition(partition)
+        assert list(actual.columns) == list(expected.columns)
+        # A single-column subset must work too.
+        one_col = client.read_partition(partition, columns=[expected.columns[0]])
+        assert list(one_col.columns) == [expected.columns[0]]
+
+
 def test_reading_diverse_dtypes(context):
     client = from_context(context)
     expected = tree["diverse"].read()

--- a/tiled/client/dataframe.py
+++ b/tiled/client/dataframe.py
@@ -162,10 +162,13 @@ class _DaskDataFrameClient(BaseClient):
         meta = structure.meta
         if columns is not None:
             meta = meta[columns]
+        # This builds a single-partition dask dataframe from one delayed object,
+        # so `divisions` must have length len(dfs) + 1 == 2 regardless of how many
+        # partitions the full dataset has.
         return dask.dataframe.from_delayed(
             [dask.delayed(self._get_partition)(partition, columns)],
             meta=meta,
-            divisions=(None,) * (1 + npartitions),
+            divisions=(None, None),
         )
 
     def read(self, columns=None):


### PR DESCRIPTION
DataFrameClient.read_partition builds a single-partition dask dataframe from one delayed object, so from_delayed requires divisions of length 2. It was passing (None,) * (1 + npartitions), copied from read() where from_map genuinely produces npartitions partitions. This stayed latent because single-partition frames give the right length and older dask did not validate it; newer dask (dask_expr) raises ValueError for any multi-partition frame. Use (None, None) instead and add a test that reads every partition of a multi-partition frame.

### Checklist
- [x] Add a Changelog entry
- [ ] ~~Add the ticket number which this PR closes to the comment section~~
