### PR TITLE
Add additional asyncio task that watches for disconnect events when streaming. Otherwise, a server with a subscription would hang on close.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
   multiple requests.
 - Fixed regression in configuration parser, which had mistyped the catalog
   configuration `adapter_by_mimetype` resulting in a spurious error.
+- Resolve issue where creating a streaming subscription would cause the server
+  to hang indefinitely on close. Added an additional asyncio task that watches
+  for disconnects and breaks out of the `buffer_live_events` loop when the
+  connection is closed. Also added a test to verify that `server.close()` does
+  not hang with an open streaming subscription.
 
 ## v0.2.16 (2026-08-21)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -74,6 +74,9 @@ sphinx_rtd_theme = "*"
 sphinxcontrib-mermaid = "*"
 types-cachetools = "*"
 
+[feature.dev.tasks]
+lint = "pre-commit run --show-diff-on-failure --color=always --all-files"
+
 [feature.formats.dependencies]
 h5netcdf = "*"
 h5py = "*"

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -15,6 +15,8 @@ from tiled.client import SERVERS, from_uri, simple
 from tiled.client.register import register
 from tiled.server import SimpleTiledServer
 
+from websockets.frames import CloseCode
+
 
 def test_default():
     "Smoke test a server with defaults (no parameters)"
@@ -222,3 +224,45 @@ def test_whoami_failing_gracefully(capsys):
         ):
             client = from_uri(server.uri)
             client.context.whoami()
+
+
+def test_close_with_open_streaming_subscription_does_not_hang(tmp_path):
+    """With an open streaming subscription, server.close() should not hang."""
+
+    server = SimpleTiledServer(directory=tmp_path)
+    client = from_uri(server.uri)
+    node = client.write_array([1, 2, 3], key="x")
+
+    subscription = node.subscribe().start_in_thread(max_size=10_000_000)
+    # Hold a reference to the live underlying connection. The Subscription would
+    # otherwise auto-reconnect on the 1012 close and replace it, hiding the code.
+    underlying = subscription._websocket._websocket
+    # Give the websocket a moment to finish connecting on the server side.
+    time.sleep(1.0)
+
+    # Close on a watchdog thread so a hang surfaces as a test failure rather
+    # than blocking the entire test suite indefinitely.
+    closed = threading.Event()
+
+    def _close():
+        server.close()
+        closed.set()
+
+    closer = threading.Thread(target=_close, daemon=True)
+    closer.start()
+    try:
+        assert closed.wait(
+            timeout=30
+        ), "server.close() hung with an open streaming subscription"
+        # uvicorn closes websockets with SERVICE_RESTART (1012) on shutdown.
+        # Wait for the closing handshake to be recorded on the connection.
+        wait_until = time.monotonic() + 10
+        while underlying.close_code is None and time.monotonic() < wait_until:
+            time.sleep(0.05)
+        assert underlying.close_code == CloseCode.SERVICE_RESTART
+    finally:
+        try:
+            subscription.disconnect()
+        except Exception:
+            pass
+        closer.join(timeout=5)

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -10,12 +10,11 @@ from pathlib import Path
 import httpx
 import pyarrow
 import pytest
+from websockets.frames import CloseCode
 
 from tiled.client import SERVERS, from_uri, simple
 from tiled.client.register import register
 from tiled.server import SimpleTiledServer
-
-from websockets.frames import CloseCode
 
 
 def test_default():

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -226,8 +226,12 @@ def test_whoami_failing_gracefully(capsys):
             client.context.whoami()
 
 
-def test_close_with_open_streaming_subscription_does_not_hang(tmp_path):
-    """With an open streaming subscription, server.close() should not hang."""
+@pytest.mark.parametrize("disconnect_first", [False, True])
+def test_close_with_open_streaming_subscription_does_not_hang(
+    tmp_path: Path, disconnect_first: bool
+):
+    """With a streaming subscription, server.close() should not hang, whether or
+    not the client disconnects the subscription before the server closes."""
 
     server = SimpleTiledServer(directory=tmp_path)
     client = from_uri(server.uri)
@@ -239,6 +243,9 @@ def test_close_with_open_streaming_subscription_does_not_hang(tmp_path):
     underlying = subscription._websocket._websocket
     # Give the websocket a moment to finish connecting on the server side.
     time.sleep(1.0)
+
+    if disconnect_first:
+        subscription.disconnect()
 
     # Close on a watchdog thread so a hang surfaces as a test failure rather
     # than blocking the entire test suite indefinitely.
@@ -253,13 +260,15 @@ def test_close_with_open_streaming_subscription_does_not_hang(tmp_path):
     try:
         assert closed.wait(
             timeout=30
-        ), "server.close() hung with an open streaming subscription"
-        # uvicorn closes websockets with SERVICE_RESTART (1012) on shutdown.
-        # Wait for the closing handshake to be recorded on the connection.
-        wait_until = time.monotonic() + 10
-        while underlying.close_code is None and time.monotonic() < wait_until:
-            time.sleep(0.05)
-        assert underlying.close_code == CloseCode.SERVICE_RESTART
+        ), "server.close() hung with a streaming subscription"
+        if not disconnect_first:
+            # With the subscription still open, uvicorn closes the websocket with
+            # SERVICE_RESTART (1012) on shutdown. Wait for the closing handshake
+            # to be recorded on the connection.
+            wait_until = time.monotonic() + 10
+            while underlying.close_code is None and time.monotonic() < wait_until:
+                time.sleep(0.05)
+            assert underlying.close_code == CloseCode.SERVICE_RESTART
     finally:
         try:
             subscription.disconnect()

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -369,14 +369,15 @@ def _make_ws_handler_common(
         disconnect_task = asyncio.create_task(watch_for_disconnect())
 
         last_sent = 0
-        if sequence is not None:
-            # If a sequence number is passed, replay old data
-            current_seq = last_sent = int(await current_sequence_getter())
-            logger.debug("Replaying old data...")
-            for s in range(sequence, current_seq + 1):
-                await stream_data(s)
         # Finally stream all buffered data into the websocket
         try:
+            if sequence is not None:
+                # If a sequence number is passed, replay old data
+                current_seq = last_sent = int(await current_sequence_getter())
+                logger.debug("Replaying old data...")
+                for s in range(sequence, current_seq + 1):
+                    await stream_data(s)
+
             while not end_stream.is_set():
                 live_seq = await stream_buffer.get()
 

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -360,8 +360,6 @@ def _make_ws_handler_common(
                     if message["type"] == "websocket.disconnect":
                         disconnect_code = message.get("code")
                         break
-            except WebSocketDisconnect as exc:
-                disconnect_code = exc.code
             except RuntimeError:
                 # Raised if the socket was already closed by the send path.
                 pass

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -407,7 +407,14 @@ def _make_ws_handler_common(
         finally:
             live_task.cancel()
             disconnect_task.cancel()
-            await asyncio.gather(live_task, disconnect_task, return_exceptions=True)
+            try:
+                await asyncio.gather(live_task, disconnect_task, return_exceptions=True)
+            except asyncio.CancelledError:
+                # In case a second cancel arrives while cleaning up, ignore it.
+                # The tasks are already cancelled and we don't want to raise an exception here.
+                # This was observed in tests using Starlette's TestClient, which cancels
+                # all tasks on exit.
+                pass
 
     return handler
 

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -217,6 +217,12 @@ class PubSub:
 # so the client reconnects and replays any sequences missed during the outage.
 _LIVE_SUBSCRIPTION_LOST = object()
 
+# Sentinel pushed onto the live-event buffer when the peer goes away (client
+# disconnect or server shutdown, both delivered as a websocket.disconnect
+# receive event). It wakes the handler's send loop, which is otherwise blocked
+# waiting for data, so the handler can return and release the connection.
+_PEER_DISCONNECTED = object()
+
 
 def _make_ws_handler_common(
     *,
@@ -335,6 +341,35 @@ def _make_ws_handler_common(
 
         live_task = asyncio.create_task(buffer_live_events())
 
+        # Track the disconnect code so we can surface it to the send loop.
+        disconnect_code = None
+
+        async def watch_for_disconnect():
+            """Wake the send loop on a disconnect event.
+
+            The send loop below blocks on an idle buffer and only sends; it never
+            reads. A client disconnect or a server shutdown arrives as a
+            websocket.disconnect receive event, so without draining ``receive()``
+            here the handler would never notice the socket is gone and would
+            keep the ASGI task (and thus graceful shutdown) alive forever.
+            """
+            nonlocal disconnect_code
+            try:
+                while True:
+                    message = await websocket.receive()
+                    if message["type"] == "websocket.disconnect":
+                        disconnect_code = message.get("code")
+                        break
+            except WebSocketDisconnect as exc:
+                disconnect_code = exc.code
+            except RuntimeError:
+                # Raised if the socket was already closed by the send path.
+                pass
+            finally:
+                stream_buffer.put_nowait(_PEER_DISCONNECTED)
+
+        disconnect_task = asyncio.create_task(watch_for_disconnect())
+
         last_sent = 0
         if sequence is not None:
             # If a sequence number is passed, replay old data
@@ -346,6 +381,12 @@ def _make_ws_handler_common(
         try:
             while not end_stream.is_set():
                 live_seq = await stream_buffer.get()
+
+                if live_seq is _PEER_DISCONNECTED:
+                    # Client disconnected or the server is shutting down. Surface
+                    # it through the shared disconnect path so the connection is
+                    # released and graceful shutdown can proceed.
+                    raise WebSocketDisconnect(code=disconnect_code or 1000)
 
                 if live_seq is _LIVE_SUBSCRIPTION_LOST:
                     # Must be an *abnormal* close: a graceful 1000 reads as
@@ -367,7 +408,8 @@ def _make_ws_handler_common(
             logger.info(f"Client disconnected from node {node_id}")
         finally:
             live_task.cancel()
-            await live_task
+            disconnect_task.cancel()
+            await asyncio.gather(live_task, disconnect_task, return_exceptions=True)
 
     return handler
 


### PR DESCRIPTION
Without this change, creating a subscription on a server would cause it to hang indefinitely on `close()`, even if the subscription is closed first client side.

Caught in a pytest unit test where a subscription was created on a `SimpleTiledServer`, which caused the
test to hang forever on fixture cleanup.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
