### PR TITLE
BUG: Fix negative step slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Write the date in place of the "Unreleased" in the case a new version is release
   only a subset of scopes. Authorization is now enforced solely against the
   scopes each endpoint requires.
 - Render `NaN` as transparent pixels.
+- Fix client-side reading of reversed array slices that reach the start of an
+  axis (e.g. `arr[::-1]`) when the selection is large enough to be fetched in
+  multiple requests. Such slices are expanded to a negative canonical `stop`,
+  which the request-splitting logic mishandled, raising "Chunks do not add up
+  to shape."
 
 ## v0.2.16 (2026-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,7 @@ Write the date in place of the "Unreleased" in the case a new version is release
 - Render `NaN` as transparent pixels.
 - Fix client-side reading of reversed array slices that reach the start of an
   axis (e.g. `arr[::-1]`) when the selection is large enough to be fetched in
-  multiple requests. Such slices are expanded to a negative canonical `stop`,
-  which the request-splitting logic mishandled, raising "Chunks do not add up
-  to shape."
+  multiple requests.
 
 ## v0.2.16 (2026-08-21)
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -112,6 +112,19 @@ def test_array_dtypes(kind, context):
     actual_via_read = client[kind].read()
     assert numpy.array_equal(actual_via_slice, actual_via_read)
     assert numpy.array_equal(actual_via_slice, expected)
+    # Exercise a range of 1-D slicing patterns end-to-end for every dtype:
+    # contiguous, negative-index, negative-start, strided, full reversal, and
+    # scalar (integer) indexing.
+    for index in (
+        slice(2, 8),
+        slice(-3, None),
+        slice(None, None, 2),
+        slice(None, None, -1),
+        slice(8, 1, -1),
+        0,
+        -1,
+    ):
+        assert numpy.array_equal(client[kind][index], expected[index]), index
 
 
 @pytest.mark.parametrize("kind", list(scalar_cases))
@@ -202,14 +215,82 @@ def test_request_chunking(context, bytesize_limit, num_gets_expected, monkeypatc
     numpy.testing.assert_equal(arr, cube_cases["chunked"])
 
 
-def test_request_slicing(context):
-    # One slice that requires data from all chunks
+@pytest.mark.parametrize(
+    "index",
+    [
+        # (multi-dim) one slice that requires data from all chunks
+        (slice(None), 42, slice(100, 300)),
+        # integer indexing, positive and negative
+        5,
+        -1,
+        # negative start / stop
+        slice(-3, None),
+        slice(2, -2),
+        # strided, positive and negative step (incl. full reversal reaching 0)
+        slice(None, None, 2),
+        slice(None, None, -1),
+        slice(8, 1, -1),
+        # mixed multi-dim: strided + integer + reversed
+        (slice(None, None, 2), 42, slice(300, 100, -1)),
+        (slice(2, 8, 3), slice(None, None, -2), 100),
+        # Ellipsis combined with integer indexing
+        (Ellipsis, 0),
+        (0, Ellipsis),
+        # empty-result slices (server is not contacted; short-circuited)
+        slice(5, 5),
+        slice(10, 3),
+    ],
+)
+def test_request_slicing(context, index):
+    # Each of these fits within a single response, so the client should make at
+    # most one GET (and none at all when the result is empty).
     client = from_context(context)["cube/chunked"]
-    expected = cube_cases["chunked"][:, 42, 100:300]
+    expected = numpy.asarray(cube_cases["chunked"])[index]
     with record_history() as h:
-        actual = client[:, 42, 100:300]
-    assert len(h.requests) == 1
+        actual = numpy.asarray(client[index])
     numpy.testing.assert_equal(actual, expected)
+    num_gets = sum(1 for entry in h.requests if entry.method == "GET")
+    assert num_gets == (0 if expected.size == 0 else 1)
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        # positive-step slices split cleanly across chunk boundaries
+        (slice(None), slice(None), slice(100, 300)),
+        slice(None, None, 2),
+        slice(1, 9, 3),
+        slice(-3, None),
+        # reversed but stopping above 0 -> positive canonical stop
+        slice(8, 1, -1),
+        (slice(None, None, -2), slice(None, None, 2)),
+        # reversed reaching 0 -> negative canonical stop
+        slice(None, None, -1),
+        slice(5, None, -1),
+        (slice(None), slice(None, None, -1), slice(None)),
+    ],
+)
+def test_request_slicing_chunked_response(context, index, monkeypatch):
+    # Force the multi-request split path by shrinking the per-response limit so
+    # that each frame (300 x 400) is fetched separately, then verify the
+    # reassembled result matches NumPy for a variety of slices.
+    monkeypatch.setattr(ArrayClient, "RESPONSE_BYTESIZE_LIMIT", 300 * 400 * 8)
+    client = from_context(context)["cube/chunked"]
+    expected = numpy.asarray(cube_cases["chunked"])[index]
+    with record_history() as h:
+        actual = numpy.asarray(client[index])
+    numpy.testing.assert_equal(actual, expected)
+    # This slice spans multiple chunks, so more than one GET is expected.
+    num_gets = sum(1 for entry in h.requests if entry.method == "GET")
+    assert num_gets > 1
+
+
+@pytest.mark.parametrize("index", [10, -11, (0, 0, 400)])
+def test_out_of_range_index_raises(context, index):
+    # Out-of-range integer indexing should raise IndexError, matching NumPy.
+    client = from_context(context)["cube/chunked"]
+    with pytest.raises(IndexError):
+        client[index]
 
 
 def test_request_empty_slice(context):

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,4 +1,5 @@
 import builtins
+import itertools
 import pathlib
 
 import numpy as np
@@ -16,6 +17,7 @@ from tiled.ndslice import (
     block_for_slice,
     build_nested_grid,
     compose_slices,
+    split_slice,
 )
 from tiled.server.app import build_app
 
@@ -185,7 +187,7 @@ def test_ndslice_conversion(as_string, as_tuple, as_json):
     assert NDSlice.from_json(as_json) == as_tuple_with_ellipsis
 
     # Normalize the string representations before comparing them
-    norm_string = as_string.strip("(][)").replace(" ", "").lstrip("0")
+    norm_string = as_string.strip("(][)").replace(" ", "")
     norm_string = "1:3" if norm_string == "1:3:" else norm_string
     assert NDSlice(*as_tuple).to_numpy_str() == norm_string
 
@@ -426,6 +428,69 @@ def test_block_for_slice_correctness(shape, data):
     # Apply slice_in_block and verify correctness
     result = concatenated[slice_in_block] if slice_in_block else concatenated
     np.testing.assert_array_equal(result, expected)
+
+
+@given(
+    shape=st.lists(st.integers(5, 20), min_size=1, max_size=3),
+    data=st.data(),
+)
+def test_split_slice_correctness(shape, data):
+    """split_slice partitions a slice into sub-slices that reassemble losslessly.
+
+    Mirrors how the array client fetches a large slice in multiple requests:
+    split the (expanded) slice, apply each piece, then reassemble the pieces on
+    the split grid. In particular this covers reversed slices that reach index 0,
+    whose expanded form has a negative canonical stop.
+    """
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    chunks = data.draw(chunks_strategy(shape))
+    test_slice = NDSlice(data.draw(ndslice_strategy(shape)))
+    expanded = test_slice.expand_for_shape(shape) if test_slice else NDSlice()
+    expected = arr[expanded] if expanded else arr
+    assume(expected.size > 0)
+
+    # Draw a per-request size limit that ranges from forcing many splits (1) up
+    # to fetching everything in one piece (the full selection size).
+    max_size = data.draw(st.integers(1, int(expected.size)))
+    chunk_bounds = tuple(
+        tuple(itertools.accumulate(axis_chunks, initial=0)) for axis_chunks in chunks
+    )
+    indexed_slices = split_slice(expanded, max_size=max_size, pref_splits=chunk_bounds)
+
+    # Every sub-slice must be a valid absolute slice (no negative/None-stop
+    # ambiguity) that selects the same elements from the full array as NumPy.
+    keys = sorted(indexed_slices)
+    reassembled = np.block(build_nested_grid(keys, lambda k: arr[indexed_slices[k]]))
+    np.testing.assert_array_equal(reassembled, expected)
+
+
+@pytest.mark.parametrize(
+    "shape, index",
+    [
+        # Reversed slices that reach index 0 expand to a negative canonical stop
+        # (e.g. [::-1] on len 10 -> slice(9, -11, -1)); the split path must not
+        # treat that stop as an absolute coordinate.
+        ((10,), slice(None, None, -1)),
+        ((10,), slice(5, None, -1)),
+        ((10,), slice(9, None, -3)),
+        ((7,), slice(None, None, -2)),  # strided reversal that lands exactly on 0
+        ((8, 6), (slice(None, None, -1), slice(None, None, -1))),
+        ((8, 6), (slice(None), slice(None, None, -1))),
+        # Reversed but stopping above 0 -> positive canonical stop (should be fine)
+        ((10,), slice(8, 1, -1)),
+    ],
+)
+@pytest.mark.parametrize("max_size", [1, 2, 3, 5])
+def test_split_slice_reversed_reaching_zero(shape, index, max_size):
+    # split_slice reassembles reversed slices, including those reaching index 0.
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    expanded = NDSlice(index).expand_for_shape(shape)
+    expected = arr[expanded]
+
+    indexed_slices = split_slice(expanded, max_size=max_size)
+    keys = sorted(indexed_slices)
+    reassembled = np.block(build_nested_grid(keys, lambda k: arr[indexed_slices[k]]))
+    np.testing.assert_array_equal(reassembled, expected)
 
 
 def test_block_for_slice_basic():

--- a/tiled/ndslice.py
+++ b/tiled/ndslice.py
@@ -99,6 +99,22 @@ def merge_slices(*args: Union["NDSlice", "NDBlock"]) -> Union["NDSlice", "NDBloc
     return _cls(*result)
 
 
+def _num_steps(slc: builtins.slice) -> int:
+    """Number of elements an expanded 1-D slice selects.
+
+    Tolerates reversed slices that reach the start of the axis, whose expanded
+    `stop` is negative (e.g. `slice(9, -11, -1)`) or `None`. For those the
+    exclusive lower bound is `-1` in Python `range` terms, regardless of the
+    particular negative value produced by `expand_for_shape`.
+    """
+    start = slc.start or 0
+    step = slc.step or 1
+    stop = slc.stop
+    if step < 0 and (stop is None or stop < 0):
+        stop = -1
+    return len(range(start, stop, step))
+
+
 def split_1d(start, stop, step, max_len: int, pref_splits: Optional[list[int]] = None):
     """Split a 1D slice into sub-slices that do not exceed max_len steps.
 
@@ -107,14 +123,21 @@ def split_1d(start, stop, step, max_len: int, pref_splits: Optional[list[int]] =
     as long as it does not violate the min/max constraints.
     """
 
+    # A reversed slice reaching the start of the axis is expanded (by ndindex) to
+    # a negative canonical stop (e.g. slice(9, -11, -1)). Such a slice has no
+    # non-negative integer stop, so partition it as if the exclusive bound were
+    # -1 and emit stop=None for the final sub-slice that reaches index 0.
+    reaches_start = step < 0 and stop is not None and stop < 0
+    eff_stop = -1 if reaches_start else stop
+
     # Total number of steps and max steps per split
-    total_steps = math.ceil(abs(stop - start) / abs(step))
+    total_steps = math.ceil(abs(eff_stop - start) / abs(step))
 
     # Convert preferred points to index space
     pref_indx = sorted(
         (x - start) // step
         for x in (pref_splits or [])
-        if x in range(start, stop, step)
+        if x in range(start, eff_stop, step)
     )
 
     result, crnt_indx, _pi = [], 0, 0
@@ -139,7 +162,7 @@ def split_1d(start, stop, step, max_len: int, pref_splits: Optional[list[int]] =
         result.append((start + crnt_indx * step, start + next_indx * step))
         crnt_indx = next_indx
 
-    result.append((start + crnt_indx * step, stop))
+    result.append((start + crnt_indx * step, None if reaches_start else stop))
 
     return result
 
@@ -189,17 +212,13 @@ def split_slice(
     sorting_order = (
         [len(ps) for ps in pref_splits]
         if pref_splits is not None
-        else [len(range(s.start, s.stop, s.step or 1)) for s in arr_slice]
+        else [_num_steps(s) for s in arr_slice]
     )
     result = [[s] for s in arr_slice]
     for d in sorted(range(ndim), key=lambda i: sorting_order[i], reverse=True):
         # Find the size of largest block along all other dimensions, excluding d
         max_other = math.prod(
-            [
-                max(len(range(s.start, s.stop, s.step or 1)) for s in result[_d])
-                for _d in range(ndim)
-                if _d != d
-            ]
+            [max(_num_steps(s) for s in result[_d]) for _d in range(ndim) if _d != d]
         )
         slc = result[d].pop()
 
@@ -214,7 +233,7 @@ def split_slice(
         result[d].extend([builtins.slice(a, b, slc.step) for a, b in splits])
 
         # Check if we need further subslicing along other dimensions
-        max_crnt = max(len(range(s.start, s.stop, s.step or 1)) for s in result[d])
+        max_crnt = max(_num_steps(s) for s in result[d])
         if max_crnt * max_other <= max_size:
             break
 
@@ -554,7 +573,7 @@ class NDSlice(tuple):
         for s in self:
             if isinstance(s, builtins.slice):
                 string_slice = (
-                    f"{(s.start or '')}:"
+                    f"{('' if s.start is None else s.start)}:"
                     + ("" if s.stop is None else f"{s.stop}")
                     + (f":{str(s.step)}" if s.step else "")
                 )


### PR DESCRIPTION
Reading a reversed slice that reaches the start of an axis (e.g. `arr[::-1]`, `arr[5::-1]`, `arr[::-2]`) fails on the client when the selection is large enough to be fetched in **multiple requests**. The single-request path was unaffected, so this went unnoticed.

### Root cause

`expand_for_shape` (via `ndindex`) expands such slices to a **negative canonical `stop`** — e.g. `[::-1]` on a length-10 axis becomes `slice(9, -11, -1)`. The split path treated that `stop` as an absolute coordinate, so `split_1d` miscounted the steps (`abs(-11 - 9) = 20` instead of `10`) and emitted invalid sub-slices like `slice(4, -1, -1)`; the reassembled chunks then failed to tile the requested shape.


### Checklist
- [x] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
