### PR TITLE
Address regression in API key auth for UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   web_frontend_checks:
-    name: WebUI Type Check and Tests
+    name: WebUI Type Check, Tests, and Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -133,6 +133,9 @@ jobs:
 
     - name: Test
       run: npm run test:run
+
+    - name: Build
+      run: npm run build
 
   windows_checks:
     name: Test on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,32 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  web_frontend_checks:
+    name: WebUI Type Check and Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-frontend
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+        cache: npm
+        cache-dependency-path: web-frontend/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Type check
+      run: npm run type-check
+
+    - name: Test
+      run: npm run test:run
+
   windows_checks:
     name: Test on Windows
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix a regression where opening a URL with an `?api_key=...` query parameter
+  in the web UI redirected to the login page instead of authenticating. The
+  server moves the API key into an `HttpOnly` cookie, which JavaScript cannot
+  read, so the UI treated the session as unauthenticated. The UI now probes
+  `/auth/whoami` on startup to detect a cookie-based session (including as a
+  fallback when refreshing an expired token fails) and clears the cookie on
+  logout.
 - Reading of individual partitions of multi-partitioned tables.
 - Fix the client showing a spurious "Retrying…" indicator (and a misleading
   "Retry scheduled" debug log) when a request failed with a *non-retryable*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Fix a regression where opening a URL with an `?api_key=...` query parameter
-  in the web UI redirected to the login page instead of authenticating. The
-  server moves the API key into an `HttpOnly` cookie, which JavaScript cannot
-  read, so the UI treated the session as unauthenticated. The UI now probes
-  `/auth/whoami` on startup to detect a cookie-based session (including as a
-  fallback when refreshing an expired token fails) and clears the cookie on
-  logout.
+  in the web UI redirected to the login page instead of authenticating.
 - Reading of individual partitions of multi-partitioned tables.
 - Fix the client showing a spurious "Retrying…" indicator (and a misleading
   "Retry scheduled" debug log) when a request failed with a *non-retryable*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 ### Fixed
 
 - Fix a regression where opening a URL with an `?api_key=...` query parameter
-  in the web UI redirected to the login page instead of authenticating.
+  in the web UI redirected to the login page instead of authenticating. This
+  now also works in single-user (`--api-key`) mode, where the server exposes no
+  `/auth` routes: the web UI detects the API-key cookie session by probing a
+  protected endpoint rather than `/auth/whoami`.
 - Reading of individual partitions of multi-partitioned tables.
 - Fix the client showing a spurious "Retrying…" indicator (and a misleading
   "Retry scheduled" debug log) when a request failed with a *non-retryable*

--- a/web-frontend/src/auth/auth-provider.test.tsx
+++ b/web-frontend/src/auth/auth-provider.test.tsx
@@ -1,0 +1,126 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { AuthProvider } from "./auth-provider";
+import { useAuth } from "./auth-context";
+import { axiosInstance } from "../client";
+import { tokenManager } from "./token-manager";
+
+vi.mock("../client", () => {
+  const interceptor = { use: vi.fn(() => 0), eject: vi.fn() };
+  return {
+    axiosInstance: {
+      get: vi.fn(),
+      post: vi.fn(),
+      interceptors: { request: interceptor, response: interceptor },
+    },
+  };
+});
+
+const get = vi.mocked(axiosInstance.get);
+
+// Minimal server auth config that requires authentication.
+const authRequired = {
+  required: true,
+  providers: [],
+} as any;
+
+function Probe() {
+  const { isAuthenticated, initialized, identity } = useAuth();
+  return (
+    <div>
+      <span data-testid="initialized">{String(initialized)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="identity">{identity ? identity.id : "none"}</span>
+    </div>
+  );
+}
+
+const renderProvider = (authentication: any) =>
+  render(
+    <AuthProvider authentication={authentication}>
+      <Probe />
+    </AuthProvider>,
+  );
+
+describe("AuthProvider cookie detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("treats a cookie-authenticated session as authenticated via whoami", async () => {
+    get.mockResolvedValue({
+      data: { uuid: "abc", identities: [{ id: "alice", provider: "toy" }] },
+    } as any);
+
+    renderProvider(authRequired);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(get).toHaveBeenCalledWith("/api/v1/auth/whoami");
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    expect(screen.getByTestId("identity")).toHaveTextContent("alice");
+  });
+
+  it("remains unauthenticated when whoami returns null", async () => {
+    get.mockResolvedValue({ data: null } as any);
+
+    renderProvider(authRequired);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+  });
+
+  it("does not become initialized until the whoami probe resolves", async () => {
+    let resolve: (v: any) => void = () => {};
+    get.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }) as any,
+    );
+
+    renderProvider(authRequired);
+
+    // Probe in flight: must not be initialized yet (prevents flash redirect).
+    expect(screen.getByTestId("initialized")).toHaveTextContent("false");
+
+    resolve({ data: null });
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+  });
+
+  it("skips the whoami probe when local tokens are present", async () => {
+    // A non-expired-looking access token so hasTokens() is true.
+    tokenManager.saveTokens({
+      access_token: "header.payload.sig",
+      refresh_token: "refresh",
+    });
+
+    renderProvider(authRequired);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(get).not.toHaveBeenCalled();
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+  });
+
+  it("skips the whoami probe when the server does not require auth", async () => {
+    renderProvider({ required: false, providers: [] } as any);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(get).not.toHaveBeenCalled();
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+  });
+});

--- a/web-frontend/src/auth/auth-provider.test.tsx
+++ b/web-frontend/src/auth/auth-provider.test.tsx
@@ -46,8 +46,17 @@ const validToken = () =>
 const expiredToken = () =>
   makeToken({ exp: Math.floor(Date.now() / 1000) - 3600 });
 
-// Minimal server auth config that requires authentication.
+// Minimal multi-user server auth config: auth is required and at least one
+// provider is configured, so the server exposes /auth routes (including
+// /auth/whoami).
 const authRequired = {
+  required: true,
+  providers: [{ provider: "toy", mode: "internal", links: {} }],
+} as any;
+
+// Single-user (API-key) server config: auth is required but there are no
+// providers, so the server has no /auth routes and whoami is absent.
+const singleUser = {
   required: true,
   providers: [],
 } as any;
@@ -175,6 +184,35 @@ describe("AuthProvider cookie detection", () => {
       expect(screen.getByTestId("initialized")).toHaveTextContent("true");
     });
     expect(get).not.toHaveBeenCalled();
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+  });
+
+  it("detects a single-user cookie session by probing a protected endpoint", async () => {
+    // Single-user servers have no /auth routes, so whoami is never called. A
+    // 200 from a protected endpoint means the API-key cookie authenticated us.
+    get.mockResolvedValue({ data: {} } as any);
+
+    renderProvider(singleUser);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(get).toHaveBeenCalledWith("/api/v1/metadata/");
+    expect(get).not.toHaveBeenCalledWith("/api/v1/auth/whoami");
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    // A single-user principal has no identity to display.
+    expect(screen.getByTestId("identity")).toHaveTextContent("none");
+  });
+
+  it("stays unauthenticated in single-user mode when the probe returns 401", async () => {
+    get.mockRejectedValue(new Error("401"));
+
+    renderProvider(singleUser);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(get).toHaveBeenCalledWith("/api/v1/metadata/");
     expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
   });
 });

--- a/web-frontend/src/auth/auth-provider.test.tsx
+++ b/web-frontend/src/auth/auth-provider.test.tsx
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import axios from "axios";
 import { AuthProvider } from "./auth-provider";
 import { useAuth } from "./auth-context";
 import { axiosInstance } from "../client";
@@ -17,7 +18,33 @@ vi.mock("../client", () => {
   };
 });
 
+// Mock the raw axios used for token refresh (auth-provider imports the default
+// export for /auth/session/refresh). By default the refresh fails, which lets
+// tests exercise the cookie-session fallback deterministically.
+vi.mock("axios", () => ({
+  default: { post: vi.fn(() => Promise.reject(new Error("refresh failed"))) },
+}));
+
 const get = vi.mocked(axiosInstance.get);
+const rawPost = vi.mocked(axios.post);
+
+// Build a JWT-shaped token whose payload decodes to the given claims. Only the
+// payload segment needs to be valid base64url JSON for tokenManager to read it.
+const makeToken = (claims: Record<string, unknown>) => {
+  const payload = btoa(JSON.stringify(claims))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `header.${payload}.sig`;
+};
+
+// A token that is still valid (expires an hour from now).
+const validToken = () =>
+  makeToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+
+// A token that has already expired.
+const expiredToken = () =>
+  makeToken({ exp: Math.floor(Date.now() / 1000) - 3600 });
 
 // Minimal server auth config that requires authentication.
 const authRequired = {
@@ -98,10 +125,10 @@ describe("AuthProvider cookie detection", () => {
     });
   });
 
-  it("skips the whoami probe when local tokens are present", async () => {
-    // A non-expired-looking access token so hasTokens() is true.
+  it("skips the whoami probe when a valid local token is present", async () => {
+    // A valid (unexpired) access token: already authenticated, no probe needed.
     tokenManager.saveTokens({
-      access_token: "header.payload.sig",
+      access_token: validToken(),
       refresh_token: "refresh",
     });
 
@@ -111,7 +138,34 @@ describe("AuthProvider cookie detection", () => {
       expect(screen.getByTestId("initialized")).toHaveTextContent("true");
     });
     expect(get).not.toHaveBeenCalled();
+    expect(rawPost).not.toHaveBeenCalled();
     expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+  });
+
+  it("falls back to the cookie probe when refreshing an expired token fails", async () => {
+    // An expired token with a refresh token that the server will reject.
+    tokenManager.saveTokens({
+      access_token: expiredToken(),
+      refresh_token: "stale-refresh",
+    });
+    // The refresh attempt fails (default mock), but an API-key cookie
+    // authenticates the whoami probe.
+    get.mockResolvedValue({
+      data: { uuid: "abc", identities: [{ id: "alice", provider: "toy" }] },
+    } as any);
+
+    renderProvider(authRequired);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+    });
+    expect(rawPost).toHaveBeenCalledWith(
+      "/api/v1/auth/session/refresh",
+      expect.anything(),
+    );
+    expect(get).toHaveBeenCalledWith("/api/v1/auth/whoami");
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    expect(screen.getByTestId("identity")).toHaveTextContent("alice");
   });
 
   it("skips the whoami probe when the server does not require auth", async () => {

--- a/web-frontend/src/auth/auth-provider.tsx
+++ b/web-frontend/src/auth/auth-provider.tsx
@@ -141,9 +141,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   //      fails, fall through to (3) in case a cookie session exists.
   //   3. An HttpOnly API-key cookie set by the server when a URL with
   //      ?api_key=... is opened. JavaScript cannot read that cookie directly,
-  //      so we ask the server via /auth/whoami, which returns HTTP 200 with a
-  //      Principal body when the request is authenticated (by cookie, header,
-  //      or token) or `null` when it is not.
+  //      so we ask the server: on multi-user servers via /auth/whoami (HTTP 200
+  //      with a Principal body when authenticated, `null` when not); on
+  //      single-user servers, which have no /auth routes, by probing a
+  //      protected endpoint. See probeCookieSession.
   //
   // `initialized` is gated on this completing (via cookieChecked) so that
   // RequireAuth does not redirect a cookie-authenticated user to /login while
@@ -156,20 +157,40 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     // Detect a cookie-based session. Only called when there is no usable local
     // access token, so the request interceptor does not attach a stale Bearer
     // header that could mask the cookie on the server.
+    //
+    // Multi-user servers expose /auth/whoami, which returns the Principal
+    // (including its identity) for a cookie-authenticated request, or `null`
+    // when the request is not authenticated. Single-user (API-key) servers have
+    // no authentication providers and therefore no /auth routes at all, so
+    // whoami is absent (404). There we detect a cookie session by probing a
+    // protected endpoint; a single-user principal has no identity to display.
+    const hasProviders = (authentication.providers ?? []).length > 0;
     const probeCookieSession = async () => {
-      try {
-        const response = await axiosInstance.get("/api/v1/auth/whoami");
-        if (!mounted) return;
-        const principal = response.data;
-        if (principal) {
-          const ident = principal.identities?.[0];
-          if (ident) {
-            setIdentity({ id: ident.id, provider: ident.provider });
+      if (hasProviders) {
+        try {
+          const response = await axiosInstance.get("/api/v1/auth/whoami");
+          if (!mounted) return;
+          const principal = response.data;
+          if (principal) {
+            const ident = principal.identities?.[0];
+            if (ident) {
+              setIdentity({ id: ident.id, provider: ident.provider });
+            }
+            setIsAuthenticated(true);
           }
-          setIsAuthenticated(true);
+        } catch {
+          // Not authenticated via cookie (or request failed) — leave as-is.
         }
+        return;
+      }
+      // Single-user mode: no /auth routes. A 200 from a protected endpoint
+      // means the API-key cookie authenticated us; a 401 means it did not.
+      try {
+        await axiosInstance.get("/api/v1/metadata/");
+        if (!mounted) return;
+        setIsAuthenticated(true);
       } catch {
-        // Not authenticated via cookie (or request failed) — leave state as-is.
+        // Not authenticated via cookie (or request failed) — leave as-is.
       }
     };
 

--- a/web-frontend/src/auth/auth-provider.tsx
+++ b/web-frontend/src/auth/auth-provider.tsx
@@ -134,41 +134,31 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     };
   }, [refreshOnce]);
 
-  // On mount: refresh expired tokens; schedule proactive refresh for valid ones.
-  useEffect(() => {
-    if (!tokenManager.hasTokens()) return;
-    if (tokenManager.isAccessTokenExpired()) {
-      refreshOnce().then((ok) => {
-        if (ok) scheduleProactiveRefresh();
-      });
-    } else {
-      scheduleProactiveRefresh();
-    }
-    return () => {
-      if (refreshTimeoutRef.current) {
-        clearTimeout(refreshTimeoutRef.current);
-      }
-    };
-  }, [refreshOnce, scheduleProactiveRefresh]);
-
-  // On startup, detect a server-side session established via an HttpOnly
-  // API-key cookie (set by the server when a URL with ?api_key=... is opened).
-  // JavaScript cannot read that cookie directly, so we ask the server via
-  // /auth/whoami. The endpoint returns HTTP 200 with a Principal body when the
-  // request is authenticated (by cookie, header, or token) or `null` when not.
+  // On startup, establish the initial authentication state. This considers
+  // three sources, in priority order:
+  //   1. A valid (unexpired) local access token — already authenticated.
+  //   2. An expired local access token — try to refresh it; if the refresh
+  //      fails, fall through to (3) in case a cookie session exists.
+  //   3. An HttpOnly API-key cookie set by the server when a URL with
+  //      ?api_key=... is opened. JavaScript cannot read that cookie directly,
+  //      so we ask the server via /auth/whoami, which returns HTTP 200 with a
+  //      Principal body when the request is authenticated (by cookie, header,
+  //      or token) or `null` when it is not.
+  //
+  // `initialized` is gated on this completing (via cookieChecked) so that
+  // RequireAuth does not redirect a cookie-authenticated user to /login while
+  // the check is still in flight.
   useEffect(() => {
     // Wait until the server's auth config is known.
     if (authentication === null) return;
     let mounted = true;
-    // If we already have local tokens, or the server does not require auth,
-    // there is nothing to detect — skip the probe.
-    if (tokenManager.hasTokens() || !authentication.required) {
-      setCookieChecked(true);
-      return;
-    }
-    axiosInstance
-      .get("/api/v1/auth/whoami")
-      .then((response) => {
+
+    // Detect a cookie-based session. Only called when there is no usable local
+    // access token, so the request interceptor does not attach a stale Bearer
+    // header that could mask the cookie on the server.
+    const probeCookieSession = async () => {
+      try {
+        const response = await axiosInstance.get("/api/v1/auth/whoami");
         if (!mounted) return;
         const principal = response.data;
         if (principal) {
@@ -178,17 +168,43 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           }
           setIsAuthenticated(true);
         }
-      })
-      .catch(() => {
+      } catch {
         // Not authenticated via cookie (or request failed) — leave state as-is.
-      })
-      .finally(() => {
-        if (mounted) setCookieChecked(true);
-      });
+      }
+    };
+
+    const startup = async () => {
+      // If the server does not require auth, there is nothing to detect.
+      if (!authentication.required) return;
+      if (tokenManager.hasTokens()) {
+        if (tokenManager.isAccessTokenExpired()) {
+          const refreshed = await refreshOnce();
+          if (refreshed) {
+            scheduleProactiveRefresh();
+          } else {
+            // Refresh failed and tokens were cleared; a cookie session may
+            // still authenticate us (e.g. a freshly opened ?api_key=... link).
+            await probeCookieSession();
+          }
+        } else {
+          scheduleProactiveRefresh();
+        }
+      } else {
+        await probeCookieSession();
+      }
+    };
+
+    startup().finally(() => {
+      if (mounted) setCookieChecked(true);
+    });
+
     return () => {
       mounted = false;
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+      }
     };
-  }, [authentication]);
+  }, [authentication, refreshOnce, scheduleProactiveRefresh]);
 
   const onLogin = useCallback(
     (accessToken: string, refreshToken: string, ident?: UserIdentity) => {

--- a/web-frontend/src/auth/auth-provider.tsx
+++ b/web-frontend/src/auth/auth-provider.tsx
@@ -29,6 +29,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   const [identity, setIdentity] = useState<UserIdentity | null>(() =>
     tokenManager.getIdentity(),
   );
+  // Whether the startup check for an existing server-side session (e.g. an
+  // HttpOnly API-key cookie set by the server via ?api_key=...) has completed.
+  // Until this is true, we must not let RequireAuth redirect to /login, or a
+  // cookie-authenticated user would be bounced to the login page on load.
+  const [cookieChecked, setCookieChecked] = useState(false);
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const refreshPromiseRef = useRef<Promise<boolean> | null>(null);
 
@@ -146,6 +151,45 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     };
   }, [refreshOnce, scheduleProactiveRefresh]);
 
+  // On startup, detect a server-side session established via an HttpOnly
+  // API-key cookie (set by the server when a URL with ?api_key=... is opened).
+  // JavaScript cannot read that cookie directly, so we ask the server via
+  // /auth/whoami. The endpoint returns HTTP 200 with a Principal body when the
+  // request is authenticated (by cookie, header, or token) or `null` when not.
+  useEffect(() => {
+    // Wait until the server's auth config is known.
+    if (authentication === null) return;
+    let mounted = true;
+    // If we already have local tokens, or the server does not require auth,
+    // there is nothing to detect — skip the probe.
+    if (tokenManager.hasTokens() || !authentication.required) {
+      setCookieChecked(true);
+      return;
+    }
+    axiosInstance
+      .get("/api/v1/auth/whoami")
+      .then((response) => {
+        if (!mounted) return;
+        const principal = response.data;
+        if (principal) {
+          const ident = principal.identities?.[0];
+          if (ident) {
+            setIdentity({ id: ident.id, provider: ident.provider });
+          }
+          setIsAuthenticated(true);
+        }
+      })
+      .catch(() => {
+        // Not authenticated via cookie (or request failed) — leave state as-is.
+      })
+      .finally(() => {
+        if (mounted) setCookieChecked(true);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [authentication]);
+
   const onLogin = useCallback(
     (accessToken: string, refreshToken: string, ident?: UserIdentity) => {
       tokenManager.saveTokens(
@@ -175,7 +219,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         authRequired: authentication?.required ?? false,
         providers: authentication?.providers ?? [],
         isAuthenticated,
-        initialized: authentication !== null,
+        initialized: authentication !== null && cookieChecked,
         identity,
         onLogin,
         onLogout,

--- a/web-frontend/src/components/tiled-app-bar/tiled-app-bar.test.tsx
+++ b/web-frontend/src/components/tiled-app-bar/tiled-app-bar.test.tsx
@@ -1,7 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TiledAppBar from "./tiled-app-bar";
+import { AuthContext, AuthContextType } from "../../auth/auth-context";
+import { axiosInstance } from "../../client";
+import { tokenManager } from "../../auth/token-manager";
+
+vi.mock("../../client", () => ({
+  axiosInstance: { post: vi.fn() },
+}));
+
+const post = vi.mocked(axiosInstance.post);
 
 describe("TiledAppBar", () => {
   const renderAppBar = (currentRoute = "/") => {
@@ -30,5 +39,78 @@ describe("TiledAppBar", () => {
     expect(navbar).toBeInTheDocument();
     expect(navbar).toHaveClass("MuiAppBar-root");
     expect(container.querySelector(".MuiToolbar-root")).toBeInTheDocument();
+  });
+});
+
+describe("TiledAppBar cookie-authenticated logout", () => {
+  const onLogout = vi.fn();
+
+  const authValue: AuthContextType = {
+    authRequired: true,
+    providers: [],
+    isAuthenticated: true,
+    initialized: true,
+    identity: { id: "alice", provider: "toy" },
+    onLogin: vi.fn(),
+    onLogout,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    post.mockResolvedValue({} as any);
+  });
+
+  const renderAuthed = () =>
+    render(
+      <MemoryRouter initialEntries={["/browse/"]}>
+        <AuthContext.Provider value={authValue}>
+          <TiledAppBar />
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    );
+
+  it("shows the identity and a logout menu when authenticated", () => {
+    renderAuthed();
+    expect(
+      screen.getByRole("button", { name: "alice" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the API-key cookie via /auth/logout when there is no refresh token", async () => {
+    renderAuthed();
+
+    fireEvent.click(screen.getByRole("button", { name: "alice" }));
+    fireEvent.click(screen.getByText("Log out"));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/api/v1/auth/logout");
+    });
+    // No refresh token present, so session/revoke is not called.
+    expect(post).not.toHaveBeenCalledWith(
+      "/api/v1/auth/session/revoke",
+      expect.anything(),
+    );
+    expect(onLogout).toHaveBeenCalled();
+  });
+
+  it("revokes the session and clears the cookie when a refresh token exists", async () => {
+    tokenManager.saveTokens({
+      access_token: "header.payload.sig",
+      refresh_token: "refresh-token",
+    });
+
+    renderAuthed();
+
+    fireEvent.click(screen.getByRole("button", { name: "alice" }));
+    fireEvent.click(screen.getByText("Log out"));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith("/api/v1/auth/logout");
+    });
+    expect(post).toHaveBeenCalledWith("/api/v1/auth/session/revoke", {
+      refresh_token: "refresh-token",
+    });
+    expect(onLogout).toHaveBeenCalled();
   });
 });

--- a/web-frontend/src/components/tiled-app-bar/tiled-app-bar.tsx
+++ b/web-frontend/src/components/tiled-app-bar/tiled-app-bar.tsx
@@ -29,6 +29,16 @@ const TiledAppBar = () => {
         // Best-effort server-side revocation.
       }
     }
+    // Clear the HttpOnly API-key cookie (set by the server when a URL with
+    // ?api_key=... is opened). session/revoke only revokes the JWT session and
+    // does not touch this cookie. /auth/logout is deprecated but is the only
+    // endpoint that clears the cookie. TODO: migrate to a non-deprecated
+    // successor once one exists.
+    try {
+      await axiosInstance.post("/api/v1/auth/logout");
+    } catch {
+      // Best-effort cookie clearing.
+    }
     onLogout();
     if (authRequired) {
       navigate("/login", { replace: true });

--- a/web-frontend/test/setup.ts
+++ b/web-frontend/test/setup.ts
@@ -1,10 +1,49 @@
 import "@testing-library/jest-dom";
 import { beforeAll } from "vitest";
 
+// Provide a working Web Storage implementation when the environment does not
+// already supply one with functional methods. jsdom normally does, but Node
+// >= 22 ships an experimental built-in `localStorage` global that shadows
+// jsdom's and exposes no methods unless `--localstorage-file` is set. Without
+// this shim, tests that touch localStorage fail with
+// "localStorage.clear is not a function" on newer Node versions.
+function installMemoryStorage() {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => void store.delete(key),
+    setItem: (key: string, value: string) => void store.set(key, String(value)),
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
 beforeAll(() => {
   global.ResizeObserver = class {
     observe() {}
     unobserve() {}
     disconnect() {}
   };
+
+  if (
+    typeof localStorage === "undefined" ||
+    typeof localStorage.clear !== "function"
+  ) {
+    installMemoryStorage();
+  }
 });


### PR DESCRIPTION
Launching Tiled like this, just for example,

```
tiled serve catalog --temp
```

prints a URL in the terminal with an `?api_key=...` query parameter. Formerly, clicking this link and opening the React UI in the browser "just worked." It worked because the server "moves" the API key from the query parameter to an `HttpOnly` cookie, which authenticates subsequent requests from the React UI.

https://github.com/bluesky/tiled/blob/24f9bb30c118c7e0262324316de257ee1f7b640f/tiled/server/authentication.py#L331-L344

The addition of the login redirect broke this, by redirecting users to the login screen even when a cookie was in place with the API key. This PR fixes that by testing an authenticated request to (`whoami`) to detect the presence of the cookie. It also updates the Log In / Log Out UI to reflect this, and clears the cookie on logout.

Finally, it incorporates the frontend in CI. I think it will totally omitted from the CI up to this point.

~~I have not yet tested this interactively.~~

AI disclosure: Opus 4.8 with detailed planning

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
