### PR TITLE
Fix Array Shape Desynchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ### Fixed
 
+- Fix reads of array data whose on-disk shape has diverged from the shape
+  recorded in the catalog structure, which can happen while an array is being
+  extended (e.g. streaming appends).
 - Fix a regression where opening a URL with an `?api_key=...` query parameter
   in the web UI redirected to the login page instead of authenticating. This
   now also works in single-user (`--api-key`) mode, where the server exposes no

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -7,15 +7,25 @@ import dask.array
 import httpx
 import numpy
 import pytest
-from starlette.status import HTTP_406_NOT_ACCEPTABLE, HTTP_422_UNPROCESSABLE_CONTENT
+from starlette.status import (
+    HTTP_406_NOT_ACCEPTABLE,
+    HTTP_422_UNPROCESSABLE_CONTENT,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
 
 from tiled.adapters.array import ArrayAdapter
 from tiled.adapters.mapping import MapAdapter
+from tiled.adapters.utils import (
+    DataNotReadyError,
+    IncompatibleShapeError,
+    force_reshape,
+)
 from tiled.client import Context, from_context, record_history
 from tiled.client.array import ArrayClient
 from tiled.ndslice import NDSlice
 from tiled.serialization.array import as_buffer
 from tiled.server.app import build_app
+from tiled.structures.array import ArrayStructure
 
 from .utils import fail_with_status_code
 
@@ -293,3 +303,83 @@ def test_array_client_repr(tmpdir, chunks, expected):
         assert f"chunks={expected}" in rep
         if client["arr"].dims:
             assert "dims=('x', 'y', 'z')" in rep
+
+
+def test_force_reshape_noop_and_genuine_reshape():
+    # Exact match is a no-op.
+    arr = numpy.arange(6).reshape((2, 3))
+    assert force_reshape(arr, (2, 3)) is arr
+    # Same total size is a genuine, well-defined reshape.
+    reshaped = force_reshape(arr, (3, 2))
+    assert reshaped.shape == (3, 2)
+    numpy.testing.assert_array_equal(reshaped.ravel(), arr.ravel())
+
+
+def test_force_reshape_trims_leading_axis_when_file_ahead():
+    # The file has grown along the leading axis beyond the advertised shape,
+    # with trailing dims unchanged. Serve exactly the advertised shape by
+    # trimming the extra leading frames.
+    arr = numpy.arange(4 * 3).reshape((4, 3))
+    trimmed = force_reshape(arr, (2, 3))
+    assert trimmed.shape == (2, 3)
+    numpy.testing.assert_array_equal(trimmed, arr[:2])
+
+
+def test_force_reshape_raises_when_structure_ahead_of_data():
+    # The structure advertises more data than is available (catalog ahead of
+    # file, e.g. during a streaming append). We must not fabricate data. This
+    # is transient: more frames may still arrive.
+    arr = numpy.ones((3, 2, 4))
+    with pytest.raises(DataNotReadyError):
+        force_reshape(arr, (5, 2, 4))
+
+
+def test_force_reshape_raises_on_incompatible_shape():
+    # Trailing dims differ and total size differs: a genuine incompatibility
+    # that retrying cannot resolve.
+    arr = numpy.ones((4, 3))
+    with pytest.raises(IncompatibleShapeError):
+        force_reshape(arr, (4, 5))
+
+
+def test_structure_ahead_of_data_returns_503():
+    # Serve an array whose stored structure claims more frames than the
+    # underlying data has, mimicking a catalog that is ahead of the file
+    # during a streaming append. The read should surface as a retryable
+    # HTTP 503, not an opaque 500.
+    data = numpy.ones((3, 2, 4))
+    ahead_structure = ArrayStructure.from_array(numpy.ones((5, 2, 4)))
+    adapter = ArrayAdapter(data, ahead_structure)
+    app = build_app(MapAdapter({"streaming": adapter}))
+    with Context.from_app(app) as ahead_context:
+        client = from_context(ahead_context)
+        with fail_with_status_code(HTTP_503_SERVICE_UNAVAILABLE):
+            client["streaming"].read()
+
+
+def test_incompatible_structure_returns_422():
+    # Serve an array whose stored structure is incompatible with the data in a
+    # way that retrying cannot fix (trailing dimensions disagree). This is a
+    # permanent error, surfaced as HTTP 422.
+    data = numpy.ones((4, 3))
+    bad_structure = ArrayStructure.from_array(numpy.ones((4, 5)))
+    adapter = ArrayAdapter(data, bad_structure)
+    app = build_app(MapAdapter({"streaming": adapter}))
+    with Context.from_app(app) as bad_context:
+        client = from_context(bad_context)
+        with fail_with_status_code(HTTP_422_UNPROCESSABLE_CONTENT):
+            client["streaming"].read()
+
+
+def test_file_ahead_of_structure_serves_trimmed():
+    # Serve an array whose underlying data has more frames than the stored
+    # structure advertises. The client sees exactly the advertised shape.
+    data = numpy.arange(4 * 2 * 4).reshape((4, 2, 4))
+    behind_structure = ArrayStructure.from_array(numpy.ones((2, 2, 4)))
+    adapter = ArrayAdapter(data, behind_structure)
+    app = build_app(MapAdapter({"streaming": adapter}))
+    with Context.from_app(app) as behind_context:
+        client = from_context(behind_context)
+        result = client["streaming"].read()
+    assert result.shape == (2, 2, 4)
+    numpy.testing.assert_array_equal(result, data[:2])

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,12 +1,15 @@
 import asyncio
+import os
 import random
 import string
+import time
 from contextlib import closing
 from dataclasses import asdict
 from pathlib import Path
 from typing import cast
 
 import dask.array
+import h5py
 import numpy
 import pandas
 import pandas.testing
@@ -25,6 +28,7 @@ from sqlalchemy.pool import AsyncAdaptedQueuePool, QueuePool, StaticPool
 from tiled.adapters.csv import CSVAdapter
 from tiled.adapters.dataframe import ArrayAdapter
 from tiled.adapters.tiff import TiffAdapter
+from tiled.adapters.utils import DataNotReadyError, IncompatibleShapeError
 from tiled.catalog import in_memory
 from tiled.catalog.adapter import WouldDeleteData
 from tiled.catalog.explain import record_explanations
@@ -441,6 +445,86 @@ async def test_lazy_sequence_tolerates_num_offset(tmpdir, num_offset):
 
         result = await x.read(slice=slice_input)
         numpy.testing.assert_array_equal(result, reference)
+    finally:
+        await adapter.shutdown()
+
+
+async def _register_ahead_hdf5(adapter, tmpdir, *, file_frames=3, ahead_frames=5):
+    """Register an external HDF5 array whose catalog structure is ahead of the file.
+
+    The backing file holds `file_frames` frames of shape `(rows, cols)`, but the
+    catalog structure advertises `ahead_frames`, mimicking a streaming append
+    where the catalog shape ran ahead of this reader's view of the file. Returns
+    the backing file path.
+    """
+    rows, cols = 2, 4
+    filepath = Path(tmpdir) / "streaming.h5"
+    with h5py.File(filepath, "w", libver="latest") as f:
+        f.create_dataset(
+            "data",
+            data=numpy.ones((file_frames, rows, cols)),
+            maxshape=(None, rows, cols),
+        )
+    ahead_structure = ArrayStructure(
+        shape=(ahead_frames, rows, cols),
+        chunks=((ahead_frames,), (rows,), (cols,)),
+        data_type=BuiltinDtype.from_numpy_dtype(numpy.dtype("float64")),
+    )
+    await adapter.create_node(
+        key="streaming",
+        structure_family=StructureFamily.array,
+        metadata={},
+        data_sources=[
+            DataSource(
+                structure_family="array",
+                mimetype="application/x-hdf5",
+                structure=asdict(ahead_structure),
+                parameters={"dataset": "data"},
+                management="external",
+                assets=[
+                    Asset(
+                        parameter="data_uris",
+                        num=0,
+                        data_uri=ensure_uri(str(filepath)),
+                        is_directory=False,
+                    )
+                ],
+            )
+        ],
+    )
+    return filepath
+
+
+@pytest.mark.asyncio
+async def test_structure_ahead_of_recently_modified_file_is_transient(tmpdir):
+    # The catalog structure is ahead of the data on disk and the backing file
+    # was just written, so a streaming append is plausibly in progress. The
+    # read raises the transient `DataNotReadyError`.
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        await _register_ahead_hdf5(adapter, tmpdir)
+        x = await adapter.lookup_adapter(["streaming"])
+        with pytest.raises(DataNotReadyError):
+            await x.read()
+    finally:
+        await adapter.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_structure_ahead_of_stale_file_is_permanent(tmpdir):
+    # The catalog structure is ahead of the data on disk but the backing file
+    # has not been touched for a long time, so the data is at rest and will not
+    # catch up. The read is downgraded to a permanent `IncompatibleShapeError`.
+    adapter = in_memory(readable_storage=[tmpdir])
+    await adapter.startup()
+    try:
+        filepath = await _register_ahead_hdf5(adapter, tmpdir)
+        stale = time.time() - 3600
+        os.utime(filepath, (stale, stale))
+        x = await adapter.lookup_adapter(["streaming"])
+        with pytest.raises(IncompatibleShapeError):
+            await x.read()
     finally:
         await adapter.shutdown()
 

--- a/tiled/adapters/utils.py
+++ b/tiled/adapters/utils.py
@@ -79,6 +79,28 @@ def init_adapter_from_catalog(
     return adapter_cls(structure=data_source.structure, **kwargs)
 
 
+class ShapeMismatchError(ValueError):
+    """Array data cannot be served at the shape the structure advertises."""
+
+
+class DataNotReadyError(ShapeMismatchError):
+    """Transient mismatch: the structure is ahead of the data.
+
+    The advertised shape exceeds the available data along the leading axis
+    only, with all trailing dimensions matching. This typically means frames
+    are still being written and the data will catch up, so the read may be
+    retried.
+    """
+
+
+class IncompatibleShapeError(ShapeMismatchError):
+    """Permanent mismatch: the data cannot be reshaped to the advertised shape.
+
+    Retrying will not help: the trailing dimensions disagree, or the total
+    sizes are otherwise incompatible.
+    """
+
+
 def force_reshape(
     arr: Union[np.array, dask.array.Array], desired_shape: Tuple[int, ...]
 ) -> Union[np.array, dask.array.Array]:
@@ -98,14 +120,44 @@ def force_reshape(
     A view of the original array
     """
 
-    if arr.shape == tuple(desired_shape):
+    desired_shape = tuple(desired_shape)
+
+    if arr.shape == desired_shape:
         return arr  # Nothing to do here
 
+    same_rank = len(arr.shape) == len(desired_shape)
+    trailing_match = same_rank and arr.shape[1:] == desired_shape[1:]
+
+    # The data in storage has grown along the leading axis beyond what Tiled's
+    # structure advertises, while every trailing dimension is unchanged. This
+    # happens when a file is extended (e.g. streaming appends) after the catalog
+    # captured its structure. Serve exactly the advertised shape by slicing the
+    # leading axis, silently ignoring the extra frames.
+    if trailing_match and arr.shape[0] > desired_shape[0]:
+        return arr[: desired_shape[0]]
+
     if arr.size == math.prod(desired_shape):
+        # Total size matches: a genuine, well-defined reshape, e.g. serving a
+        # `(6, 200, 300)` array as `(3, 2, 200, 300)`.
         return arr.reshape(desired_shape)
 
-    raise ValueError(
-        f"Can not reshape {arr.shape} array data to {tuple(desired_shape)}"
+    if trailing_match and arr.shape[0] < desired_shape[0]:
+        # The structure advertises more frames than are available, along the
+        # leading axis only. This arises transiently during streaming appends,
+        # when the catalog's shape is updated (or observed from another server)
+        # before this reader's view of the file has caught up. We must never
+        # advertise one shape and then transmit another, and we cannot fabricate
+        # the missing data, but the data will likely catch up, so this is retryable.
+        raise DataNotReadyError(
+            f"The structure advertises shape {desired_shape}, but only "
+            f"{arr.shape} is currently available in the storage. The data may "
+            "still be arriving; please, retry the read later."
+        )
+
+    # Any other mismatch cannot be resolved by more frames arriving (the
+    # trailing dimensions disagree, or the total sizes are incompatible).
+    raise IncompatibleShapeError(
+        f"Can not reshape {arr.shape} array data to {desired_shape}"
     )
 
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -8,6 +8,7 @@ import operator
 import os
 import shutil
 import sys
+import time
 import uuid
 from contextlib import closing
 from datetime import datetime, timezone
@@ -67,6 +68,7 @@ from tiled.queries import (
     StructureFamilyQuery,
 )
 
+from ..adapters.utils import DataNotReadyError, IncompatibleShapeError
 from ..mimetypes import (
     APACHE_ARROW_FILE_MIME_TYPE,
     AWKWARD_BUFFERS_MIMETYPE,
@@ -102,6 +104,7 @@ from ..storage import (
     ObjectStorage,
     SQLStorage,
     get_storage,
+    mtime_from_uri,
     parse_storage,
     register_storage,
 )
@@ -126,6 +129,13 @@ if TYPE_CHECKING:
     from ..ndslice import NDBlock
 
 logger = logging.getLogger(__name__)
+
+# When a read fails because the catalog structure shape is ahead of the data
+# actually present in storage, treat it as a transient "not ready"
+# condition (rather than a permanent error) only if the backing file was
+# modified within this many seconds. This distinguishes an in-progress
+# streaming append from a write that was aborted and left at rest.
+ARRAY_NOT_READY_WINDOW = float(os.getenv("TILED_ARRAY_NOT_READY_WINDOW", "10.0"))
 
 # When data is uploaded, how is it saved?
 # TODO: Make this configurable at Catalog construction time.
@@ -1818,6 +1828,33 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
 
 
 class CatalogArrayAdapter(CatalogNodeAdapter):
+    async def _assets_recently_modified(self) -> Optional[bool]:
+        """Report whether a backing asset was modified within the freshness window.
+
+        Returns `True` if at least one backing asset was modified within
+        `ARRAY_NOT_READY_WINDOW` seconds (an append is likely in progress),
+        `False` if backing assets exist but none were recently modified (the
+        data appears to be at rest), or `None` if freshness cannot be
+        determined for any asset (for example, an unsupported URI scheme or an
+        asset that cannot be stat'd).
+        """
+        try:
+            data_sources = await self.data_sources(include_assets=True)
+        except Exception:
+            return None
+        now = time.time()
+        found = False
+        for data_source in data_sources:
+            for asset in data_source.assets:
+                try:
+                    mtime = mtime_from_uri(asset.data_uri)
+                except (OSError, ValueError):
+                    continue
+                found = True
+                if now - mtime < ARRAY_NOT_READY_WINDOW:
+                    return True
+        return False if found else None
+
     async def read(self, *args, **kwargs):
         if not self.node.data_sources:
             fields = kwargs.get("fields")
@@ -1826,22 +1863,34 @@ class CatalogArrayAdapter(CatalogNodeAdapter):
             return self
         # Try lazy per-frame resolution for a plain slice read (no field
         # selection). Falls back to the full adapter build if not applicable.
-        if "fields" not in kwargs:
-            slice_ = args[0] if args else kwargs.get("slice", ...)
-            adapter = await self._get_lazy_adapter(slice=slice_)
-            if adapter is not None:
-                return await ensure_awaitable(adapter.read, *args, **kwargs)
-        return await ensure_awaitable((await self.get_adapter()).read, *args, **kwargs)
+        try:
+            if "fields" not in kwargs:
+                slice_ = args[0] if args else kwargs.get("slice", ...)
+                adapter = await self._get_lazy_adapter(slice=slice_)
+                if adapter is not None:
+                    return await ensure_awaitable(adapter.read, *args, **kwargs)
+            return await ensure_awaitable(
+                (await self.get_adapter()).read, *args, **kwargs
+            )
+        except DataNotReadyError as err:
+            if (await self._assets_recently_modified()) is False:
+                raise IncompatibleShapeError(str(err)) from err
+            raise
 
     async def read_block(self, *args, **kwargs):
-        block = args[0] if args else kwargs.get("block")
-        if block is not None:
-            adapter = await self._get_lazy_adapter(block=block)
-            if adapter is not None:
-                return await ensure_awaitable(adapter.read_block, *args, **kwargs)
-        return await ensure_awaitable(
-            (await self.get_adapter()).read_block, *args, **kwargs
-        )
+        try:
+            block = args[0] if args else kwargs.get("block")
+            if block is not None:
+                adapter = await self._get_lazy_adapter(block=block)
+                if adapter is not None:
+                    return await ensure_awaitable(adapter.read_block, *args, **kwargs)
+            return await ensure_awaitable(
+                (await self.get_adapter()).read_block, *args, **kwargs
+            )
+        except DataNotReadyError as err:
+            if (await self._assets_recently_modified()) is False:
+                raise IncompatibleShapeError(str(err)) from err
+            raise
 
     async def _stream(self, media_type, entry, body, shape, block=None, offset=None):
         sequence = await self.context.streaming_cache.incr_seq(self.node.id)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -37,9 +37,11 @@ from starlette.status import (
     HTTP_410_GONE,
     HTTP_422_UNPROCESSABLE_CONTENT,
     HTTP_500_INTERNAL_SERVER_ERROR,
+    HTTP_503_SERVICE_UNAVAILABLE,
 )
 
 from tiled.adapters.protocols import AnyAdapter
+from tiled.adapters.utils import DataNotReadyError, ShapeMismatchError
 from tiled.authenticators import ProxiedOIDCAuthenticator
 from tiled.media_type_registration import SerializationRegistry
 from tiled.query_registration import QueryRegistry
@@ -110,6 +112,11 @@ from .utils import (
 )
 
 T = TypeVar("T")
+
+# When an array read fails because the catalog structure is ahead of the data
+# actually present on disk (a streaming append in progress), the client is told
+# to retry after this many seconds.
+ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 
 
 def _patch_route_signature(
@@ -611,6 +618,16 @@ def get_router(
                     status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                     detail="Block index out of range",
                 )
+            except DataNotReadyError as err:
+                raise HTTPException(
+                    status_code=HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=str(err),
+                    headers={"Retry-After": str(ARRAY_RETRY_AFTER_SECONDS)},
+                )
+            except ShapeMismatchError as err:
+                raise HTTPException(
+                    status_code=HTTP_422_UNPROCESSABLE_CONTENT, detail=str(err)
+                )
             # Something is wrong with the shape of the data vs the value in the structure
             if (expected_shape is not None) and (expected_shape != array.shape):
                 raise HTTPException(
@@ -691,6 +708,16 @@ def get_router(
         except IndexError:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST, detail="Block index out of range"
+            )
+        except DataNotReadyError as err:
+            raise HTTPException(
+                status_code=HTTP_503_SERVICE_UNAVAILABLE,
+                detail=str(err),
+                headers={"Retry-After": str(ARRAY_RETRY_AFTER_SECONDS)},
+            )
+        except ShapeMismatchError as err:
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_CONTENT, detail=str(err)
             )
         if (expected_shape is not None) and (expected_shape != array.shape):
             raise HTTPException(

--- a/tiled/storage.py
+++ b/tiled/storage.py
@@ -420,6 +420,31 @@ def size_from_uri(data_uri: str) -> int:
     )
 
 
+def mtime_from_uri(data_uri: str) -> float:
+    """Return the last-modified time of the asset at `data_uri`.
+
+    The time is a POSIX timestamp (seconds since the epoch).
+
+    Dispatches on URI scheme: `file://` URIs are stat'd on the local
+    filesystem; object-store URIs (those in `SUPPORTED_OBJECT_URI_SCHEMES`)
+    issue a HEAD via obstore. Raises `ValueError` for any other scheme.
+    Underlying I/O errors (`FileNotFoundError`, network errors, etc.)
+    propagate; callers that want best-effort behavior should catch them at
+    the call site.
+    """
+    scheme = urlparse(data_uri).scheme
+    if scheme == "file":
+        return path_from_uri(data_uri).stat().st_mtime
+    if scheme in SUPPORTED_OBJECT_URI_SCHEMES:
+        storage = get_storage(data_uri)
+        _, _, path = ObjectStorage.parse_blob_uri(data_uri)
+        store = storage.get_obstore_location()
+        return store.head(path)["last_modified"].timestamp()
+    raise ValueError(
+        f"Cannot stat URI with unsupported scheme {scheme!r}: {data_uri!r}"
+    )
+
+
 class DirectoryContainer(Mapping[str, bytes]):
     """A storage container for byte-arrays representing Awkward Array buffers
 


### PR DESCRIPTION
## Summary

Reading an array can fail when the shape recorded in the catalog structure has diverged from the shape of the data actually present in storage. This happens while an array is being extended out-of-band (e.g. streaming appends), because the write path is non-atomic and observable out of sync: the file and the catalog `structure` row are updated separately, and a reader can observe them in either order.

Previously both directions surfaced as an opaque `500`. This PR handles them explicitly.

## Behavior

- **Storage ahead of structure** (data file has grown along the leading axis, trailing dimensions unchanged): Tiled serves exactly the shape the structure advertises, silently ignoring the extra frames, instead of failing. (#1461)
- **Structure ahead of storage** (the advertised shape cannot be served without fabricating data): Tiled distinguishes a transient lag from a permanent mismatch.
  - If the mismatch is confined to the leading axis **and** a backing asset was modified recently (a streaming append is likely still in progress), the read returns a retryable **`503 Service Unavailable`** with a `Retry-After` header. The Tiled client retries these automatically, so a live read succeeds once the writer catches up.
  - If the backing asset has not been modified for a while (the data appears to be at rest and will not catch up), or the mismatch is otherwise unresolvable (e.g. trailing dimensions disagree), the read returns **`422 Unprocessable Content`**. (#1314)

The freshness window is configurable via `TILED_ARRAY_NOT_READY_WINDOW` (default `10` seconds) and the retry hint via `TILED_ARRAY_RETRY_AFTER` (default `1` second).

Note: the Zarr adapter that writes Tiled-native data was never affected (it trims with a stencil rather than reshaping); the affected adapters are those that register external assets and serve through `force_reshape` (HDF5, TIFF, npy, JPEG, file sequences).

## Implementation

- `tiled/adapters/utils.py`: introduce a `ShapeMismatchError` hierarchy — `DataNotReadyError` (transient) and `IncompatibleShapeError` (permanent) — and rework `force_reshape` to trim a leading-axis overshoot, preserve genuine equal-size reshapes, and otherwise raise the appropriate typed error.
- `tiled/storage.py`: add `mtime_from_uri`, mirroring `size_from_uri`, returning an asset's last-modified time for both `file://` and object-store URIs.
- `tiled/catalog/adapter.py`: on `DataNotReadyError`, consult asset freshness via `mtime_from_uri` and downgrade to a permanent error when the data is at rest.
- `tiled/server/router.py`: map `DataNotReadyError` to `503` + `Retry-After` and other shape mismatches to `422`.

## Tests

- `force_reshape` unit tests (trim, genuine reshape, transient vs permanent typed errors).
- HTTP-level tests asserting `503` for structure-ahead and `422` for incompatible structures.
- Catalog-level freshness tests: a recently-modified backing file is treated as transient; a stale file is treated as permanent.

Related Issues: #1314, #1461

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
