### PR TITLE
Refactor `node_id` to `node_path_parts` in the Graph Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Changed
+
+- Refactor the experimental graph API to tie entities to catalog nodes by
+  `nodePathParts` (a list of key segments) instead of by the internal `nodeId`.
+  Internal catalog node ids are no longer exposed to clients: `createEntity`
+  and `updateEntity` take a `nodePathParts` and the server resolves it to the
+  node's id, the `catalogNodeId` query is removed, and an entity now reports a
+  read-only boolean `isNodeBound` in place of `nodeId`. Passing a
+  `nodePathParts` that names no existing node raises an error.
+
 ### Fixed
 
 - Reading of individual partitions of multi-partitioned tables.

--- a/docs/source/user-guide/graph-and-links.md
+++ b/docs/source/user-guide/graph-and-links.md
@@ -220,36 +220,29 @@ than being stored as a literal string.
 `updateEntity`, `deleteEntity`, `updateLink`, and `deleteLink` are also
 available; deleting an entity cascades to any links attached to it.
 
-## Tie entities to data: `nodeId` vs `uri`
+## Tie entities to data: `nodePathParts` vs `uri`
 
 An entity can reference the data it describes in two independent ways:
 
-- **`nodeId`** --- the internal id of a node in *this* server's own catalog
-  tree, for an entity that represents (or is closely tied to) a dataset
-  hosted right here. Catalog node ids are internal and are not otherwise
-  exposed to clients, so resolve one from a catalog path with the
-  `catalogNodeId` query before creating or updating an entity:
-
-  ```graphql
-  query {
-    catalogNodeId(path: ["raw_dataset"])
-  }
-  ```
-
-  `path` is the list of key segments leading to the node (`["raw_dataset"]`
-  for a top-level entry, `["a", "b"]` for a nested one). It returns `null` if
-  no such node exists.
+- **`nodePathParts`** --- the path of key segments to a node in *this* server's
+  own catalog tree, for an entity that represents (or is closely tied to) a
+  dataset hosted right here. Pass it directly to `createEntity` (`["raw_dataset"]`
+  for a top-level entry, `["a", "b"]` for a nested one); the server resolves it to
+  the node's internal id, which is never exposed to clients. The read-only
+  `isNodeBound` field on an entity reports whether it is tied to a node, and the
+  query and mutation both raise an error if `nodePathParts` names no existing
+  node.
 
 - **`uri`** --- a free-form locator, stored and returned verbatim with no
   lookup or validation. Follow this convention when setting it:
   - If the entity points at data hosted by *this* server, set `uri` to the
-    full Tiled URL alongside `nodeId` (e.g.
+    full Tiled URL alongside `nodePathParts` (e.g.
     `http://host:port/api/v1/metadata/raw_dataset`), so the entity is
-    resolvable both internally (via `nodeId`) and as a plain link (via
+    resolvable both internally (via the bound node) and as a plain link (via
     `uri`).
   - If it points at data hosted elsewhere (a dataset on a different Tiled
     deployment, a DOI, anything with a stable external address), set `uri`
-    to that address and leave `nodeId` unset.
+    to that address and leave `nodePathParts` unset.
   - If it doesn't point at any addressable resource (e.g. a workflow or
     software entity that only exists as a description), leave `uri` unset
     (`null`).
@@ -261,7 +254,7 @@ An entity can reference the data it describes in two independent ways:
   mutation CreateEntity($input: CreateEntityInput!) {
     createEntity(input: $input) {
       id
-      nodeId
+      isNodeBound
       uri
     }
   }
@@ -272,7 +265,7 @@ An entity can reference the data it describes in two independent ways:
     "input": {
       "entityType": "dataset",
       "name": "raw_dataset",
-      "nodeId": 1,
+      "nodePathParts": ["raw_dataset"],
       "uri": "http://127.0.0.1:8000/api/v1/metadata/raw_dataset",
       "properties": { "schema:encodingFormat": "application/x-zarr" }
     }
@@ -302,10 +295,11 @@ An entity can reference the data it describes in two independent ways:
   }
   ```
 
-  This entity has no `nodeId`---it isn't in this server's catalog---but it
-  can still be linked into the graph like any other entity, for example as
-  the object of a `prov:wasDerivedFrom` link from a local dataset, to record
-  that the local data was derived from an experiment run somewhere else.
+  This entity is not node-bound (`isNodeBound` is false)---it isn't in this
+  server's catalog---but it can still be linked into the graph like any other
+  entity, for example as the object of a `prov:wasDerivedFrom` link from a local
+  dataset, to record that the local data was derived from an experiment run
+  somewhere else.
 
   See the `dif_beam_hdf5_image` entity in `example_configs/graphs/input.json`
   for a worked example.

--- a/example_configs/graphs/create_links.py
+++ b/example_configs/graphs/create_links.py
@@ -43,12 +43,6 @@ query($subjectId: ID!, $predicate: String!, $objectId: ID!) {
 }
 """
 
-CATALOG_NODE_ID_QUERY = """
-query($path: [String!]!) {
-    catalogNodeId(path: $path)
-}
-"""
-
 DATASET_NAMES = {dataset["name"] for dataset in DATASETS}
 
 
@@ -127,10 +121,13 @@ def main() -> None:
 
             properties = dict(item.get("properties") or {})
 
+            node_path_parts = item.get("nodePathParts")
             if name in DATASET_NAMES:
-                # Points at data hosted by this server: link to it by its
-                # full Tiled URL rather than an ad hoc relative path.
+                # Points at data hosted by this server: bind the entity to the
+                # catalog node by its path (the server resolves it to the
+                # internal node id) and link to it by its full Tiled URL.
                 uri = f"{base_url}/api/v1/metadata/{name}"
+                node_path_parts = [name]
             else:
                 # Points elsewhere (e.g. a dataset on another Tiled server)
                 # if the input document says so, or nowhere at all otherwise.
@@ -140,9 +137,10 @@ def main() -> None:
                 "entityType": item.get("entityType", "entity"),
                 "name": name,
                 "uri": uri,
-                "nodeId": item.get("nodeId"),
                 "properties": properties,
             }
+            if node_path_parts is not None:
+                entity_input["nodePathParts"] = node_path_parts
             if "accessBlob" in item:
                 entity_input["accessBlob"] = item["accessBlob"]
 
@@ -183,19 +181,6 @@ def main() -> None:
             print(f"Registered namespace: {prefix} -> {uri}")
 
         entity_ids: dict[str, str] = {}
-
-        # For entities that are real catalog datasets, resolve the catalog
-        # node's internal id so it lands in the entity's `nodeId` (and thus
-        # the `node_id` column), instead of being duplicated into `properties`.
-        for name, entity in entities.items():
-            if entity["nodeId"] is None and name in DATASET_NAMES:
-                lookup = _post_graphql(client, CATALOG_NODE_ID_QUERY, {"path": [name]})
-                node_id = lookup["data"]["catalogNodeId"]
-                if node_id is None:
-                    raise RuntimeError(
-                        f"Could not resolve catalog node id for dataset '{name}'."
-                    )
-                entity["nodeId"] = node_id
 
         existing = _post_graphql(client, LIST_ENTITIES_QUERY, {})
         for entity in existing["data"]["entities"]:

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -168,8 +168,13 @@ async def _execute(query, context, variables=None):
     return result
 
 
-async def _insert_node(store, node_id, access_blob, key="node", parent=None):
-    """Insert a synthetic catalog node row for entity/node delegation tests."""
+async def _insert_node(store, node_id, access_blob, key="node", parent=0):
+    """Insert a synthetic catalog node row for entity/node delegation tests.
+
+    Nodes are placed under the catalog root (parent=0) so that they are
+    reachable by path via the store's `resolve_node_id`, matching how real
+    catalog nodes are laid out.
+    """
     async with store._engine.begin() as conn:
         await conn.execute(
             sa_insert(_nodes).values(
@@ -521,7 +526,7 @@ async def test_create_entity_rejects_node_id_with_access_blob(store, policy):
             "input": {
                 "entityType": "sample",
                 "name": "bad",
-                "nodeId": 1,
+                "nodePathParts": ["node"],
                 "accessBlob": {"tags": ["team"]},
             }
         },
@@ -540,7 +545,13 @@ async def test_update_entity_rejects_setting_access_blob_on_node_linked_entity(
     created = await _execute(
         CREATE_ENTITY_MUTATION,
         alice_ctx,
-        {"input": {"entityType": "sample", "name": "linked", "nodeId": 1}},
+        {
+            "input": {
+                "entityType": "sample",
+                "name": "linked",
+                "nodePathParts": ["node"],
+            }
+        },
     )
     assert created.errors is None
     entity_id = created.data["createEntity"]["id"]
@@ -562,8 +573,8 @@ async def test_update_entity_rejects_setting_access_blob_on_node_linked_entity(
 @pytest.mark.asyncio
 async def test_update_entity_detaching_node_reinitializes_access_blob(store, policy):
     """
-    Detaching node_id (setting it to null) with no access_blob supplied in
-    the same call must not leave the entity with node_id=None AND
+    Detaching a node binding (setting node_path_parts to null) with no access_blob
+    supplied in the same call must not leave the entity with node_id=None AND
     access_blob=None -- that would make it invisible to everyone.
     """
     await _insert_node(store, 1, {"tags": ["team"]})
@@ -572,7 +583,13 @@ async def test_update_entity_detaching_node_reinitializes_access_blob(store, pol
     created = await _execute(
         CREATE_ENTITY_MUTATION,
         alice_ctx,
-        {"input": {"entityType": "sample", "name": "linked", "nodeId": 1}},
+        {
+            "input": {
+                "entityType": "sample",
+                "name": "linked",
+                "nodePathParts": ["node"],
+            }
+        },
     )
     assert created.errors is None
     entity_id = created.data["createEntity"]["id"]
@@ -583,7 +600,7 @@ async def test_update_entity_detaching_node_reinitializes_access_blob(store, pol
     }
     """
     detached = await _execute(
-        update_mutation, alice_ctx, {"id": entity_id, "input": {"nodeId": None}}
+        update_mutation, alice_ctx, {"id": entity_id, "input": {"nodePathParts": None}}
     )
     assert detached.errors is None
 

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -70,6 +70,27 @@ async def _namespaces(info: Info) -> dict[str, str]:
     return await _store(info).list_namespaces()
 
 
+async def _resolve_node_binding(
+    info: Info,
+    node_path_parts: Optional[list[str]],
+) -> Optional[int]:
+    """Resolve the catalog node (ID) an entity should bind to given node path
+
+    The provided node path is resolved to the id of an internal node in the catalog
+    (so clients never handle catalog integer ids). Returns None when node_path_parts
+    is None (an unbound, external entity). Raises if the path names no existing node.
+    """
+    if node_path_parts is None:
+        return None
+    resolved = await _store(info).resolve_node_id(node_path_parts)
+    if resolved is None:
+        raise GraphQLError(
+            f"No catalog node found at path {node_path_parts!r}.",
+            extensions={"code": "NODE_NOT_FOUND"},
+        )
+    return resolved
+
+
 class _PolicyNode:
     def __init__(self, access_blob: Optional[dict]):
         self.access_blob = access_blob or {}
@@ -186,7 +207,7 @@ async def _modify_access_blob(
 @strawberry.type
 class Entity:
     id: strawberry.ID
-    node_id: Optional[int]
+    is_node_bound: bool
     entity_type: str
     name: str
     uri: Optional[str]
@@ -286,7 +307,7 @@ def _entity_from_record(r: EntityRecord, namespaces: dict[str, str]) -> Entity:
     properties = compact_value(r.properties, namespaces) if r.properties else None
     return Entity(
         id=strawberry.ID(r.id),
-        node_id=r.node_id,
+        is_node_bound=r.node_id is not None,
         entity_type=r.entity_type,
         name=r.name,
         uri=r.uri,
@@ -316,7 +337,9 @@ def _link_from_record(r: LinkRecord, namespaces: dict[str, str]) -> Link:
 @strawberry.input
 class UpdateEntityInput:
     name: Optional[str] = None
-    node_id: Optional[int] | UnsetType = UNSET
+    # Re-bind to a catalog node by path (list of key segments), detach with an
+    # explicit null, or leave the current binding unchanged by omitting it.
+    node_path_parts: Optional[list[str]] | UnsetType = UNSET
     uri: Optional[str] | UnsetType = UNSET
     entity_type: Optional[str] = None
     access_blob: Optional[JSON] | UnsetType = UNSET  # type: ignore[valid-type]
@@ -332,7 +355,11 @@ class UpdateLinkInput:
 class CreateEntityInput:
     entity_type: str
     name: str
-    node_id: Optional[int] = None
+    # Bind this entity to a catalog node by its path of key segments
+    # (e.g. ["a", "b"]). Resolved to the internal node id server-side, so
+    # clients never handle the catalog's integer ids. Omit for an entity that
+    # is not tied to a node in this server's catalog.
+    node_path_parts: Optional[list[str]] = None
     uri: Optional[str] = None
     properties: Optional[JSON] = None  # type: ignore[valid-type]
     access_blob: Optional[JSON] = None  # type: ignore[valid-type]
@@ -369,31 +396,28 @@ class Query:
         self,
         info: Info,
         entity_type: Optional[str] = None,
+        node_path_parts: Optional[list[str]] = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
         access_filters = await _policy_access_filters(info, "read:metadata")
         if access_filters is NO_ACCESS:
             return []
+        node_id = None
+        if node_path_parts is not None:
+            node_id = await _store(info).resolve_node_id(node_path_parts)
+            if node_id is None:
+                # No such catalog node -> it can have no bound entities.
+                return []
         records = await _store(info).list_entities(
             entity_type=entity_type,
+            node_id=node_id,
             limit=limit,
             offset=offset,
             access_filters=access_filters or None,
         )
         namespaces = await _namespaces(info)
         return [_entity_from_record(r, namespaces) for r in records]
-
-    @strawberry.field(
-        description=(
-            "Resolve the internal catalog node id for a path of key "
-            "segments (e.g. ['raw_dataset']), for use as CreateEntityInput's "
-            "nodeId. Returns null if no such catalog node exists."
-        )
-    )
-    async def catalog_node_id(self, info: Info, path: list[str]) -> Optional[int]:
-        _assert_authn_scope(info, "read:metadata")
-        return await _store(info).resolve_node_id(path)
 
     @strawberry.field
     async def link(self, info: Info, id: strawberry.ID) -> Optional[Link]:
@@ -447,7 +471,8 @@ class Mutation:
     async def create_entity(self, info: Info, input: CreateEntityInput) -> Entity:
         _assert_authn_scope(info, "write:metadata")
         namespaces = await _namespaces(info)
-        if input.node_id is not None:
+        node_id = await _resolve_node_binding(info, input.node_path_parts)
+        if node_id is not None:
             if input.access_blob:
                 raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
             access_blob = None
@@ -456,7 +481,7 @@ class Mutation:
         record = await _store(info).create_entity(
             entity_type=input.entity_type,
             name=input.name,
-            node_id=input.node_id,
+            node_id=node_id,
             uri=input.uri,
             properties=expand_value(input.properties or {}, namespaces),
             access_blob=access_blob,
@@ -527,7 +552,17 @@ class Mutation:
         await _assert_allowed(
             info, await _effective_access_blob(info, current), "write:metadata"
         )
-        effective_node_id = current.node_id if input.node_id is UNSET else input.node_id
+        # Resolve the requested node binding into a tri-state on the internal
+        # node id: UNSET (leave), None (detach), or an int (bind).
+        # node_path_parts is resolved to the id, so the store never sees a path.
+        if input.node_path_parts is UNSET:
+            node_id = STORE_UNSET
+        elif input.node_path_parts is None:
+            node_id = None
+        else:
+            node_id = await _resolve_node_binding(info, input.node_path_parts)
+        node_binding_changed = node_id is not STORE_UNSET
+        effective_node_id = current.node_id if node_id is STORE_UNSET else node_id
         access_blob = UNSET
         if effective_node_id is not None:
             if input.access_blob is not UNSET and (input.access_blob or {}):
@@ -538,12 +573,11 @@ class Mutation:
             access_blob = await _modify_access_blob(
                 info, current.access_blob, requested_access_blob
             )
-        elif input.node_id is not UNSET and current.access_blob is None:
-            # Detaching from a node (node_id set to null) with no
+        elif node_binding_changed and current.access_blob is None:
+            # Detaching from a node (node_path_parts set to null) with no
             # access_blob supplied in the same call: the entity needs its
             # own access_blob now that it no longer delegates to a node.
             access_blob = await _init_access_blob(info, None)
-        node_id = STORE_UNSET if input.node_id is UNSET else input.node_id
         uri = STORE_UNSET if input.uri is UNSET else input.uri
         record = await _store(info).update_entity(
             str(id),

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -238,6 +238,7 @@ class GraphSQLAlchemyStore:
     async def list_entities(
         self,
         entity_type: Optional[str] = None,
+        node_id: Optional[int] = None,
         limit: int = 100,
         offset: int = 0,
         access_filters: Optional[list[AccessBlobFilter]] = None,
@@ -245,6 +246,8 @@ class GraphSQLAlchemyStore:
         stmt = select(_entities).order_by(_entities.c.created_at)
         if entity_type is not None:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
+        if node_id is not None:
+            stmt = stmt.where(_entities.c.node_id == node_id)
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
             # An entity's effective access_blob is its node's access_blob


### PR DESCRIPTION
## Reference catalog nodes by path in the graph API (keep the internal node-id FK)

This changes only the API surface. Internally, entities are still bound to catalog nodes by the `entities.node_id` integer foreign key — the server just resolves a client-supplied path to that id instead of having the client pass the id directly.

### Motivation

The experimental graph-of-links API had clients reference a catalog node using `nodeId` — the catalog's **internal integer primary key**. That's the wrong abstraction to expose *at the API boundary*:

- It's an internal SQL detail. `nodeId` is stable *within one database* but **not portable**: a dump/restore, replication, or migration reassigns ids, so a stored `nodeId` silently points at the wrong node.
- Clients had no natural way to get one. Binding an entity meant first calling a separate `catalogNodeId(path)` query to translate a path the client already knew into an opaque integer, then passing it to `createEntity` — two round trips for one intent.
- Clients identify data by *path* (`client["a"]["b"]`), not by a database row id.

This PR replaces `nodeId` at the API surface with **`nodePathParts`** — a list of key segments (`["raw_dataset"]`, or `["a", "b"]` for a nested node). The server resolves the path to the internal id itself, keeping the integer id on the server side where it belongs.

### What changed

- `createEntity`/`updateEntity` take `nodePathParts: [String!]` instead of `nodeId: Int`; a path naming no existing node raises an error.
- The `catalogNodeId` query is **removed**.
- The entity's `nodeId` output field is replaced with a read-only boolean **`isNodeBound`** (clients needing "which node" use the entity's `uri`).
- `updateEntity`'s `nodePathParts` is tri-state: omit = leave binding, `null` = detach, path = (re)bind.
- The `entities` query gains a `nodePathParts` filter (with matching `node_id` filter in `list_entities`).
- Example config, access-control tests, docs, and CHANGELOG updated.

The integer FK stays internal because it does work a path/URL string can't: `entities.node_id` has `ON DELETE CASCADE`, and node-bound entities delegate access control via an integer-FK join (`entities.node_id == nodes.id`). `uri` is an independent, free-form locator; the two are orthogonal.

### Performance

Net effect: **fewer client↔server round trips**, with negligible added server cost only on writes and node-filtered reads.

- **Resolution is one indexed query.** `resolve_node_id` builds a single statement chaining N self-joins (N = path depth), each served by the `nodes` `UniqueConstraint("key", "parent")` index — sub-millisecond for real paths, run co-located with the DB.
- **One fewer network round trip per node-bound write.** Old: a `catalogNodeId` query followed by a `createEntity` mutation (two HTTP round trips, since a GraphQL query result can't feed a mutation in the same request). New: a single `createEntity` mutation carrying `nodePathParts`, resolved server-side. RTT dwarfs a local lookup, so this is a latency win.
- **Reads are unchanged and stay cheap.** Output is `isNodeBound` (`node_id IS NOT NULL`), a free boolean; we deliberately do **not** emit `nodePathParts` on read, which would require walking parent pointers (recursive CTE / N+1 per entity).

Caveat: the resolve currently runs on its own connection, so a create is two statements across two connections — a minor overhead (foldable into one transaction later), not a correctness issue, since the FK makes a create fail cleanly if the node disappears mid-write.


### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
