### PR TITLE
Initial implementation of multi-websocket endpoint (#1472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 # Changelog
 
+## v0.2.19 (Unreleased)
+
+### Added
+- Websocket endpoint that uses a single connection to stream multiple Tiled
+  nodes along with protocol
+
 ## v0.2.18 (2026-09-02)
 
 ### Fixed

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -43,6 +43,7 @@ from starlette.status import (
 
 from tiled.access_control.scopes import NO_SCOPES, PUBLIC_SCOPES, SINGLE_USER_SCOPES
 from tiled.authenticators import ProxiedOIDCAuthenticator
+from tiled.stream_messages import ConnectionAuthMsg
 
 # To hide third-party warning
 # .../jose/backends/cryptography_backend.py:18: CryptographyDeprecationWarning:
@@ -459,7 +460,6 @@ async def get_current_scopes_websocket(
 
 async def authenticate_websocket_first_message(
     websocket: WebSocket,
-    message: dict,
     settings: Settings,
     db_factory: Callable,
 ) -> tuple[bool, Optional[schemas.Principal], Optional[set], set]:
@@ -473,8 +473,15 @@ async def authenticate_websocket_first_message(
     credentials were valid, False otherwise.  ``principal`` may legitimately
     be None in single-user API-key mode even when auth succeeds.
     """
-    api_key = message.get("api_key")
-    access_token = message.get("access_token")
+    await websocket.accept()
+    try:
+        json_message = await websocket.receive_json()
+        message = ConnectionAuthMsg.model_validate(json_message)
+    except Exception:
+        await websocket.close(code=4001, reason="Expected JSON auth message")
+        return False, None, None, NO_SCOPES
+    api_key = message.api_key
+    access_token = message.access_token
 
     if api_key is not None:
         try:

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections.abc
 import dataclasses
 import inspect
@@ -18,6 +19,8 @@ import msgpack
 from fastapi import HTTPException, Response, WebSocket
 from starlette.responses import JSONResponse, StreamingResponse
 from starlette.status import HTTP_200_OK, HTTP_304_NOT_MODIFIED, HTTP_400_BAD_REQUEST
+
+from tiled.stream_messages import NextMsg
 
 # Some are not directly used, but they register things on import.
 from .. import queries
@@ -763,21 +766,25 @@ def get_websocket_envelope_formatter(
     if envelope_format == "msgpack":
 
         async def stream_msgpack(
-            websocket: WebSocket,
+            sink: WebSocket | asyncio.Queue,
             metadata: dict,
             payload_bytes: Optional[bytes],
         ):
             if payload_bytes is not None:
                 metadata["payload"] = payload_bytes
-            data = msgpack.packb(metadata)
-            await websocket.send_bytes(data)
-
+            if isinstance(sink, WebSocket):
+                data = msgpack.packb(metadata)
+                await sink.send_bytes(data)
+            elif isinstance(sink, asyncio.Queue):
+                data = NextMsg(path=metadata["path"], metadata=metadata)
+                await sink.put(data)
+    
         return stream_msgpack
 
     elif envelope_format == "json":
 
         async def stream_json(
-            websocket: WebSocket,
+            sink: WebSocket | asyncio.Queue,
             metadata: dict,
             payload_bytes: Optional[bytes],
         ):
@@ -821,7 +828,11 @@ def get_websocket_envelope_formatter(
             if "arrow_schema" in metadata:
                 metadata["arrow_schema"] = str(metadata["arrow_schema"])
             data = safe_json_dump(metadata)
-            await websocket.send_text(data.decode())
+            if isinstance(sink, WebSocket):
+                await sink.send_text(data.decode())
+            elif isinstance(sink, asyncio.Queue):
+                data = NextMsg(path=metadata["path"], metadata=metadata)
+                await sink.put(data)
 
         return stream_json
 

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -48,11 +48,12 @@ from tiled.query_registration import QueryRegistry
 from tiled.schemas import About
 from tiled.server.protocols import ExternalAuthenticator, InternalAuthenticator
 from tiled.server.schemas import Principal
+from tiled.server.websocket_comm import WebSocketConnectionManager
 
 from .. import __version__
 from ..links import links_for_node
 from ..ndslice import NDBlock, NDSlice
-from ..stream_messages import ArrayPatch
+from ..stream_messages import ArrayPatch, ConnectionAckMsg
 from ..structures.core import Spec, StructureFamily
 from ..type_aliases import AccessTags, Scopes
 from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
@@ -774,6 +775,54 @@ def get_router(
         )
         await entry.close_stream()
 
+    @router.websocket("/stream/multi")
+    async def multi_websocket_endpoint(
+        websocket: WebSocket,
+        envelope_format: schemas.EnvelopeFormat = schemas.EnvelopeFormat.json,
+        principal: Optional[schemas.Principal] = Depends(
+            get_current_principal_websocket
+        ),
+        authn_access_tags: Optional[AccessTags] = Depends(
+            get_current_access_tags_websocket
+        ),
+        authn_scopes: Scopes = Depends(get_current_scopes_websocket),
+        settings: Settings = Depends(get_settings),
+        db_factory: Callable = Depends(get_database_session_factory),
+        api_key: Optional[str] = Depends(get_api_key_websocket),
+        decoded_access_token: Optional[dict] = Depends(
+            get_decoded_access_token_websocket
+        ),
+    ):
+        has_credentials = api_key is not None or decoded_access_token is not None
+        needs_first_message_auth = (
+            not has_credentials and not settings.allow_anonymous_access
+        )
+        if needs_first_message_auth:
+            (
+                success,
+                principal,
+                authn_access_tags,
+                authn_scopes,
+            ) = await authenticate_websocket_first_message(
+                websocket, settings, db_factory
+            )
+            if not success:
+                await websocket.close(code=4003, reason="Authentication failed")
+                return
+            else:
+                await websocket.send_json(ConnectionAckMsg())
+
+        websocket_manager = WebSocketConnectionManager(
+            websocket,
+            envelope_format,
+            principal,
+            authn_access_tags,
+            authn_scopes,
+            deserialization_registry
+        )
+
+        await websocket_manager.run()
+
     @router.websocket("/stream/single/{path:path}")
     async def websocket_endpoint(
         websocket: WebSocket,
@@ -809,24 +858,13 @@ def get_router(
             not has_credentials and not settings.allow_anonymous_access
         )
         if needs_first_message_auth:
-            await websocket.accept()
-            try:
-                message = await websocket.receive_json()
-            except Exception:
-                await websocket.close(code=4001, reason="Expected JSON auth message")
-                return
-            if not isinstance(message, dict) or message.get("type") != "auth":
-                await websocket.close(
-                    code=4001, reason='Expected {"type": "auth", ...}'
-                )
-                return
             (
                 success,
                 principal,
                 authn_access_tags,
                 authn_scopes,
             ) = await authenticate_websocket_first_message(
-                websocket, message, settings, db_factory
+                websocket, settings, db_factory
             )
             if not success:
                 await websocket.close(code=4003, reason="Authentication failed")

--- a/tiled/server/streaming.py
+++ b/tiled/server/streaming.py
@@ -8,9 +8,11 @@ from typing import Any, Callable, Dict, Optional, Protocol
 
 import cachetools
 import orjson
-from fastapi import WebSocketDisconnect
+from fastapi import WebSocket, WebSocketDisconnect
 from redis import asyncio as redis
 from redis.asyncio.sentinel import Sentinel
+
+from tiled.stream_messages import CompleteMsg, ErrorMsg
 
 from ..ndslice import NDSlice
 from ..utils import safe_json_dump as _safe_json_dump
@@ -226,7 +228,7 @@ _PEER_DISCONNECTED = object()
 
 def _make_ws_handler_common(
     *,
-    websocket,
+    sink: WebSocket | asyncio.Queue,
     formatter,
     uri: str,
     node_id: str,
@@ -281,12 +283,12 @@ def _make_ws_handler_common(
     """
 
     async def handler(sequence: Optional[int] = None, already_accepted: bool = False):
-        if not already_accepted:
-            await websocket.accept()
+        if not already_accepted and isinstance(sink, WebSocket):
+            await sink.accept()
         end_stream = asyncio.Event()
 
         # Send schema to provide client context to interpret what follows.
-        await formatter(websocket, schema, None)
+        await formatter(sink, schema, None)
 
         async def stream_data(sequence):
             """Helper function to stream a specific sequence number to a websocket"""
@@ -313,7 +315,7 @@ def _make_ws_handler_common(
                 else:
                     s = ",".join(f":{dim}" for dim in metadata["shape"])
                     metadata["uri"] = f"{uri}?slice={s}"
-            await formatter(websocket, metadata, payload_bytes)
+            await formatter(sink, metadata, payload_bytes)
 
         # Setup buffer
         stream_buffer = asyncio.Queue()
@@ -392,7 +394,10 @@ def _make_ws_handler_common(
                     # ConnectionClosedOK on the client and would not reconnect.
                     # 1012 yields ConnectionClosedError, so the client reconnects
                     # and resumes from its last received sequence.
-                    await websocket.close(code=1012, reason="Live subscription lost")
+                    if isinstance(sink, WebSocket):
+                        await sink.close(code=1012, reason="Live subscription lost")
+                    elif isinstance(sink, asyncio.Queue):
+                        await sink.put(ErrorMsg(path=node_id, error="Live subscription lost"))
                     return
 
                 # Skip duplicates or already replayed messages
@@ -401,8 +406,10 @@ def _make_ws_handler_common(
 
                 await stream_data(live_seq)
                 last_sent = live_seq
-
-            await websocket.close(code=1000, reason="Producer ended stream")
+            if isinstance(sink, WebSocket):
+                await sink.close(code=1000, reason="Producer ended stream")
+            elif isinstance(sink, asyncio.Queue):
+                await sink.put(CompleteMsg(path=node_id))
         except WebSocketDisconnect:
             logger.info(f"Client disconnected from node {node_id}")
         finally:
@@ -525,7 +532,7 @@ class TTLCacheDatastore(StreamingDatastore):
             return agen, agen.aclose
 
         return _make_ws_handler_common(
-            websocket=websocket,
+            sink=websocket,
             formatter=formatter,
             uri=uri,
             node_id=node_id,
@@ -619,7 +626,7 @@ class RedisStreamingDatastore(StreamingDatastore):
             return live_iter(), cleanup
 
         return _make_ws_handler_common(
-            websocket=websocket,
+            sink=websocket,
             formatter=formatter,
             uri=uri,
             node_id=node_id,

--- a/tiled/server/websocket_comm.py
+++ b/tiled/server/websocket_comm.py
@@ -1,0 +1,154 @@
+import asyncio
+import logging
+from typing import Any
+
+from fastapi import WebSocket
+import msgpack
+from starlette.requests import URL
+
+from tiled.server.core import get_websocket_envelope_formatter
+from tiled.server.dependencies import get_entry
+from tiled.server.schemas import EnvelopeFormat
+from tiled.server.utils import get_base_url_websocket
+from tiled.stream_messages import CompleteMsg, SubscribeMsg, WebsocketMsg, websocket_msg_adapter, ErrorMsg, Ping, Pong
+from tiled.structures.core import StructureFamily
+
+
+logger = logging.getLogger(__name__)
+
+
+
+
+class WebSocketConnectionManager:
+    def __init__(self, websocket: WebSocket, envelope_format: EnvelopeFormat, principal, authn_access_tags, authn_scopes, deserialization_registry):
+        self.websocket = websocket
+        self.envelope_format = envelope_format
+        self.principal = principal
+        self.authn_access_tags = authn_access_tags
+        self.authn_scopes = authn_scopes
+        self.deserialization_registry = deserialization_registry
+        # Buffers should only contain pydantic models
+        self.send_buffer: asyncio.Queue[Any] = asyncio.Queue()
+        self.recv_buffer: asyncio.Queue[WebsocketMsg] = asyncio.Queue()
+        # Keep track of live streaming tasks keyed by path
+        self.streaming_tasks: dict[str, asyncio.Task] = {}
+
+    async def send_messages(self):
+        """
+          This method's only job is to send messages from buffer into WS.
+          Potentially implement back-pressure code here?  
+        """
+        while True:
+            message = await self.send_buffer.get()
+            match self.envelope_format:
+                case EnvelopeFormat.msgpack:
+                    message = msgpack.packb(message.model_dump(mode="python"))
+                    await self.websocket.send_bytes(message)
+                case EnvelopeFormat.json:
+                    message = message.model_dump_json()
+                    await self.websocket.send_text(message)
+
+    async def recv_messages(self):
+        """
+          This method only receives messages and puts it in a buffer  
+        """
+        while True:
+            raw_message = await self.websocket.receive()
+            match raw_message["type"]:
+                case "websocket.receive":
+                    if (json_message:=raw_message.get("text")) is not None:
+                        try:
+                            message = websocket_msg_adapter.validate_strings(json_message)
+                        except Exception:
+                            await self.send_buffer.put(ErrorMsg(error="Could not decode JSON message"))
+                    elif (bytes_message:=raw_message.get("bytes")) is not None:
+                        try:
+                            message = websocket_msg_adapter.validate_python(msgpack.unpackb(bytes_message))
+                        except Exception:
+                            await self.send_buffer.put(ErrorMsg(error="Could not decode msgpack message"))
+                    await self.recv_buffer.put(message)
+                case "websocket.disconnect":
+                    break
+
+
+    async def setup_stream(self, message: SubscribeMsg):
+        """
+          This function creates a task for each node subscribed.
+          Re-uses most of the code written for single websocket stream, but
+          instead of pushing data to a websocket connection, it pushes to send buffer
+        """
+        entry = await get_entry(
+            message.path,
+            ["read:data", "read:metadata"],
+            self.principal,
+            self.authn_access_tags,
+            self.authn_scopes,
+            self.websocket.app.state.root_tree,
+            {},
+            self.websocket.state.metrics,
+            {
+                StructureFamily.array,
+                StructureFamily.container,
+                StructureFamily.ragged,
+                StructureFamily.sparse,
+                StructureFamily.table,
+            },
+            getattr(self.websocket.app.state, "access_policy", None),
+        )
+        formatter = get_websocket_envelope_formatter(
+            self.envelope_format, entry, self.deserialization_registry
+        )
+        base_websocket_url = URL(get_base_url_websocket(self.websocket))
+        scheme = "https" if base_websocket_url.scheme == "wss" else "http"
+        path_parts = [segment for segment in message.path.split("/") if segment]
+        path_str = "/".join(path_parts)
+        uri = f"{base_websocket_url.replace(scheme=scheme)}/array/full/{path_str}"
+        handler = entry.make_ws_handler(self.send_buffer, formatter, uri)
+        self.streaming_tasks[message.path] = asyncio.create_task(handler(message.start, already_accepted=True))
+        
+
+    async def process_messages(self):
+        """
+          Gets messages from the receive buffer and figures out what to do with it  
+        """
+        while True:
+            message = await self.recv_buffer.get()
+            match message:
+                case Ping():
+                    await self.send_buffer.put(Pong(payload=message.payload))
+                case Pong():
+                    logger.info("Received pong with payload: %s", message.payload)
+                case SubscribeMsg():
+                    await self.setup_stream(message)
+                case CompleteMsg():
+                    task = self.streaming_tasks.get(message.path)
+                    if task is not None:
+                        task.cancel()
+                        self.streaming_tasks.pop(message.path, None)
+
+
+    async def run(self):
+        """
+          Setup and teardown of all async tasks run by this class.
+          By the time you're here, the assumption is that the websocket connection is already
+          authenticated.
+          No auth happens in this class  
+        """
+        tasks = {
+            asyncio.create_task(self.send_messages()),
+            asyncio.create_task(self.recv_messages()),
+            asyncio.create_task(self.process_messages())
+        }
+
+        try:
+            await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            all_tasks = (*tasks, *self.streaming_tasks.values())
+            for task in all_tasks:
+                task.cancel()
+            await asyncio.gather(*all_tasks, return_exceptions=True)
+            
+

--- a/tiled/stream_messages.py
+++ b/tiled/stream_messages.py
@@ -1,7 +1,10 @@
 from datetime import datetime
-from typing import Generic, Literal, Optional, TypeVar, Union
+from typing import Annotated, Generic, Literal, Optional, TypeVar, Union, Any
+from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter
+
+from tiled.server.schemas import EnvelopeFormat
 
 from .structures.array import ArrayStructure, BuiltinDtype, StructDtype
 from .structures.core import Spec, StructureFamily
@@ -110,3 +113,60 @@ class TableData(Update):
     append: bool
     payload: bytes
     arrow_schema: str
+
+
+## Definition of a bi-directional websocket protocol. Based off of https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+
+# Client -> Server. Authenticate client via websocket connection
+class ConnectionAuthMsg(BaseModel):
+    type: Literal["connection_auth"] = "connection_auth"
+    envelope_format: EnvelopeFormat = EnvelopeFormat.json
+    api_key: Optional[str] = None
+    access_token: Optional[str] = None
+
+# Server -> Client. Auth successfully, server acknowledges client
+class ConnectionAckMsg(BaseModel):
+    type: Literal["connection_ack"] = "connection_ack"
+
+# Client -> Server. Subscribe to tiled node
+class SubscribeMsg(BaseModel):
+    type: Literal["subscribe"] = "subscribe"
+    path: str
+    start: int = 0
+
+
+class SubscribeAckMsg(BaseModel):
+    type: Literal["subscribe_ack"]
+    path: str
+    node_id: UUID
+
+# Server -> Client. Packet of data, use the same UUID that was used to subscribe
+class NextMsg(BaseModel):
+    id: UUID
+    type: Literal["next"] = "next"
+    metadata: Any
+    # sequence: int
+
+# Server -> Client. Error message
+class ErrorMsg(BaseModel):
+    # path: Optional[str] = None
+    id: Optional[UUID] = None
+    type: Literal["error"] = "error"
+    error: str
+
+# Bidirectional. Either client or server stops a node from streaming
+class CompleteMsg(BaseModel):
+    path: Optional[UUID] = None
+    type: Literal["complete"] = "complete"
+
+class Ping(BaseModel):
+    type: Literal["ping"] = "ping"
+    payload: Optional[str] = None
+
+class Pong(BaseModel):
+    type: Literal["pong"] = "pong"
+    payload: Optional[str] = None
+
+WebsocketMsg = Annotated[Union[ConnectionAuthMsg, ConnectionAckMsg, SubscribeMsg, NextMsg, ErrorMsg, CompleteMsg, Ping, Pong], Field(discriminator="type"),]
+
+websocket_msg_adapter = TypeAdapter(WebsocketMsg)


### PR DESCRIPTION
Addresses #1472 

- Adds /stream/multi multiplexed WebSocket endpoint for subscribing to multiple live Tiled nodes over one connection.
- Defines typed JSON/MessagePack websocket protocol messages for connection auth, subscription, streamed data, completion/errors, and ping/pong.
- Introduces connection manager to receive client commands, manage per-path stream tasks, and serialize outgoing buffered messages.
- Refactors existing streaming handlers and envelope formatters to write either directly to a websocket or into shared async queue, preserving single-stream behavior.
- Standardizes first-message WebSocket authentication through validated connection_auth messages; multi-stream clients receive connection acknowledgement after successful auth.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
