### PR TITLE
Fix the config parser for adapters_by_mimetype

### DIFF
--- a/docs/source/explanations/specialized-formats.md
+++ b/docs/source/explanations/specialized-formats.md
@@ -88,8 +88,8 @@ trees:
     tree: tiled.catalog:from_uri
     args:
       uri: ./catalog.db
-        readable_storage:
-          - ./data/
+      readable_storage:
+        - ./data/
       adapters_by_mimetype:
         application/x-xdi: tiled.examples.xdi:read_xdi
 ```

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,6 +185,20 @@ def test_pydantic_config():
     Config.model_validate({"catalog": {"uri": "sqlite:///:memory:"}})
 
 
+def test_catalog_adapters_by_mimetype_mapping():
+    Config.model_validate(
+        {
+            "catalog": {
+                "uri": "sqlite:///:memory:",
+                "adapters_by_mimetype": {
+                    "application/x-edf": "tiled.examples.xdi:read_xdi",
+                    "application/x-gb": "tiled.examples.xdi:read_xdi",
+                },
+            }
+        }
+    )
+
+
 def test_duplicate_auth_providers():
     with pytest.raises(ValidationError, match="provider names must be unique"):
         Config.model_validate(

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -64,7 +64,7 @@ class CatalogConfig(BaseSettings):
     writable_storage: Optional[list[str]] = None
     readable_storage: Optional[list[str]] = None
     init_if_not_exists: bool = False
-    adapters_by_mimetype: Optional[list[EntryPointString]] = None
+    adapters_by_mimetype: Optional[dict[str, EntryPointString]] = None
     top_level_access_blob: Optional[dict] = None
     mount_node: Optional[Union[str, list[str]]] = None
     catalog_pool_size: int = 5


### PR DESCRIPTION
### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section

The config parser defines a catalog's `adapters_by_mimetype` as a list of entries. It should be a dict with the mimetype as a key.