### PR TITLE
BUG: decode bytes columns when serializing tables to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix `TypeError: Type is not JSON serializable: bytes` when serializing a
+  table with a bytes-dtype (numpy `S`) column to `application/json` or
+  `application/json-seq`. Such values are now decoded to strings.
 - Reading of individual partitions of multi-partitioned tables.
 - Fix the client showing a spurious "Retrying…" indicator (and a misleading
   "Retry scheduled" debug log) when a request failed with a *non-retryable*

--- a/tests/test_table_json_serialization.py
+++ b/tests/test_table_json_serialization.py
@@ -13,6 +13,7 @@ from tiled.adapters.dataframe import DataFrameAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
+from tiled.structures.core import StructureFamily
 
 # DataFrame with every problematic type in one place:
 #   - numpy float32 / int32 (orjson rejects non-native numpy scalars)
@@ -145,3 +146,32 @@ def test_timestamp_object(client, reader):
     assert isinstance(col[0], str)
     assert col[1] is None  # NaT → None
     assert isinstance(col[2], str)
+
+
+@pytest.mark.parametrize("media_type", ["application/json", "application/json-seq"])
+def test_bytes_column(media_type):
+    """A DataFrame column of genuine bytes must be decoded to str.
+
+    orjson cannot serialize bytes. The serializer is exercised directly here
+    rather than through an adapter, because adapters that round-trip data
+    through Arrow decode bytes to str before the serializer ever sees them,
+    leaving the decode branch uncovered. Includes a non-UTF-8 value to cover
+    the latin-1 fallback.
+    """
+    from tiled.serialization.table import default_serialization_registry
+
+    # b"abc": ASCII; "café".encode(): valid multi-byte UTF-8; b"\xff\xfe": not
+    # valid UTF-8, so it exercises the latin-1 fallback (decoding to "ÿþ").
+    df = pandas.DataFrame({"bytes_col": [b"abc", "café".encode("utf-8"), b"\xff\xfe"]})
+    serializer = default_serialization_registry.dispatch(
+        StructureFamily.table, media_type
+    )
+    output = serializer(media_type, df, {})
+    if media_type == "application/json-seq":
+        rows = [
+            json.loads(line) for line in b"".join(output).splitlines() if line.strip()
+        ]
+        col = [row["bytes_col"] for row in rows]
+    else:
+        col = json.loads(output)["bytes_col"]
+    assert col == ["abc", "café", "ÿþ"]

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -6,6 +6,7 @@ Persistent stores are being developed externally to the tiled package.
 
 import base64
 import collections
+import json
 import math
 import os
 import pathlib
@@ -832,6 +833,30 @@ async def test_container_export(tree, buffer):
         a = client.create_container("a")
         a.write_array([1, 2, 3], key="b")
         client.export(buffer, format="application/json")
+
+
+@pytest.mark.parametrize("media_type", ["application/json", "application/json-seq"])
+def test_table_bytes_column_json_export(tree, buffer, media_type):
+    "Binary columns are decoded to text so they can be JSON-serialized."
+    # b"\xff\xfe" is not valid UTF-8; it exercises the latin-1 fallback.
+    df = pandas.DataFrame(
+        {
+            "label": [b"abc", "café".encode(), b"\xff\xfe"],
+            "n": [1, 2, 3],
+        }
+    )
+    expected = ["abc", "café", b"\xff\xfe".decode("latin-1")]
+    with Context.from_app(build_app(tree)) as context:
+        client = from_context(context)
+        client.write_table(df, key="t")
+        client["t"].export(buffer, format=media_type)
+        payload = buffer.getvalue().decode("utf-8")
+
+    if media_type == "application/json":
+        assert json.loads(payload)["label"] == expected
+    else:
+        rows = [json.loads(line) for line in payload.splitlines()]
+        assert [row["label"] for row in rows] == expected
 
 
 def test_write_with_specified_mimetype(tree):

--- a/tiled/serialization/table.py
+++ b/tiled/serialization/table.py
@@ -134,6 +134,13 @@ if modules_available("orjson"):
                 return float(v)
             if isinstance(v, pandas.Timestamp):
                 return v.isoformat()
+            if isinstance(v, bytes):
+                # orjson cannot serialize bytes. Decode to text, falling back to
+                # latin-1 (which never raises) for non-UTF-8 byte strings.
+                try:
+                    return v.decode("utf-8")
+                except UnicodeDecodeError:
+                    return v.decode("latin-1")
             return v
 
         return [to_native(v) for v in arr]


### PR DESCRIPTION
orjson raises `TypeError: Type is not JSON serializable: bytes` on bytes-dtype (numpy `S`) table columns. Decode such values to str (UTF-8, falling back to latin-1) in the `application/json` and `application/json-seq` serializers.

### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
