### PR TITLE
Convert from access_blobs to access_tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,12 @@ jobs:
       shell: bash -l {0}
       run: source continuous_integration/scripts/start_redis.sh
 
-    - name: Start Minio service in container.
-      #TODO: This product is leaving open-source container distribution
-      # Find a new image or product to use
-      # https://github.com/minio/minio/issues/21647#issuecomment-3418675115
-      shell: bash -l {0}
-      run: source continuous_integration/scripts/start_minio.sh
+    # minio/minio repository has been removed from Docker Hub
+    # TODO Find a new image to use.
+    # https://github.com/bluesky/tiled/issues/1205
+    # - name: Start Minio service in container.
+    #   shell: bash -l {0}
+    #   run: source continuous_integration/scripts/start_minio.sh
 
     - name: Ensure example data is migrated to current catalog database schema.
       # The example data is expected to be kept up to date to the latest Tiled
@@ -94,7 +94,10 @@ jobs:
         # Provide test suite with PostgreSQL and Redis databases to use.
         TILED_TEST_POSTGRESQL_URI: postgresql://postgres:secret@localhost:5432
         TILED_TEST_REDIS: redis://localhost:6379
-        TILED_TEST_BUCKET: http://minioadmin:minioadmin@localhost:9000/buck
+        # minio/minio repository has been removed from Docker Hub
+        # TODO Find a new image to use.
+        # https://github.com/bluesky/tiled/issues/1205
+        # TILED_TEST_BUCKET: http://minioadmin:minioadmin@localhost:9000/buck
         # TODO Reinstate after finding a new image to use
         # https://github.com/bluesky/tiled/issues/1109
         # # Opt in to LDAPAuthenticator tests.

--- a/config.example.yml
+++ b/config.example.yml
@@ -82,7 +82,7 @@
 #   # Metadata the root node of the catalog
 #   metadata: {}
 #   specs: []
-#   top_level_access_blob: null
+#   top_level_access_tags: null
 #
 #   # Database connection pool tuning
 #   catalog_pool_size: 5

--- a/docs/source/explanations/access-control.md
+++ b/docs/source/explanations/access-control.md
@@ -67,11 +67,15 @@ Tags can also inherit the ACLs of other tags, using the `auto_tags` field. There
 Lastly, only "owners" of a tag can apply that tag to a node. Tag owners are defined in
 this same tag definitions file, under the `tag_owners` key.
 
+The compiler writes the compiled tag definitions into the catalog database itself,
+where the tiled server reads them. Compile the tags before writing tagged data:
+tags must be defined before they can be applied to nodes.
+
 To try out this access control configuration, an example server can be prepped and launched:
 ```
-# prep the access tags and catalog databases
+# compile the access tags into the catalog database, then populate the catalog
 python example_configs/access_tags/compile_tags.py
 python example_configs/catalog/create_catalog.py
-# launch the example server, which loads these databases
+# launch the example server, which loads this database
 ALICE_PASSWORD=secret1 BOB_PASSWORD=secret2 CARA_PASSWORD=secret3 tiled serve config example_configs/toy_authentication.yml
 ```

--- a/docs/source/reference/authentication.md
+++ b/docs/source/reference/authentication.md
@@ -28,9 +28,9 @@ is included with the tiled source code, and start a server like so.
    :caption: example_configs/toy_authentication.yml
 ```
 
-Note that you will need to run these helper tools to prep the backing databases that Tiled needs:
+Note that you will need to run these helper tools to prep the backing catalog database that Tiled needs:
 ```
-# prep the access tags and catalog databases
+# compile the access tags into the catalog database, then populate the catalog
 python example_configs/access_tags/compile_tags.py
 python example_configs/catalog/create_catalog.py
 ```

--- a/docs/source/user-guide/api-keys.md
+++ b/docs/source/user-guide/api-keys.md
@@ -48,10 +48,10 @@ in the example below with that address.
 ALICE_PASSWORD=secret1 tiled serve config example_configs/toy_authentication.yml
 ```
 
-Note that you will need to run these helper tools to prep the backing databases that Tiled needs,
+Note that you will need to run these helper tools to prep the backing catalog database that Tiled needs,
 before you can use the example config shown above:
 ```
-# prep the access tags and catalog databases
+# compile the access tags into the catalog database, then populate the catalog
 python example_configs/access_tags/compile_tags.py
 python example_configs/catalog/create_catalog.py
 ```

--- a/docs/source/user-guide/graph-and-links.md
+++ b/docs/source/user-guide/graph-and-links.md
@@ -73,7 +73,7 @@ query {
     predicate
     objectId
     properties
-    accessBlob
+    accessTags
     createdAt
     subject {
       id

--- a/example_configs/access_tags/compile_tags.py
+++ b/example_configs/access_tags/compile_tags.py
@@ -1,7 +1,10 @@
+import asyncio
 from pathlib import Path
 
 from tiled.access_control.access_tags import AccessTagsCompiler
 from tiled.access_control.scopes import ALL_SCOPES
+from tiled.server.connection_pool import close_database_connection_pool
+from tiled.server.settings import DatabaseSettings
 
 
 def group_parser(groupname):
@@ -11,20 +14,31 @@ def group_parser(groupname):
     }[groupname]
 
 
-def main():
+async def main():
     file_directory = Path(__file__).resolve().parent
+
+    # The compiler writes the tag definitions into the catalog database,
+    # where the tiled server (its AccessTagsParser) reads them. This is the
+    # same database configured under 'trees' in toy_authentication.yml.
+    # Run this script before example_configs/catalog/create_catalog.py:
+    # create_catalog.py applies access tags to the data it writes, and tags
+    # must be defined (compiled) before they can be applied. The compiler
+    # creates the access tag tables itself if the catalog database does not
+    # exist yet.
+    catalog_database = file_directory.parent / "catalog" / "catalog.db"
+    database_settings = DatabaseSettings(uri=f"sqlite+aiosqlite:///{catalog_database}")
 
     access_tags_compiler = AccessTagsCompiler(
         ALL_SCOPES,
         Path(file_directory, "tag_definitions.yml"),
-        {"uri": f"file:{file_directory}/compiled_tags.sqlite"},
+        database_settings,
         group_parser,
     )
 
     access_tags_compiler.load_tag_config()
-    access_tags_compiler.compile()
-    access_tags_compiler.connection.close()
+    await access_tags_compiler.compile()
+    await close_database_connection_pool(database_settings)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/example_configs/access_tags/compile_tags.py
+++ b/example_configs/access_tags/compile_tags.py
@@ -2,9 +2,24 @@ import asyncio
 from pathlib import Path
 
 from tiled.access_control.access_tags import AccessTagsCompiler
-from tiled.access_control.scopes import ALL_SCOPES
 from tiled.server.connection_pool import close_database_connection_pool
 from tiled.server.settings import DatabaseSettings
+
+# The valid scopes for compilation. The compiler and the access policy must
+# be fed the same scope list: the scopes in the catalog database must be a
+# subset of the policy's scopes (the server warns at startup otherwise), and
+# the policy ignores any tag grant that is not a pure subset of its scopes.
+# This list matches the policy 'scopes' in toy_authentication.yml.
+SCOPES = [
+    "read:metadata",
+    "read:data",
+    "write:metadata",
+    "write:data",
+    "delete:revision",
+    "delete:node",
+    "create:node",
+    "register",
+]
 
 
 def group_parser(groupname):
@@ -29,7 +44,7 @@ async def main():
     database_settings = DatabaseSettings(uri=f"sqlite+aiosqlite:///{catalog_database}")
 
     access_tags_compiler = AccessTagsCompiler(
-        ALL_SCOPES,
+        SCOPES,
         Path(file_directory, "tag_definitions.yml"),
         database_settings,
         group_parser,

--- a/example_configs/access_tags/compile_tags.py
+++ b/example_configs/access_tags/compile_tags.py
@@ -43,16 +43,34 @@ async def main():
     catalog_database = file_directory.parent / "catalog" / "catalog.db"
     database_settings = DatabaseSettings(uri=f"sqlite+aiosqlite:///{catalog_database}")
 
+    # The compiler also reads the authentication database (the 'database'
+    # section of toy_authentication.yml) to generate a principal tag
+    # ('user:alice', ...) for every principal that has logged in, granting
+    # each principal scopes on their own data. The provider must match the
+    # access policy's. The server creates this database at first startup; on
+    # the very first compilation, before it exists, the compiler warns and
+    # skips principal tags -- they appear on the next compilation, so
+    # principals can only create nodes without explicit access tags after
+    # a compilation that ran after their first login.
+    authn_database = file_directory.parent / "authn.db"
+    authn_database_settings = DatabaseSettings(
+        uri=f"sqlite+aiosqlite:///{authn_database}"
+    )
+
     access_tags_compiler = AccessTagsCompiler(
         SCOPES,
         Path(file_directory, "tag_definitions.yml"),
         database_settings,
         group_parser,
+        authn_database_settings=authn_database_settings,
+        provider="toy",
     )
 
     access_tags_compiler.load_tag_config()
+    await access_tags_compiler.load_principal_tags()
     await access_tags_compiler.compile()
     await close_database_connection_pool(database_settings)
+    await close_database_connection_pool(authn_database_settings)
 
 
 if __name__ == "__main__":

--- a/example_configs/graphs/README.md
+++ b/example_configs/graphs/README.md
@@ -73,7 +73,7 @@ query {
     predicate
     objectId
     properties
-    accessBlob
+    accessTags
     createdAt
     subject {
       id

--- a/example_configs/graphs/create_links.py
+++ b/example_configs/graphs/create_links.py
@@ -141,8 +141,8 @@ def main() -> None:
             }
             if node_path_parts is not None:
                 entity_input["nodePathParts"] = node_path_parts
-            if "accessBlob" in item:
-                entity_input["accessBlob"] = item["accessBlob"]
+            if "accessTags" in item:
+                entity_input["accessTags"] = item["accessTags"]
 
             entities[name] = entity_input
             item_id = item.get("@id")
@@ -167,8 +167,8 @@ def main() -> None:
                 "object": _resolve_entity_name(object_, entities_by_id),
                 "properties": item.get("properties") or {},
             }
-            if "accessBlob" in item:
-                link_input["accessBlob"] = item["accessBlob"]
+            if "accessTags" in item:
+                link_input["accessTags"] = item["accessTags"]
             links.append(link_input)
 
     with httpx.Client(base_url=base_url, headers=headers, timeout=30.0) as client:
@@ -239,8 +239,8 @@ def main() -> None:
                         "objectId": entity_ids[object_name],
                         "properties": link["properties"],
                         **(
-                            {"accessBlob": link["accessBlob"]}
-                            if "accessBlob" in link
+                            {"accessTags": link["accessTags"]}
+                            if "accessTags" in link
                             else {}
                         ),
                     }

--- a/example_configs/keycloak_oidc/README.md
+++ b/example_configs/keycloak_oidc/README.md
@@ -92,7 +92,7 @@ Valid tags: `["beamline_x_user", "beamline_y_user", "facility_admin", "public"]`
 
 The [example_data.py](example_data.py) script creates sample data with these access levels:
 
-| Data | Access Blob     |
+| Data | Access Tags     |
 |------|-----------------|
 | A    | public          |
 | B    | beamline_x_user |

--- a/example_configs/keycloak_oidc/config.yaml
+++ b/example_configs/keycloak_oidc/config.yaml
@@ -33,4 +33,4 @@ trees:
       #
       # separately.
       init_if_not_exists: true
-      top_level_access_blob: {"tags": ["public"]}
+      top_level_access_tags: ["public"]

--- a/example_configs/keycloak_oidc/tiled_policy/example_pdp.py
+++ b/example_configs/keycloak_oidc/tiled_policy/example_pdp.py
@@ -4,8 +4,9 @@ from typing import Optional
 from pydantic import HttpUrl
 
 from tiled.access_control.access_policies import ExternalPolicyDecisionPoint
+from tiled.access_control.protocols import AccessTags
 from tiled.server.schemas import Principal
-from tiled.type_aliases import AccessBlob, AccessTags, Scopes
+from tiled.type_aliases import Scopes
 
 
 class ExampleAuthorizationPolicy(ExternalPolicyDecisionPoint):
@@ -17,7 +18,7 @@ class ExampleAuthorizationPolicy(ExternalPolicyDecisionPoint):
         allowed_tags_endpoint: str,
         scopes_endpoint: str,
         modify_node_endpoint: Optional[str] = None,
-        empty_access_blob_public: bool = False,
+        empty_access_tags_public: bool = False,
         provider: Optional[str] = None,
     ):
         self._token_audience = token_audience
@@ -30,7 +31,7 @@ class ExampleAuthorizationPolicy(ExternalPolicyDecisionPoint):
             scopes_endpoint=scopes_endpoint,
             provider=provider,
             modify_node_endpoint=modify_node_endpoint,
-            empty_access_blob_public=empty_access_blob_public,
+            empty_access_tags_public=empty_access_tags_public,
         )
 
     def build_input(
@@ -38,13 +39,13 @@ class ExampleAuthorizationPolicy(ExternalPolicyDecisionPoint):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
+        access_tags: Optional[AccessTags] = None,
     ) -> str:
         _input = {"audience": self._token_audience}
 
         if principal.access_token is not None:
             _input["token"] = principal.access_token.get_secret_value()
 
-        if access_blob is not None:
-            _input.update(access_blob)
+        if access_tags is not None:
+            _input["tags"] = sorted(access_tags)
         return json.dumps({"input": _input})

--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -25,8 +25,7 @@ access_control:
     - "delete:node"
     - "create:node"
     - "register"
-    tags_db:
-      uri: "file:example_configs/access_tags/compiled_tags.sqlite"
+    # Access tag definitions are read from the catalog database (see trees).
     access_tags_parser: "tiled.access_control.access_tags:AccessTagsParser"
 trees:
   - path: /

--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -35,4 +35,4 @@ trees:
       uri: "sqlite+aiosqlite:///./example_configs/catalog/catalog.db"
       writable_storage: "./example_configs/catalog/data"
       init_if_not_exists: true
-      top_level_access_blob: {"tags": ["public"]}
+      top_level_access_tags: ["public"]

--- a/example_configs/toy_authentication.yml
+++ b/example_configs/toy_authentication.yml
@@ -12,6 +12,14 @@ authentication:
   tiled_admins:
     - provider: toy
       id: admin
+database:
+  # The authentication database, where the server records principals
+  # (users and services) as they first log in. The access tags compiler
+  # (example_configs/access_tags/compile_tags.py) reads it to generate a
+  # principal tag ('user:alice', ...) for each principal, which is what
+  # lets a principal create nodes without explicit access tags.
+  uri: "sqlite:///./example_configs/authn.db"
+  init_if_not_exists: true
 access_control:
   access_policy: "tiled.access_control.access_policies:TagBasedAccessPolicy"
   args:

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -867,9 +867,12 @@ def test_update_node_access_control(access_control_test_context_factory):
         cursor = db.cursor()
         cursor.execute(
             """
-            UPDATE access_blobs
-            SET kind = 'tags', username = NULL, tags = json(?)
-            WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+                UPDATE access_blobs
+                SET kind = 'tags', username = NULL, tags = json(?)
+                WHERE id = (
+                    SELECT access_blob_id FROM node_access_blobs
+                    WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+                )
             """,
             ('["undefined_tag", "biologists_tag"]', data),
         )
@@ -917,8 +920,8 @@ def test_empty_access_blob_access_control(access_control_test_context_factory):
         cursor = db.cursor()
         cursor.execute(
             """
-            DELETE FROM access_blobs
-            WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
+                DELETE FROM node_access_blobs
+                WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
             """
         )
         db.commit()

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -866,8 +866,12 @@ def test_update_node_access_control(access_control_test_context_factory):
         db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
         cursor = db.cursor()
         cursor.execute(
-            "UPDATE nodes SET access_blob = ? WHERE key = ?",
-            ('{"tags": ["undefined_tag", "biologists_tag"]}', data),
+            """
+            UPDATE access_blobs
+            SET kind = 'tags', username = NULL, tags = json(?)
+            WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
+            """,
+            ('["undefined_tag", "biologists_tag"]', data),
         )
         db.commit()
         with fail_with_status_code(HTTP_403_FORBIDDEN):
@@ -899,9 +903,9 @@ def test_update_node_access_control(access_control_test_context_factory):
 
 def test_empty_access_blob_access_control(access_control_test_context_factory):
     """
-    Test the cases where a node in the catalog has an empty access blob.
+    Test the cases where a node in the catalog has no access blob row.
     This case occurs when migrating an older catalog without also
-      populating the access_blob column.
+      populating the access_blobs association table.
     """
     admin_client = access_control_test_context_factory("admin", "admin")
     alice_client = access_control_test_context_factory("alice", "alice")
@@ -912,7 +916,10 @@ def test_empty_access_blob_access_control(access_control_test_context_factory):
         db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
         cursor = db.cursor()
         cursor.execute(
-            "UPDATE nodes SET access_blob = json('{}') WHERE key == 'data_M'"
+            """
+            DELETE FROM access_blobs
+            WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
+            """
         )
         db.commit()
 

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -203,7 +203,7 @@ def _server_config(catalog_uri, authn_uri, tmp_path):
     -- at startup; the tags must already be defined (the compiler runs first).
     """
 
-    def _tree(path, tags):
+    def _tree(path, access_tags):
         mount = path.strip("/").upper()
         return {
             "tree": "catalog",
@@ -211,14 +211,17 @@ def _server_config(catalog_uri, authn_uri, tmp_path):
                 "uri": catalog_uri,
                 "writable_storage": str(tmp_path / mount.lower()),
                 "mount_node": f"/{mount}",
-                "top_level_access_tags": tags,
+                "top_level_access_tags": access_tags,
             },
             "path": path,
         }
 
     return {
         "create_mount_nodes_if_not_exist": True,
-        "trees": [_tree(f"/{name}", tags) for name, tags in TOP_LEVEL_TAGS.items()],
+        "trees": [
+            _tree(f"/{name}", access_tags)
+            for name, access_tags in TOP_LEVEL_TAGS.items()
+        ],
         "access_control": {
             "access_policy": (
                 "tiled.access_control.access_policies:TagBasedAccessPolicy"
@@ -525,27 +528,34 @@ def catalog_db_execute(catalog_uri, statements):
     return asyncio.run(_run())
 
 
-def _tag_exists(catalog_uri, tag_name):
+def _access_tag_exists(catalog_uri, access_tag_name):
     rows = catalog_db_execute(
         catalog_uri,
-        [("SELECT 1 FROM access_tags WHERE name = :n", {"n": tag_name})],
+        [("SELECT 1 FROM access_tags WHERE name = :n", {"n": access_tag_name})],
     )
     return bool(rows)
 
 
-def _tag_is_public(catalog_uri, tag_name):
+def _access_tag_is_public(catalog_uri, access_tag_name):
     rows = catalog_db_execute(
         catalog_uri,
-        [("SELECT 1 FROM access_tags WHERE name = :n AND is_public", {"n": tag_name})],
+        [
+            (
+                "SELECT 1 FROM access_tags WHERE name = :n AND is_public",
+                {"n": access_tag_name},
+            )
+        ],
     )
     return bool(rows)
 
 
-def _principal_has_scope_on_tag(catalog_uri, tag_name, principal, scope_name=None):
+def _principal_has_scope_on_access_tag(
+    catalog_uri, access_tag_name, principal, scope_name=None
+):
     """
     Whether ``principal`` has any scope (or a specific ``scope_name``) on
-    ``tag_name`` in the catalog database. Replaces the old sidecar
-    ``user_tag_scopes`` lookups (tag_name/user_name/scope_name), which are now
+    ``access_tag_name`` in the catalog database. Replaces the old sidecar
+    ``user_tag_scopes`` lookups (access_tag_name/user_name/scope_name), which are now
     the ``access_tag_principal_scopes`` junction joined to ``access_tags``,
     ``access_tags_principals`` and (for a scope name) ``scopes``.
     """
@@ -555,7 +565,7 @@ def _principal_has_scope_on_tag(catalog_uri, tag_name, principal, scope_name=Non
         "JOIN access_tags t ON t.id = aps.tag_id "
         "JOIN access_tags_principals p ON p.id = aps.principal_id "
     )
-    params = {"t": tag_name, "p": principal}
+    params = {"t": access_tag_name, "p": principal}
     if scope_name is not None:
         sql += "JOIN scopes s ON s.id = aps.scope_id "
         params["s"] = scope_name
@@ -566,10 +576,10 @@ def _principal_has_scope_on_tag(catalog_uri, tag_name, principal, scope_name=Non
     return bool(rows)
 
 
-def _set_node_tags(catalog_uri, node_key, tag_names):
+def _set_node_access_tags(catalog_uri, node_key, access_tag_names):
     """
     Surgically set the access tags on the catalog node with key ``node_key`` to
-    exactly ``tag_names`` (creating bare ``access_tags`` rows for any tag that
+    exactly ``access_tag_names`` (creating bare ``access_tags`` rows for any tag that
     does not yet exist). Replaces the old sidecar surgery that rewrote an
     ``access_blobs`` row's JSON ``tags``; the node<->tag mapping now lives in
     the ``node_access_tags`` junction.
@@ -577,7 +587,7 @@ def _set_node_tags(catalog_uri, node_key, tag_names):
     statements = []
     # Ensure each tag name exists in access_tags (name-only bare row is fine
     # for these tests, which check policy behavior, not tag semantics).
-    for name in tag_names:
+    for name in access_tag_names:
         statements.append(
             (
                 # CAST the reused parameter so asyncpg can deduce a single,
@@ -599,7 +609,7 @@ def _set_node_tags(catalog_uri, node_key, tag_names):
         )
     )
     # Associate the node with each of the requested tags.
-    for name in tag_names:
+    for name in access_tag_names:
         statements.append(
             (
                 "INSERT INTO node_access_tags (node_id, tag_id) "
@@ -611,7 +621,7 @@ def _set_node_tags(catalog_uri, node_key, tag_names):
     catalog_db_execute(catalog_uri, statements)
 
 
-def _delete_node_tags(catalog_uri, node_key):
+def _delete_node_access_tags(catalog_uri, node_key):
     """
     Surgically remove ALL access-tag rows for the node with key ``node_key``,
     leaving a node with zero ``node_access_tags`` entries. In the access-tags
@@ -630,9 +640,9 @@ def _delete_node_tags(catalog_uri, node_key):
     )
 
 
-def _principal_owns_tag(catalog_uri, tag_name, principal=None):
+def _principal_owns_access_tag(catalog_uri, access_tag_name, principal=None):
     """
-    Whether ``tag_name`` has any owner (or specifically ``principal`` as owner).
+    Whether ``access_tag_name`` has any owner (or specifically ``principal`` as owner).
     Replaces the old sidecar ``user_tag_owners`` lookups; owners now live in the
     ``access_tag_owners`` junction joined to ``access_tags`` and
     ``access_tags_principals``.
@@ -640,7 +650,7 @@ def _principal_owns_tag(catalog_uri, tag_name, principal=None):
     sql = (
         "SELECT 1 " "FROM access_tag_owners o " "JOIN access_tags t ON t.id = o.tag_id "
     )
-    params = {"t": tag_name}
+    params = {"t": access_tag_name}
     if principal is not None:
         sql += "JOIN access_tags_principals p ON p.id = o.principal_id "
     sql += "WHERE t.name = :t"
@@ -651,10 +661,10 @@ def _principal_owns_tag(catalog_uri, tag_name, principal=None):
     return bool(rows)
 
 
-def _node_has_tag(catalog_uri, node_key, tag_name):
+def _node_has_access_tag(catalog_uri, node_key, access_tag_name):
     """
     Whether the catalog node with key ``node_key`` is still assigned
-    ``tag_name`` in the ``node_access_tags`` junction (joined through
+    ``access_tag_name`` in the ``node_access_tags`` junction (joined through
     ``access_tags`` and ``nodes``). Used to confirm the compiler never deletes
     an in-use node<->tag assignment even when the tag is dropped from config.
     """
@@ -667,7 +677,7 @@ def _node_has_tag(catalog_uri, node_key, tag_name):
                 "JOIN access_tags t ON t.id = nat.tag_id "
                 "JOIN nodes n ON n.id = nat.node_id "
                 "WHERE n.key = :k AND t.name = :t",
-                {"k": node_key, "t": tag_name},
+                {"k": node_key, "t": access_tag_name},
             )
         ],
     )
@@ -731,39 +741,39 @@ def test_access_tag_compiler(compile_access_tags_tables_with_reset, catalog_uri)
     _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # check that new tag was added and compiled with user+scopes
-    assert _tag_exists(catalog_uri, "new_tag")
-    assert _principal_has_scope_on_tag(catalog_uri, "new_tag", "tony")
+    assert _access_tag_exists(catalog_uri, "new_tag")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "new_tag", "tony")
 
     # check that new role was added - note roles do not get saved in the db
     assert "new_role" in access_tags_compiler.roles
 
     # check that newly added user and group were given scopes on tag
-    assert _principal_has_scope_on_tag(catalog_uri, "biologists_tag", "tony")
-    assert _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "chris")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "biologists_tag", "tony")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "physicists_tag", "chris")
 
     # check that auto_tag added ACL to parent tag
-    assert _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "tony")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "chemists_tag", "tony")
 
     # check tag was added to tag_owners section
-    assert _principal_owns_tag(catalog_uri, "new_tag")
+    assert _principal_owns_access_tag(catalog_uri, "new_tag")
 
     # check adding new user and group to owners of tags
-    assert _principal_owns_tag(catalog_uri, "biologists_tag", "tony")
-    assert _principal_owns_tag(catalog_uri, "chemists_tag", "chris")
+    assert _principal_owns_access_tag(catalog_uri, "biologists_tag", "tony")
+    assert _principal_owns_access_tag(catalog_uri, "chemists_tag", "chris")
 
     # check that the role/scopes changes for a user and group on a tag were effective
-    assert not _principal_has_scope_on_tag(
+    assert not _principal_has_scope_on_access_tag(
         catalog_uri, "alice_tag", "alice", "write:metadata"
     )
-    assert _principal_has_scope_on_tag(
+    assert _principal_has_scope_on_access_tag(
         catalog_uri, "biologists_tag", "chris", "write:metadata"
     )
 
     # check tha tag was marked as public after inheriting public tag
-    assert _tag_is_public(catalog_uri, "alice_tag")
+    assert _access_tag_is_public(catalog_uri, "alice_tag")
 
     # check that user added to group was compiled into tag ACL
-    assert _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "kate")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "chemists_tag", "kate")
 
     # attempt redefining the public tag (and fail)
     compiler_tag_config["tags"].update(
@@ -781,39 +791,41 @@ def test_access_tag_compiler(compile_access_tags_tables_with_reset, catalog_uri)
     _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # check that new tag was removed and no longer compiled
-    assert not _tag_exists(catalog_uri, "new_tag")
-    assert not _principal_has_scope_on_tag(catalog_uri, "new_tag", "tony")
+    assert not _access_tag_exists(catalog_uri, "new_tag")
+    assert not _principal_has_scope_on_access_tag(catalog_uri, "new_tag", "tony")
 
     # check that new role was removed - note roles do not get saved in the db
     assert "new_role" not in access_tags_compiler.roles
 
     # check that removed user and group were not given scopes on tag
-    assert not _principal_has_scope_on_tag(catalog_uri, "biologists_tag", "tony")
-    assert not _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "chris")
+    assert not _principal_has_scope_on_access_tag(catalog_uri, "biologists_tag", "tony")
+    assert not _principal_has_scope_on_access_tag(
+        catalog_uri, "physicists_tag", "chris"
+    )
 
     # check that auto_tag ACL removed from parent tag
-    assert not _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "tony")
+    assert not _principal_has_scope_on_access_tag(catalog_uri, "chemists_tag", "tony")
 
     # check tag was removed from tag_owners section
-    assert not _principal_owns_tag(catalog_uri, "new_tag")
+    assert not _principal_owns_access_tag(catalog_uri, "new_tag")
 
     # check removing user and group from owners of tags
-    assert not _principal_owns_tag(catalog_uri, "biologists_tag", "tony")
-    assert not _principal_owns_tag(catalog_uri, "chemists_tag", "chris")
+    assert not _principal_owns_access_tag(catalog_uri, "biologists_tag", "tony")
+    assert not _principal_owns_access_tag(catalog_uri, "chemists_tag", "chris")
 
     # check that the role/scopes changes for a user and group on a tag were undone
-    assert _principal_has_scope_on_tag(
+    assert _principal_has_scope_on_access_tag(
         catalog_uri, "alice_tag", "alice", "write:metadata"
     )
-    assert not _principal_has_scope_on_tag(
+    assert not _principal_has_scope_on_access_tag(
         catalog_uri, "biologists_tag", "chris", "write:metadata"
     )
 
     # check tha tag was unmarked as public after removing the public auto_tag
-    assert not _tag_is_public(catalog_uri, "alice_tag")
+    assert not _access_tag_is_public(catalog_uri, "alice_tag")
 
     # check that user removed from group was compiled out of tag ACL
-    assert not _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "kate")
+    assert not _principal_has_scope_on_access_tag(catalog_uri, "chemists_tag", "kate")
 
 
 def test_basic_access_control(access_control_test_context_factory):
@@ -1136,7 +1148,7 @@ def test_update_node_access_control(access_control_test_context_factory, catalog
         admin_client[top][data].replace_metadata(access_tags=["biologists_tag"])
 
         # surgically add an undefined tag to the node, then fail when trying to remove it
-        _set_node_tags(catalog_uri, data, ["undefined_tag", "biologists_tag"])
+        _set_node_access_tags(catalog_uri, data, ["undefined_tag", "biologists_tag"])
         with fail_with_status_code(HTTP_403_FORBIDDEN):
             alice_client[top][data].replace_metadata(access_tags=["biologists_tag"])
 
@@ -1181,7 +1193,7 @@ def test_empty_tags_node_access_control(
     top = "qux"
     for data in ["data_M"]:
         admin_client[top].write_array(arr, key=data, access_tags=["alice_tag"])
-        _delete_node_tags(catalog_uri, data)
+        _delete_node_access_tags(catalog_uri, data)
 
         assert data in admin_client[top]
         admin_client[top][data]
@@ -1300,12 +1312,16 @@ def test_principal_tag_generated_from_authn_db(
     # user:alice exists and carries scopes from alice's authn role ('user',
     # which grants read/write) -- it could only have come from the authn DB,
     # since the config never defined it.
-    assert _tag_exists(catalog_uri, "user:alice")
-    assert _principal_has_scope_on_tag(catalog_uri, "user:alice", "alice", "read:data")
-    assert _principal_has_scope_on_tag(catalog_uri, "user:alice", "alice", "write:data")
+    assert _access_tag_exists(catalog_uri, "user:alice")
+    assert _principal_has_scope_on_access_tag(
+        catalog_uri, "user:alice", "alice", "read:data"
+    )
+    assert _principal_has_scope_on_access_tag(
+        catalog_uri, "user:alice", "alice", "write:data"
+    )
     # 'register' is not in alice's 'user' role, so a pure-authn compilation must
     # NOT grant it (this would only appear if a config definition contributed).
-    assert not _principal_has_scope_on_tag(
+    assert not _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", "register"
     )
 
@@ -1344,13 +1360,13 @@ def test_principal_tag_config_scopes_unioned_with_auth_scopes(
     _compile_with_principal_tags(tag_config, catalog_uri, factory.authn_uri)
 
     # The config-only scope is present (it is not in alice's authn role)...
-    assert _principal_has_scope_on_tag(
+    assert _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", config_only_scope
     )
     # ...and an authn-role-only scope is also present (the config entry omitted
     # it) -- confirming the two scope sets were unioned, not one overriding the
     # other.
-    assert _principal_has_scope_on_tag(
+    assert _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", authn_only_scope
     )
 
@@ -1381,9 +1397,9 @@ def test_in_use_tag_retained_on_recompile(
 
     # Baseline: the tag is defined, public-status false, has grants, and the
     # node is assigned the tag.
-    assert _tag_exists(catalog_uri, "physicists_tag")
-    assert _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "alice")
-    assert _node_has_tag(catalog_uri, node_key, "physicists_tag")
+    assert _access_tag_exists(catalog_uri, "physicists_tag")
+    assert _principal_has_scope_on_access_tag(catalog_uri, "physicists_tag", "alice")
+    assert _node_has_access_tag(catalog_uri, node_key, "physicists_tag")
 
     # Drop physicists_tag entirely from the config and recompile. clear_raw_tags
     # is required because load_tag_config merges (updates) into the compiler's
@@ -1400,18 +1416,20 @@ def test_in_use_tag_retained_on_recompile(
         _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # The access_tags row is retained (not deleted, since it is still in use).
-    # Check this first: _node_has_tag joins through access_tags, so it can only
+    # Check this first: _node_has_access_tag joins through access_tags, so it can only
     # be meaningfully True if the tag row still exists -- establishing the row
     # survived makes the assignment check below unambiguous.
-    assert _tag_exists(catalog_uri, "physicists_tag")
+    assert _access_tag_exists(catalog_uri, "physicists_tag")
     # The node<->tag assignment is preserved: the compiler never deletes
     # node_access_tags rows for an in-use tag.
-    assert _node_has_tag(catalog_uri, node_key, "physicists_tag")
+    assert _node_has_access_tag(catalog_uri, node_key, "physicists_tag")
     # The retained tag row is forced non-public and stripped of all grants
     # (confers no access).
-    assert not _tag_is_public(catalog_uri, "physicists_tag")
-    assert not _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "alice")
-    assert not _principal_owns_tag(catalog_uri, "physicists_tag")
+    assert not _access_tag_is_public(catalog_uri, "physicists_tag")
+    assert not _principal_has_scope_on_access_tag(
+        catalog_uri, "physicists_tag", "alice"
+    )
+    assert not _principal_owns_access_tag(catalog_uri, "physicists_tag")
 
     # The node itself is still readable by an admin (admins bypass tag checks).
     assert node_key in admin_client[top]

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -237,9 +237,7 @@ def _server_config(catalog_uri, authn_uri, tmp_path):
             "providers": [
                 {
                     "provider": "toy",
-                    "authenticator": (
-                        "tiled.authenticators:DictionaryAuthenticator"
-                    ),
+                    "authenticator": ("tiled.authenticators:DictionaryAuthenticator"),
                     "args": {
                         "users_to_passwords": {
                             "alice": "alice",
@@ -375,8 +373,15 @@ def compile_access_tags_tables(catalog_uri, tmp_path_factory):
     # the app's startup revision check. initialize_database alone does not
     # stamp.
     subprocess.run(
-        [sys.executable, "-m", "tiled", "catalog", "init", "--if-not-exists",
-         ensure_specified_sql_driver(catalog_uri)],
+        [
+            sys.executable,
+            "-m",
+            "tiled",
+            "catalog",
+            "init",
+            "--if-not-exists",
+            ensure_specified_sql_driver(catalog_uri),
+        ],
         check=True,
         capture_output=True,
     )
@@ -633,9 +638,7 @@ def _principal_owns_tag(catalog_uri, tag_name, principal=None):
     ``access_tags_principals``.
     """
     sql = (
-        "SELECT 1 "
-        "FROM access_tag_owners o "
-        "JOIN access_tags t ON t.id = o.tag_id "
+        "SELECT 1 " "FROM access_tag_owners o " "JOIN access_tags t ON t.id = o.tag_id "
     )
     params = {"t": tag_name}
     if principal is not None:
@@ -1262,7 +1265,9 @@ def test_node_export_access_control(
 
 
 def test_principal_tag_generated_from_authn_db(
-    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+    access_control_test_context_factory,
+    compile_access_tags_tables_with_reset,
+    catalog_uri,
 ):
     """
     A principal tag (``user:<id>``) is generated purely from the authn database
@@ -1296,12 +1301,8 @@ def test_principal_tag_generated_from_authn_db(
     # which grants read/write) -- it could only have come from the authn DB,
     # since the config never defined it.
     assert _tag_exists(catalog_uri, "user:alice")
-    assert _principal_has_scope_on_tag(
-        catalog_uri, "user:alice", "alice", "read:data"
-    )
-    assert _principal_has_scope_on_tag(
-        catalog_uri, "user:alice", "alice", "write:data"
-    )
+    assert _principal_has_scope_on_tag(catalog_uri, "user:alice", "alice", "read:data")
+    assert _principal_has_scope_on_tag(catalog_uri, "user:alice", "alice", "write:data")
     # 'register' is not in alice's 'user' role, so a pure-authn compilation must
     # NOT grant it (this would only appear if a config definition contributed).
     assert not _principal_has_scope_on_tag(
@@ -1310,7 +1311,9 @@ def test_principal_tag_generated_from_authn_db(
 
 
 def test_principal_tag_config_scopes_unioned_with_auth_scopes(
-    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+    access_control_test_context_factory,
+    compile_access_tags_tables_with_reset,
+    catalog_uri,
 ):
     """
     When a ``user:<id>`` tag is defined in the tag config with its own scopes
@@ -1353,7 +1356,9 @@ def test_principal_tag_config_scopes_unioned_with_auth_scopes(
 
 
 def test_in_use_tag_retained_on_recompile(
-    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+    access_control_test_context_factory,
+    compile_access_tags_tables_with_reset,
+    catalog_uri,
 ):
     """
     When a tag is dropped from the tag config but is still assigned to a node,
@@ -1463,7 +1468,9 @@ def test_apikey_auth_access_control(access_control_test_context_factory):
 
 
 def test_service_principal_access_control(
-    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+    access_control_test_context_factory,
+    compile_access_tags_tables_with_reset,
+    catalog_uri,
 ):
     """
     Test that access control works for service principals.

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -1,58 +1,33 @@
+import asyncio
 import json
-import sqlite3
+import subprocess
+import sys
 from copy import deepcopy
 
 import numpy
 import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 from starlette.status import HTTP_403_FORBIDDEN
 
 from tiled.access_control.access_tags import AccessTagsCompiler
 from tiled.access_control.scopes import ALL_SCOPES
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
+from tiled.server.connection_pool import close_database_connection_pool
+from tiled.server.settings import DatabaseSettings
+from tiled.utils import ensure_specified_sql_driver
 
-from .utils import enter_username_password, fail_with_status_code
+from .conftest import TILED_TEST_POSTGRESQL_URI
+from .utils import enter_username_password, fail_with_status_code, temp_postgres
 
 arr = numpy.ones((5, 5))
 
 
-server_config = {
-    "access_control": {
-        "access_policy": "tiled.access_control.access_policies:TagBasedAccessPolicy",
-        "args": {
-            "provider": "toy",
-            "tags_db": {
-                "uri": "file:compiled_tags_mem?mode=memory&cache=shared"  # in-memory and shareable
-            },
-            "access_tags_parser": "tiled.access_control.access_tags:AccessTagsParser",
-        },
-    },
-    "authentication": {
-        "tiled_admins": [{"provider": "toy", "id": "admin"}],
-        "allow_anonymous_access": True,
-        "secret_keys": ["SECRET"],
-        "providers": [
-            {
-                "provider": "toy",
-                "authenticator": "tiled.authenticators:DictionaryAuthenticator",
-                "args": {
-                    "users_to_passwords": {
-                        "alice": "alice",
-                        "bob": "bob",
-                        "chris": "chris",
-                        "sue": "sue",
-                        "zoe": "zoe",
-                        "admin": "admin",
-                    },
-                },
-            },
-        ],
-    },
-    "database": {
-        "uri": "sqlite:///file:authn_mem?mode=memory&cache=shared&uri=true",  # in-memory
-    },
-}
-
+# The access tag definitions compiled into the catalog database. These are the
+# same set the original SQLite-sidecar tests used; the compiler now writes them
+# into the catalog database, where the server's AccessTagsParser reads them.
 access_tag_config = {
     "roles": {
         "facility_user": {
@@ -206,78 +181,255 @@ def group_parser(groupname):
     }[groupname]
 
 
-@pytest.fixture(scope="module")
-def compile_access_tags_db():
-    access_tags_compiler = AccessTagsCompiler(
+TOP_LEVEL_TAGS = {
+    "foo": ["alice_tag"],
+    "bar": ["chemists_tag"],
+    "baz": ["physicists_tag"],
+    "qux": ["public"],
+}
+
+
+def _server_config(catalog_uri, authn_uri, tmp_path):
+    """
+    Build the server config: four catalog trees (foo/bar/baz/qux), each a mount
+    of a distinct top-level node in ONE shared catalog database, under a
+    MapAdapter root -- the same topology used in production (multiple mounts,
+    one catalog database). Plus the TagBasedAccessPolicy and toy authentication.
+
+    Each mount node carries its own top-level access tags; the MapAdapter root
+    (a plain in-memory map, not a catalog) has no access control, matching the
+    original tests' assumptions about the top level. create_mount_nodes_if_not_
+    exist lets the server create the mount nodes -- applying their access tags
+    -- at startup; the tags must already be defined (the compiler runs first).
+    """
+
+    def _tree(path, tags):
+        mount = path.strip("/").upper()
+        return {
+            "tree": "catalog",
+            "args": {
+                "uri": catalog_uri,
+                "writable_storage": str(tmp_path / mount.lower()),
+                "mount_node": f"/{mount}",
+                "top_level_access_tags": tags,
+            },
+            "path": path,
+        }
+
+    return {
+        "create_mount_nodes_if_not_exist": True,
+        "trees": [_tree(f"/{name}", tags) for name, tags in TOP_LEVEL_TAGS.items()],
+        "access_control": {
+            "access_policy": (
+                "tiled.access_control.access_policies:TagBasedAccessPolicy"
+            ),
+            "args": {
+                "provider": "toy",
+                "access_tags_parser": (
+                    "tiled.access_control.access_tags:AccessTagsParser"
+                ),
+            },
+        },
+        "authentication": {
+            "tiled_admins": [{"provider": "toy", "id": "admin"}],
+            "allow_anonymous_access": True,
+            "secret_keys": ["SECRET"],
+            "providers": [
+                {
+                    "provider": "toy",
+                    "authenticator": (
+                        "tiled.authenticators:DictionaryAuthenticator"
+                    ),
+                    "args": {
+                        "users_to_passwords": {
+                            "alice": "alice",
+                            "bob": "bob",
+                            "chris": "chris",
+                            "sue": "sue",
+                            "zoe": "zoe",
+                            "admin": "admin",
+                        },
+                    },
+                },
+            ],
+        },
+        "database": {
+            "uri": authn_uri,
+            "init_if_not_exists": True,
+        },
+    }
+
+
+@pytest_asyncio.fixture(scope="module", params=["sqlite", "postgres"])
+async def catalog_uri(request, tmp_path_factory):
+    """
+    A catalog-database URI on the requested backend, module-scoped so the
+    catalog, compiler run, and app are built once per backend. On postgres a
+    disposable database is created (and dropped) for the module; skips if
+    TILED_TEST_POSTGRESQL_URI is not configured.
+    """
+    if request.param == "sqlite":
+        tmp_path = tmp_path_factory.mktemp("access_control_sqlite")
+        yield f"sqlite:///{tmp_path}/catalog.sqlite"
+        return
+
+    # postgres
+    if not TILED_TEST_POSTGRESQL_URI:
+        pytest.skip("No TILED_TEST_POSTGRESQL_URI configured")
+
+    async with temp_postgres(TILED_TEST_POSTGRESQL_URI) as uri:
+        yield uri
+
+
+def _database_settings(uri):
+    return DatabaseSettings(uri=ensure_specified_sql_driver(uri))
+
+
+def _compiler_run(compiler, catalog_uri, method="compile"):
+    """
+    Run ``compiler.<method>()`` (compile or recompile) on a fresh event loop
+    with a fresh database engine bound to that loop, then dispose it.
+
+    The compiler is a long-lived Python object reused across several
+    ``asyncio.run`` calls (each opens and closes its own event loop). Its
+    pooled asyncpg engine, however, cannot outlive the loop it was created on;
+    reusing it on a later loop raises "attached to a different loop". So for
+    each run we swap in a fresh engine for the current loop and dispose it
+    afterward, leaving the in-memory compiler state (tag_config, roles, ...)
+    intact between calls. On SQLite this is equally correct and cheap.
+    """
+
+    async def _run():
+        engine = create_async_engine(ensure_specified_sql_driver(catalog_uri))
+        compiler._engine = engine
+        try:
+            await getattr(compiler, method)()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _make_compiler(tag_config, catalog_uri):
+    return AccessTagsCompiler(
         ALL_SCOPES,
-        access_tag_config,
-        {"uri": "file:compiled_tags_mem?mode=memory&cache=shared"},
+        tag_config,
+        _database_settings(catalog_uri),
         group_parser,
     )
 
-    access_tags_compiler.load_tag_config()
-    access_tags_compiler.compile()
-    yield access_tags_compiler
-    access_tags_compiler.connection.close()
 
+def _compile_with_principal_tags(tag_config, catalog_uri, authn_uri):
+    """
+    Build an AccessTagsCompiler wired to both the catalog and the authentication
+    databases, load principal tags from the authn database (generating a
+    ``user:<id>`` / ``service:<uuid>`` tag for each principal), then compile.
 
-@pytest.fixture
-def compile_access_tags_db_with_reset(compile_access_tags_db):
-    access_tags_compiler = compile_access_tags_db
-    access_tag_config_copy = deepcopy(access_tag_config)
-    access_tags_compiler.tag_config = access_tag_config_copy
-    yield access_tags_compiler
-    access_tags_compiler.tag_config = access_tag_config
-    access_tags_compiler.group_parser = group_parser
-    access_tags_compiler.clear_raw_tags()
-    access_tags_compiler.load_tag_config()
-    access_tags_compiler.recompile()
+    Unlike ``_compiler_run``, this exercises ``load_principal_tags()`` -- the
+    path that reads the authn database -- so the authn database must already be
+    populated (i.e. the app has been built and the relevant users have logged
+    in). Fresh loop-local engines are used for both databases so nothing is
+    reused across event loops (which PostgreSQL forbids).
+    """
+    compiler = AccessTagsCompiler(
+        ALL_SCOPES,
+        tag_config,
+        _database_settings(catalog_uri),
+        group_parser,
+        authn_database_settings=_database_settings(authn_uri),
+        provider="toy",
+    )
+    compiler.load_tag_config()
+
+    async def _run():
+        catalog_engine = create_async_engine(ensure_specified_sql_driver(catalog_uri))
+        authn_engine = create_async_engine(ensure_specified_sql_driver(authn_uri))
+        compiler._engine = catalog_engine
+        compiler._authn_engine = authn_engine
+        try:
+            await compiler.load_principal_tags()
+            await compiler.compile()
+        finally:
+            await catalog_engine.dispose()
+            await authn_engine.dispose()
+
+    asyncio.run(_run())
+    return compiler
 
 
 @pytest.fixture(scope="module")
-def access_control_test_context_factory(tmpdir_module, compile_access_tags_db):
-    config = {
-        "trees": [
-            {
-                "tree": "tiled.catalog:in_memory",
-                "args": {
-                    "named_memory": "catalog_foo",
-                    "writable_storage": str(tmpdir_module / "foo"),
-                    "top_level_access_blob": {"tags": ["alice_tag"]},
-                },
-                "path": "/foo",
-            },
-            {
-                "tree": "tiled.catalog:in_memory",
-                "args": {
-                    "named_memory": "catalog_bar",
-                    "writable_storage": str(tmpdir_module / "bar"),
-                    "top_level_access_blob": {"tags": ["chemists_tag"]},
-                },
-                "path": "/bar",
-            },
-            {
-                "tree": "tiled.catalog:in_memory",
-                "args": {
-                    "named_memory": "catalog_baz",
-                    "writable_storage": str(tmpdir_module / "baz"),
-                    "top_level_access_blob": {"tags": ["physicists_tag"]},
-                },
-                "path": "/baz",
-            },
-            {
-                "tree": "tiled.catalog:in_memory",
-                "args": {
-                    "named_memory": "catalog_qux",
-                    "writable_storage": str(tmpdir_module / "qux"),
-                    "top_level_access_blob": {"tags": ["public"]},
-                },
-                "path": "/qux",
-            },
-        ],
-    }
+def compile_access_tags_tables(catalog_uri, tmp_path_factory):
+    """
+    Initialize the catalog database and compile the access tag definitions
+    into it, once per backend. Yields the compiler (for the recompile tests
+    to reuse) alongside the catalog URI.
 
-    config.update(server_config)
+    Order matters: the catalog schema (and its root/public tag) must exist,
+    then the tags must be compiled, before the app's mount nodes -- which
+    reference these tags -- are created at app startup.
+    """
+    settings = _database_settings(catalog_uri)
+
+    # Initialize (create tables + alembic stamp) the catalog database exactly
+    # as the app's init_if_not_exists path does, so a file-based catalog passes
+    # the app's startup revision check. initialize_database alone does not
+    # stamp.
+    subprocess.run(
+        [sys.executable, "-m", "tiled", "catalog", "init", "--if-not-exists",
+         ensure_specified_sql_driver(catalog_uri)],
+        check=True,
+        capture_output=True,
+    )
+
+    compiler = _make_compiler(access_tag_config, catalog_uri)
+    # Constructing the compiler opened a pooled catalog engine keyed by the
+    # default DatabaseSettings (pool_size=5). We never use it -- _compiler_run
+    # swaps in a fresh, loop-local engine for each compile -- but if left
+    # registered, a later app built with the same default settings would reuse
+    # this engine across event loops and fail on PostgreSQL ("attached to a
+    # different loop"). Dispose it now; each user's app uses a distinct
+    # catalog_pool_size (>= 6) and so gets its own pool.
+    asyncio.run(close_database_connection_pool(settings))
+    compiler.load_tag_config()
+    _compiler_run(compiler, catalog_uri, "compile")
+    yield compiler, catalog_uri
+    asyncio.run(close_database_connection_pool(settings))
+
+
+@pytest.fixture
+def compile_access_tags_tables_with_reset(compile_access_tags_tables):
+    """
+    Give a test a compiler whose tag_config is a private deep copy it may
+    freely mutate and recompile; on teardown, restore the original config and
+    recompile so the shared catalog database returns to its baseline state.
+
+    This mirrors the original fixture of the same name: the tests that use it
+    are a carefully ordered sequence of mutate-then-restore steps, preserved
+    verbatim.
+    """
+    compiler, catalog_uri = compile_access_tags_tables
+    compiler.tag_config = deepcopy(access_tag_config)
+    yield compiler
+    compiler.tag_config = access_tag_config
+    compiler.group_parser = group_parser
+    compiler.clear_raw_tags()
+    compiler.load_tag_config()
+    _compiler_run(compiler, catalog_uri, "recompile")
+
+
+@pytest.fixture(scope="module")
+def access_control_test_context_factory(compile_access_tags_tables, tmp_path_factory):
+    """
+    Build the server app (four catalog mounts sharing one database) once per
+    backend, seed the standard data, and return a factory that logs in a user
+    and caches the resulting client (Context construction is the expensive
+    step, so contexts are created once per user and reused).
+    """
+    _compiler, catalog_uri = compile_access_tags_tables
+    tmp_path = tmp_path_factory.mktemp("access_control_app")
+    authn_uri = f"sqlite:///{tmp_path}/authn.sqlite"
+    config = _server_config(catalog_uri, authn_uri, tmp_path)
+
     contexts = []
     clients = {}
 
@@ -287,7 +439,22 @@ def access_control_test_context_factory(tmpdir_module, compile_access_tags_db):
 
         if client := clients.get(username, None):
             return client
-        app = build_app_from_config(config)
+        # Each user gets its own app, and each app's TestClient runs its own
+        # event loop. On PostgreSQL, asyncpg connections are bound to the loop
+        # that opened them, and the catalog connection pool is shared across
+        # apps when their DatabaseSettings are identical -- which would let one
+        # app touch another app's loop-bound connections ("attached to a
+        # different loop"). Give each app a distinct catalog_pool_size so its
+        # DatabaseSettings differ, keying a separate connection pool per app
+        # (per loop). All still point at the same catalog database. (On SQLite
+        # this is harmless.)
+        per_user_config = deepcopy(config)
+        # Set the top-level catalog_pool_size (config validation overwrites any
+        # per-tree value with this). A distinct size per app keys a separate
+        # catalog connection pool, so no asyncpg connection is shared across
+        # apps' event loops.
+        per_user_config["catalog_pool_size"] = 6 + len(clients)
+        app = build_app_from_config(per_user_config)
         context = Context.from_app(
             app, uri=f"http://local-tiled-app-{username}/api/v1", api_key=api_key
         )
@@ -299,8 +466,15 @@ def access_control_test_context_factory(tmpdir_module, compile_access_tags_db):
                 client.context.login(remember_me=False)
         return client
 
+    # Expose the authentication-database URI so tests that build their own
+    # AccessTagsCompiler can load principal tags from the same authn database
+    # the app populates when users log in.
+    _create_and_login_context.authn_uri = authn_uri
+
     admin_client = _create_and_login_context("admin", "admin")
-    for k in ["foo", "bar", "baz", "qux"]:
+    # The four mount nodes (foo/bar/baz/qux) are created by the app at startup
+    # with their access tags. Seed the standard data set into each.
+    for k in TOP_LEVEL_TAGS:
         admin_client[k].write_array(arr, key="data_A", access_tags=["alice_tag"])
         admin_client[k].write_array(arr, key="data_B", access_tags=["chemists_tag"])
         admin_client[k].write_array(arr, key="data_C", access_tags=["public"])
@@ -311,7 +485,193 @@ def access_control_test_context_factory(tmpdir_module, compile_access_tags_db):
         context.close()
 
 
-def test_access_tag_compiler(compile_access_tags_db_with_reset):
+def catalog_db_execute(catalog_uri, statements):
+    """
+    Execute SQL statement(s) against the catalog database and return the rows
+    of the LAST statement (as a list of tuples). For the tests that inspect or
+    surgically edit catalog tables directly.
+
+    Runs on the shared async engine (the same pool the app uses), so it works
+    identically on SQLite and PostgreSQL with only asyncpg installed -- no
+    separate synchronous driver required. `statements` is a SQL string or an
+    iterable of (sql, params) / sql items; a single string is treated as one
+    statement with no params.
+    """
+    if isinstance(statements, str):
+        statements = [statements]
+
+    async def _run():
+        engine = create_async_engine(ensure_specified_sql_driver(catalog_uri))
+        try:
+            rows = []
+            async with engine.begin() as connection:
+                for statement in statements:
+                    if isinstance(statement, tuple):
+                        sql, params = statement
+                    else:
+                        sql, params = statement, {}
+                    result = await connection.execute(text(sql), params)
+                    if result.returns_rows:
+                        rows = list(result.all())
+            return rows
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _tag_exists(catalog_uri, tag_name):
+    rows = catalog_db_execute(
+        catalog_uri,
+        [("SELECT 1 FROM access_tags WHERE name = :n", {"n": tag_name})],
+    )
+    return bool(rows)
+
+
+def _tag_is_public(catalog_uri, tag_name):
+    rows = catalog_db_execute(
+        catalog_uri,
+        [("SELECT 1 FROM access_tags WHERE name = :n AND is_public", {"n": tag_name})],
+    )
+    return bool(rows)
+
+
+def _principal_has_scope_on_tag(catalog_uri, tag_name, principal, scope_name=None):
+    """
+    Whether ``principal`` has any scope (or a specific ``scope_name``) on
+    ``tag_name`` in the catalog database. Replaces the old sidecar
+    ``user_tag_scopes`` lookups (tag_name/user_name/scope_name), which are now
+    the ``access_tag_principal_scopes`` junction joined to ``access_tags``,
+    ``access_tags_principals`` and (for a scope name) ``scopes``.
+    """
+    sql = (
+        "SELECT 1 "
+        "FROM access_tag_principal_scopes aps "
+        "JOIN access_tags t ON t.id = aps.tag_id "
+        "JOIN access_tags_principals p ON p.id = aps.principal_id "
+    )
+    params = {"t": tag_name, "p": principal}
+    if scope_name is not None:
+        sql += "JOIN scopes s ON s.id = aps.scope_id "
+        params["s"] = scope_name
+    sql += "WHERE t.name = :t AND p.name = :p"
+    if scope_name is not None:
+        sql += " AND s.name = :s"
+    rows = catalog_db_execute(catalog_uri, [(sql, params)])
+    return bool(rows)
+
+
+def _set_node_tags(catalog_uri, node_key, tag_names):
+    """
+    Surgically set the access tags on the catalog node with key ``node_key`` to
+    exactly ``tag_names`` (creating bare ``access_tags`` rows for any tag that
+    does not yet exist). Replaces the old sidecar surgery that rewrote an
+    ``access_blobs`` row's JSON ``tags``; the node<->tag mapping now lives in
+    the ``node_access_tags`` junction.
+    """
+    statements = []
+    # Ensure each tag name exists in access_tags (name-only bare row is fine
+    # for these tests, which check policy behavior, not tag semantics).
+    for name in tag_names:
+        statements.append(
+            (
+                # CAST the reused parameter so asyncpg can deduce a single,
+                # consistent type for it (it appears in both the SELECT list
+                # and the WHERE clause). Harmless on SQLite.
+                "INSERT INTO access_tags (name, is_public) "
+                "SELECT CAST(:n AS VARCHAR), false "
+                "WHERE NOT EXISTS ("
+                "SELECT 1 FROM access_tags WHERE name = CAST(:n AS VARCHAR))",
+                {"n": name},
+            )
+        )
+    # Clear existing tag associations for this node.
+    statements.append(
+        (
+            "DELETE FROM node_access_tags WHERE node_id = "
+            "(SELECT id FROM nodes WHERE key = :k)",
+            {"k": node_key},
+        )
+    )
+    # Associate the node with each of the requested tags.
+    for name in tag_names:
+        statements.append(
+            (
+                "INSERT INTO node_access_tags (node_id, tag_id) "
+                "SELECT (SELECT id FROM nodes WHERE key = :k), "
+                "(SELECT id FROM access_tags WHERE name = :n)",
+                {"k": node_key, "n": name},
+            )
+        )
+    catalog_db_execute(catalog_uri, statements)
+
+
+def _delete_node_tags(catalog_uri, node_key):
+    """
+    Surgically remove ALL access-tag rows for the node with key ``node_key``,
+    leaving a node with zero ``node_access_tags`` entries. In the access-tags
+    model such a node is admin-only (no tag grants any principal access),
+    replacing the old "node has no access_blob row" migration edge case.
+    """
+    catalog_db_execute(
+        catalog_uri,
+        [
+            (
+                "DELETE FROM node_access_tags WHERE node_id = "
+                "(SELECT id FROM nodes WHERE key = :k)",
+                {"k": node_key},
+            )
+        ],
+    )
+
+
+def _principal_owns_tag(catalog_uri, tag_name, principal=None):
+    """
+    Whether ``tag_name`` has any owner (or specifically ``principal`` as owner).
+    Replaces the old sidecar ``user_tag_owners`` lookups; owners now live in the
+    ``access_tag_owners`` junction joined to ``access_tags`` and
+    ``access_tags_principals``.
+    """
+    sql = (
+        "SELECT 1 "
+        "FROM access_tag_owners o "
+        "JOIN access_tags t ON t.id = o.tag_id "
+    )
+    params = {"t": tag_name}
+    if principal is not None:
+        sql += "JOIN access_tags_principals p ON p.id = o.principal_id "
+    sql += "WHERE t.name = :t"
+    if principal is not None:
+        sql += " AND p.name = :p"
+        params["p"] = principal
+    rows = catalog_db_execute(catalog_uri, [(sql, params)])
+    return bool(rows)
+
+
+def _node_has_tag(catalog_uri, node_key, tag_name):
+    """
+    Whether the catalog node with key ``node_key`` is still assigned
+    ``tag_name`` in the ``node_access_tags`` junction (joined through
+    ``access_tags`` and ``nodes``). Used to confirm the compiler never deletes
+    an in-use node<->tag assignment even when the tag is dropped from config.
+    """
+    rows = catalog_db_execute(
+        catalog_uri,
+        [
+            (
+                "SELECT 1 "
+                "FROM node_access_tags nat "
+                "JOIN access_tags t ON t.id = nat.tag_id "
+                "JOIN nodes n ON n.id = nat.node_id "
+                "WHERE n.key = :k AND t.name = :t",
+                {"k": node_key, "t": tag_name},
+            )
+        ],
+    )
+    return bool(rows)
+
+
+def test_access_tag_compiler(compile_access_tags_tables_with_reset, catalog_uri):
     """
     Test that compilation of access tags is working. This tests:
     - Adding and removing a tag
@@ -327,7 +687,7 @@ def test_access_tag_compiler(compile_access_tags_db_with_reset):
     - Making a tag public/not-public
     - Disallow redefining the `public` tag
     """
-    access_tags_compiler = compile_access_tags_db_with_reset
+    access_tags_compiler = compile_access_tags_tables_with_reset
     compiler_tag_config = access_tags_compiler.tag_config
 
     def new_group_parser(groupname):
@@ -365,90 +725,42 @@ def test_access_tag_compiler(compile_access_tags_db_with_reset):
     compiler_tag_config["tags"]["alice_tag"].update({"auto_tags": [{"name": "public"}]})
 
     access_tags_compiler.load_tag_config()
-    access_tags_compiler.recompile()
+    _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
-    db = sqlite3.connect("file:compiled_tags_mem?mode=memory&cache=shared", uri=True)
-    cursor = db.cursor()
     # check that new tag was added and compiled with user+scopes
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM tags WHERE name = ?);",
-        ("new_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("new_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _tag_exists(catalog_uri, "new_tag")
+    assert _principal_has_scope_on_tag(catalog_uri, "new_tag", "tony")
 
     # check that new role was added - note roles do not get saved in the db
     assert "new_role" in access_tags_compiler.roles
 
     # check that newly added user and group were given scopes on tag
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("biologists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("physicists_tag", "chris"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _principal_has_scope_on_tag(catalog_uri, "biologists_tag", "tony")
+    assert _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "chris")
 
     # check that auto_tag added ACL to parent tag
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "tony")
 
     # check tag was added to tag_owners section
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ?);",
-        ("new_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _principal_owns_tag(catalog_uri, "new_tag")
 
     # check adding new user and group to owners of tags
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ? AND user_name = ?);",
-        ("biologists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "chris"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _principal_owns_tag(catalog_uri, "biologists_tag", "tony")
+    assert _principal_owns_tag(catalog_uri, "chemists_tag", "chris")
 
     # check that the role/scopes changes for a user and group on a tag were effective
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes "
-        "WHERE tag_name = ? AND user_name = ? AND scope_name = ?);",
-        ("alice_tag", "alice", "write:metadata"),
+    assert not _principal_has_scope_on_tag(
+        catalog_uri, "alice_tag", "alice", "write:metadata"
     )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes "
-        "WHERE tag_name = ? AND user_name = ? AND scope_name = ?);",
-        ("biologists_tag", "chris", "write:metadata"),
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "biologists_tag", "chris", "write:metadata"
     )
-    assert bool(cursor.fetchone()[0])
 
     # check tha tag was marked as public after inheriting public tag
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM public_tags WHERE name = ?);",
-        ("alice_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _tag_is_public(catalog_uri, "alice_tag")
 
     # check that user added to group was compiled into tag ACL
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "kate"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "kate")
 
     # attempt redefining the public tag (and fail)
     compiler_tag_config["tags"].update(
@@ -456,95 +768,49 @@ def test_access_tag_compiler(compile_access_tags_db_with_reset):
     )
     access_tags_compiler.load_tag_config()
     with pytest.raises(ValueError):
-        access_tags_compiler.recompile()
+        _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # remove all changes/additions by reverting to the original config
     access_tags_compiler.tag_config = access_tag_config
     access_tags_compiler.group_parser = group_parser
     access_tags_compiler.clear_raw_tags()
     access_tags_compiler.load_tag_config()
-    access_tags_compiler.recompile()
+    _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # check that new tag was removed and no longer compiled
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM tags WHERE name = ?);",
-        ("new_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("new_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _tag_exists(catalog_uri, "new_tag")
+    assert not _principal_has_scope_on_tag(catalog_uri, "new_tag", "tony")
 
     # check that new role was removed - note roles do not get saved in the db
     assert "new_role" not in access_tags_compiler.roles
 
     # check that removed user and group were not given scopes on tag
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("biologists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("physicists_tag", "chris"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _principal_has_scope_on_tag(catalog_uri, "biologists_tag", "tony")
+    assert not _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "chris")
 
     # check that auto_tag ACL removed from parent tag
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "tony")
 
     # check tag was removed from tag_owners section
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ?);",
-        ("new_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _principal_owns_tag(catalog_uri, "new_tag")
 
     # check removing user and group from owners of tags
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ? AND user_name = ?);",
-        ("biologists_tag", "tony"),
-    )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_owners WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "chris"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _principal_owns_tag(catalog_uri, "biologists_tag", "tony")
+    assert not _principal_owns_tag(catalog_uri, "chemists_tag", "chris")
 
     # check that the role/scopes changes for a user and group on a tag were undone
-    cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM user_tag_scopes "
-        "WHERE tag_name = ? AND user_name = ? AND scope_name = ?);",
-        ("alice_tag", "alice", "write:metadata"),
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "alice_tag", "alice", "write:metadata"
     )
-    assert bool(cursor.fetchone()[0])
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes "
-        "WHERE tag_name = ? AND user_name = ? AND scope_name = ?);",
-        ("biologists_tag", "chris", "write:metadata"),
+    assert not _principal_has_scope_on_tag(
+        catalog_uri, "biologists_tag", "chris", "write:metadata"
     )
-    assert bool(cursor.fetchone()[0])
 
     # check tha tag was unmarked as public after removing the public auto_tag
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM public_tags WHERE name = ?);",
-        ("alice_tag",),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _tag_is_public(catalog_uri, "alice_tag")
 
     # check that user removed from group was compiled out of tag ACL
-    cursor.execute(
-        "SELECT NOT EXISTS(SELECT 1 FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?);",
-        ("chemists_tag", "kate"),
-    )
-    assert bool(cursor.fetchone()[0])
+    assert not _principal_has_scope_on_tag(catalog_uri, "chemists_tag", "kate")
 
 
 def test_basic_access_control(access_control_test_context_factory):
@@ -647,7 +913,7 @@ def test_writing_access_control(access_control_test_context_factory):
     sue_client[top].write_array(
         arr, key="data_W", access_tags=["physicists_tag", "chemists_tag"]
     )
-    access_tags = sue_client[top]["data_W"].access_blob["tags"]
+    access_tags = sue_client[top]["data_W"].access_tags
     assert "physicists_tag" in access_tags
     assert "chemists_tag" in access_tags
     with fail_with_status_code(HTTP_403_FORBIDDEN):
@@ -677,6 +943,12 @@ def test_user_owned_node_access_control(access_control_test_context_factory):
       are visible after creation and can be modified by the user.
     Also test that the data is visible after a tag is applied, and
       that other users cannot see user-owned nodes.
+
+    This exercises the principal tag (``user:<id>``) purely through the access
+    policy's intrinsic self-grant: the tag has no compiled definition here (the
+    config defines no ``user:alice`` and load_principal_tags is never called),
+    so access is conferred entirely by the policy interpreting the node's own
+    principal tag against the authenticated principal.
     """
 
     alice_client = access_control_test_context_factory("alice", "alice")
@@ -688,15 +960,13 @@ def test_user_owned_node_access_control(access_control_test_context_factory):
         alice_client[top].write_array(arr, key=data)
         assert data in alice_client[top]
         alice_client[top][data]
-        access_blob = alice_client[top][data].access_blob
-        assert "user" in access_blob
-        assert "alice" in access_blob["user"]
+        # A user-owned node is tagged with the owner's principal tag.
+        assert "user:alice" in alice_client[top][data].access_tags
         # Convert from user-owned node to a tagged node
         alice_client[top][data].replace_metadata(access_tags=["alice_tag"])
-        access_blob = alice_client[top][data].access_blob
-        assert "user" not in access_blob
-        assert "tags" in access_blob
-        assert "alice_tag" in access_blob["tags"]
+        access_tags = alice_client[top][data].access_tags
+        assert "user:alice" not in access_tags
+        assert "alice_tag" in access_tags
         assert data in alice_client[top]
         alice_client[top][data]
 
@@ -769,7 +1039,7 @@ def test_admin_access_control(access_control_test_context_factory):
             admin_client[top][data].replace_metadata(access_tags=["undefined_tag"])
 
 
-def test_update_node_access_control(access_control_test_context_factory):
+def test_update_node_access_control(access_control_test_context_factory, catalog_uri):
     """
     Test that access control on metadata changes is working.
 
@@ -814,7 +1084,7 @@ def test_update_node_access_control(access_control_test_context_factory):
 
         # succeeds to add a new access tag and remove the old access tag
         alice_client[top][data].replace_metadata(access_tags=["biologists_tag"])
-        access_tags = alice_client[top][data].access_blob["tags"]
+        access_tags = alice_client[top][data].access_tags
         assert "alice_tag" not in access_tags
         assert "biologists_tag" in access_tags
 
@@ -863,20 +1133,7 @@ def test_update_node_access_control(access_control_test_context_factory):
         admin_client[top][data].replace_metadata(access_tags=["biologists_tag"])
 
         # surgically add an undefined tag to the node, then fail when trying to remove it
-        db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
-        cursor = db.cursor()
-        cursor.execute(
-            """
-                UPDATE access_blobs
-                SET kind = 'tags', username = NULL, tags = json(?)
-                WHERE id = (
-                    SELECT access_blob_id FROM node_access_blobs
-                    WHERE node_id = (SELECT id FROM nodes WHERE key = ?)
-                )
-            """,
-            ('["undefined_tag", "biologists_tag"]', data),
-        )
-        db.commit()
+        _set_node_tags(catalog_uri, data, ["undefined_tag", "biologists_tag"])
         with fail_with_status_code(HTTP_403_FORBIDDEN):
             alice_client[top][data].replace_metadata(access_tags=["biologists_tag"])
 
@@ -904,11 +1161,16 @@ def test_update_node_access_control(access_control_test_context_factory):
             sue_client[top][data].replace_metadata(access_tags=["chemists_tag"])
 
 
-def test_empty_access_blob_access_control(access_control_test_context_factory):
+def test_empty_tags_node_access_control(
+    access_control_test_context_factory, catalog_uri
+):
     """
-    Test the cases where a node in the catalog has no access blob row.
-    This case occurs when migrating an older catalog without also
-      populating the access_blobs association table.
+    Test the case where a node in the catalog has zero access-tag rows.
+
+    In the access-tags model, a node with no tags grants no principal any
+    access, so it is visible only to admins. (This replaces the old
+    "node has no access_blob row" migration edge case, which likewise
+    left the node admin-only.)
     """
     admin_client = access_control_test_context_factory("admin", "admin")
     alice_client = access_control_test_context_factory("alice", "alice")
@@ -916,15 +1178,7 @@ def test_empty_access_blob_access_control(access_control_test_context_factory):
     top = "qux"
     for data in ["data_M"]:
         admin_client[top].write_array(arr, key=data, access_tags=["alice_tag"])
-        db = sqlite3.connect(f"file:catalog_{top}?mode=memory&cache=shared", uri=True)
-        cursor = db.cursor()
-        cursor.execute(
-            """
-                DELETE FROM node_access_blobs
-                WHERE node_id = (SELECT id FROM nodes WHERE key == 'data_M')
-            """
-        )
-        db.commit()
+        _delete_node_tags(catalog_uri, data)
 
         assert data in admin_client[top]
         admin_client[top][data]
@@ -1007,6 +1261,158 @@ def test_node_export_access_control(
         sue_exported_data["contents"][top]["contents"][data]
 
 
+def test_principal_tag_generated_from_authn_db(
+    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+):
+    """
+    A principal tag (``user:<id>``) is generated purely from the authn database
+    -- with NO definition of it in the tag config -- proving the authn-database
+    compilation path works on its own.
+
+    ``load_principal_tags`` reads the authn database and defines a ``user:<id>``
+    tag per principal, granting the scopes of that principal's authenticated
+    role. This test isolates that path: the tag config contains no ``user:alice``
+    entry, so if the tag exists with alice's role-derived grants afterward, it
+    can only have come from the authn database.
+
+    (That a ``user:<id>`` tag confers access to a user-owned node is covered by
+    test_user_owned_node_access_control via the intrinsic policy self-grant,
+    without any compiled definition; that behavior is not re-tested here.)
+    """
+    factory = access_control_test_context_factory
+    # Log alice in so the authn database contains her identity (the source
+    # load_principal_tags reads to generate 'user:alice').
+    factory("alice", "alice")
+
+    # Compile with principal tags loaded from the authn database, WITHOUT any
+    # user:alice entry in the config -- so the tag can only be generated from
+    # the authn database, not the config.
+    access_tags_compiler = compile_access_tags_tables_with_reset
+    tag_config = access_tags_compiler.tag_config
+    assert "user:alice" not in tag_config["tags"]
+    _compile_with_principal_tags(tag_config, catalog_uri, factory.authn_uri)
+
+    # user:alice exists and carries scopes from alice's authn role ('user',
+    # which grants read/write) -- it could only have come from the authn DB,
+    # since the config never defined it.
+    assert _tag_exists(catalog_uri, "user:alice")
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "user:alice", "alice", "read:data"
+    )
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "user:alice", "alice", "write:data"
+    )
+    # 'register' is not in alice's 'user' role, so a pure-authn compilation must
+    # NOT grant it (this would only appear if a config definition contributed).
+    assert not _principal_has_scope_on_tag(
+        catalog_uri, "user:alice", "alice", "register"
+    )
+
+
+def test_principal_tag_config_scopes_unioned_with_auth_scopes(
+    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+):
+    """
+    When a ``user:<id>`` tag is defined in the tag config with its own scopes
+    AND that principal is generated from the authn database, the compiled grant
+    for the principal is the UNION of the config-defined scopes and the scopes
+    derived from the principal's authenticated role.
+
+    ``load_principal_tags`` appends an authn-derived users entry alongside the
+    config users entry (both keyed by the same identifier); ``compile`` unions
+    per-user scopes. Here alice's authn role ('user') grants read/write/etc but
+    NOT 'register'; the config grants 'register' but not (say) 'write:data'.
+    The compiled user:alice grant must contain BOTH sets.
+    """
+    factory = access_control_test_context_factory
+    factory("alice", "alice")  # populate authn DB with alice's identity
+
+    # 'register' is a valid tag scope (used by facility_admin) but is NOT in
+    # alice's authn 'user' role, so it can only come from the config. Conversely
+    # 'write:data' comes only from her authn role (the config entry omits it).
+    config_only_scope = "register"
+    authn_only_scope = "write:data"
+
+    access_tags_compiler = compile_access_tags_tables_with_reset
+    tag_config = access_tags_compiler.tag_config
+    tag_config["tags"]["user:alice"] = {
+        "users": [{"name": "alice", "scopes": [config_only_scope, "read:metadata"]}]
+    }
+    _compile_with_principal_tags(tag_config, catalog_uri, factory.authn_uri)
+
+    # The config-only scope is present (it is not in alice's authn role)...
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "user:alice", "alice", config_only_scope
+    )
+    # ...and an authn-role-only scope is also present (the config entry omitted
+    # it) -- confirming the two scope sets were unioned, not one overriding the
+    # other.
+    assert _principal_has_scope_on_tag(
+        catalog_uri, "user:alice", "alice", authn_only_scope
+    )
+
+
+def test_in_use_tag_retained_on_recompile(
+    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
+):
+    """
+    When a tag is dropped from the tag config but is still assigned to a node,
+    the compiler must NOT delete the node<->tag assignment.
+
+    The compiler retains the ``access_tags`` row (stripped of grants and forced
+    non-public) so the cascade never destroys the ``node_access_tags`` row,
+    warning that the tag was retained with grants revoked. This test asserts:
+      - the node<->tag assignment in ``node_access_tags`` survives the recompile
+      - the ``access_tags`` row survives but is no longer public and has no grants
+      - a warning naming the retained tag is emitted
+    """
+    admin_client = access_control_test_context_factory("admin", "admin")
+
+    # Write a node tagged with physicists_tag, which grants alice write access
+    # (via facility_admin) and is owned by alice.
+    top = "baz"
+    node_key = "data_retain"
+    admin_client[top].write_array(arr, key=node_key, access_tags=["physicists_tag"])
+
+    # Baseline: the tag is defined, public-status false, has grants, and the
+    # node is assigned the tag.
+    assert _tag_exists(catalog_uri, "physicists_tag")
+    assert _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "alice")
+    assert _node_has_tag(catalog_uri, node_key, "physicists_tag")
+
+    # Drop physicists_tag entirely from the config and recompile. clear_raw_tags
+    # is required because load_tag_config merges (updates) into the compiler's
+    # accumulated raw tags rather than replacing them; without it the deleted
+    # tag would linger in self.tags and be recompiled.
+    access_tags_compiler = compile_access_tags_tables_with_reset
+    compiler_tag_config = access_tags_compiler.tag_config
+    del compiler_tag_config["tags"]["physicists_tag"]
+    del compiler_tag_config["tag_owners"]["physicists_tag"]
+    access_tags_compiler.clear_raw_tags()
+    access_tags_compiler.load_tag_config()
+
+    with pytest.warns(UserWarning, match="physicists_tag"):
+        _compiler_run(access_tags_compiler, catalog_uri, "recompile")
+
+    # The access_tags row is retained (not deleted, since it is still in use).
+    # Check this first: _node_has_tag joins through access_tags, so it can only
+    # be meaningfully True if the tag row still exists -- establishing the row
+    # survived makes the assignment check below unambiguous.
+    assert _tag_exists(catalog_uri, "physicists_tag")
+    # The node<->tag assignment is preserved: the compiler never deletes
+    # node_access_tags rows for an in-use tag.
+    assert _node_has_tag(catalog_uri, node_key, "physicists_tag")
+    # The retained tag row is forced non-public and stripped of all grants
+    # (confers no access).
+    assert not _tag_is_public(catalog_uri, "physicists_tag")
+    assert not _principal_has_scope_on_tag(catalog_uri, "physicists_tag", "alice")
+    assert not _principal_owns_tag(catalog_uri, "physicists_tag")
+
+    # The node itself is still readable by an admin (admins bypass tag checks).
+    assert node_key in admin_client[top]
+    admin_client[top][node_key]
+
+
 def test_apikey_auth_access_control(access_control_test_context_factory):
     """
     Test access control when authenticated by an API key, including:
@@ -1057,7 +1463,7 @@ def test_apikey_auth_access_control(access_control_test_context_factory):
 
 
 def test_service_principal_access_control(
-    access_control_test_context_factory, compile_access_tags_db_with_reset
+    access_control_test_context_factory, compile_access_tags_tables_with_reset, catalog_uri
 ):
     """
     Test that access control works for service principals.
@@ -1071,7 +1477,7 @@ def test_service_principal_access_control(
         sp["uuid"], api_key=sp_apikey_info["secret"]
     )
 
-    access_tags_compiler = compile_access_tags_db_with_reset
+    access_tags_compiler = compile_access_tags_tables_with_reset
     compiler_tag_config = access_tags_compiler.tag_config
 
     compiler_tag_config["tags"]["physicists_tag"]["users"].append(
@@ -1082,7 +1488,7 @@ def test_service_principal_access_control(
     )
 
     access_tags_compiler.load_tag_config()
-    access_tags_compiler.recompile()
+    _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     top = "baz"
     for data in ["data_A"]:

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -25,9 +25,7 @@ from .utils import enter_username_password, fail_with_status_code, temp_postgres
 arr = numpy.ones((5, 5))
 
 
-# The access tag definitions compiled into the catalog database. These are the
-# same set the original SQLite-sidecar tests used; the compiler now writes them
-# into the catalog database, where the server's AccessTagsParser reads them.
+# The access tag definitions compiled into the catalog database.
 access_tag_config = {
     "roles": {
         "facility_user": {
@@ -190,19 +188,6 @@ TOP_LEVEL_TAGS = {
 
 
 def _server_config(catalog_uri, authn_uri, tmp_path):
-    """
-    Build the server config: four catalog trees (foo/bar/baz/qux), each a mount
-    of a distinct top-level node in ONE shared catalog database, under a
-    MapAdapter root -- the same topology used in production (multiple mounts,
-    one catalog database). Plus the TagBasedAccessPolicy and toy authentication.
-
-    Each mount node carries its own top-level access tags; the MapAdapter root
-    (a plain in-memory map, not a catalog) has no access control, matching the
-    original tests' assumptions about the top level. create_mount_nodes_if_not_
-    exist lets the server create the mount nodes -- applying their access tags
-    -- at startup; the tags must already be defined (the compiler runs first).
-    """
-
     def _tree(path, access_tags):
         mount = path.strip("/").upper()
         return {
@@ -288,7 +273,7 @@ def _database_settings(uri):
 
 def _compiler_run(compiler, catalog_uri, method="compile"):
     """
-    Run ``compiler.<method>()`` (compile or recompile) on a fresh event loop
+    Run ``compiler.<method>()`` (e.g. compile or recompile) on a fresh event loop
     with a fresh database engine bound to that loop, then dispose it.
 
     The compiler is a long-lived Python object reused across several
@@ -410,10 +395,6 @@ def compile_access_tags_tables_with_reset(compile_access_tags_tables):
     Give a test a compiler whose tag_config is a private deep copy it may
     freely mutate and recompile; on teardown, restore the original config and
     recompile so the shared catalog database returns to its baseline state.
-
-    This mirrors the original fixture of the same name: the tests that use it
-    are a carefully ordered sequence of mutate-then-restore steps, preserved
-    verbatim.
     """
     compiler, catalog_uri = compile_access_tags_tables
     compiler.tag_config = deepcopy(access_tag_config)
@@ -428,9 +409,9 @@ def compile_access_tags_tables_with_reset(compile_access_tags_tables):
 @pytest.fixture(scope="module")
 def access_control_test_context_factory(compile_access_tags_tables, tmp_path_factory):
     """
-    Build the server app (four catalog mounts sharing one database) once per
+    Build the server app (mulitple catalog mounts sharing one database) once per
     backend, seed the standard data, and return a factory that logs in a user
-    and caches the resulting client (Context construction is the expensive
+    and caches the resulting client (Context construction is an expensive
     step, so contexts are created once per user and reused).
     """
     _compiler, catalog_uri = compile_access_tags_tables
@@ -480,8 +461,6 @@ def access_control_test_context_factory(compile_access_tags_tables, tmp_path_fac
     _create_and_login_context.authn_uri = authn_uri
 
     admin_client = _create_and_login_context("admin", "admin")
-    # The four mount nodes (foo/bar/baz/qux) are created by the app at startup
-    # with their access tags. Seed the standard data set into each.
     for k in TOP_LEVEL_TAGS:
         admin_client[k].write_array(arr, key="data_A", access_tags=["alice_tag"])
         admin_client[k].write_array(arr, key="data_B", access_tags=["chemists_tag"])
@@ -500,10 +479,9 @@ def catalog_db_execute(catalog_uri, statements):
     surgically edit catalog tables directly.
 
     Runs on the shared async engine (the same pool the app uses), so it works
-    identically on SQLite and PostgreSQL with only asyncpg installed -- no
-    separate synchronous driver required. `statements` is a SQL string or an
-    iterable of (sql, params) / sql items; a single string is treated as one
-    statement with no params.
+    identically on SQLite and PostgreSQL.
+    `statements` is a SQL string or an iterable of (sql, params) / sql items;
+    a single string is treated as one statement with no params.
     """
     if isinstance(statements, str):
         statements = [statements]
@@ -554,10 +532,7 @@ def _principal_has_scope_on_access_tag(
 ):
     """
     Whether ``principal`` has any scope (or a specific ``scope_name``) on
-    ``access_tag_name`` in the catalog database. Replaces the old sidecar
-    ``user_tag_scopes`` lookups (access_tag_name/user_name/scope_name), which are now
-    the ``access_tag_principal_scopes`` junction joined to ``access_tags``,
-    ``access_tags_principals`` and (for a scope name) ``scopes``.
+    ``access_tag_name`` in the catalog database.
     """
     sql = (
         "SELECT 1 "
@@ -580,13 +555,9 @@ def _set_node_access_tags(catalog_uri, node_key, access_tag_names):
     """
     Surgically set the access tags on the catalog node with key ``node_key`` to
     exactly ``access_tag_names`` (creating bare ``access_tags`` rows for any tag that
-    does not yet exist). Replaces the old sidecar surgery that rewrote an
-    ``access_blobs`` row's JSON ``tags``; the node<->tag mapping now lives in
-    the ``node_access_tags`` junction.
+    does not yet exist).
     """
     statements = []
-    # Ensure each tag name exists in access_tags (name-only bare row is fine
-    # for these tests, which check policy behavior, not tag semantics).
     for name in access_tag_names:
         statements.append(
             (
@@ -625,8 +596,7 @@ def _delete_node_access_tags(catalog_uri, node_key):
     """
     Surgically remove ALL access-tag rows for the node with key ``node_key``,
     leaving a node with zero ``node_access_tags`` entries. In the access-tags
-    model such a node is admin-only (no tag grants any principal access),
-    replacing the old "node has no access_blob row" migration edge case.
+    model such a node is admin-only (no tag grants any principal access).
     """
     catalog_db_execute(
         catalog_uri,
@@ -643,9 +613,6 @@ def _delete_node_access_tags(catalog_uri, node_key):
 def _principal_owns_access_tag(catalog_uri, access_tag_name, principal=None):
     """
     Whether ``access_tag_name`` has any owner (or specifically ``principal`` as owner).
-    Replaces the old sidecar ``user_tag_owners`` lookups; owners now live in the
-    ``access_tag_owners`` junction joined to ``access_tags`` and
-    ``access_tags_principals``.
     """
     sql = (
         "SELECT 1 " "FROM access_tag_owners o " "JOIN access_tags t ON t.id = o.tag_id "
@@ -954,9 +921,10 @@ def test_deletion_access_control(access_control_test_context_factory):
 
 def test_user_owned_node_access_control(access_control_test_context_factory):
     """
-    Test that user-owned nodes (i.e. nodes created without access tags applied)
-      are visible after creation and can be modified by the user.
-    Also test that the data is visible after a tag is applied, and
+    Test that user-owned nodes (i.e. nodes created without specific
+    access tags applied) are visible after creation and can be modified
+    by the user.
+    Also test that the data is visible after a different tag is applied, and
       that other users cannot see user-owned nodes.
 
     This exercises the principal tag (``user:<id>``) purely through the access
@@ -1183,9 +1151,7 @@ def test_empty_tags_node_access_control(
     Test the case where a node in the catalog has zero access-tag rows.
 
     In the access-tags model, a node with no tags grants no principal any
-    access, so it is visible only to admins. (This replaces the old
-    "node has no access_blob row" migration edge case, which likewise
-    left the node admin-only.)
+    access, so it is visible only to admins.
     """
     admin_client = access_control_test_context_factory("admin", "admin")
     alice_client = access_control_test_context_factory("alice", "alice")
@@ -1283,14 +1249,8 @@ def test_principal_tag_generated_from_authn_db(
 ):
     """
     A principal tag (``user:<id>``) is generated purely from the authn database
-    -- with NO definition of it in the tag config -- proving the authn-database
+    with no definition of it in the tag config, proving the authn-database
     compilation path works on its own.
-
-    ``load_principal_tags`` reads the authn database and defines a ``user:<id>``
-    tag per principal, granting the scopes of that principal's authenticated
-    role. This test isolates that path: the tag config contains no ``user:alice``
-    entry, so if the tag exists with alice's role-derived grants afterward, it
-    can only have come from the authn database.
 
     (That a ``user:<id>`` tag confers access to a user-owned node is covered by
     test_user_owned_node_access_control via the intrinsic policy self-grant,
@@ -1301,9 +1261,6 @@ def test_principal_tag_generated_from_authn_db(
     # load_principal_tags reads to generate 'user:alice').
     factory("alice", "alice")
 
-    # Compile with principal tags loaded from the authn database, WITHOUT any
-    # user:alice entry in the config -- so the tag can only be generated from
-    # the authn database, not the config.
     access_tags_compiler = compile_access_tags_tables_with_reset
     tag_config = access_tags_compiler.tag_config
     assert "user:alice" not in tag_config["tags"]
@@ -1319,8 +1276,8 @@ def test_principal_tag_generated_from_authn_db(
     assert _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", "write:data"
     )
-    # 'register' is not in alice's 'user' role, so a pure-authn compilation must
-    # NOT grant it (this would only appear if a config definition contributed).
+    # 'register' is not in alice's 'user' role, so a pure-authn compilation would
+    # not grant it (this would only appear if a config definition contributed).
     assert not _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", "register"
     )
@@ -1340,15 +1297,12 @@ def test_principal_tag_config_scopes_unioned_with_auth_scopes(
     ``load_principal_tags`` appends an authn-derived users entry alongside the
     config users entry (both keyed by the same identifier); ``compile`` unions
     per-user scopes. Here alice's authn role ('user') grants read/write/etc but
-    NOT 'register'; the config grants 'register' but not (say) 'write:data'.
-    The compiled user:alice grant must contain BOTH sets.
+    not 'register'; the config grants 'register' but not (say) 'write:data'.
+    The compiled user:alice grant will contain both sets.
     """
     factory = access_control_test_context_factory
     factory("alice", "alice")  # populate authn DB with alice's identity
 
-    # 'register' is a valid tag scope (used by facility_admin) but is NOT in
-    # alice's authn 'user' role, so it can only come from the config. Conversely
-    # 'write:data' comes only from her authn role (the config entry omits it).
     config_only_scope = "register"
     authn_only_scope = "write:data"
 
@@ -1363,9 +1317,8 @@ def test_principal_tag_config_scopes_unioned_with_auth_scopes(
     assert _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", config_only_scope
     )
-    # ...and an authn-role-only scope is also present (the config entry omitted
-    # it) -- confirming the two scope sets were unioned, not one overriding the
-    # other.
+    # ...and an authn-role-only scope is also present
+    # confirms the two scope sets were unioned, not one overridden
     assert _principal_has_scope_on_access_tag(
         catalog_uri, "user:alice", "alice", authn_only_scope
     )
@@ -1416,9 +1369,6 @@ def test_in_use_tag_retained_on_recompile(
         _compiler_run(access_tags_compiler, catalog_uri, "recompile")
 
     # The access_tags row is retained (not deleted, since it is still in use).
-    # Check this first: _node_has_access_tag joins through access_tags, so it can only
-    # be meaningfully True if the tag row still exists -- establishing the row
-    # survived makes the assignment check below unambiguous.
     assert _access_tag_exists(catalog_uri, "physicists_tag")
     # The node<->tag assignment is preserved: the compiler never deletes
     # node_access_tags rows for an in-use tag.

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -56,8 +56,8 @@ async def test_node_access_allowed(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (True, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (True, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -72,8 +72,8 @@ async def test_node_access_denied(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -91,8 +91,8 @@ async def test_node_modify_allowed(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (True, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (True, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -110,8 +110,8 @@ async def test_node_modify_denied(
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -128,7 +128,7 @@ async def test_node_modify_denied_when_none_returned(
             principal=principal,
             authn_access_tags=set(),
             authn_scopes=set([]),
-            access_blob={"tags": {"beamline_x_user"}},
+            access_blob=AccessBlob(tags=["beamline_x_user"]),
         )
 
 
@@ -137,14 +137,14 @@ async def test_node_modify_with_same_not_modified(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = {"tags": {"beamline_x_user"}}
+    node.access_blob = AccessBlob(tags=["beamline_x_user"])
     assert await external_policy.modify_node(
         node=node,
         principal=principal,
         authn_access_tags=set(),
         authn_scopes=set([]),
-        access_blob={"tags": {"beamline_x_user"}},
-    ) == (False, {"tags": {"beamline_x_user"}})
+        access_blob=AccessBlob(tags=["beamline_x_user"]),
+    ) == (False, AccessBlob(tags=["beamline_x_user"]))
 
 
 @pytest.mark.asyncio

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -240,7 +240,7 @@ async def test_empty_access_blob_public(
         authn_access_tags=set(),
         authn_scopes=set([]),
         access_blob=None,
-    ) == (allow if allow is not None else remote_allow, None)
+    ) == (allow if allow is not None else remote_allow, AccessBlob(tags=[]))
 
     if route:
         assert route.call_count == 1

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -8,10 +8,11 @@ from httpx import Response
 from pydantic import HttpUrl, SecretStr
 
 from tiled.access_control.access_policies import ExternalPolicyDecisionPoint
+from tiled.access_control.protocols import AccessTags
 from tiled.access_control.scopes import NO_SCOPES
-from tiled.queries import AccessBlobFilter
+from tiled.queries import AccessTagsFilter
 from tiled.server.schemas import Principal, PrincipalType
-from tiled.type_aliases import AccessBlob, AccessTags, Scopes
+from tiled.type_aliases import Scopes
 
 
 @pytest.fixture
@@ -22,7 +23,7 @@ def external_policy() -> ExternalPolicyDecisionPoint:
             principal: Principal,
             authn_access_tags: Optional[AccessTags],
             authn_scopes: Scopes,
-            access_blob: Optional[AccessBlob] = None,
+            access_tags: Optional[AccessTags] = None,
         ) -> str:
             return ""
 
@@ -54,10 +55,10 @@ async def test_node_access_allowed(
     )
     assert await external_policy.init_node(
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=AccessBlob(tags=["beamline_x_user"]),
-    ) == (True, AccessBlob(tags=["beamline_x_user"]))
+        access_tags=AccessTags(["beamline_x_user"]),
+    ) == (True, AccessTags(["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -70,10 +71,10 @@ async def test_node_access_denied(
     )
     assert await external_policy.init_node(
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=AccessBlob(tags=["beamline_x_user"]),
-    ) == (False, AccessBlob(tags=["beamline_x_user"]))
+        access_tags=AccessTags(["beamline_x_user"]),
+    ) == (False, AccessTags(["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -82,17 +83,17 @@ async def test_node_modify_allowed(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = None
+    node.access_tags = None
     respx.post(external_policy._create_node).mock(
         return_value=Response(200, json={"result": True})
     )
     assert await external_policy.modify_node(
         node=node,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=AccessBlob(tags=["beamline_x_user"]),
-    ) == (True, AccessBlob(tags=["beamline_x_user"]))
+        access_tags=AccessTags(["beamline_x_user"]),
+    ) == (True, AccessTags(["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -101,17 +102,17 @@ async def test_node_modify_denied(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = None
+    node.access_tags = None
     respx.post(external_policy._create_node).mock(
         return_value=Response(200, json={"result": False})
     )
     assert await external_policy.modify_node(
         node=node,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=AccessBlob(tags=["beamline_x_user"]),
-    ) == (False, AccessBlob(tags=["beamline_x_user"]))
+        access_tags=AccessTags(["beamline_x_user"]),
+    ) == (False, AccessTags(["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -120,15 +121,15 @@ async def test_node_modify_denied_when_none_returned(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = None
+    node.access_tags = None
     respx.post(external_policy._create_node).mock(return_value=Response(200))
     with pytest.raises(ValueError):
         await external_policy.modify_node(
             node=node,
             principal=principal,
-            authn_access_tags=set(),
+            authn_access_tags=AccessTags(),
             authn_scopes=set([]),
-            access_blob=AccessBlob(tags=["beamline_x_user"]),
+            access_tags=AccessTags(["beamline_x_user"]),
         )
 
 
@@ -137,14 +138,14 @@ async def test_node_modify_with_same_not_modified(
     external_policy: ExternalPolicyDecisionPoint, principal: Principal
 ):
     node = MagicMock()
-    node.access_blob = AccessBlob(tags=["beamline_x_user"])
+    node.access_tags = AccessTags(["beamline_x_user"])
     assert await external_policy.modify_node(
         node=node,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=AccessBlob(tags=["beamline_x_user"]),
-    ) == (False, AccessBlob(tags=["beamline_x_user"]))
+        access_tags=AccessTags(["beamline_x_user"]),
+    ) == (False, AccessTags(["beamline_x_user"]))
 
 
 @pytest.mark.asyncio
@@ -158,11 +159,11 @@ async def test_access_filters(
     filters = await external_policy.filters(
         node=MagicMock(),
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
         scopes=set([]),
     )
-    assert filters == [AccessBlobFilter(tags=["beamline_x"], user_id=None)]
+    assert filters == [AccessTagsFilter(tags=["beamline_x"])]
 
 
 @pytest.mark.asyncio
@@ -177,7 +178,7 @@ async def test_allowed_scopes(
     allowed_scopes = await external_policy.allowed_scopes(
         node=None,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
     )
     assert allowed_scopes == {"read:data", "write:data"}
@@ -193,7 +194,7 @@ async def test_allowed_scopes_return_no_scopes_if_invalid_response(
     allowed_scopes = await external_policy.allowed_scopes(
         node=None,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
     )
     assert allowed_scopes == NO_SCOPES
@@ -209,7 +210,7 @@ async def test_allowed_scopes_return_no_scopes_if_validation_error(
     allowed_scopes = await external_policy.allowed_scopes(
         node=None,
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
     )
     assert allowed_scopes == NO_SCOPES
@@ -220,13 +221,13 @@ async def test_allowed_scopes_return_no_scopes_if_validation_error(
 @pytest.mark.parametrize(
     "allow,remote_allow", [(True, None), (False, None), (None, True), (None, False)]
 )
-async def test_empty_access_blob_public(
+async def test_empty_access_tags_public(
     external_policy: ExternalPolicyDecisionPoint,
     principal: Principal,
     allow: Optional[bool],
     remote_allow: Optional[bool],
 ):
-    external_policy._empty_access_blob_public = allow
+    external_policy._empty_access_tags_public = allow
     policy = external_policy
     if remote_allow is not None:
         route = respx.post(policy._create_node).mock(
@@ -237,10 +238,10 @@ async def test_empty_access_blob_public(
 
     assert await policy.init_node(
         principal=principal,
-        authn_access_tags=set(),
+        authn_access_tags=AccessTags(),
         authn_scopes=set([]),
-        access_blob=None,
-    ) == (allow if allow is not None else remote_allow, AccessBlob(tags=[]))
+        access_tags=None,
+    ) == (allow if allow is not None else remote_allow, AccessTags())
 
     if route:
         assert route.call_count == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import random
 import string
@@ -60,6 +61,22 @@ async def client(catalog_adapter):
     app = build_app(catalog_adapter)
     with Context.from_app(app) as context:
         yield from_context(context)
+
+
+@pytest.mark.asyncio
+async def test_root_node_has_default_access_blob(a):
+    tags = (
+        await a.context.execute(
+            "SELECT access_blobs.tags "
+            "FROM access_blobs "
+            "JOIN node_access_blobs "
+            "ON node_access_blobs.access_blob_id = access_blobs.id "
+            "WHERE node_access_blobs.node_id = 0"
+        )
+    ).scalar_one()
+    if isinstance(tags, str):
+        tags = json.loads(tags)
+    assert tags == ["public"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -64,7 +64,7 @@ async def client(catalog_adapter):
 
 @pytest.mark.asyncio
 async def test_root_node_has_default_access_tags(a):
-    tags = (
+    access_tags = (
         (
             await a.context.execute(
                 "SELECT access_tags.name "
@@ -77,7 +77,7 @@ async def test_root_node_has_default_access_tags(a):
         .scalars()
         .all()
     )
-    assert list(tags) == ["public"]
+    assert list(access_tags) == ["public"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -65,14 +65,18 @@ async def client(catalog_adapter):
 @pytest.mark.asyncio
 async def test_root_node_has_default_access_tags(a):
     tags = (
-        await a.context.execute(
-            "SELECT access_tags.name "
-            "FROM access_tags "
-            "JOIN node_access_tags "
-            "ON node_access_tags.tag_id = access_tags.id "
-            "WHERE node_access_tags.node_id = 0"
+        (
+            await a.context.execute(
+                "SELECT access_tags.name "
+                "FROM access_tags "
+                "JOIN node_access_tags "
+                "ON node_access_tags.tag_id = access_tags.id "
+                "WHERE node_access_tags.node_id = 0"
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert list(tags) == ["public"]
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import os
 import random
 import string
@@ -64,19 +63,17 @@ async def client(catalog_adapter):
 
 
 @pytest.mark.asyncio
-async def test_root_node_has_default_access_blob(a):
+async def test_root_node_has_default_access_tags(a):
     tags = (
         await a.context.execute(
-            "SELECT access_blobs.tags "
-            "FROM access_blobs "
-            "JOIN node_access_blobs "
-            "ON node_access_blobs.access_blob_id = access_blobs.id "
-            "WHERE node_access_blobs.node_id = 0"
+            "SELECT access_tags.name "
+            "FROM access_tags "
+            "JOIN node_access_tags "
+            "ON node_access_tags.tag_id = access_tags.id "
+            "WHERE node_access_tags.node_id = 0"
         )
-    ).scalar_one()
-    if isinstance(tags, str):
-        tags = json.loads(tags)
-    assert tags == ["public"]
+    ).scalars().all()
+    assert list(tags) == ["public"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -1,5 +1,7 @@
 import pytest
-from sqlalchemy import delete as sa_delete, insert as sa_insert, select as sa_select
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import insert as sa_insert
+from sqlalchemy import select as sa_select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -5,21 +5,22 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 
-from tiled.catalog import in_memory
+from tiled.access_control.protocols import AccessTags
+from tiled.catalog import in_memory as catalog_in_memory
 from tiled.catalog.core import initialize_database
 from tiled.config import Database
 from tiled.graph.schema import schema
 from tiled.graph.store import (
     GraphSQLAlchemyStore,
-    _access_blobs,
+    _access_tags,
     _entities,
-    _entity_access_blobs,
-    _link_access_blobs,
+    _entity_access_tags,
+    _link_access_tags,
     _links,
-    _node_access_blobs,
+    _node_access_tags,
     _nodes,
 )
-from tiled.queries import AccessBlobFilter
+from tiled.queries import AccessTagsFilter
 from tiled.server.app import build_app
 from tiled.server.authentication import (
     get_current_access_tags,
@@ -31,7 +32,6 @@ from tiled.server.connection_pool import (
     get_database_engine,
 )
 from tiled.server.settings import DatabaseSettings
-from tiled.type_aliases import AccessBlob
 
 CREATE_ENTITY_MUTATION = """
 mutation($input: CreateEntityInput!) {
@@ -47,9 +47,22 @@ mutation($input: CreateLinkInput!) {
 }
 """
 
+# Tag associations may only reference defined tags (rows in access_tags), so
+# the fixtures provision every tag definition these tests use up front -- the
+# access tags compiler's job in a real deployment. The principal tags follow
+# the access policy's ``user:<username>`` convention.
+TAG_DEFINITIONS = (
+    "team",
+    "alice_tag",
+    "node_team",
+    "other",
+    "user:alice",
+    "user:bob",
+)
+
 
 class FakeTagPolicy:
-    """Policy stub mirroring the node access_blob lifecycle and scope checks."""
+    """Policy stub mirroring the node access tags lifecycle and scope checks."""
 
     def __init__(self, user_tags):
         self.user_tags = user_tags
@@ -59,13 +72,13 @@ class FakeTagPolicy:
         principal,
         authn_access_tags,
         authn_scopes,
-        access_blob=None,
+        access_tags=None,
     ):
-        if access_blob is None:
-            return (True, AccessBlob(username=principal))
-        if access_blob.tags is not None:
-            return (False, access_blob)
-        raise ValueError("access_blob updates must use tags for this test")
+        if access_tags is None:
+            # No tags supplied: tag the new node with its creator's
+            # principal tag, as TagBasedAccessPolicy does.
+            return (True, AccessTags([f"user:{principal}"]))
+        return (False, access_tags)
 
     async def modify_node(
         self,
@@ -73,11 +86,11 @@ class FakeTagPolicy:
         principal,
         authn_access_tags,
         authn_scopes,
-        access_blob,
+        access_tags,
     ):
-        if access_blob.tags is not None:
-            return (False, access_blob)
-        raise ValueError("access_blob updates must use tags for this test")
+        if access_tags is not None:
+            return (False, access_tags)
+        return (False, AccessTags(node.access_tags or ()))
 
     async def allowed_scopes(
         self,
@@ -86,10 +99,9 @@ class FakeTagPolicy:
         authn_access_tags,
         authn_scopes,
     ):
-        access_blob = node.access_blob
-        if access_blob.username == principal:
+        tags = set(node.access_tags or ())
+        if f"user:{principal}" in tags:
             return set(authn_scopes)
-        tags = set(access_blob.tags or [])
         if tags.intersection(self.user_tags.get(principal, set())):
             return set(authn_scopes)
         return set()
@@ -119,7 +131,7 @@ class FilterPolicy(FakeTagPolicy):
         scopes,
     ):
         self.filter_calls += 1
-        return [AccessBlobFilter(user_id=None, tags=["team"])]
+        return [AccessTagsFilter(tags=["team"])]
 
 
 @pytest.fixture
@@ -132,6 +144,10 @@ async def store():
     engine = get_database_engine(database_settings)
     await initialize_database(engine)
     s = await GraphSQLAlchemyStore.from_database_settings(database_settings)
+    async with s._engine.begin() as conn:
+        await conn.execute(
+            sa_insert(_access_tags), [{"name": name} for name in TAG_DEFINITIONS]
+        )
     yield s
     # Tear down the shared pool entry (rather than just `s.close()`, which is
     # a no-op here) so each test gets an isolated in-memory database instead
@@ -178,7 +194,16 @@ async def _execute(query, context, variables=None):
     return result
 
 
-async def _insert_node(store, node_id, access_blob, key="node", parent=0):
+async def _tag_ids(conn, tag_names):
+    rows = (
+        await conn.execute(
+            sa_select(_access_tags.c.id).where(_access_tags.c.name.in_(tag_names))
+        )
+    ).scalars()
+    return list(rows)
+
+
+async def _insert_node(store, node_id, access_tags, key="node", parent=None):
     """Insert a synthetic catalog node row for entity/node delegation tests.
 
     Nodes are placed under the catalog root (parent=0) so that they are
@@ -196,145 +221,139 @@ async def _insert_node(store, node_id, access_blob, key="node", parent=0):
                 specs=[],
             )
         )
-        access_blob_result = await conn.execute(
-            sa_insert(_access_blobs).values(
-                kind="user" if "user" in access_blob else "tags",
-                username=access_blob.get("user"),
-                tags=None if "user" in access_blob else access_blob.get("tags", []),
+        access_tag_ids = await _access_tag_ids(conn, access_tags)
+        assert len(access_tag_ids) == len(set(access_tags)), f"undefined tags among {access_tags}"
+        if access_tag_ids:
+            await conn.execute(
+                sa_insert(_node_access_tags),
+                [{"node_id": node_id, "access_tag_id": access_tag_id} for access_tag_id in access_tag_ids],
             )
-        )
-        await conn.execute(
-            sa_insert(_node_access_blobs).values(
-                node_id=node_id,
-                access_blob_id=access_blob_result.inserted_primary_key[0],
-            )
-        )
 
 
 @pytest.mark.asyncio
-async def test_deleting_node_deletes_orphaned_access_blob(store):
-    await _insert_node(store, 1, {"tags": ["team"]})
+async def test_deleting_node_removes_tag_associations_but_not_tag(store):
+    await _insert_node(store, 1, ["team"])
     async with store._engine.begin() as conn:
-        access_blob_id = await conn.scalar(
-            sa_select(_node_access_blobs.c.access_blob_id).where(
-                _node_access_blobs.c.node_id == 1
+        tag_id = await conn.scalar(
+            sa_select(_node_access_tags.c.tag_id).where(
+                _node_access_tags.c.node_id == 1
             )
         )
+        assert tag_id is not None
         await conn.execute(sa_delete(_nodes).where(_nodes.c.id == 1))
-        access_blob = await conn.scalar(
-            sa_select(_access_blobs.c.id).where(_access_blobs.c.id == access_blob_id)
+        remaining_assoc = await conn.scalar(
+            sa_select(_node_access_tags.c.tag_id).where(
+                _node_access_tags.c.node_id == 1
+            )
         )
-    assert access_blob is None
+        # The association cascades away with the node, but the deduplicated
+        # tag definition is shared and must survive.
+        surviving_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        )
+    assert remaining_assoc is None
+    assert surviving_tag == tag_id
 
 
 @pytest.mark.asyncio
-async def test_access_blob_cannot_belong_to_node_and_link(store):
-    await _insert_node(store, 1, {"tags": ["team"]})
-    subject = await store.create_entity(entity_type="sample", name="subject")
-    object_ = await store.create_entity(entity_type="sample", name="object")
-    link = await store.create_link(subject.id, "relates_to", object_.id)
-    async with store._engine.begin() as conn:
-        node_access_blob_id = await conn.scalar(
-            sa_select(_node_access_blobs.c.access_blob_id).where(
-                _node_access_blobs.c.node_id == 1
-            )
-        )
-        with pytest.raises(IntegrityError):
-            await conn.execute(
-                sa_insert(_link_access_blobs).values(
-                    link_id=link.id,
-                    access_blob_id=node_access_blob_id,
-                )
-            )
-
-
-@pytest.mark.asyncio
-async def test_entity_access_blob_cleanup_and_node_exclusivity(store):
+async def test_tag_is_shared_across_node_entity_and_link(store):
+    """
+    Access tags are deduplicated and shared many-to-many with
+    nodes, entities, and links via association.
+    """
+    await _insert_node(store, 1, ["team"])
     entity = await store.create_entity(
-        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+        entity_type="sample", name="entity", access_tags=["team"]
+    )
+    subject = await store.create_entity(
+        entity_type="sample", name="subject", access_tags=["team"]
+    )
+    object_ = await store.create_entity(
+        entity_type="sample", name="object", access_tags=["team"]
+    )
+    link = await store.create_link(
+        subject.id, "relates_to", object_.id, access_tags=["team"]
+    )
+    assert entity.access_tags == frozenset({"team"})
+    assert link.access_tags == frozenset({"team"})
+    async with store._engine.connect() as conn:
+        (tag_id,) = await _tag_ids(conn, ["team"])
+        node_tag = await conn.scalar(
+            sa_select(_node_access_tags.c.tag_id).where(
+                _node_access_tags.c.node_id == 1,
+                _node_access_tags.c.tag_id == tag_id,
+            )
+        )
+        entity_tag = await conn.scalar(
+            sa_select(_entity_access_tags.c.tag_id).where(
+                _entity_access_tags.c.entity_id == entity.id,
+                _entity_access_tags.c.tag_id == tag_id,
+            )
+        )
+        link_tag = await conn.scalar(
+            sa_select(_link_access_tags.c.tag_id).where(
+                _link_access_tags.c.link_id == link.id,
+                _link_access_tags.c.tag_id == tag_id,
+            )
+        )
+    assert node_tag == entity_tag == link_tag == tag_id
+
+
+@pytest.mark.asyncio
+async def test_deleting_entity_removes_tag_associations_but_not_tag(store):
+    entity = await store.create_entity(
+        entity_type="sample", name="entity", access_tags=["team"]
     )
     async with store._engine.begin() as conn:
-        access_blob_id = await conn.scalar(
-            sa_select(_entity_access_blobs.c.access_blob_id).where(
-                _entity_access_blobs.c.entity_id == entity.id
+        tag_id = await conn.scalar(
+            sa_select(_entity_access_tags.c.tag_id).where(
+                _entity_access_tags.c.entity_id == entity.id
             )
         )
-        await conn.execute(
-            sa_insert(_nodes).values(
-                id=2,
-                parent=None,
-                key="unassociated-node",
-                structure_family="container",
-                metadata={},
-                specs=[],
-            )
-        )
-        with pytest.raises(IntegrityError):
-            await conn.execute(
-                sa_insert(_node_access_blobs).values(
-                    node_id=2, access_blob_id=access_blob_id
-                )
-            )
+        assert tag_id is not None
         await conn.execute(sa_delete(_entities).where(_entities.c.id == entity.id))
-        assert (
-            await conn.scalar(
-                sa_select(_access_blobs.c.id).where(
-                    _access_blobs.c.id == access_blob_id
-                )
+        remaining_assoc = await conn.scalar(
+            sa_select(_entity_access_tags.c.tag_id).where(
+                _entity_access_tags.c.entity_id == entity.id
             )
-            is None
         )
+        surviving_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        )
+    assert remaining_assoc is None
+    assert surviving_tag == tag_id
 
 
 @pytest.mark.asyncio
-async def test_entity_access_blob_cannot_belong_to_link(store):
-    entity = await store.create_entity(
-        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+async def test_deleting_link_removes_tag_associations_but_not_tag(store):
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(
+        subject.id, "relates_to", object_.id, access_tags=["team"]
     )
-    subject = await store.create_entity(entity_type="sample", name="subject")
-    object_ = await store.create_entity(entity_type="sample", name="object")
-    link = await store.create_link(subject.id, "relates_to", object_.id)
     async with store._engine.begin() as conn:
-        access_blob_id = await conn.scalar(
-            sa_select(_entity_access_blobs.c.access_blob_id).where(
-                _entity_access_blobs.c.entity_id == entity.id
+        tag_id = await conn.scalar(
+            sa_select(_link_access_tags.c.tag_id).where(
+                _link_access_tags.c.link_id == link.id
             )
         )
-        with pytest.raises(IntegrityError):
-            await conn.execute(
-                sa_insert(_link_access_blobs).values(
-                    link_id=link.id, access_blob_id=access_blob_id
-                )
-            )
-
-
-@pytest.mark.asyncio
-async def test_deleting_link_deletes_orphaned_access_blob(store):
-    subject = await store.create_entity(entity_type="sample", name="subject")
-    object_ = await store.create_entity(entity_type="sample", name="object")
-    link = await store.create_link(subject.id, "relates_to", object_.id)
-    async with store._engine.begin() as conn:
-        access_blob_id = await conn.scalar(
-            sa_select(_link_access_blobs.c.access_blob_id).where(
-                _link_access_blobs.c.link_id == link.id
-            )
-        )
+        assert tag_id is not None
         await conn.execute(sa_delete(_links).where(_links.c.id == link.id))
-        assert (
-            await conn.scalar(
-                sa_select(_access_blobs.c.id).where(
-                    _access_blobs.c.id == access_blob_id
-                )
+        remaining_assoc = await conn.scalar(
+            sa_select(_link_access_tags.c.tag_id).where(
+                _link_access_tags.c.link_id == link.id
             )
-            is None
         )
+        surviving_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        )
+    assert remaining_assoc is None
+    assert surviving_tag == tag_id
 
 
 @pytest.mark.asyncio
-async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
-    store, policy
-):
-    """Create without tags, verify user-owned blob and read visibility rules."""
+async def test_entity_create_defaults_to_user_tag_and_read_visibility(store, policy):
+    """Create without tags, verify creator's principal tag and read visibility."""
 
     alice_ctx = _context(store, policy, "alice", {"read:metadata", "write:metadata"})
     result = await _execute(
@@ -346,7 +365,7 @@ async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
     entity_id = result.data["createEntity"]["id"]
 
     record = await store.get_entity(entity_id)
-    assert record.access_blob == AccessBlob(username="alice")
+    assert record.access_tags == frozenset({"user:alice"})
 
     alice_read = await _execute(READ_ENTITY_QUERY, alice_ctx, {"id": entity_id})
     assert alice_read.errors is None
@@ -371,7 +390,7 @@ async def test_entity_can_be_tagged_and_shared_for_reads(store, policy):
                 "entityType": "sample",
                 "name": "Etag",
                 "properties": {},
-                "accessBlob": {"tags": ["team"]},
+                "accessTags": ["team"],
             }
         },
     )
@@ -416,7 +435,7 @@ async def test_entity_update_and_delete_enforce_access_control(store, policy):
         alice_ctx,
         {
             "id": entity_id,
-            "input": {"uri": "new-uri", "accessBlob": {"tags": ["team"]}},
+            "input": {"uri": "new-uri", "accessTags": ["team"]},
         },
     )
     assert allowed_update.errors is None
@@ -448,7 +467,7 @@ async def test_link_crud_and_access_control(store, policy):
                 "entityType": "sample",
                 "name": "S",
                 "properties": {},
-                "accessBlob": {"tags": ["team"]},
+                "accessTags": ["team"],
             }
         },
     )
@@ -460,7 +479,7 @@ async def test_link_crud_and_access_control(store, policy):
                 "entityType": "sample",
                 "name": "O",
                 "properties": {},
-                "accessBlob": {"tags": ["team"]},
+                "accessTags": ["team"],
             }
         },
     )
@@ -482,17 +501,18 @@ async def test_link_crud_and_access_control(store, policy):
     )
     assert link_created.errors is None
     link_id = link_created.data["createLink"]["id"]
+    # No tags supplied at creation: the policy tagged the link with its
+    # creator's principal tag.
     async with store._engine.connect() as conn:
-        access_blob = (
+        link_tag_names = (
             await conn.execute(
-                sa_select(_link_access_blobs, _access_blobs)
-                .join(_access_blobs)
-                .where(_link_access_blobs.c.link_id == link_id)
+                sa_select(_access_tags.c.name)
+                .select_from(_link_access_tags)
+                .join(_access_tags, _access_tags.c.id == _link_access_tags.c.tag_id)
+                .where(_link_access_tags.c.link_id == link_id)
             )
-        ).one()
-    assert access_blob.kind == "user"
-    assert access_blob.username == "alice"
-    assert access_blob.tags is None
+        ).scalars()
+        assert set(link_tag_names) == {"user:alice"}
 
     bob_read_ctx = _context(store, policy, "bob", {"read:metadata"})
     read_link = await _execute(
@@ -513,7 +533,7 @@ async def test_link_crud_and_access_control(store, policy):
         bob_read_ctx,
         {
             "id": link_id,
-            "input": {"predicate": "blocked", "accessBlob": {"tags": ["team"]}},
+            "input": {"predicate": "blocked", "accessTags": ["team"]},
         },
     )
     assert denied_update.errors
@@ -522,7 +542,7 @@ async def test_link_crud_and_access_control(store, policy):
     updated = await _execute(
         update_link,
         alice_ctx,
-        {"id": link_id, "input": {"accessBlob": {"tags": ["team"]}}},
+        {"id": link_id, "input": {"accessTags": ["team"]}},
     )
     assert updated.errors is None
 
@@ -546,7 +566,7 @@ async def test_link_crud_and_access_control(store, policy):
 
 @pytest.mark.asyncio
 async def test_query_paths_use_access_policy_filters(store, filter_policy):
-    """Confirm list queries call policy.filters and honor AccessBlobFilter output."""
+    """Confirm list queries call policy.filters and honor AccessTagsFilter output."""
 
     alice_ctx = _context(
         store, filter_policy, "alice", {"read:metadata", "write:metadata"}
@@ -560,7 +580,7 @@ async def test_query_paths_use_access_policy_filters(store, filter_policy):
                 "entityType": "sample",
                 "name": "team-visible",
                 "properties": {},
-                "accessBlob": {"tags": ["team"]},
+                "accessTags": ["team"],
             }
         },
     )
@@ -620,7 +640,7 @@ async def test_pagination_applies_after_access_filtering(store, filter_policy):
                     "entityType": "sample",
                     "name": f"team-{i}",
                     "properties": {},
-                    "accessBlob": {"tags": ["team"]},
+                    "accessTags": ["team"],
                 }
             },
         )
@@ -642,33 +662,55 @@ async def test_pagination_applies_after_access_filtering(store, filter_policy):
 
 
 @pytest.mark.asyncio
-async def test_entity_node_access_blob_trigger_rejects_both_set(store):
+async def test_entity_node_access_tags_rejected_when_both_set(store):
     """
-    The database trigger is the data-integrity backstop: even calling the
-    store directly (bypassing the GraphQL mutation's app-level validation)
-    must fail if node_id and access_blob are both set, on insert or update.
+    Even calling the store directly (bypassing the GraphQL mutation's
+    app-level validation) must fail if node_id and access_tags are both
+    set, on insert or update.
     """
-    await _insert_node(store, 1, {"tags": ["team"]})
+    await _insert_node(store, 1, ["team"])
 
     with pytest.raises(IntegrityError):
         await store.create_entity(
             entity_type="sample",
             name="bad",
             node_id=1,
-            access_blob=AccessBlob(tags=["team"]),
+            access_tags=["team"],
         )
 
     entity = await store.create_entity(
-        entity_type="sample", name="ok", node_id=1, access_blob=None
+        entity_type="sample", name="ok", node_id=1, access_tags=None
     )
     with pytest.raises(IntegrityError):
-        await store.update_entity(entity.id, access_blob=AccessBlob(tags=["team"]))
+        await store.update_entity(entity.id, access_tags=["team"])
 
 
 @pytest.mark.asyncio
-async def test_create_entity_rejects_node_id_with_access_blob(store, policy):
+async def test_entity_node_access_tags_trigger_rejects_direct_insert(store):
+    """
+    The database trigger is the data-integrity backstop: a raw INSERT into
+    entity_access_tags (bypassing even the store) for a node-backed entity
+    must be rejected by the database itself.
+    """
+    await _insert_node(store, 1, ["team"])
+    entity = await store.create_entity(
+        entity_type="sample", name="linked", node_id=1, access_tags=None
+    )
+    async with store._engine.connect() as conn:
+        (tag_id,) = await _tag_ids(conn, ["team"])
+    with pytest.raises(IntegrityError):
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                sa_insert(_entity_access_tags).values(
+                    entity_id=entity.id, tag_id=tag_id
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_entity_rejects_node_id_with_access_tags(store, policy):
     """The GraphQL mutation gives a friendly error instead of a raw DB error."""
-    await _insert_node(store, 1, {"tags": ["team"]})
+    await _insert_node(store, 1, ["team"])
     alice_ctx = _context(store, policy, "alice", {"read:metadata", "write:metadata"})
 
     result = await _execute(
@@ -679,7 +721,7 @@ async def test_create_entity_rejects_node_id_with_access_blob(store, policy):
                 "entityType": "sample",
                 "name": "bad",
                 "nodePathParts": ["node"],
-                "accessBlob": {"tags": ["team"]},
+                "accessTags": ["team"],
             }
         },
     )
@@ -688,10 +730,10 @@ async def test_create_entity_rejects_node_id_with_access_blob(store, policy):
 
 
 @pytest.mark.asyncio
-async def test_update_entity_rejects_setting_access_blob_on_node_linked_entity(
+async def test_update_entity_rejects_setting_access_tags_on_node_linked_entity(
     store, policy
 ):
-    await _insert_node(store, 1, {"tags": ["team"]})
+    await _insert_node(store, 1, ["team"])
     alice_ctx = _context(store, policy, "alice", {"read:metadata", "write:metadata"})
 
     created = await _execute(
@@ -716,20 +758,20 @@ async def test_update_entity_rejects_setting_access_blob_on_node_linked_entity(
     result = await _execute(
         update_mutation,
         alice_ctx,
-        {"id": entity_id, "input": {"accessBlob": {"tags": ["other"]}}},
+        {"id": entity_id, "input": {"accessTags": ["other"]}},
     )
     assert result.errors
     assert "access is controlled by the referenced node" in result.errors[0].message
 
 
 @pytest.mark.asyncio
-async def test_update_entity_detaching_node_reinitializes_access_blob(store, policy):
+async def test_update_entity_detaching_node_reinitializes_access_tags(store, policy):
     """
-    Detaching a node binding (setting node_path_parts to null) with no access_blob
+    Detaching a node binding (setting node_path_parts to null) with no access tags
     supplied in the same call must not leave the entity with node_id=None AND
-    access_blob=None -- that would make it invisible to everyone.
+    no access tags of its own -- that would make it invisible to everyone.
     """
-    await _insert_node(store, 1, {"tags": ["team"]})
+    await _insert_node(store, 1, ["team"])
     alice_ctx = _context(store, policy, "alice", {"read:metadata", "write:metadata"})
 
     created = await _execute(
@@ -758,20 +800,20 @@ async def test_update_entity_detaching_node_reinitializes_access_blob(store, pol
 
     record = await store.get_entity(entity_id)
     assert record.node_id is None
-    assert record.access_blob == AccessBlob(username="alice")
+    assert record.access_tags == frozenset({"user:alice"})
 
 
 @pytest.mark.asyncio
-async def test_entity_read_access_delegates_to_node_access_blob(store):
+async def test_entity_read_access_delegates_to_node_access_tags(store):
     """
-    An entity with node_id set has no access_blob of its own (enforced by
-    the trigger), so its visibility must be resolved from the node's
-    access_blob instead.
+    An entity with node_id set has no access tags of its own (enforced by
+    the trigger), so its visibility must be resolved from the node's tags
+    instead.
     """
     node_policy = FakeTagPolicy({"alice": {"node_team"}, "bob": {"team"}})
-    await _insert_node(store, 1, {"tags": ["node_team"]})
+    await _insert_node(store, 1, ["node_team"])
     entity = await store.create_entity(
-        entity_type="sample", name="linked", node_id=1, access_blob=None
+        entity_type="sample", name="linked", node_id=1, access_tags=None
     )
 
     alice_ctx = _context(store, node_policy, "alice", {"read:metadata"})
@@ -787,16 +829,16 @@ async def test_entity_read_access_delegates_to_node_access_blob(store):
 
 
 @pytest.mark.asyncio
-async def test_entities_listing_filters_by_node_access_blob(store, filter_policy):
+async def test_entities_listing_filters_by_node_access_tags(store, filter_policy):
     """The paginated `entities` query's SQL-level access filter must also
     resolve through the node when node_id is set (not just single fetches)."""
-    await _insert_node(store, 1, {"tags": ["team"]}, key="visible-node")
-    await _insert_node(store, 2, {"tags": ["other"]}, key="hidden-node")
+    await _insert_node(store, 1, ["team"], key="visible-node")
+    await _insert_node(store, 2, ["other"], key="hidden-node")
     await store.create_entity(
-        entity_type="sample", name="node-linked-visible", node_id=1, access_blob=None
+        entity_type="sample", name="node-linked-visible", node_id=1, access_tags=None
     )
     await store.create_entity(
-        entity_type="sample", name="node-linked-hidden", node_id=2, access_blob=None
+        entity_type="sample", name="node-linked-hidden", node_id=2, access_tags=None
     )
 
     bob_ctx = _context(store, filter_policy, "bob", {"read:metadata"})
@@ -940,10 +982,21 @@ async def test_graphql_expands_and_compacts_curies(store, policy):
     ]
 
 
-def test_graphql_http_route_access_control_integration(tmp_path, policy):
+def test_graphql_http_route_access_control_integration(policy):
     """Validate HTTP GraphQL route wiring with auth dependencies and policy checks."""
 
-    catalog = in_memory(writable_storage=str(tmp_path / "storage"))
+    catalog = catalog_in_memory()
+
+    async def define_tags():
+        """Inserts tag definitions into a catalog database (the access tags
+        compiler's job in a real deployment)."""
+        async with catalog.context.engine.begin() as conn:
+            await conn.execute(
+                sa_insert(_access_tags),
+                [{"name": name} for name in TAG_DEFINITIONS],
+            )
+
+    catalog.startup_tasks.append(define_tags)
     app = build_app(
         catalog,
         access_policy=policy,
@@ -967,7 +1020,7 @@ def test_graphql_http_route_access_control_integration(tmp_path, policy):
                         "entityType": "sample",
                         "name": "S",
                         "properties": {},
-                        "accessBlob": {"tags": ["team"]},
+                        "accessTags": ["team"],
                     }
                 },
             },
@@ -981,7 +1034,7 @@ def test_graphql_http_route_access_control_integration(tmp_path, policy):
                         "entityType": "sample",
                         "name": "O",
                         "properties": {},
-                        "accessBlob": {"tags": ["team"]},
+                        "accessTags": ["team"],
                     }
                 },
             },
@@ -1005,7 +1058,7 @@ def test_graphql_http_route_access_control_integration(tmp_path, policy):
                         "predicate": "relates_to",
                         "objectId": object_id,
                         "properties": {},
-                        "accessBlob": {"tags": ["team"]},
+                        "accessTags": ["team"],
                     }
                 },
             },

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -12,7 +12,10 @@ from tiled.graph.schema import schema
 from tiled.graph.store import (
     GraphSQLAlchemyStore,
     _access_blobs,
+    _entities,
+    _entity_access_blobs,
     _link_access_blobs,
+    _links,
     _node_access_blobs,
     _nodes,
 )
@@ -28,6 +31,7 @@ from tiled.server.connection_pool import (
     get_database_engine,
 )
 from tiled.server.settings import DatabaseSettings
+from tiled.type_aliases import AccessBlob
 
 CREATE_ENTITY_MUTATION = """
 mutation($input: CreateEntityInput!) {
@@ -58,12 +62,10 @@ class FakeTagPolicy:
         access_blob=None,
     ):
         if access_blob is None:
-            return (True, {"user": principal})
-        if "tags" in access_blob:
+            return (True, AccessBlob(username=principal))
+        if access_blob.tags is not None:
             return (False, access_blob)
-        raise ValueError(
-            "access_blob must be either null or {'tags': [...]} for this test"
-        )
+        raise ValueError("access_blob updates must use tags for this test")
 
     async def modify_node(
         self,
@@ -73,9 +75,9 @@ class FakeTagPolicy:
         authn_scopes,
         access_blob,
     ):
-        if "tags" in access_blob:
+        if access_blob.tags is not None:
             return (False, access_blob)
-        raise ValueError("access_blob updates must use {'tags': [...]} for this test")
+        raise ValueError("access_blob updates must use tags for this test")
 
     async def allowed_scopes(
         self,
@@ -84,10 +86,10 @@ class FakeTagPolicy:
         authn_access_tags,
         authn_scopes,
     ):
-        access_blob = getattr(node, "access_blob", {}) or {}
-        if access_blob.get("user") == principal:
+        access_blob = node.access_blob
+        if access_blob.username == principal:
             return set(authn_scopes)
-        tags = set(access_blob.get("tags", []))
+        tags = set(access_blob.tags or [])
         if tags.intersection(self.user_tags.get(principal, set())):
             return set(authn_scopes)
         return set()
@@ -247,6 +249,88 @@ async def test_access_blob_cannot_belong_to_node_and_link(store):
 
 
 @pytest.mark.asyncio
+async def test_entity_access_blob_cleanup_and_node_exclusivity(store):
+    entity = await store.create_entity(
+        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+    )
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_entity_access_blobs.c.access_blob_id).where(
+                _entity_access_blobs.c.entity_id == entity.id
+            )
+        )
+        await conn.execute(
+            sa_insert(_nodes).values(
+                id=2,
+                parent=None,
+                key="unassociated-node",
+                structure_family="container",
+                metadata={},
+                specs=[],
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_node_access_blobs).values(
+                    node_id=2, access_blob_id=access_blob_id
+                )
+            )
+        await conn.execute(sa_delete(_entities).where(_entities.c.id == entity.id))
+        assert (
+            await conn.scalar(
+                sa_select(_access_blobs.c.id).where(
+                    _access_blobs.c.id == access_blob_id
+                )
+            )
+            is None
+        )
+
+
+@pytest.mark.asyncio
+async def test_entity_access_blob_cannot_belong_to_link(store):
+    entity = await store.create_entity(
+        entity_type="sample", name="entity", access_blob=AccessBlob(tags=["team"])
+    )
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_entity_access_blobs.c.access_blob_id).where(
+                _entity_access_blobs.c.entity_id == entity.id
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_link_access_blobs).values(
+                    link_id=link.id, access_blob_id=access_blob_id
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_deleting_link_deletes_orphaned_access_blob(store):
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_link_access_blobs.c.access_blob_id).where(
+                _link_access_blobs.c.link_id == link.id
+            )
+        )
+        await conn.execute(sa_delete(_links).where(_links.c.id == link.id))
+        assert (
+            await conn.scalar(
+                sa_select(_access_blobs.c.id).where(
+                    _access_blobs.c.id == access_blob_id
+                )
+            )
+            is None
+        )
+
+
+@pytest.mark.asyncio
 async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
     store, policy
 ):
@@ -262,7 +346,7 @@ async def test_entity_create_defaults_to_user_access_blob_and_read_visibility(
     entity_id = result.data["createEntity"]["id"]
 
     record = await store.get_entity(entity_id)
-    assert record.access_blob == {"user": "alice"}
+    assert record.access_blob == AccessBlob(username="alice")
 
     alice_read = await _execute(READ_ENTITY_QUERY, alice_ctx, {"id": entity_id})
     assert alice_read.errors is None
@@ -571,14 +655,14 @@ async def test_entity_node_access_blob_trigger_rejects_both_set(store):
             entity_type="sample",
             name="bad",
             node_id=1,
-            access_blob={"tags": ["team"]},
+            access_blob=AccessBlob(tags=["team"]),
         )
 
     entity = await store.create_entity(
         entity_type="sample", name="ok", node_id=1, access_blob=None
     )
     with pytest.raises(IntegrityError):
-        await store.update_entity(entity.id, access_blob={"tags": ["team"]})
+        await store.update_entity(entity.id, access_blob=AccessBlob(tags=["team"]))
 
 
 @pytest.mark.asyncio
@@ -674,7 +758,7 @@ async def test_update_entity_detaching_node_reinitializes_access_blob(store, pol
 
     record = await store.get_entity(entity_id)
     assert record.node_id is None
-    assert record.access_blob == {"user": "alice"}
+    assert record.access_blob == AccessBlob(username="alice")
 
 
 @pytest.mark.asyncio

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import insert as sa_insert
+from sqlalchemy import delete as sa_delete, insert as sa_insert, select as sa_select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 
@@ -7,7 +7,13 @@ from tiled.catalog import in_memory
 from tiled.catalog.core import initialize_database
 from tiled.config import Database
 from tiled.graph.schema import schema
-from tiled.graph.store import GraphSQLAlchemyStore, _nodes
+from tiled.graph.store import (
+    GraphSQLAlchemyStore,
+    _access_blobs,
+    _link_access_blobs,
+    _node_access_blobs,
+    _nodes,
+)
 from tiled.queries import AccessBlobFilter
 from tiled.server.app import build_app
 from tiled.server.authentication import (
@@ -184,9 +190,58 @@ async def _insert_node(store, node_id, access_blob, key="node", parent=0):
                 structure_family="container",
                 metadata={},
                 specs=[],
-                access_blob=access_blob,
             )
         )
+        access_blob_result = await conn.execute(
+            sa_insert(_access_blobs).values(
+                kind="user" if "user" in access_blob else "tags",
+                username=access_blob.get("user"),
+                tags=None if "user" in access_blob else access_blob.get("tags", []),
+            )
+        )
+        await conn.execute(
+            sa_insert(_node_access_blobs).values(
+                node_id=node_id,
+                access_blob_id=access_blob_result.inserted_primary_key[0],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_deleting_node_deletes_orphaned_access_blob(store):
+    await _insert_node(store, 1, {"tags": ["team"]})
+    async with store._engine.begin() as conn:
+        access_blob_id = await conn.scalar(
+            sa_select(_node_access_blobs.c.access_blob_id).where(
+                _node_access_blobs.c.node_id == 1
+            )
+        )
+        await conn.execute(sa_delete(_nodes).where(_nodes.c.id == 1))
+        access_blob = await conn.scalar(
+            sa_select(_access_blobs.c.id).where(_access_blobs.c.id == access_blob_id)
+        )
+    assert access_blob is None
+
+
+@pytest.mark.asyncio
+async def test_access_blob_cannot_belong_to_node_and_link(store):
+    await _insert_node(store, 1, {"tags": ["team"]})
+    subject = await store.create_entity(entity_type="sample", name="subject")
+    object_ = await store.create_entity(entity_type="sample", name="object")
+    link = await store.create_link(subject.id, "relates_to", object_.id)
+    async with store._engine.begin() as conn:
+        node_access_blob_id = await conn.scalar(
+            sa_select(_node_access_blobs.c.access_blob_id).where(
+                _node_access_blobs.c.node_id == 1
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await conn.execute(
+                sa_insert(_link_access_blobs).values(
+                    link_id=link.id,
+                    access_blob_id=node_access_blob_id,
+                )
+            )
 
 
 @pytest.mark.asyncio
@@ -341,6 +396,17 @@ async def test_link_crud_and_access_control(store, policy):
     )
     assert link_created.errors is None
     link_id = link_created.data["createLink"]["id"]
+    async with store._engine.connect() as conn:
+        access_blob = (
+            await conn.execute(
+                sa_select(_link_access_blobs, _access_blobs)
+                .join(_access_blobs)
+                .where(_link_access_blobs.c.link_id == link_id)
+            )
+        ).one()
+    assert access_blob.kind == "user"
+    assert access_blob.username == "alice"
+    assert access_blob.tags is None
 
     bob_read_ctx = _context(store, policy, "bob", {"read:metadata"})
     read_link = await _execute(

--- a/tests/test_graph_access_control.py
+++ b/tests/test_graph_access_control.py
@@ -51,7 +51,7 @@ mutation($input: CreateLinkInput!) {
 # the fixtures provision every tag definition these tests use up front -- the
 # access tags compiler's job in a real deployment. The principal tags follow
 # the access policy's ``user:<username>`` convention.
-TAG_DEFINITIONS = (
+ACCESS_TAG_DEFINITIONS = (
     "team",
     "alice_tag",
     "node_team",
@@ -64,8 +64,8 @@ TAG_DEFINITIONS = (
 class FakeTagPolicy:
     """Policy stub mirroring the node access tags lifecycle and scope checks."""
 
-    def __init__(self, user_tags):
-        self.user_tags = user_tags
+    def __init__(self, user_access_tags):
+        self.user_access_tags = user_access_tags
 
     async def init_node(
         self,
@@ -99,10 +99,10 @@ class FakeTagPolicy:
         authn_access_tags,
         authn_scopes,
     ):
-        tags = set(node.access_tags or ())
-        if f"user:{principal}" in tags:
+        node_access_tags = set(node.access_tags or ())
+        if f"user:{principal}" in node_access_tags:
             return set(authn_scopes)
-        if tags.intersection(self.user_tags.get(principal, set())):
+        if node_access_tags.intersection(self.user_access_tags.get(principal, set())):
             return set(authn_scopes)
         return set()
 
@@ -118,8 +118,8 @@ class FakeTagPolicy:
 
 
 class FilterPolicy(FakeTagPolicy):
-    def __init__(self, user_tags):
-        super().__init__(user_tags)
+    def __init__(self, user_access_tags):
+        super().__init__(user_access_tags)
         self.filter_calls = 0
 
     async def filters(
@@ -146,7 +146,7 @@ async def store():
     s = await GraphSQLAlchemyStore.from_database_settings(database_settings)
     async with s._engine.begin() as conn:
         await conn.execute(
-            sa_insert(_access_tags), [{"name": name} for name in TAG_DEFINITIONS]
+            sa_insert(_access_tags), [{"name": name} for name in ACCESS_TAG_DEFINITIONS]
         )
     yield s
     # Tear down the shared pool entry (rather than just `s.close()`, which is
@@ -194,16 +194,18 @@ async def _execute(query, context, variables=None):
     return result
 
 
-async def _tag_ids(conn, tag_names):
+async def _access_tag_ids(conn, access_tag_names):
     rows = (
         await conn.execute(
-            sa_select(_access_tags.c.id).where(_access_tags.c.name.in_(tag_names))
+            sa_select(_access_tags.c.id).where(
+                _access_tags.c.name.in_(access_tag_names)
+            )
         )
     ).scalars()
     return list(rows)
 
 
-async def _insert_node(store, node_id, access_tags, key="node", parent=None):
+async def _insert_node(store, node_id, access_tags, key="node", parent=0):
     """Insert a synthetic catalog node row for entity/node delegation tests.
 
     Nodes are placed under the catalog root (parent=0) so that they are
@@ -222,11 +224,16 @@ async def _insert_node(store, node_id, access_tags, key="node", parent=None):
             )
         )
         access_tag_ids = await _access_tag_ids(conn, access_tags)
-        assert len(access_tag_ids) == len(set(access_tags)), f"undefined tags among {access_tags}"
+        assert len(access_tag_ids) == len(
+            set(access_tags)
+        ), f"undefined tags among {access_tags}"
         if access_tag_ids:
             await conn.execute(
                 sa_insert(_node_access_tags),
-                [{"node_id": node_id, "access_tag_id": access_tag_id} for access_tag_id in access_tag_ids],
+                [
+                    {"node_id": node_id, "tag_id": access_tag_id}
+                    for access_tag_id in access_tag_ids
+                ],
             )
 
 
@@ -234,12 +241,12 @@ async def _insert_node(store, node_id, access_tags, key="node", parent=None):
 async def test_deleting_node_removes_tag_associations_but_not_tag(store):
     await _insert_node(store, 1, ["team"])
     async with store._engine.begin() as conn:
-        tag_id = await conn.scalar(
+        access_tag_id = await conn.scalar(
             sa_select(_node_access_tags.c.tag_id).where(
                 _node_access_tags.c.node_id == 1
             )
         )
-        assert tag_id is not None
+        assert access_tag_id is not None
         await conn.execute(sa_delete(_nodes).where(_nodes.c.id == 1))
         remaining_assoc = await conn.scalar(
             sa_select(_node_access_tags.c.tag_id).where(
@@ -248,11 +255,11 @@ async def test_deleting_node_removes_tag_associations_but_not_tag(store):
         )
         # The association cascades away with the node, but the deduplicated
         # tag definition is shared and must survive.
-        surviving_tag = await conn.scalar(
-            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        surviving_access_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == access_tag_id)
         )
     assert remaining_assoc is None
-    assert surviving_tag == tag_id
+    assert surviving_access_tag == access_tag_id
 
 
 @pytest.mark.asyncio
@@ -277,26 +284,26 @@ async def test_tag_is_shared_across_node_entity_and_link(store):
     assert entity.access_tags == frozenset({"team"})
     assert link.access_tags == frozenset({"team"})
     async with store._engine.connect() as conn:
-        (tag_id,) = await _tag_ids(conn, ["team"])
-        node_tag = await conn.scalar(
+        (access_tag_id,) = await _access_tag_ids(conn, ["team"])
+        node_access_tag = await conn.scalar(
             sa_select(_node_access_tags.c.tag_id).where(
                 _node_access_tags.c.node_id == 1,
-                _node_access_tags.c.tag_id == tag_id,
+                _node_access_tags.c.tag_id == access_tag_id,
             )
         )
-        entity_tag = await conn.scalar(
+        entity_access_tag = await conn.scalar(
             sa_select(_entity_access_tags.c.tag_id).where(
                 _entity_access_tags.c.entity_id == entity.id,
-                _entity_access_tags.c.tag_id == tag_id,
+                _entity_access_tags.c.tag_id == access_tag_id,
             )
         )
-        link_tag = await conn.scalar(
+        link_access_tag = await conn.scalar(
             sa_select(_link_access_tags.c.tag_id).where(
                 _link_access_tags.c.link_id == link.id,
-                _link_access_tags.c.tag_id == tag_id,
+                _link_access_tags.c.tag_id == access_tag_id,
             )
         )
-    assert node_tag == entity_tag == link_tag == tag_id
+    assert node_access_tag == entity_access_tag == link_access_tag == access_tag_id
 
 
 @pytest.mark.asyncio
@@ -305,23 +312,23 @@ async def test_deleting_entity_removes_tag_associations_but_not_tag(store):
         entity_type="sample", name="entity", access_tags=["team"]
     )
     async with store._engine.begin() as conn:
-        tag_id = await conn.scalar(
+        access_tag_id = await conn.scalar(
             sa_select(_entity_access_tags.c.tag_id).where(
                 _entity_access_tags.c.entity_id == entity.id
             )
         )
-        assert tag_id is not None
+        assert access_tag_id is not None
         await conn.execute(sa_delete(_entities).where(_entities.c.id == entity.id))
         remaining_assoc = await conn.scalar(
             sa_select(_entity_access_tags.c.tag_id).where(
                 _entity_access_tags.c.entity_id == entity.id
             )
         )
-        surviving_tag = await conn.scalar(
-            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        surviving_access_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == access_tag_id)
         )
     assert remaining_assoc is None
-    assert surviving_tag == tag_id
+    assert surviving_access_tag == access_tag_id
 
 
 @pytest.mark.asyncio
@@ -332,23 +339,23 @@ async def test_deleting_link_removes_tag_associations_but_not_tag(store):
         subject.id, "relates_to", object_.id, access_tags=["team"]
     )
     async with store._engine.begin() as conn:
-        tag_id = await conn.scalar(
+        access_tag_id = await conn.scalar(
             sa_select(_link_access_tags.c.tag_id).where(
                 _link_access_tags.c.link_id == link.id
             )
         )
-        assert tag_id is not None
+        assert access_tag_id is not None
         await conn.execute(sa_delete(_links).where(_links.c.id == link.id))
         remaining_assoc = await conn.scalar(
             sa_select(_link_access_tags.c.tag_id).where(
                 _link_access_tags.c.link_id == link.id
             )
         )
-        surviving_tag = await conn.scalar(
-            sa_select(_access_tags.c.id).where(_access_tags.c.id == tag_id)
+        surviving_access_tag = await conn.scalar(
+            sa_select(_access_tags.c.id).where(_access_tags.c.id == access_tag_id)
         )
     assert remaining_assoc is None
-    assert surviving_tag == tag_id
+    assert surviving_access_tag == access_tag_id
 
 
 @pytest.mark.asyncio
@@ -504,7 +511,7 @@ async def test_link_crud_and_access_control(store, policy):
     # No tags supplied at creation: the policy tagged the link with its
     # creator's principal tag.
     async with store._engine.connect() as conn:
-        link_tag_names = (
+        link_access_tag_names = (
             await conn.execute(
                 sa_select(_access_tags.c.name)
                 .select_from(_link_access_tags)
@@ -512,7 +519,7 @@ async def test_link_crud_and_access_control(store, policy):
                 .where(_link_access_tags.c.link_id == link_id)
             )
         ).scalars()
-        assert set(link_tag_names) == {"user:alice"}
+        assert set(link_access_tag_names) == {"user:alice"}
 
     bob_read_ctx = _context(store, policy, "bob", {"read:metadata"})
     read_link = await _execute(
@@ -697,12 +704,12 @@ async def test_entity_node_access_tags_trigger_rejects_direct_insert(store):
         entity_type="sample", name="linked", node_id=1, access_tags=None
     )
     async with store._engine.connect() as conn:
-        (tag_id,) = await _tag_ids(conn, ["team"])
+        (access_tag_id,) = await _access_tag_ids(conn, ["team"])
     with pytest.raises(IntegrityError):
         async with store._engine.begin() as conn:
             await conn.execute(
                 sa_insert(_entity_access_tags).values(
-                    entity_id=entity.id, tag_id=tag_id
+                    entity_id=entity.id, tag_id=access_tag_id
                 )
             )
 
@@ -993,7 +1000,7 @@ def test_graphql_http_route_access_control_integration(policy):
         async with catalog.context.engine.begin() as conn:
             await conn.execute(
                 sa_insert(_access_tags),
-                [{"name": name} for name in TAG_DEFINITIONS],
+                [{"name": name} for name in ACCESS_TAG_DEFINITIONS],
             )
 
     catalog.startup_tasks.append(define_tags)

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -220,8 +220,8 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         # Intermediate nodes should have empty specs and access_blob.
         assert client["X"].specs == []
         assert client["X"]["Y"].specs == []
-        assert not client["X"].access_blob
-        assert not client["X"]["Y"].access_blob
+        assert client["X"].access_blob.get("tags") == []
+        assert client["X"]["Y"].access_blob.get("tags") == []
         # The leaf (mount node) should carry the configured specs.
         assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]
         assert client["X"]["Y"]["Z"].access_blob.get("tags") == ["_ROOT_NODE"]

--- a/tests/test_mount_node.py
+++ b/tests/test_mount_node.py
@@ -1,9 +1,31 @@
+import asyncio
+
 import numpy
 import pytest
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import create_async_engine
 
+from tiled.catalog import orm
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
 from tiled.structures.core import Spec
+from tiled.utils import ensure_specified_sql_driver
+
+
+def define_access_tags(uri, names):
+    """Insert tag definitions into a catalog database (the access tags
+    compiler's job in a real deployment). Nodes may only be associated
+    with tags that are defined."""
+
+    async def _run():
+        engine = create_async_engine(ensure_specified_sql_driver(uri))
+        async with engine.begin() as conn:
+            await conn.execute(
+                insert(orm.AccessTag.__table__), [{"name": name} for name in names]
+            )
+        await engine.dispose()
+
+    asyncio.run(_run())
 
 
 def test_mount_node(sqlite_or_postgres_uri, tmpdir):
@@ -174,6 +196,7 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
     # Mount a tree at a nonexistent path with create_mount_nodes_if_not_exist=True.
     # This should auto-create intermediate container nodes /X/Y/Z.
     # The leaf node should receive the configured specs and access_tags.
+    define_access_tags(sqlite_or_postgres_uri, ["_ROOT_NODE"])
     mount_config = {
         "create_mount_nodes_if_not_exist": True,
         "trees": [
@@ -185,7 +208,7 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
                     "writable_storage": [tmpdir / "data"],
                     "mount_node": "/X/Y/Z",
                     "specs": [{"name": "MyCustomSpec", "version": "3.0"}],
-                    "top_level_access_blob": {"tags": ["_ROOT_NODE"]},
+                    "top_level_access_tags": ["_ROOT_NODE"],
                 },
             },
         ],
@@ -217,14 +240,14 @@ def test_create_mount_nodes_if_not_exist(sqlite_or_postgres_uri, tmpdir):
         assert "Y" in list(client["X"])
         assert "Z" in list(client["X"]["Y"])
         assert "child" in list(client["X"]["Y"]["Z"])
-        # Intermediate nodes should have empty specs and access_blob.
+        # Intermediate nodes should have empty specs and access_tags.
         assert client["X"].specs == []
         assert client["X"]["Y"].specs == []
-        assert client["X"].access_blob.get("tags") == []
-        assert client["X"]["Y"].access_blob.get("tags") == []
+        assert list(client["X"].access_tags) == []
+        assert list(client["X"]["Y"].access_tags) == []
         # The leaf (mount node) should carry the configured specs.
         assert client["X"]["Y"]["Z"].specs == [Spec(name="MyCustomSpec", version="3.0")]
-        assert client["X"]["Y"]["Z"].access_blob.get("tags") == ["_ROOT_NODE"]
+        assert list(client["X"]["Y"]["Z"].access_tags) == ["_ROOT_NODE"]
 
 
 def test_create_mount_nodes_partial(sqlite_or_postgres_uri, tmpdir):
@@ -248,6 +271,7 @@ def test_create_mount_nodes_partial(sqlite_or_postgres_uri, tmpdir):
         client.create_container("A")
 
     # Mount at /A/B/C with auto-create. /A exists, /A/B and /A/B/C do not.
+    define_access_tags(sqlite_or_postgres_uri, ["_LEAF"])
     mount_config = {
         "create_mount_nodes_if_not_exist": True,
         "trees": [
@@ -259,7 +283,7 @@ def test_create_mount_nodes_partial(sqlite_or_postgres_uri, tmpdir):
                     "writable_storage": [tmpdir / "data"],
                     "mount_node": "/A/B/C",
                     "specs": [{"name": "PartialSpec", "version": "1.0"}],
-                    "top_level_access_blob": {"tags": ["_LEAF"]},
+                    "top_level_access_tags": ["_LEAF"],
                 },
             },
         ],
@@ -282,4 +306,4 @@ def test_create_mount_nodes_partial(sqlite_or_postgres_uri, tmpdir):
         assert client["A"]["B"].specs == []
         # Leaf /A/B/C should carry the configured specs.
         assert client["A"]["B"]["C"].specs == [Spec(name="PartialSpec", version="1.0")]
-        assert client["A"]["B"]["C"].access_blob.get("tags") == ["_LEAF"]
+        assert list(client["A"]["B"]["C"].access_tags) == ["_LEAF"]

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -493,8 +493,8 @@ class CustomAccessPolicy(AccessPolicy):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def modify_node(
         self,
@@ -502,9 +502,9 @@ class CustomAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+        access_blob: Optional[AccessBlob],
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def allowed_scopes(
         self,

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from pytest_mock import MockFixture
 
 from tiled.access_control.access_policies import ALL_ACCESS
-from tiled.access_control.protocols import AccessPolicy
+from tiled.access_control.protocols import AccessPolicy, AccessTags
 from tiled.access_control.scopes import ALL_SCOPES
 from tiled.adapters.protocols import (
     ArrayAdapter,
@@ -31,7 +31,6 @@ from tiled.structures.core import Spec, StructureFamily
 from tiled.structures.ragged import RaggedStructure
 from tiled.structures.sparse import COOStructure
 from tiled.structures.table import TableStructure
-from tiled.access_control.protocols import AccessTags
 from tiled.type_aliases import JSON, Filters, Scopes
 
 
@@ -483,7 +482,7 @@ def test_tableadapter_protocol(mocker: MockFixture) -> None:
 
 class CustomAccessPolicy(AccessPolicy):
     def __init__(self, scopes: Optional[Scopes] = None) -> None:
-        self.scopes = scopes if (scopes is not None) else ALL_SCOPES
+        self.scopes: Scopes = scopes if (scopes is not None) else set(ALL_SCOPES)
 
     def _get_id(self, principal: Principal) -> None:
         return None
@@ -557,7 +556,7 @@ async def test_accesspolicy_protocol(mocker: MockFixture) -> None:
     principal = Principal(
         uuid="12345678124123412345678123456781", type=PrincipalType.user
     )
-    authn_access_tags = {"qux", "quux"}
+    authn_access_tags = AccessTags({"qux", "quux"})
     authn_scopes = {"abc", "baz"}
     scopes = {"abc"}
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -31,7 +31,8 @@ from tiled.structures.core import Spec, StructureFamily
 from tiled.structures.ragged import RaggedStructure
 from tiled.structures.sparse import COOStructure
 from tiled.structures.table import TableStructure
-from tiled.type_aliases import JSON, AccessBlob, AccessTags, Filters, Scopes
+from tiled.access_control.protocols import AccessTags
+from tiled.type_aliases import JSON, Filters, Scopes
 
 
 class CustomArrayAdapter:
@@ -492,9 +493,9 @@ class CustomAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, AccessBlob]:
-        return (False, access_blob or AccessBlob(tags=[]))
+        access_tags: Optional[AccessTags] = None,
+    ) -> Tuple[bool, AccessTags]:
+        return (False, access_tags or AccessTags())
 
     async def modify_node(
         self,
@@ -502,9 +503,9 @@ class CustomAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, AccessBlob]:
-        return (False, access_blob or AccessBlob(tags=[]))
+        access_tags: Optional[AccessTags],
+    ) -> Tuple[bool, AccessTags]:
+        return (False, access_tags or AccessTags())
 
     async def allowed_scopes(
         self,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -44,6 +44,7 @@ from tiled.server.webhooks import (
     _sign,
     check_url_ssrf_safety,
 )
+from tiled.type_aliases import AccessBlob
 
 from .conftest import TOY_AUTHENTICATION
 from .utils import enter_username_password
@@ -853,7 +854,7 @@ def _make_close_stream_adapter(
     mock_node.key = node_key
     mock_node.structure_family = "container"
     mock_node.specs = []
-    mock_node.access_blob = {}
+    mock_node.access_blob = AccessBlob(tags=[])
 
     adapter = CatalogNodeAdapter(mock_context, mock_node)
     adapter.path_segments = AsyncMock(return_value=[node_key])

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -44,6 +44,7 @@ from tiled.server.webhooks import (
     _sign,
     check_url_ssrf_safety,
 )
+
 from .conftest import TOY_AUTHENTICATION
 from .utils import enter_username_password
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -44,8 +44,6 @@ from tiled.server.webhooks import (
     _sign,
     check_url_ssrf_safety,
 )
-from tiled.type_aliases import AccessBlob
-
 from .conftest import TOY_AUTHENTICATION
 from .utils import enter_username_password
 
@@ -854,7 +852,7 @@ def _make_close_stream_adapter(
     mock_node.key = node_key
     mock_node.structure_family = "container"
     mock_node.specs = []
-    mock_node.access_blob = AccessBlob(tags=[])
+    mock_node.access_tags = []
 
     adapter = CatalogNodeAdapter(mock_context, mock_node)
     adapter.path_segments = AsyncMock(return_value=[node_key])

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -10,7 +10,7 @@ from ..adapters.protocols import BaseAdapter
 from ..queries import AccessBlobFilter
 from ..server.schemas import Principal
 from ..type_aliases import AccessBlob, AccessTags, Filters, Scopes
-from ..utils import Sentinel, import_object
+from ..utils import Sentinel, access_blob_matches, import_object
 from .protocols import AccessPolicy
 from .scopes import ALL_SCOPES, NO_SCOPES, PUBLIC_SCOPES
 
@@ -118,17 +118,17 @@ class TagBasedAccessPolicy(AccessPolicy):
             identifier = self._get_id(principal)
 
         if access_blob:
-            if len(access_blob) != 1 or "tags" not in access_blob:
+            if access_blob.username is not None or access_blob.tags is None:
                 raise ValueError(
                     f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                     f"""Received {access_blob=}"""
                 )
-            if not access_blob["tags"]:
+            if not access_blob.tags:
                 if not self._is_admin(authn_scopes):
                     raise ValueError(
                         "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                     )
-            access_tags = set(access_blob["tags"])
+            access_tags = set(access_blob.tags)
             include_public_tag = False
             for tag in access_tags:
                 if authn_access_tags is not None:
@@ -161,7 +161,7 @@ class TagBasedAccessPolicy(AccessPolicy):
             if include_public_tag:
                 access_tags_from_policy.add(self.public_tag)
 
-            access_blob_from_policy = {"tags": list(access_tags_from_policy)}
+            access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
             access_blob_modified = access_tags != access_tags_from_policy
 
             # admin principals are not subject to scope reduction restriction
@@ -183,7 +183,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                     f"Current API key does not permit action on user-owned nodes.\n"
                     f"Please provide a tag allowed by this API key: {authn_access_tags}"
                 )
-            access_blob_from_policy = {"user": identifier}
+            access_blob_from_policy = AccessBlob(username=identifier)
             access_blob_modified = True
 
         logger.info(
@@ -205,24 +205,24 @@ class TagBasedAccessPolicy(AccessPolicy):
         else:
             identifier = self._get_id(principal)
 
-        if access_blob == node.access_blob:
+        if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
             )
             return False, node.access_blob
 
-        if len(access_blob) != 1 or "tags" not in access_blob:
+        if access_blob is None or access_blob.username is not None or access_blob.tags is None:
             raise ValueError(
                 f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                 f"""Received {access_blob=}\n"""
                 f"""If this was a merge patch on a user-owned node, use a replace op instead."""
             )
-        if not access_blob["tags"]:
+        if not access_blob.tags:
             if not self._is_admin(authn_scopes):
                 raise ValueError(
                     "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                 )
-        access_tags = set(access_blob["tags"])
+        access_tags = set(access_blob.tags)
         include_public_tag = False
         # check for tags that need to be added
         for tag in access_tags:
@@ -231,7 +231,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                     raise ValueError(
                         f"Cannot apply tag to node: API key is restricted to access tags: {authn_access_tags}."
                     )
-            if tag in node.access_blob.get("tags", []):
+            if tag in (node.access_blob.tags or []):
                 # node already has this tag - no action.
                 # or: access_blob does not have "tags" key,
                 # so it must have a "user" key currently
@@ -265,8 +265,8 @@ class TagBasedAccessPolicy(AccessPolicy):
             access_tags_from_policy.add(self.public_tag)
 
         # check for tags that need to be removed
-        if "tags" in node.access_blob:
-            for tag in set(node.access_blob["tags"]).difference(
+        if node.access_blob.tags is not None:
+            for tag in set(node.access_blob.tags).difference(
                 access_tags_from_policy
             ):
                 if authn_access_tags is not None:
@@ -295,7 +295,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                         f"Cannot remove tag from node: '{tag}' is not a valid tag name."
                     )
 
-        access_blob_from_policy = {"tags": list(access_tags_from_policy)}
+        access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
         access_blob_modified = access_tags != access_tags_from_policy
 
         # admin principals are not subject to scope reduction restriction
@@ -343,11 +343,11 @@ class TagBasedAccessPolicy(AccessPolicy):
                 identifier = self._get_id(principal)
 
             allowed = set()
-            if "user" in node.access_blob:
-                if authn_access_tags is None and identifier == node.access_blob["user"]:
+            if node.access_blob.username is not None:
+                if authn_access_tags is None and identifier == node.access_blob.username:
                     allowed = self.scopes
-            elif "tags" in node.access_blob:
-                for tag in node.access_blob["tags"]:
+            elif node.access_blob.tags is not None:
+                for tag in node.access_blob.tags:
                     if authn_access_tags is not None:
                         if tag not in authn_access_tags:
                             continue
@@ -518,7 +518,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
     ) -> Tuple[bool, Optional[AccessBlob]]:
-        if access_blob == node.access_blob:
+        if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
             )

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -39,7 +39,7 @@ class DummyAccessPolicy(AccessPolicy):
         access_blob: Optional[AccessBlob] = None,
     ) -> Tuple[bool, AccessBlob]:
         "Do nothing; there is no persistent state to initialize."
-        return (False, access_blob)
+        return (False, access_blob or AccessBlob(tags=[]))
 
     async def allowed_scopes(
         self,
@@ -503,16 +503,16 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         if access_blob is None and self._empty_access_blob_public is not None:
-            return self._empty_access_blob_public, access_blob
+            return self._empty_access_blob_public, AccessBlob(tags=[])
         decision = await self._get_external_decision(
             self._create_node,
             self.build_input(principal, authn_access_tags, authn_scopes, access_blob),
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob)
+            return (decision.result, access_blob or AccessBlob(tags=[]))
         raise ValueError("Permission denied not able to add the node")
 
     async def modify_node(
@@ -522,7 +522,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         if access_blob_matches(access_blob, node.access_blob):
             logger.info(
                 f"Node access_blob not modified; access_blob is identical: {access_blob}"
@@ -534,7 +534,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob)
+            return (decision.result, access_blob or AccessBlob(tags=[]))
         raise ValueError("Permission denied not able to add the node")
 
     async def filters(

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -211,7 +211,11 @@ class TagBasedAccessPolicy(AccessPolicy):
             )
             return False, node.access_blob
 
-        if access_blob is None or access_blob.username is not None or access_blob.tags is None:
+        if (
+            access_blob is None
+            or access_blob.username is not None
+            or access_blob.tags is None
+        ):
             raise ValueError(
                 f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
                 f"""Received {access_blob=}\n"""
@@ -266,9 +270,7 @@ class TagBasedAccessPolicy(AccessPolicy):
 
         # check for tags that need to be removed
         if node.access_blob.tags is not None:
-            for tag in set(node.access_blob.tags).difference(
-                access_tags_from_policy
-            ):
+            for tag in set(node.access_blob.tags).difference(access_tags_from_policy):
                 if authn_access_tags is not None:
                     if tag not in authn_access_tags:
                         raise ValueError(
@@ -344,7 +346,10 @@ class TagBasedAccessPolicy(AccessPolicy):
 
             allowed = set()
             if node.access_blob.username is not None:
-                if authn_access_tags is None and identifier == node.access_blob.username:
+                if (
+                    authn_access_tags is None
+                    and identifier == node.access_blob.username
+                ):
                     allowed = self.scopes
             elif node.access_blob.tags is not None:
                 for tag in node.access_blob.tags:

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -141,9 +141,8 @@ class TagBasedAccessPolicy(AccessPolicy):
                     raise ValueError(
                         "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                     )
-            if (
-                any(tag.startswith("user:") for tag in access_tags) or
-                any(tag.startswith("service:") for tag in access_tags)
+            if any(tag.startswith("user:") for tag in access_tags) or any(
+                tag.startswith("service:") for tag in access_tags
             ):
                 raise ValueError(
                     f"Cannot manually tag node with user tags.\n"
@@ -231,9 +230,7 @@ class TagBasedAccessPolicy(AccessPolicy):
             identifier = self._get_id(principal)
 
         if access_tags is None:
-            logger.info(
-                "Node access_tags not modified; no access_tags provided."
-            )
+            logger.info("Node access_tags not modified; no access_tags provided.")
             return False, node.access_tags
         try:
             access_tags = AccessTags(access_tags)
@@ -253,9 +250,8 @@ class TagBasedAccessPolicy(AccessPolicy):
                 raise ValueError(
                     "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                 )
-        if (
-            any(tag.startswith("user:") for tag in access_tags) or
-            any(tag.startswith("service:") for tag in access_tags)
+        if any(tag.startswith("user:") for tag in access_tags) or any(
+            tag.startswith("service:") for tag in access_tags
         ):
             raise ValueError(
                 f"Cannot manually tag node with user tags.\n"
@@ -317,9 +313,7 @@ class TagBasedAccessPolicy(AccessPolicy):
                         "Cannot remove 'public' tag from node: only Tiled admins can remove the 'public' tag."
                     )
             elif not await self.is_tag_defined(tag):
-                raise ValueError(
-                    f"Cannot remove tag from node: {tag=} is not defined"
-                )
+                raise ValueError(f"Cannot remove tag from node: {tag=} is not defined")
             elif not await self.is_tag_owner(tag, identifier):
                 # admins can ignore the tag ownership check
                 if not self._is_admin(authn_scopes):

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -308,6 +308,9 @@ class TagBasedAccessPolicy(AccessPolicy):
                         f"Cannot remove tag from node: "
                         f"API key is restricted to access tags: {authn_access_tags}."
                     )
+            if tag in self._get_principal_tag(principal.type, identifier):
+                # A principal intrinsically owns its own principal tag
+                continue
             if tag == self.public_tag:
                 if not self._is_admin(authn_scopes):
                     raise ValueError(

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -516,7 +516,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         access_tags: Optional[AccessTags] = None,
     ) -> Tuple[bool, AccessTags]:
         if access_tags is None and self._empty_access_tags_public is not None:
-            return self._empty_access_tags_public, access_tags
+            return self._empty_access_tags_public, AccessTags()
         decision = await self._get_external_decision(
             self._create_node,
             self.build_input(principal, authn_access_tags, authn_scopes, access_tags),

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -190,14 +190,16 @@ class TagBasedAccessPolicy(AccessPolicy):
         else:
             if (
                 authn_access_tags is not None
-                and f"{principal.type}:{identifier}" not in authn_access_tags
+                and f"{principal.type.value}:{identifier}" not in authn_access_tags
             ):
                 raise ValueError(
                     f"Cannot init node as user-tagged node.\n"
                     f"Current API key does not permit action on user-owned nodes.\n"
                     f"Please provide only tags allowed by this API key: {authn_access_tags}"
                 )
-            access_tags_from_policy = AccessTags([f"{principal.type}:{identifier}"])
+            access_tags_from_policy = AccessTags(
+                [f"{principal.type.value}:{identifier}"]
+            )
             access_tags_modified = True
 
         logger.info(

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -68,7 +68,6 @@ class TagBasedAccessPolicy(AccessPolicy):
         self,
         *,
         provider,
-        tags_db,
         access_tags_parser,
         scopes=None,
     ):
@@ -76,7 +75,9 @@ class TagBasedAccessPolicy(AccessPolicy):
         self.scopes = scopes if (scopes is not None) else ALL_SCOPES
 
         access_tags_parser = import_object(access_tags_parser)
-        self.access_tags_parser = access_tags_parser.from_uri(tags_db["uri"])
+        # The parser reads tag definitions from the catalog database; it is
+        # connected with the catalog's database settings at server startup.
+        self.access_tags_parser = access_tags_parser()
         self.is_tag_defined = self.access_tags_parser.is_tag_defined
         self.get_public_tags = self.access_tags_parser.get_public_tags
         self.get_scopes_from_tag = self.access_tags_parser.get_scopes_from_tag

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -7,11 +7,11 @@ import httpx
 from pydantic import BaseModel, HttpUrl, TypeAdapter, ValidationError
 
 from ..adapters.protocols import BaseAdapter
-from ..queries import AccessBlobFilter
+from ..queries import AccessTagsFilter
 from ..server.schemas import Principal
-from ..type_aliases import AccessBlob, AccessTags, Filters, Scopes
-from ..utils import Sentinel, access_blob_matches, import_object
-from .protocols import AccessPolicy
+from ..type_aliases import Filters, Scopes
+from ..utils import Sentinel, import_object
+from .protocols import AccessPolicy, AccessTags
 from .scopes import ALL_SCOPES, NO_SCOPES, PUBLIC_SCOPES
 
 ALL_ACCESS = []
@@ -36,10 +36,10 @@ class DummyAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, AccessBlob]:
+        access_tags: Optional[AccessTags] = None,
+    ) -> Tuple[bool, AccessTags]:
         "Do nothing; there is no persistent state to initialize."
-        return (False, access_blob or AccessBlob(tags=[]))
+        return (False, access_tags or AccessTags())
 
     async def allowed_scopes(
         self,
@@ -110,25 +110,35 @@ class TagBasedAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, AccessBlob]:
+        access_tags: Optional[AccessTags] = None,
+    ) -> Tuple[bool, AccessTags]:
         if principal.type == "service":
             identifier = str(principal.uuid)
         else:
             identifier = self._get_id(principal)
 
-        if access_blob:
-            if access_blob.username is not None or access_blob.tags is None:
+        if access_tags is not None:
+            try:
+                access_tags = AccessTags(access_tags)
+            except TypeError as exc:
                 raise ValueError(
-                    f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
-                    f"""Received {access_blob=}"""
-                )
-            if not access_blob.tags:
+                    "access_tags must be an iterable of tags, "
+                    "e.g. ['tag1', 'tag2', ...]\n"
+                    f"Received {access_tags=}"
+                ) from exc
+            if not access_tags:
                 if not self._is_admin(authn_scopes):
                     raise ValueError(
                         "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                     )
-            access_tags = set(access_blob.tags)
+            if (
+                any(tag.startswith("user:") for tag in access_tags) or
+                any(tag.startswith("service:") for tag in access_tags)
+            ):
+                raise ValueError(
+                    f"Cannot manually tag node with user tags.\n"
+                    f"Received {access_tags=}\n"
+                )
             include_public_tag = False
             for tag in access_tags:
                 if authn_access_tags is not None:
@@ -161,36 +171,39 @@ class TagBasedAccessPolicy(AccessPolicy):
             if include_public_tag:
                 access_tags_from_policy.add(self.public_tag)
 
-            access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
-            access_blob_modified = access_tags != access_tags_from_policy
+            access_tags_from_policy = AccessTags(access_tags_from_policy)
+            access_tags_modified = access_tags != access_tags_from_policy
 
             # admin principals are not subject to scope reduction restriction
             if not self._is_admin(authn_scopes):
-                # check that the access_blob would not result in invalid scopes for user.
+                # check that the access_tags would not result in invalid scopes for user.
                 new_scopes = set()
                 for tag in access_tags_from_policy:
                     new_scopes.update(await self.get_scopes_from_tag(tag, identifier))
                 if not all(scope in new_scopes for scope in self.unremovable_scopes):
                     raise ValueError(
                         f"Cannot init node with tags: operation does not grant necessary scopes.\n"
-                        f"The resulting access_blob would be: {access_blob_from_policy}\n"
-                        f"This access_blob does not confer the minimum scopes: {self.unremovable_scopes}"
+                        f"The resulting access_tags would be: {access_tags_from_policy}\n"
+                        f"These access tags do not confer the minimum scopes: {self.unremovable_scopes}"
                     )
         else:
-            if authn_access_tags is not None:
+            if (
+                authn_access_tags is not None
+                and f"{principal.type}:{identifier}" not in authn_access_tags
+            ):
                 raise ValueError(
-                    f"Cannot init node as user-owned node.\n"
+                    f"Cannot init node as user-tagged node.\n"
                     f"Current API key does not permit action on user-owned nodes.\n"
-                    f"Please provide a tag allowed by this API key: {authn_access_tags}"
+                    f"Please provide only tags allowed by this API key: {authn_access_tags}"
                 )
-            access_blob_from_policy = AccessBlob(username=identifier)
-            access_blob_modified = True
+            access_tags_from_policy = AccessTags([f"{principal.type}:{identifier}"])
+            access_tags_modified = True
 
         logger.info(
-            f"Node to be initialized with access_blob: {access_blob_from_policy}"
+            f"Node to be initialized with access_tags: {access_tags_from_policy}"
         )
-        # modified means the blob to-be-used was changed in comparison to the user input
-        return access_blob_modified, access_blob_from_policy
+        # modified means the tags to-be-used was changed in comparison to the user input
+        return access_tags_modified, access_tags_from_policy
 
     async def modify_node(
         self,
@@ -198,35 +211,44 @@ class TagBasedAccessPolicy(AccessPolicy):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, AccessBlob]:
+        access_tags: Optional[AccessTags],
+    ) -> Tuple[bool, AccessTags]:
         if principal.type == "service":
             identifier = str(principal.uuid)
         else:
             identifier = self._get_id(principal)
 
-        if access_blob_matches(access_blob, node.access_blob):
+        if access_tags is None:
             logger.info(
-                f"Node access_blob not modified; access_blob is identical: {access_blob}"
+                "Node access_tags not modified; no access_tags provided."
             )
-            return False, node.access_blob
-
-        if (
-            access_blob is None
-            or access_blob.username is not None
-            or access_blob.tags is None
-        ):
+            return False, node.access_tags
+        try:
+            access_tags = AccessTags(access_tags)
+        except TypeError as exc:
             raise ValueError(
-                f"""access_blob must be in the form '{{"tags": ["tag1", "tag2", ...]}}'\n"""
-                f"""Received {access_blob=}\n"""
-                f"""If this was a merge patch on a user-owned node, use a replace op instead."""
+                "access_tags must be an iterable of tags, "
+                "e.g. ['tag1', 'tag2', ...]\n"
+                f"Received {access_tags=}"
+            ) from exc
+        if access_tags == node.access_tags:
+            logger.info(
+                f"Node access_tags not modified; access tags are identical: {access_tags}"
             )
-        if not access_blob.tags:
+            return False, node.access_tags
+        if not access_tags:
             if not self._is_admin(authn_scopes):
                 raise ValueError(
                     "Cannot apply empty tag list to node: only Tiled admins can apply an empty tag list."
                 )
-        access_tags = set(access_blob.tags)
+        if (
+            any(tag.startswith("user:") for tag in access_tags) or
+            any(tag.startswith("service:") for tag in access_tags)
+        ):
+            raise ValueError(
+                f"Cannot manually tag node with user tags.\n"
+                f"Received {access_tags=}\n"
+            )
         include_public_tag = False
         # check for tags that need to be added
         for tag in access_tags:
@@ -235,10 +257,8 @@ class TagBasedAccessPolicy(AccessPolicy):
                     raise ValueError(
                         f"Cannot apply tag to node: API key is restricted to access tags: {authn_access_tags}."
                     )
-            if tag in (node.access_blob.tags or []):
+            if tag in node.access_tags:
                 # node already has this tag - no action.
-                # or: access_blob does not have "tags" key,
-                # so it must have a "user" key currently
                 include_public_tag = include_public_tag or (
                     tag.casefold() == self.public_tag
                 )
@@ -269,58 +289,57 @@ class TagBasedAccessPolicy(AccessPolicy):
             access_tags_from_policy.add(self.public_tag)
 
         # check for tags that need to be removed
-        if node.access_blob.tags is not None:
-            for tag in set(node.access_blob.tags).difference(access_tags_from_policy):
-                if authn_access_tags is not None:
-                    if tag not in authn_access_tags:
-                        raise ValueError(
-                            f"Cannot remove tag from node: "
-                            f"API key is restricted to access tags: {authn_access_tags}."
-                        )
-                if tag == self.public_tag:
-                    if not self._is_admin(authn_scopes):
-                        raise ValueError(
-                            "Cannot remove 'public' tag from node: only Tiled admins can remove the 'public' tag."
-                        )
-                elif not await self.is_tag_defined(tag):
+        for tag in node.access_tags.difference(access_tags_from_policy):
+            if authn_access_tags is not None:
+                if tag not in authn_access_tags:
                     raise ValueError(
-                        f"Cannot remove tag from node: {tag=} is not defined"
+                        f"Cannot remove tag from node: "
+                        f"API key is restricted to access tags: {authn_access_tags}."
                     )
-                elif not await self.is_tag_owner(tag, identifier):
-                    # admins can ignore the tag ownership check
-                    if not self._is_admin(authn_scopes):
-                        raise ValueError(
-                            f"Cannot remove tag from node: user='{identifier}' is not an owner of {tag=}"
-                        )
-                elif tag.casefold() in self.invalid_tag_names:
+            if tag == self.public_tag:
+                if not self._is_admin(authn_scopes):
                     raise ValueError(
-                        f"Cannot remove tag from node: '{tag}' is not a valid tag name."
+                        "Cannot remove 'public' tag from node: only Tiled admins can remove the 'public' tag."
                     )
+            elif not await self.is_tag_defined(tag):
+                raise ValueError(
+                    f"Cannot remove tag from node: {tag=} is not defined"
+                )
+            elif not await self.is_tag_owner(tag, identifier):
+                # admins can ignore the tag ownership check
+                if not self._is_admin(authn_scopes):
+                    raise ValueError(
+                        f"Cannot remove tag from node: user='{identifier}' is not an owner of {tag=}"
+                    )
+            elif tag.casefold() in self.invalid_tag_names:
+                raise ValueError(
+                    f"Cannot remove tag from node: '{tag}' is not a valid tag name."
+                )
 
-        access_blob_from_policy = AccessBlob(tags=list(access_tags_from_policy))
-        access_blob_modified = access_tags != access_tags_from_policy
+        access_tags_from_policy = AccessTags(access_tags_from_policy)
+        access_tags_modified = access_tags != access_tags_from_policy
 
         # admin principals are not subject to scope reduction restriction
         if not self._is_admin(authn_scopes):
-            # check that the access_blob change would not result in invalid scopes for user.
+            # check that the access_tags change would not result in invalid scopes for user.
             # this applies when removing tags, but also must be done when
-            # converting from user-owned node to shared (tagged) node
+            # converting from user-owned node (user tag only) to shared (no user tag) node
             new_scopes = set()
             for tag in access_tags_from_policy:
                 new_scopes.update(await self.get_scopes_from_tag(tag, identifier))
             if not all(scope in new_scopes for scope in self.unremovable_scopes):
                 raise ValueError(
                     f"Cannot modify tags on node: operation removes unremovable scopes.\n"
-                    f"The current access_blob is: {node.access_blob}\n"
-                    f"The new access_blob would be: {access_blob_from_policy}\n"
+                    f"The current access tags on this Node are: {node.access_tags}\n"
+                    f"The new access_tags would be: {access_tags_from_policy}\n"
                     f"These scopes cannot be self-removed: {self.unremovable_scopes}"
                 )
 
         logger.info(
-            f"Node to be modified with new access_blob: {access_blob_from_policy}"
+            f"Node to be modified with new access_tags: {access_tags_from_policy}"
         )
-        # modified means the blob to-be-used was changed in comparison to the user input
-        return access_blob_modified, access_blob_from_policy
+        # modified means the tags to-be-used was changed in comparison to the user input
+        return access_tags_modified, access_tags_from_policy
 
     async def allowed_scopes(
         self,
@@ -332,7 +351,7 @@ class TagBasedAccessPolicy(AccessPolicy):
         # If this is being called, filter_for_access has let us get this far.
         # However, filters and allowed_scopes should always be implemented to
         # give answers consistent with each other.
-        if not hasattr(node, "access_blob"):
+        if not hasattr(node, "access_tags"):
             allowed = self.scopes
         elif self._is_admin(authn_scopes):
             allowed = self.scopes
@@ -345,28 +364,21 @@ class TagBasedAccessPolicy(AccessPolicy):
                 identifier = self._get_id(principal)
 
             allowed = set()
-            if node.access_blob.username is not None:
-                if (
-                    authn_access_tags is None
-                    and identifier == node.access_blob.username
-                ):
-                    allowed = self.scopes
-            elif node.access_blob.tags is not None:
-                for tag in node.access_blob.tags:
-                    if authn_access_tags is not None:
-                        if tag not in authn_access_tags:
-                            continue
-                    if await self.is_tag_public(tag):
-                        allowed.update(self.read_scopes)
-                        if tag == self.public_tag:
-                            continue
-                    elif not await self.is_tag_defined(tag):
+            for tag in node.access_tags:
+                if authn_access_tags is not None:
+                    if tag not in authn_access_tags:
                         continue
-                    if identifier is not None:
-                        tag_scopes = await self.get_scopes_from_tag(tag, identifier)
-                        allowed.update(
-                            tag_scopes if tag_scopes.issubset(self.scopes) else set()
-                        )
+                if await self.is_tag_public(tag):
+                    allowed.update(self.read_scopes)
+                    if tag == self.public_tag:
+                        continue
+                elif not await self.is_tag_defined(tag):
+                    continue
+                if identifier is not None:
+                    tag_scopes = await self.get_scopes_from_tag(tag, identifier)
+                    allowed.update(
+                        tag_scopes if tag_scopes.issubset(self.scopes) else set()
+                    )
 
         return allowed
 
@@ -378,7 +390,9 @@ class TagBasedAccessPolicy(AccessPolicy):
         authn_scopes: Scopes,
         scopes: Scopes,
     ) -> Filters:
-        if not hasattr(node, "access_blob"):
+        if not hasattr(node, "access_tags"):
+            return ALL_ACCESS
+        if self._is_admin(authn_scopes):
             return ALL_ACCESS
         if not scopes.issubset(self.scopes):
             return NO_ACCESS
@@ -389,8 +403,6 @@ class TagBasedAccessPolicy(AccessPolicy):
         else:
             if principal.type == "service":
                 identifier = str(principal.uuid)
-            elif self._is_admin(authn_scopes):
-                return ALL_ACCESS
             else:
                 identifier = self._get_id(principal)
             tag_list.update(
@@ -412,10 +424,9 @@ class TagBasedAccessPolicy(AccessPolicy):
         )
 
         if authn_access_tags is not None:
-            identifier = None
             tag_list.intersection_update(authn_access_tags)
 
-        return [AccessBlobFilter(identifier, tag_list)]
+        return [AccessTagsFilter(AccessTags(tag_list))]
 
 
 T = TypeVar("T")
@@ -434,7 +445,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         scopes_endpoint: str,
         modify_node_endpoint: Optional[str] = None,
         provider: Optional[str] = None,
-        empty_access_blob_public: Optional[bool] = None,
+        empty_access_tags_public: Optional[bool] = None,
     ):
         """
         Initialize an access policy configuration.
@@ -454,8 +465,8 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
             Defaults to create_node_endpoint if not set
         provider : Optional[str], optional
             The name of the authorization provider, by default None.
-        empty_access_blob_public: bool, optional
-            Should a node (e.g. the root node) with no access_blob be treated as public,
+        empty_access_tags_public: bool, optional
+            Should a node (e.g. the root node) with no access_tags be treated as public,
             read/writable by any request with correct scopes? Default None, which does not
             short circuit the logic and lets the remote provider decide.
         empty_tag_list_include_all: bool, optional, default False
@@ -468,7 +479,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         )
         self._user_tags = str(authorization_provider) + allowed_tags_endpoint
         self._node_scopes = str(authorization_provider) + scopes_endpoint
-        self._empty_access_blob_public = empty_access_blob_public
+        self._empty_access_tags_public = empty_access_tags_public
         self._provider = provider
 
     @abstractmethod
@@ -477,7 +488,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
+        access_tags: Optional[AccessTags] = None,
     ) -> str:
         ...
 
@@ -502,17 +513,17 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, AccessBlob]:
-        if access_blob is None and self._empty_access_blob_public is not None:
-            return self._empty_access_blob_public, AccessBlob(tags=[])
+        access_tags: Optional[AccessTags] = None,
+    ) -> Tuple[bool, AccessTags]:
+        if access_tags is None and self._empty_access_tags_public is not None:
+            return self._empty_access_tags_public, access_tags
         decision = await self._get_external_decision(
             self._create_node,
-            self.build_input(principal, authn_access_tags, authn_scopes, access_blob),
+            self.build_input(principal, authn_access_tags, authn_scopes, access_tags),
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob or AccessBlob(tags=[]))
+            return (decision.result, access_tags or AccessTags())
         raise ValueError("Permission denied not able to add the node")
 
     async def modify_node(
@@ -521,20 +532,21 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, AccessBlob]:
-        if access_blob_matches(access_blob, node.access_blob):
+        access_tags: Optional[AccessTags],
+    ) -> Tuple[bool, AccessTags]:
+        # fix this to match TBAP
+        if access_tags == node.access_tags:
             logger.info(
-                f"Node access_blob not modified; access_blob is identical: {access_blob}"
+                f"Node access_tags not modified; access_tags is identical: {access_tags}"
             )
-            return (False, node.access_blob)
+            return (False, node.access_tags)
         decision = await self._get_external_decision(
             self._modify_node,
-            self.build_input(principal, authn_access_tags, authn_scopes, access_blob),
+            self.build_input(principal, authn_access_tags, authn_scopes, access_tags),
             ResultHolder[bool],
         )
         if decision:
-            return (decision.result, access_blob or AccessBlob(tags=[]))
+            return (decision.result, access_tags or AccessTags())
         raise ValueError("Permission denied not able to add the node")
 
     async def filters(
@@ -551,7 +563,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
             ResultHolder[list[str]],
         )
         if tags is not None:
-            return [AccessBlobFilter(tags=tags.result, user_id=None)]
+            return [AccessTagsFilter(AccessTags(tags.result))]
         else:
             return NO_ACCESS
 
@@ -568,7 +580,7 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
                 principal,
                 authn_access_tags,
                 authn_scopes,
-                getattr(node, "access_blob", None),
+                getattr(node, "access_tags", None),
             ),
             ResultHolder[set[str]],
         )

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -106,6 +106,15 @@ class TagBasedAccessPolicy(AccessPolicy):
             return True
         return False
 
+    def _get_principal_tag(self, principal_type, identifier):
+        """
+        The principal-tag literal(s) that refer to this principal.
+        """
+        principal_tag = {f"user:{identifier}"}
+        if principal_type == "service":
+            principal_tag.add(f"service:{identifier}")
+        return principal_tag
+
     async def init_node(
         self,
         principal: Principal,
@@ -366,11 +375,20 @@ class TagBasedAccessPolicy(AccessPolicy):
             else:
                 identifier = self._get_id(principal)
 
+            principal_tag = (
+                self._get_principal_tag(principal.type, identifier)
+                if identifier is not None
+                else set()
+            )
+
             allowed = set()
             for tag in node.access_tags:
                 if authn_access_tags is not None:
                     if tag not in authn_access_tags:
                         continue
+                if tag in principal_tag:
+                    # Intrinsic self-grant from principal's own tag
+                    allowed.update(set(authn_scopes) & set(self.scopes))
                 if await self.is_tag_public(tag):
                     allowed.update(self.read_scopes)
                     if tag == self.public_tag:
@@ -416,6 +434,10 @@ class TagBasedAccessPolicy(AccessPolicy):
                     ]
                 )
             )
+            # Intrinsic self-grant from principal's own tag
+            # Principal's tag qualifies if it covers every requested scope
+            if scopes.issubset(set(authn_scopes) & set(self.scopes)):
+                tag_list.update(self._get_principal_tag(principal.type, identifier))
 
         tag_list.update(
             set.intersection(

--- a/tiled/access_control/access_policies.py
+++ b/tiled/access_control/access_policies.py
@@ -579,13 +579,13 @@ class ExternalPolicyDecisionPoint(AccessPolicy, ABC):
         authn_scopes: Scopes,
         scopes: Scopes,
     ) -> Filters:
-        tags = await self._get_external_decision(
+        access_tags_decision = await self._get_external_decision(
             self._user_tags,
             self.build_input(principal, authn_access_tags, authn_scopes),
             ResultHolder[list[str]],
         )
-        if tags is not None:
-            return [AccessTagsFilter(AccessTags(tags.result))]
+        if access_tags_decision is not None:
+            return [AccessTagsFilter(AccessTags(access_tags_decision.result))]
         else:
             return NO_ACCESS
 

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -323,7 +323,9 @@ async def update_access_tags_tables(engine, scopes, tags, owners, public_tags):
             )
         }
         scopes_to_id = {
-            intern(name): scope_id
+            # name is a ScopeName enum member; key by its interned string
+            # value (not str(member), which is e.g. "ScopeName.read_data")
+            intern(name.value): scope_id
             for scope_id, name in await connection.execute(
                 select(scopes_table.c.id, scopes_table.c.name)
             )

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -7,10 +7,13 @@ from sqlalchemy import delete, func, insert, inspect, select, tuple_, update
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
 from sqlalchemy.dialects.sqlite import insert as sqlite_upsert
 
+from ..authn_database import orm as authn_orm
 from ..catalog import orm
 from ..graph import orm as graph_orm
 from ..server.connection_pool import get_database_engine
+from ..server.schemas import PrincipalType
 from ..utils import InterningLoader
+from .protocols import PRINCIPAL_TAG_PREFIXES
 
 # The access_tag_principal_scopes junction table, joined to the tables its
 # three foreign keys reference so that it can be queried by name. Shared by
@@ -405,6 +408,9 @@ class AccessTagsCompiler:
         tag_config,
         database_settings,
         group_parser,
+        *,
+        authn_database_settings=None,
+        provider=None,
     ):
         self.scopes = scopes or {}
         self.tag_config = tag_config
@@ -414,6 +420,21 @@ class AccessTagsCompiler:
         self._engine = get_database_engine(database_settings)
         self._tables_created = False
         self.group_parser = group_parser
+        # Optionally, load_principal_tags() reads principals from the
+        # authentication database and defines a principal tag ('user:...'
+        # or 'service:...') for each
+        if (authn_database_settings is None) != (provider is None):
+            raise ValueError(
+                "authn_database_settings and provider must be given together: "
+                "principal tags are generated from the identities associated "
+                "with the given provider."
+            )
+        self._authn_engine = (
+            get_database_engine(authn_database_settings)
+            if authn_database_settings is not None
+            else None
+        )
+        self.provider = provider
 
         self.max_tag_nesting = max(self._MAX_TAG_NESTING, 0)
         self.public_tag = intern("public".casefold())
@@ -544,6 +565,135 @@ class AccessTagsCompiler:
         self.compiled_tags[current_tag] = users
         return users, public_auto_tag
 
+    async def load_principal_tags(self):
+        """
+        Load a principal tag definition for every principal in the
+        authentication database.
+
+        User principals are identified by their identity id from the
+        configured provider (tag 'user:<id>'); service principals by their
+        uuid (tags 'service:<uuid>' and 'user:<uuid>', since either literal
+        may be used to refer to them).
+
+        If the authentication database is missing, uninitialized, or
+        unreachable, warn and load nothing; the compilation proceeds with
+        the config-defined tags.
+        """
+        if self._authn_engine is None:
+            raise RuntimeError(
+                "Principal tags cannot be loaded: the compiler was "
+                "constructed without authn_database_settings and provider."
+            )
+
+        # Connecting to a nonexistent SQLite database would create it as an
+        # empty file, which the server then refuses to initialize at startup.
+        # The compiler must only ever read this database, so check for the
+        # file first instead of connecting.
+        url = self._authn_engine.url
+        if url.get_backend_name() == "sqlite":
+            database = url.database
+            if (
+                database
+                and database != ":memory:"
+                and "mode=memory" not in database
+                and not Path(database).exists()
+            ):
+                warnings.warn(
+                    "The authentication database is not initialized yet; "
+                    "no principal tags were generated.",
+                    UserWarning,
+                )
+                return
+
+        association = authn_orm.principal_role_association_table
+        principals_with_roles = authn_orm.Principal.__table__.join(
+            association, association.c.principal_id == authn_orm.Principal.id
+        )
+        try:
+            async with self._authn_engine.connect() as conn:
+                if not await conn.run_sync(
+                    lambda sync_conn: inspect(sync_conn).has_table(
+                        authn_orm.Principal.__tablename__
+                    )
+                ):
+                    warnings.warn(
+                        "The authentication database is not initialized yet; "
+                        "no principal tags were generated.",
+                        UserWarning,
+                    )
+                    return
+                # Read the roles once; the scopes granted through a role are
+                # the intersection of the role's scopes with the compiler's.
+                granted_scopes_of_role = {
+                    role_id: set(role_scopes) & set(self.scopes)
+                    for role_id, role_scopes in await conn.execute(
+                        select(authn_orm.Role.id, authn_orm.Role.scopes)
+                    )
+                }
+                user_rows = list(
+                    await conn.execute(
+                        select(authn_orm.Identity.id, association.c.role_id)
+                        .select_from(
+                            principals_with_roles.join(
+                                authn_orm.Identity,
+                                authn_orm.Identity.principal_id
+                                == authn_orm.Principal.id,
+                            )
+                        )
+                        .where(
+                            authn_orm.Principal.type == PrincipalType.user,
+                            authn_orm.Identity.provider == self.provider,
+                        )
+                    )
+                )
+                service_rows = list(
+                    await conn.execute(
+                        select(authn_orm.Principal.uuid, association.c.role_id)
+                        .select_from(principals_with_roles)
+                        .where(authn_orm.Principal.type == PrincipalType.service)
+                    )
+                )
+        except Exception as exc:
+            # Not just DBAPIError: connection failures from the async drivers
+            # (e.g. asyncpg) can propagate unwrapped, and no failure to read
+            # the authentication database should abort the compilation.
+            warnings.warn(
+                f"The authentication database could not be read "
+                f"({exc.__class__.__name__}: {exc}); no principal tags were "
+                f"generated. Compilation proceeds with the config-defined "
+                f"tags only. Previously generated principal tags will be "
+                f"treated as stale until a compilation can read the "
+                f"authentication database again.",
+                UserWarning,
+            )
+            return
+
+        # A principal may hold several roles (several rows); union the scopes
+        # its roles grant. A user is named by its provider identity id, a
+        # service by its uuid; a service may be referred to by either literal.
+        tag_scopes = {}
+        for identifier, role_id in user_rows:
+            tag_scopes.setdefault(f"user:{identifier}", set()).update(
+                granted_scopes_of_role[role_id]
+            )
+        for identifier, role_id in service_rows:
+            granted = granted_scopes_of_role[role_id]
+            tag_scopes.setdefault(f"service:{identifier}", set()).update(granted)
+            tag_scopes.setdefault(f"user:{identifier}", set()).update(granted)
+
+        for tag_name, granted_scopes in tag_scopes.items():
+            # Merge with (do not overwrite) a definition that the tag config
+            # may provide for this tag; compilation unions the grants. A
+            # principal whose roles grant nothing gets a definition with no
+            # 'users' entry: _dfs rejects a user entry with empty scopes, and
+            # an empty definition compiles to an empty grant set.
+            identifier = tag_name.partition(":")[2]
+            definition = self.tags.setdefault(intern(tag_name), {})
+            if granted_scopes:
+                definition.setdefault("users", []).append(
+                    {"name": identifier, "scopes": granted_scopes}
+                )
+
     async def compile(self):
         if not self._tables_created:
             await create_access_tags_tables(self._engine)
@@ -558,6 +708,15 @@ class AccessTagsCompiler:
                 raise ValueError(
                     f"Scopes for {role=} are not in the valid set of scopes. The invalid scopes are:"
                     f'{set(role["scopes"]).difference(self.scopes)}'
+                )
+
+        for tag in self.tag_owners:
+            if tag.casefold().startswith(PRINCIPAL_TAG_PREFIXES):
+                raise ValueError(
+                    f"Tag '{tag}' uses a principal-tag prefix "
+                    f"{PRINCIPAL_TAG_PREFIXES}.\n"
+                    f"Principal tags cannot have owners: they are never "
+                    f"applied to nodes manually, only by the access policy."
                 )
 
         adjacent_tags = {}

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -1,13 +1,14 @@
-import sqlite3
 import warnings
-from contextlib import closing
 from pathlib import Path
 from sys import intern
 
 import yaml
-from sqlalchemy import select
+from sqlalchemy import delete, func, insert, inspect, select, tuple_, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
+from sqlalchemy.dialects.sqlite import insert as sqlite_upsert
 
 from ..catalog import orm
+from ..graph import orm as graph_orm
 from ..server.connection_pool import get_database_engine
 from ..utils import InterningLoader
 
@@ -115,218 +116,278 @@ class AccessTagsParser:
         return user_scope_tags
 
 
-def create_access_tags_tables(db):
-    with closing(db.cursor()) as cursor:
-        tables_setup_sql = """
-PRAGMA journal_mode = WAL;
-PRAGMA synchronous = NORMAL;
-PRAGMA temp_store = MEMORY;
-PRAGMA foreign_keys = ON;
-BEGIN TRANSACTION;
-CREATE TABLE IF NOT EXISTS tags (
-  id        INTEGER PRIMARY KEY,
-  name      TEXT    UNIQUE NOT NULL,
-  is_public INTEGER NOT NULL DEFAULT 0
-    CHECK (is_public IN (0,1))
-);
-CREATE TABLE IF NOT EXISTS users (
-  id   INTEGER PRIMARY KEY,
-  name TEXT    UNIQUE NOT NULL
-);
-CREATE TABLE IF NOT EXISTS scopes (
-  id   INTEGER PRIMARY KEY,
-  name TEXT    UNIQUE NOT NULL
-);
-CREATE TABLE IF NOT EXISTS tags_users_scopes (
-  tag_id    INTEGER NOT NULL
-    REFERENCES tags(id)
-    ON UPDATE CASCADE
-    ON DELETE CASCADE,
-  user_id   INTEGER NOT NULL
-    REFERENCES users(id)
-    ON UPDATE CASCADE
-    ON DELETE CASCADE,
-  scope_id  INTEGER NOT NULL
-    REFERENCES scopes(id)
-    ON UPDATE CASCADE
-    ON DELETE CASCADE,
-  PRIMARY KEY (tag_id, user_id, scope_id)
-);
-CREATE TABLE IF NOT EXISTS tag_owners (
-  tag_id   INTEGER NOT NULL
-    REFERENCES tags(id)
-    ON UPDATE CASCADE
-    ON DELETE CASCADE,
-  user_id  INTEGER NOT NULL
-    REFERENCES users(id)
-    ON UPDATE CASCADE
-    ON DELETE CASCADE,
-  PRIMARY KEY (tag_id, user_id)
-);
-CREATE INDEX IF NOT EXISTS idx_tags_is_public ON tags (is_public);
-CREATE INDEX IF NOT EXISTS idx_tus_users_scopes ON tags_users_scopes (user_id, scope_id);
-CREATE INDEX IF NOT EXISTS idx_tus_users_scopes_scopeid ON tags_users_scopes (scope_id);
-CREATE INDEX IF NOT EXISTS idx_tag_owners ON tag_owners (user_id);
-CREATE VIEW IF NOT EXISTS public_tags AS
-  SELECT name
-  FROM tags
-  WHERE is_public = 1;
-CREATE VIEW IF NOT EXISTS user_tag_scopes AS
-  SELECT
-    u.name AS user_name,
-    t.name AS tag_name,
-    s.name AS scope_name
-  FROM tags_users_scopes tus
-    JOIN users  u ON u.id = tus.user_id
-    JOIN tags   t ON t.id = tus.tag_id
-    JOIN scopes s ON s.id = tus.scope_id;
-CREATE VIEW IF NOT EXISTS user_tag_owners AS
-  SELECT
-    u.name AS user_name,
-    t.name AS tag_name
-  FROM tag_owners towner
-    JOIN users u ON u.id = towner.user_id
-    JOIN tags  t ON t.id = towner.tag_id;
-PRAGMA optimize;
-"""
-        cursor.executescript(tables_setup_sql)
-        db.commit()
+# The tables that the access tags compiler writes. They belong to the catalog
+# schema (normally created by catalog initialization and migrations), but the
+# compiler ensures they exist so that it can also run against a catalog
+# database that has not been initialized yet. The set is self-contained: no
+# foreign key in it references a table outside of it, and catalog
+# initialization tolerates their prior existence (create_all with checkfirst).
+ACCESS_TAGS_TABLES = [
+    orm.AccessTag.__table__,
+    orm.AccessTagsPrincipal.__table__,
+    orm.Scope.__table__,
+    orm.AccessTagPrincipalScope.__table__,
+    orm.AccessTagOwner.__table__,
+]
+
+# Association tables recording which tags are assigned to which data. Unlike
+# the grant junctions above, their contents are not derived from the compiled
+# tag definitions -- deleting a tag cascades to these rows, destroying state
+# that a later compile cannot restore. The compiler never writes these tables;
+# it only checks them before deleting a tag.
+ASSIGNMENT_TABLES = [
+    orm.NodeAccessTag.__table__,
+    graph_orm.entity_access_tags,
+    graph_orm.link_access_tags,
+]
+
+# PostgreSQL advisory lock key serializing concurrent compiles against the
+# same database (e.g. a scheduled sync overlapping a manual run). The value
+# is arbitrary but must be fixed and not collide with other advisory lock
+# users of the catalog database; tiled uses no other advisory locks.
+# 746 spells "tag" in digits.
+ACCESS_TAGS_COMPILER_LOCK_KEY = 746
 
 
-def update_access_tags_tables(db, scopes, tags, owners, public_tags):
-    with closing(db.cursor()) as cursor:
-        tables_stage_sql = """
-BEGIN TRANSACTION;
-CREATE TEMP TABLE IF NOT EXISTS stage_tags (
-  id        INTEGER,
-  name      TEXT    NOT NULL,
-  is_public INTEGER NOT NULL
-    CHECK (is_public IN (0,1))
-);
-CREATE TEMP TABLE IF NOT EXISTS stage_users (
-  id   INTEGER,
-  name TEXT NOT NULL
-);
-CREATE TEMP TABLE IF NOT EXISTS stage_scopes (
-  id   INTEGER,
-  name TEXT NOT NULL
-);
-CREATE TEMP TABLE IF NOT EXISTS stage_tags_users_scopes (
-  tag_id   INTEGER NOT NULL,
-  user_id  INTEGER NOT NULL,
-  scope_id INTEGER NOT NULL
-);
-CREATE TEMP TABLE IF NOT EXISTS stage_tag_owners (
-  tag_id  INTEGER NOT NULL,
-  user_id INTEGER NOT NULL
-);
-"""
-        cursor.executescript(tables_stage_sql)
+def _upsert(engine):
+    "Return the dialect-specific INSERT ... ON CONFLICT construct."
+    if engine.dialect.name == "postgresql":
+        return postgresql_upsert
+    return sqlite_upsert
 
-        # put all items into staging
-        all_tags = [(tag, 0) for tag in tags] + [(tag, 0) for tag in owners]
-        all_public = [(tag,) for tag in public_tags]
-        all_users = {(user,) for users in tags.values() for user in users}
-        all_users.update({(user,) for users in owners.values() for user in users})
-        all_scopes = [(scope,) for scope in scopes]
-        cursor.executemany(
-            "INSERT INTO stage_tags(name, is_public) VALUES (?,?);",
-            all_tags,
-        )
-        cursor.executemany(
-            "UPDATE stage_tags SET is_public = 1 WHERE name = (?);", all_public
-        )
-        cursor.executemany(
-            "INSERT INTO stage_users(name) VALUES (?);",
-            all_users,
-        )
-        cursor.executemany(
-            "INSERT INTO stage_scopes(name) VALUES (?);",
-            all_scopes,
+
+async def create_access_tags_tables(engine):
+    "Create the access tag tables and their indexes, if they do not exist."
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            orm.Base.metadata.create_all,
+            tables=ACCESS_TAGS_TABLES,
+            checkfirst=True,
         )
 
-        # push item names and metadata from staging to prod
-        # then pull back ID values from prod to staging
-        # note that UPSERT should always have a WHERE clause
-        #   to avoid ambiguity. See the SQLite docs section 2.2
-        #   https://www.sqlite.org/lang_upsert.html
-        stage_push_sql = """
-BEGIN TRANSACTION;
-INSERT INTO tags (name, is_public)
-  SELECT name, is_public
-  FROM stage_tags
-  WHERE true
-  ON CONFLICT (name)
-  DO UPDATE SET is_public = excluded.is_public;
-INSERT INTO users(name) SELECT name FROM stage_users WHERE true ON CONFLICT(name) DO NOTHING;
-INSERT INTO scopes(name) SELECT name FROM stage_scopes WHERE true ON CONFLICT(name) DO NOTHING;
-UPDATE stage_tags SET id = (SELECT id FROM tags WHERE tags.name = stage_tags.name);
-UPDATE stage_users SET id = (SELECT id FROM users WHERE users.name = stage_users.name);
-UPDATE stage_scopes SET id = (SELECT id FROM scopes WHERE scopes.name = stage_scopes.name);
-"""
-        cursor.executescript(stage_push_sql)
+
+async def update_access_tags_tables(engine, scopes, tags, owners, public_tags):
+    """
+    Synchronize the access tag tables with the compiled tag state.
+
+    Names are upserted, so existing rows -- and therefore their ids, which the
+    node_access_tags association table references -- are preserved across
+    recompilations. Definitions absent from the compiled state are deleted;
+    deleting a definition cascades to the rows that reference it, including
+    node_access_tags rows for a deleted tag. The whole update is a single
+    transaction.
+    """
+    upsert = _upsert(engine)
+    tags_table = orm.AccessTag.__table__
+    users_table = orm.AccessTagsPrincipal.__table__
+    scopes_table = orm.Scope.__table__
+    tags_users_scopes_table = orm.AccessTagPrincipalScope.__table__
+    tag_owners_table = orm.AccessTagOwner.__table__
+
+    # stage all items in memory, deduplicated
+    # (a name may appear in both tags and owners)
+    all_tags = {name: (name in public_tags) for name in (*tags, *owners)}
+    all_users = {user for users in tags.values() for user in users}
+    all_users.update(user for users in owners.values() for user in users)
+    all_scopes = set(scopes)
+
+    async with engine.begin() as connection:
+        if engine.dialect.name == "postgresql":
+            # Serialize concurrent compiles. Transaction-scoped: the lock is
+            # released automatically on commit or rollback, including when
+            # the session dies. SQLite needs no equivalent; its writers are
+            # serialized by database-level locking.
+            await connection.execute(
+                select(func.pg_advisory_xact_lock(ACCESS_TAGS_COMPILER_LOCK_KEY))
+            )
+
+        # push item names and metadata, preserving ids of existing names
+        tags_statement = upsert(tags_table).values(
+            [
+                {"name": name, "is_public": is_public}
+                for name, is_public in all_tags.items()
+            ]
+        )
+        await connection.execute(
+            tags_statement.on_conflict_do_update(
+                index_elements=["name"],
+                set_={"is_public": tags_statement.excluded.is_public},
+            )
+        )
+        if all_users:
+            await connection.execute(
+                upsert(users_table)
+                .values([{"name": name} for name in all_users])
+                .on_conflict_do_nothing(index_elements=["name"])
+            )
+        if all_scopes:
+            await connection.execute(
+                upsert(scopes_table)
+                .values([{"name": name} for name in all_scopes])
+                .on_conflict_do_nothing(index_elements=["name"])
+            )
+
+        # Among tags dropped from the compiled state, retain any that are
+        # still assigned to data: deleting them would cascade-destroy the
+        # assignments, which -- unlike the grants, which are re-derived from
+        # the compiled state on every run -- could not be restored by a later
+        # compile. A retained tag keeps its id and assignments but is
+        # stripped of all grants (its junction rows are pruned below) and
+        # made non-public, so it confers no access. If a later compile
+        # restores the name, the same row is reused and its grants resume;
+        # once nothing is assigned to it, the next compile deletes it.
+        stale_tags = {
+            name: tag_id
+            for tag_id, name in await connection.execute(
+                select(tags_table.c.id, tags_table.c.name).where(
+                    tags_table.c.name.not_in(list(all_tags))
+                )
+            )
+        }
+        retained_tag_ids = set()
+        if stale_tags:
+            stale_tag_ids = list(stale_tags.values())
+            # The assignment tables may not exist yet (e.g. compiling into a
+            # catalog database that has not been initialized); a table that
+            # does not exist holds no assignments.
+            existing_table_names = await connection.run_sync(
+                lambda sync_connection: set(inspect(sync_connection).get_table_names())
+            )
+            for assignment_table in ASSIGNMENT_TABLES:
+                if assignment_table.name not in existing_table_names:
+                    continue
+                retained_tag_ids.update(
+                    (
+                        await connection.execute(
+                            select(assignment_table.c.tag_id.distinct()).where(
+                                assignment_table.c.tag_id.in_(stale_tag_ids)
+                            )
+                        )
+                    ).scalars()
+                )
+        if retained_tag_ids:
+            retained_tag_names = sorted(
+                name
+                for name, tag_id in stale_tags.items()
+                if tag_id in retained_tag_ids
+            )
+            warnings.warn(
+                "These tags were dropped from the compiled tag definitions but "
+                "are still assigned to data, so instead of being deleted they "
+                f"are retained with all grants revoked: {retained_tag_names}",
+                UserWarning,
+            )
+            await connection.execute(
+                update(tags_table)
+                .where(tags_table.c.id.in_(list(retained_tag_ids)))
+                .values(is_public=False)
+            )
+
+        # delete outdated items; deletes cascade to the association tables
+        deleted_tag_ids = [
+            tag_id
+            for tag_id in stale_tags.values()
+            if tag_id not in retained_tag_ids
+        ]
+        if deleted_tag_ids:
+            await connection.execute(
+                delete(tags_table).where(tags_table.c.id.in_(deleted_tag_ids))
+            )
+        await connection.execute(
+            delete(users_table).where(users_table.c.name.not_in(list(all_users)))
+        )
+        await connection.execute(
+            delete(scopes_table).where(scopes_table.c.name.not_in(list(all_scopes)))
+        )
 
         # load db IDs for items into memory
-        cursor.execute("SELECT id, name FROM stage_tags")
-        tags_to_id = {intern(name): tag_id for (tag_id, name) in cursor.fetchall()}
-        cursor.execute("SELECT id, name FROM stage_users")
-        users_to_id = {intern(name): user_id for (user_id, name) in cursor.fetchall()}
-        cursor.execute("SELECT id, name FROM stage_scopes")
+        tags_to_id = {
+            intern(name): tag_id
+            for tag_id, name in await connection.execute(
+                select(tags_table.c.id, tags_table.c.name)
+            )
+        }
+        users_to_id = {
+            intern(name): user_id
+            for user_id, name in await connection.execute(
+                select(users_table.c.id, users_table.c.name)
+            )
+        }
         scopes_to_id = {
-            intern(name): scope_id for (scope_id, name) in cursor.fetchall()
+            intern(name): scope_id
+            for scope_id, name in await connection.execute(
+                select(scopes_table.c.id, scopes_table.c.name)
+            )
         }
 
-        # flatten relationships and push to staging
-        tags_users_scopes = [
+        # flatten relationships and diff against current table contents
+        tags_users_scopes = {
             (tags_to_id[tag], users_to_id[user], scopes_to_id[scope])
             for tag, users in tags.items()
-            for user, scopes in users.items()
-            for scope in scopes
-        ]
-        tag_owners = [
+            for user, user_scopes in users.items()
+            for scope in user_scopes
+        }
+        tag_owners = {
             (tags_to_id[tag], users_to_id[user])
             for tag, users in owners.items()
             for user in users
-        ]
-        cursor.executemany(
-            "INSERT INTO stage_tags_users_scopes(tag_id, user_id, scope_id) VALUES (?,?,?);",
-            tags_users_scopes,
-        )
-        cursor.executemany(
-            "INSERT INTO stage_tag_owners(tag_id, user_id) VALUES (?,?);", tag_owners
-        )
+        }
+        existing_tags_users_scopes = {
+            tuple(row)
+            for row in await connection.execute(
+                select(
+                    tags_users_scopes_table.c.tag_id,
+                    tags_users_scopes_table.c.principal_id,
+                    tags_users_scopes_table.c.scope_id,
+                )
+            )
+        }
+        existing_tag_owners = {
+            tuple(row)
+            for row in await connection.execute(
+                select(tag_owners_table.c.tag_id, tag_owners_table.c.principal_id)
+            )
+        }
 
-        # delete outdated tags from prod and add updated relationships to db
-        # finally, drop the staging tables
-        # to-do: consider refactoring this to indvidual execute statements
-        #        to avoid implicit pre-mature commit by executescript()
-        upsert_delete_sql = """
-BEGIN TRANSACTION;
-DELETE from tags WHERE id NOT in (SELECT id FROM stage_tags);
-DELETE from users WHERE id NOT in (SELECT id FROM stage_users);
-DELETE from scopes WHERE id NOT in (SELECT id FROM stage_scopes);
-INSERT INTO tags_users_scopes (tag_id, user_id, scope_id)
-  SELECT tag_id, user_id, scope_id FROM stage_tags_users_scopes
-  WHERE true
-  ON CONFLICT (tag_id, user_id, scope_id) DO NOTHING;
-DELETE FROM tags_users_scopes
-  WHERE (tag_id, user_id, scope_id)
-  NOT IN (SELECT tag_id, user_id, scope_id FROM stage_tags_users_scopes);
-INSERT INTO tag_owners (tag_id, user_id)
-  SELECT tag_id, user_id FROM stage_tag_owners
-  WHERE true
-  ON CONFLICT (tag_id, user_id) DO NOTHING;
-DELETE FROM tag_owners
-  WHERE (tag_id, user_id) NOT IN (SELECT tag_id, user_id FROM stage_tag_owners);
-DROP TABLE IF EXISTS stage_tags;
-DROP TABLE IF EXISTS stage_users;
-DROP TABLE IF EXISTS stage_scopes;
-DROP TABLE IF EXISTS stage_tags_users_scopes;
-DROP TABLE IF EXISTS stage_tag_owners;
-PRAGMA optimize;
-"""
-        cursor.executescript(upsert_delete_sql)
-        db.commit()
+        # add updated relationships and delete outdated ones
+        new_tags_users_scopes = tags_users_scopes - existing_tags_users_scopes
+        if new_tags_users_scopes:
+            await connection.execute(
+                insert(tags_users_scopes_table),
+                [
+                    {"tag_id": tag_id, "principal_id": user_id, "scope_id": scope_id}
+                    for tag_id, user_id, scope_id in new_tags_users_scopes
+                ],
+            )
+        stale_tags_users_scopes = existing_tags_users_scopes - tags_users_scopes
+        if stale_tags_users_scopes:
+            await connection.execute(
+                delete(tags_users_scopes_table).where(
+                    tuple_(
+                        tags_users_scopes_table.c.tag_id,
+                        tags_users_scopes_table.c.principal_id,
+                        tags_users_scopes_table.c.scope_id,
+                    ).in_(list(stale_tags_users_scopes))
+                )
+            )
+        new_tag_owners = tag_owners - existing_tag_owners
+        if new_tag_owners:
+            await connection.execute(
+                insert(tag_owners_table),
+                [
+                    {"tag_id": tag_id, "principal_id": user_id}
+                    for tag_id, user_id in new_tag_owners
+                ],
+            )
+        stale_tag_owners = existing_tag_owners - tag_owners
+        if stale_tag_owners:
+            await connection.execute(
+                delete(tag_owners_table).where(
+                    tuple_(
+                        tag_owners_table.c.tag_id, tag_owners_table.c.principal_id
+                    ).in_(list(stale_tag_owners))
+                )
+            )
 
 
 class AccessTagsCompiler:
@@ -336,14 +397,16 @@ class AccessTagsCompiler:
         self,
         scopes,
         tag_config,
-        tags_db,
+        database_settings,
         group_parser,
     ):
         self.scopes = scopes or {}
         self.tag_config = tag_config
-        self.connection = sqlite3.connect(
-            tags_db["uri"], uri=True, check_same_thread=False
-        )
+        # Reuse the pooled engine keyed by these settings; when the compiler
+        # runs inside a tiled server, the pool is shared with the catalog
+        # adapter connected to the same database.
+        self._engine = get_database_engine(database_settings)
+        self._tables_created = False
         self.group_parser = group_parser
 
         self.max_tag_nesting = max(self._MAX_TAG_NESTING, 0)
@@ -356,8 +419,6 @@ class AccessTagsCompiler:
         self.compiled_tags = {self.public_tag: {}}
         self.compiled_public = set({self.public_tag})
         self.compiled_tag_owners = {}
-
-        create_access_tags_tables(self.connection)
 
     def load_tag_config(self):
         if isinstance(self.tag_config, str) or isinstance(self.tag_config, Path):
@@ -477,7 +538,11 @@ class AccessTagsCompiler:
         self.compiled_tags[current_tag] = users
         return users, public_auto_tag
 
-    def compile(self):
+    async def compile(self):
+        if not self._tables_created:
+            await create_access_tags_tables(self._engine)
+            self._tables_created = True
+
         for role in self.roles.values():
             if "scopes" not in role:
                 raise ValueError(f"Scopes must be defined for a role. {role=}")
@@ -540,8 +605,8 @@ class AccessTagsCompiler:
                             username = intern(username)
                             self.compiled_tag_owners[tag].add(username)
 
-        update_access_tags_tables(
-            self.connection,
+        await update_access_tags_tables(
+            self._engine,
             self.scopes,
             self.compiled_tags,
             self.compiled_tag_owners,
@@ -553,8 +618,8 @@ class AccessTagsCompiler:
         self.tags = {}
         self.tag_owners = {}
 
-    def recompile(self):
+    async def recompile(self):
         self.compiled_tags = {self.public_tag: {}}
         self.compiled_public = set({self.public_tag})
         self.compiled_tag_owners = {}
-        self.compile()
+        await self.compile()

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -4,90 +4,114 @@ from contextlib import closing
 from pathlib import Path
 from sys import intern
 
-import aiosqlite
 import yaml
+from sqlalchemy import select
 
-from ..utils import InterningLoader, ensure_specified_sql_driver
+from ..catalog import orm
+from ..server.connection_pool import get_database_engine
+from ..utils import InterningLoader
+
+# The access_tag_principal_scopes junction table, joined to the tables its
+# three foreign keys reference so that it can be queried by name. Shared by
+# the lookups in both directions: (tag, principal) -> scopes and
+# (principal, scope) -> tags.
+access_tag_principal_scopes_named = (
+    orm.AccessTagPrincipalScope.__table__.join(
+        orm.AccessTag.__table__,
+        orm.AccessTag.id == orm.AccessTagPrincipalScope.tag_id,
+    )
+    .join(
+        orm.AccessTagsPrincipal.__table__,
+        orm.AccessTagsPrincipal.id == orm.AccessTagPrincipalScope.principal_id,
+    )
+    .join(
+        orm.Scope.__table__,
+        orm.Scope.id == orm.AccessTagPrincipalScope.scope_id,
+    )
+)
 
 
 class AccessTagsParser:
-    @classmethod
-    def from_uri(cls, uri):
-        if uri.startswith("file:"):
-            uri = uri.split(":", 1)[1]
-        uri = ensure_specified_sql_driver(uri)
-        if not uri.startswith("sqlite+aiosqlite:"):
-            raise ValueError(
-                f"AccessTagsParser must be given a SQLite database URI, "
-                f"i.e. 'sqlite:///...', 'sqlite+aiosqlite:///...'\n"
-                f"Given URI results in: {uri=}"
-            )
-        uri_path = uri.split(":", 1)[1]
-        if not uri_path.startswith("///"):
-            raise ValueError(
-                "Invalid URI provided, URI must contain 3 forward slashes, "
-                "e.g. 'sqlite:///...'."
-            )
-        uri = f"file:{uri_path[3:]}"
-        uri = uri if "?" in uri else f"{uri}?mode=ro"
-        return cls(uri=uri)
+    """
+    Read access tag definitions from the catalog database.
 
-    def __init__(self, db=None, uri=None):
-        self._uri = uri
-        self._db = db
+    Serves the lookups that TagBasedAccessPolicy needs. Tag definitions live
+    in the catalog database (written there by the access tags compiler), so
+    the parser connects with the catalog's own database settings -- there is
+    no separate tag database to configure. Queries are SQLAlchemy Core
+    statements and run on any supported dialect (SQLite and PostgreSQL).
+    """
 
-    async def connect(self):
-        if self._db is None:
-            self._db = await aiosqlite.connect(
-                self._uri, uri=True, check_same_thread=False
-            )
+    def __init__(self, engine=None):
+        self._engine = engine
+
+    async def connect(self, database_settings):
+        if self._engine is None:
+            # Reuse the pooled engine keyed by these settings; the pool is
+            # shared with the catalog adapter connected to the same database.
+            self._engine = get_database_engine(database_settings)
 
     async def is_tag_defined(self, name):
-        async with self._db.cursor() as cursor:
-            await cursor.execute("SELECT 1 FROM tags WHERE name = ?;", (name,))
-            row = await cursor.fetchone()
-            found_tagname = bool(row)
+        statement = select(orm.AccessTag.id).where(orm.AccessTag.name == name)
+        async with self._engine.connect() as conn:
+            found_tagname = (await conn.execute(statement)).first() is not None
         return found_tagname
 
     async def get_public_tags(self):
-        async with self._db.cursor() as cursor:
-            await cursor.execute("SELECT name FROM public_tags;")
-            public_tags = {name for (name,) in await cursor.fetchall()}
+        statement = select(orm.AccessTag.name).where(orm.AccessTag.is_public)
+        async with self._engine.connect() as conn:
+            public_tags = set((await conn.execute(statement)).scalars())
         return public_tags
 
     async def get_scopes_from_tag(self, tagname, username):
-        async with self._db.cursor() as cursor:
-            await cursor.execute(
-                "SELECT scope_name FROM user_tag_scopes WHERE tag_name = ? AND user_name = ?;",
-                (tagname, username),
+        statement = (
+            select(orm.Scope.name)
+            .select_from(access_tag_principal_scopes_named)
+            .where(
+                orm.AccessTag.name == tagname,
+                orm.AccessTagsPrincipal.name == username,
             )
-            user_tag_scopes = {scope for (scope,) in await cursor.fetchall()}
+        )
+        async with self._engine.connect() as conn:
+            user_tag_scopes = set((await conn.execute(statement)).scalars())
         return user_tag_scopes
 
     async def is_tag_owner(self, tagname, username):
-        async with self._db.cursor() as cursor:
-            await cursor.execute(
-                "SELECT 1 FROM user_tag_owners WHERE tag_name = ? AND user_name = ?;",
-                (tagname, username),
+        statement = (
+            select(orm.AccessTagOwner.tag_id)
+            .join(orm.AccessTag, orm.AccessTag.id == orm.AccessTagOwner.tag_id)
+            .join(
+                orm.AccessTagsPrincipal,
+                orm.AccessTagsPrincipal.id == orm.AccessTagOwner.principal_id,
             )
-            row = await cursor.fetchone()
-            found_owner = bool(row)
+            .where(
+                orm.AccessTag.name == tagname,
+                orm.AccessTagsPrincipal.name == username,
+            )
+        )
+        async with self._engine.connect() as conn:
+            found_owner = (await conn.execute(statement)).first() is not None
         return found_owner
 
     async def is_tag_public(self, name):
-        async with self._db.cursor() as cursor:
-            await cursor.execute("SELECT 1 FROM public_tags WHERE name = ?;", (name,))
-            row = await cursor.fetchone()
-            found_public = bool(row)
+        statement = select(orm.AccessTag.id).where(
+            orm.AccessTag.name == name, orm.AccessTag.is_public
+        )
+        async with self._engine.connect() as conn:
+            found_public = (await conn.execute(statement)).first() is not None
         return found_public
 
     async def get_tags_from_scope(self, scope, username):
-        async with self._db.cursor() as cursor:
-            await cursor.execute(
-                "SELECT tag_name FROM user_tag_scopes WHERE user_name = ? AND scope_name = ?;",
-                (username, scope),
+        statement = (
+            select(orm.AccessTag.name)
+            .select_from(access_tag_principal_scopes_named)
+            .where(
+                orm.Scope.name == scope,
+                orm.AccessTagsPrincipal.name == username,
             )
-            user_scope_tags = {tag for (tag,) in await cursor.fetchall()}
+        )
+        async with self._engine.connect() as conn:
+            user_scope_tags = set((await conn.execute(statement)).scalars())
         return user_scope_tags
 
 

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -294,9 +294,7 @@ async def update_access_tags_tables(engine, scopes, tags, owners, public_tags):
 
         # delete outdated items; deletes cascade to the association tables
         deleted_tag_ids = [
-            tag_id
-            for tag_id in stale_tags.values()
-            if tag_id not in retained_tag_ids
+            tag_id for tag_id in stale_tags.values() if tag_id not in retained_tag_ids
         ]
         if deleted_tag_ids:
             await connection.execute(

--- a/tiled/access_control/access_tags.py
+++ b/tiled/access_control/access_tags.py
@@ -64,6 +64,12 @@ class AccessTagsParser:
             public_tags = set((await conn.execute(statement)).scalars())
         return public_tags
 
+    async def get_defined_scopes(self):
+        statement = select(orm.Scope.name)
+        async with self._engine.connect() as conn:
+            defined_scopes = set((await conn.execute(statement)).scalars())
+        return defined_scopes
+
     async def get_scopes_from_tag(self, tagname, username):
         statement = (
             select(orm.Scope.name)

--- a/tiled/access_control/protocols.py
+++ b/tiled/access_control/protocols.py
@@ -14,7 +14,7 @@ class AccessPolicy(ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, Optional[AccessBlob]]:
+    ) -> Tuple[bool, AccessBlob]:
         pass
 
     async def modify_node(
@@ -24,8 +24,8 @@ class AccessPolicy(ABC):
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
         access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, Optional[AccessBlob]]:
-        return (False, access_blob)
+    ) -> Tuple[bool, AccessBlob]:
+        return (False, access_blob or AccessBlob(tags=[]))
 
     @abstractmethod
     async def allowed_scopes(

--- a/tiled/access_control/protocols.py
+++ b/tiled/access_control/protocols.py
@@ -3,7 +3,16 @@ from typing import Optional, Tuple
 
 from ..adapters.protocols import BaseAdapter
 from ..server.schemas import Principal
-from ..type_aliases import AccessBlob, AccessTags, Filters, Scopes
+from ..type_aliases import Filters, Scopes
+
+
+class AccessTags(frozenset[str]):
+    def __new__(cls, tags=()):
+        if isinstance(tags, str):
+            raise TypeError(
+                "AccessTags expects an iterable of strings, not a single string."
+            )
+        return super().__new__(cls, tags)
 
 
 class AccessPolicy(ABC):
@@ -13,8 +22,8 @@ class AccessPolicy(ABC):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob] = None,
-    ) -> Tuple[bool, AccessBlob]:
+        access_tags: Optional[AccessTags] = None,
+    ) -> Tuple[bool, AccessTags]:
         pass
 
     async def modify_node(
@@ -23,9 +32,9 @@ class AccessPolicy(ABC):
         principal: Principal,
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
-        access_blob: Optional[AccessBlob],
-    ) -> Tuple[bool, AccessBlob]:
-        return (False, access_blob or AccessBlob(tags=[]))
+        access_tags: Optional[AccessTags],
+    ) -> Tuple[bool, AccessTags]:
+        return (False, access_tags or AccessTags())
 
     @abstractmethod
     async def allowed_scopes(

--- a/tiled/access_control/protocols.py
+++ b/tiled/access_control/protocols.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple
+
+from typing_extensions import Self
 
 from ..adapters.protocols import BaseAdapter
 from ..server.schemas import Principal
 from ..type_aliases import Filters, Scopes
-
 
 # Prefixes of principal tags ('user:<id>', 'service:<uuid>'), which mark
 # nodes as owned by a single principal.
@@ -12,7 +13,7 @@ PRINCIPAL_TAG_PREFIXES = ("user:", "service:")
 
 
 class AccessTags(frozenset[str]):
-    def __new__(cls, tags=()):
+    def __new__(cls, tags: Iterable[str] = ()) -> Self:
         if isinstance(tags, str):
             raise TypeError(
                 "AccessTags expects an iterable of strings, not a single string."

--- a/tiled/access_control/protocols.py
+++ b/tiled/access_control/protocols.py
@@ -6,6 +6,11 @@ from ..server.schemas import Principal
 from ..type_aliases import Filters, Scopes
 
 
+# Prefixes of principal tags ('user:<id>', 'service:<uuid>'), which mark
+# nodes as owned by a single principal.
+PRINCIPAL_TAG_PREFIXES = ("user:", "service:")
+
+
 class AccessTags(frozenset[str]):
     def __new__(cls, tags=()):
         if isinstance(tags, str):

--- a/tiled/access_control/scopes.py
+++ b/tiled/access_control/scopes.py
@@ -1,47 +1,80 @@
+import enum
+
+
+class ScopeName(str, enum.Enum):
+    """
+    The canonical set of permission scopes.
+
+    ``ScopeName`` compares and hashes equal to the corresponding plain
+    string and can be used interchangeably wherever a scope-name string is
+    expected -- including in the ``ScopeName``-valued sets derived below and
+    the catalog ``scopes`` table's enum column.
+    """
+
+    read_metadata = "read:metadata"
+    read_data = "read:data"
+    write_metadata = "write:metadata"
+    write_data = "write:data"
+    delete_revision = "delete:revision"
+    delete_node = "delete:node"
+    create_node = "create:node"
+    register = "register"
+    metrics = "metrics"
+    create_apikeys = "create:apikeys"
+    revoke_apikeys = "revoke:apikeys"
+    admin_apikeys = "admin:apikeys"
+    read_principals = "read:principals"
+    write_principals = "write:principals"
+    read_webhooks = "read:webhooks"
+    write_webhooks = "write:webhooks"
+
+
 SCOPES = {
-    "read:metadata": {"description": "Read metadata."},
-    "read:data": {"description": "Read data."},
-    "write:metadata": {"description": "Write metadata."},
-    "write:data": {"description": "Write data."},
-    "delete:revision": {"description": "Delete metadata revisions."},
-    "delete:node": {"description": "Delete a node."},
-    "create:node": {"description": "Add a node."},
-    "register": {"description": "Register externally-managed assets."},
-    "metrics": {"description": "Access (Prometheus) metrics."},
-    "create:apikeys": {
+    ScopeName.read_metadata: {"description": "Read metadata."},
+    ScopeName.read_data: {"description": "Read data."},
+    ScopeName.write_metadata: {"description": "Write metadata."},
+    ScopeName.write_data: {"description": "Write data."},
+    ScopeName.delete_revision: {"description": "Delete metadata revisions."},
+    ScopeName.delete_node: {"description": "Delete a node."},
+    ScopeName.create_node: {"description": "Add a node."},
+    ScopeName.register: {"description": "Register externally-managed assets."},
+    ScopeName.metrics: {"description": "Access (Prometheus) metrics."},
+    ScopeName.create_apikeys: {
         "description": "Create API keys as the currently-authenticated user or service."
     },
-    "revoke:apikeys": {
+    ScopeName.revoke_apikeys: {
         "description": "Revoke API keys as the currently-authenticated user or service."
     },
-    "admin:apikeys": {
+    ScopeName.admin_apikeys: {
         "description": "Create and revoke API keys on behalf of any user or service."
     },
-    "read:principals": {
+    ScopeName.read_principals: {
         "description": "Read list of all users and services and their attributes."
     },
-    "write:principals": {
+    ScopeName.write_principals: {
         "description": "Edit list of all users and services and their attributes."
     },
-    "read:webhooks": {"description": "Read webhooks and delivery history."},
-    "write:webhooks": {"description": "Register and delete webhooks."},
+    ScopeName.read_webhooks: {"description": "Read webhooks and delivery history."},
+    ScopeName.write_webhooks: {"description": "Register and delete webhooks."},
 }
 
-ALL_SCOPES: set[str] = frozenset(SCOPES)
-PUBLIC_SCOPES: set[str] = frozenset(("read:metadata", "read:data"))
-SINGLE_USER_SCOPES: set[str] = frozenset(
+ALL_SCOPES: frozenset[ScopeName] = frozenset(SCOPES)
+PUBLIC_SCOPES: frozenset[ScopeName] = frozenset(
+    (ScopeName.read_metadata, ScopeName.read_data)
+)
+SINGLE_USER_SCOPES: frozenset[ScopeName] = frozenset(
     (
-        "read:metadata",
-        "read:data",
-        "write:metadata",
-        "write:data",
-        "delete:revision",
-        "delete:node",
-        "create:node",
-        "register",
-        "metrics",
-        "read:webhooks",
-        "write:webhooks",
+        ScopeName.read_metadata,
+        ScopeName.read_data,
+        ScopeName.write_metadata,
+        ScopeName.write_data,
+        ScopeName.delete_revision,
+        ScopeName.delete_node,
+        ScopeName.create_node,
+        ScopeName.register,
+        ScopeName.metrics,
+        ScopeName.read_webhooks,
+        ScopeName.write_webhooks,
     )
 )
-NO_SCOPES: set[str] = frozenset()
+NO_SCOPES: frozenset[ScopeName] = frozenset()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -38,6 +38,7 @@ from sqlalchemy import (
     not_,
     or_,
     select,
+    String,
     text,
     true,
     type_coerce,
@@ -1539,11 +1540,19 @@ class CatalogNodeAdapter:
                 )
             if access_blob is not None:
                 await db.execute(
-                    delete(orm.AccessBlob).where(orm.AccessBlob.node_id == self.node.id)
+                    delete(orm.NodeAccessBlob).where(
+                        orm.NodeAccessBlob.node_id == self.node.id
+                    )
                 )
                 access_blob_orm = _access_blob_to_orm(access_blob)
-                access_blob_orm.node_id = self.node.id
                 db.add(access_blob_orm)
+                await db.flush()
+                db.add(
+                    orm.NodeAccessBlob(
+                        node_id=self.node.id,
+                        access_blob_id=access_blob_orm.id,
+                    )
+                )
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2405,7 +2414,7 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = select(orm.AccessBlob.node_id).where(
+                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                     orm.AccessBlob.kind == "tags",
                     select(1)
                     .select_from(access_tags_json)
@@ -2413,15 +2422,17 @@ def access_blob_filter(query, tree):
                     .exists(),
                 )
             elif dialect_name == "postgresql":
-                tags_match = select(orm.AccessBlob.node_id).where(
+                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                     orm.AccessBlob.kind == "tags",
-                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT))),
+                    type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
+                        sql_cast(query.tags, ARRAY(String()))
+                    ),
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
-            user_match = select(orm.AccessBlob.node_id).where(
+            user_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
                 orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
             )
             filters.append(orm.Node.id.in_(user_match))
@@ -2598,12 +2609,17 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
                 )
                 access_blob_orm = _access_blob_to_orm(node_access_blob)
-                await conn.execute(
+                access_blob_result = await conn.execute(
                     insert(orm.AccessBlob).values(
-                        node_id=node_id,
                         kind=access_blob_orm.kind,
                         username=access_blob_orm.username,
                         tags=access_blob_orm.tags,
+                    )
+                )
+                await conn.execute(
+                    insert(orm.NodeAccessBlob).values(
+                        node_id=node_id,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
                     )
                 )
                 logger.info(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -178,6 +178,12 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class AccessBlobMock:
+    username: str | None = None
+    tags: list[str] | None = None
+
+
 class RootNode:
     """
     Node representing the root of the tree.
@@ -198,7 +204,17 @@ class RootNode:
         self.specs = specs or []
         self.key = ""
         self.data_sources = None
-        self.access_blob = top_level_access_blob or {}
+
+        if top_level_access_blob is None:
+            self.access_blob = None
+        elif "user" in top_level_access_blob:
+            self.access_blob = AccessBlobMock(
+                username=top_level_access_blob["user"]
+            )
+        else:
+            self.access_blob = AccessBlobMock(
+                tags=top_level_access_blob["tags"]
+            )
 
 
 class Context:
@@ -1509,7 +1525,6 @@ class CatalogNodeAdapter:
                     # SQLAlchemy reserved word 'metadata'.
                     metadata_=current.metadata_,
                     specs=current.specs,
-                    access_blob=current.access_blob,
                     node_id=current.id,
                     revision_number=next_revision_number,
                 )

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 import anyio
 from fastapi import HTTPException
 from sqlalchemy import (
+    String,
     delete,
     exists,
     false,
@@ -38,7 +39,6 @@ from sqlalchemy import (
     not_,
     or_,
     select,
-    String,
     text,
     true,
     type_coerce,
@@ -2414,26 +2414,39 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                    orm.AccessBlob.kind == "tags",
-                    select(1)
-                    .select_from(access_tags_json)
-                    .where(access_tags_json.c.value.in_(query.tags))
-                    .exists(),
+                tags_match = (
+                    select(orm.NodeAccessBlob.node_id)
+                    .join(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.kind == "tags",
+                        select(1)
+                        .select_from(access_tags_json)
+                        .where(access_tags_json.c.value.in_(query.tags))
+                        .exists(),
+                    )
                 )
             elif dialect_name == "postgresql":
-                tags_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                    orm.AccessBlob.kind == "tags",
-                    type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
-                        sql_cast(query.tags, ARRAY(String()))
-                    ),
+                tags_match = (
+                    select(orm.NodeAccessBlob.node_id)
+                    .join(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.kind == "tags",
+                        type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
+                            sql_cast(query.tags, ARRAY(String()))
+                        ),
+                    )
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
-            user_match = select(orm.NodeAccessBlob.node_id).join(orm.AccessBlob).where(
-                orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
+            user_match = (
+                select(orm.NodeAccessBlob.node_id)
+                .join(orm.AccessBlob)
+                .where(
+                    orm.AccessBlob.kind == "user",
+                    orm.AccessBlob.username == query.user_id,
+                )
             )
             filters.append(orm.Node.id.in_(user_match))
         condition = or_(*filters) if filters else false()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1085,7 +1085,11 @@ class CatalogNodeAdapter:
                     "specs": [spec.model_dump() for spec in (specs or [])],
                     "metadata": metadata,
                     "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                    "access_blob": refreshed_node.access_blob,
+                    "access_blob": (
+                        {"user": refreshed_node.access_blob.username}
+                        if refreshed_node.access_blob.username is not None
+                        else {"tags": refreshed_node.access_blob.tags}
+                    ),
                 }
 
                 # Cache data in Redis with a TTL, and publish
@@ -2389,35 +2393,40 @@ def specs(query, tree):
 
 def access_blob_filter(query, tree):
     dialect_name = tree.context.engine.url.get_dialect().name
-    access_blob = orm.Node.access_blob
     if not (query.user_id or query.tags):
         # Results cannot possibly match an empty value or list,
         # so put a False condition in the list ensuring that
         # there are no rows returned.
         condition = false()
-    elif dialect_name == "sqlite":
-        attr_id = access_blob["user"]
-        attr_tags = access_blob["tags"]
-        access_tags_json = func.json_each(attr_tags).table_valued("value")
-        condition = (
-            select(1)
-            .select_from(access_tags_json)
-            .where(access_tags_json.c.value.in_(query.tags))
-            .exists()
-        )
-        if query.user_id is not None:
-            user_match = (
-                func.json_extract(func.json_quote(attr_id), "$") == query.user_id
-            )
-            condition = or_(condition, user_match)
-    elif dialect_name == "postgresql":
-        access_blob_jsonb = type_coerce(access_blob, JSONB)
-        condition = access_blob_jsonb["tags"].has_any(sql_cast(query.tags, ARRAY(TEXT)))
-        if query.user_id is not None:
-            user_match = access_blob_jsonb["user"].astext == query.user_id
-            condition = or_(condition, user_match)
     else:
-        raise UnsupportedQueryType("access_blob_filter")
+        filters = []
+        if query.tags:
+            if dialect_name == "sqlite":
+                access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
+                    "value"
+                )
+                tags_match = (
+                    select(orm.AccessBlob.node_id)
+                    .where(
+                        select(1)
+                        .select_from(access_tags_json)
+                        .where(access_tags_json.c.value.in_(query.tags))
+                        .exists()
+                    )
+                )
+            elif dialect_name == "postgresql":
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                )
+            else:
+                raise UnsupportedQueryType("access_blob_filter")
+            filters.append(orm.Node.id.in_(tags_match))
+        if query.user_id is not None:
+            user_match = select(orm.AccessBlob.node_id).where(
+                orm.AccessBlob.username == query.user_id
+            )
+            filters.append(orm.Node.id.in_(user_match))
+        condition = or_(*filters) if filters else false()
 
     return tree.new_variation(conditions=tree.conditions + [condition])
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -109,6 +109,7 @@ from ..storage import (
     register_storage,
 )
 from ..structures.core import Spec, StructureFamily
+from ..type_aliases import AccessBlob
 from ..utils import (
     UNCHANGED,
     Conflicts,
@@ -119,7 +120,6 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
-from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -2405,14 +2405,11 @@ def access_blob_filter(query, tree):
                 access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
                     "value"
                 )
-                tags_match = (
-                    select(orm.AccessBlob.node_id)
-                    .where(
-                        select(1)
-                        .select_from(access_tags_json)
-                        .where(access_tags_json.c.value.in_(query.tags))
-                        .exists()
-                    )
+                tags_match = select(orm.AccessBlob.node_id).where(
+                    select(1)
+                    .select_from(access_tags_json)
+                    .where(access_tags_json.c.value.in_(query.tags))
+                    .exists()
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
@@ -2595,7 +2592,9 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     )
                 )
                 node_id = result.inserted_primary_key[0]
-                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                node_access_blob = (
+                    access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                )
                 access_blob_orm = _access_blob_to_orm(node_access_blob)
                 await conn.execute(
                     insert(orm.AccessBlob).values(

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -119,6 +119,7 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
+from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession
@@ -178,12 +179,6 @@ STORAGE_ADAPTERS_BY_MIMETYPE = OneShotCachedMap[str, type](
 )
 
 
-@dataclasses.dataclass(frozen=True)
-class AccessBlobMock:
-    username: str | None = None
-    tags: list[str] | None = None
-
-
 class RootNode:
     """
     Node representing the root of the tree.
@@ -206,15 +201,21 @@ class RootNode:
         self.data_sources = None
 
         if top_level_access_blob is None:
-            self.access_blob = None
+            self.access_blob = AccessBlob(tags=[])
         elif "user" in top_level_access_blob:
-            self.access_blob = AccessBlobMock(
-                username=top_level_access_blob["user"]
-            )
+            self.access_blob = AccessBlob(username=top_level_access_blob["user"])
         else:
-            self.access_blob = AccessBlobMock(
-                tags=top_level_access_blob["tags"]
-            )
+            self.access_blob = AccessBlob(tags=top_level_access_blob["tags"])
+
+
+def _access_blob_to_orm(access_blob: AccessBlob | None) -> orm.AccessBlob:
+    if access_blob is None:
+        return orm.AccessBlob(kind="tags", tags=[])
+    if access_blob.username is not None:
+        return orm.AccessBlob(kind="user", username=access_blob.username)
+    if access_blob.tags is not None:
+        return orm.AccessBlob(kind="tags", tags=access_blob.tags)
+    return orm.AccessBlob(kind="tags", tags=[])
 
 
 class Context:
@@ -937,7 +938,8 @@ class CatalogNodeAdapter:
         data_sources=None,
         access_blob=None,
     ):
-        access_blob = access_blob or {}
+        if access_blob is None:
+            access_blob = AccessBlob(tags=[])
         key = key or self.context.key_maker()
         data_sources = data_sources or []
 
@@ -947,8 +949,8 @@ class CatalogNodeAdapter:
             metadata_=metadata,
             structure_family=structure_family,
             specs=specs or [],
-            access_blob=access_blob,
         )
+        node.access_blob = _access_blob_to_orm(access_blob)
         async with self.context.session() as db:
             # TODO Consider using nested transitions to ensure that
             # both the node is created (name not already taken)
@@ -1501,8 +1503,6 @@ class CatalogNodeAdapter:
             values["metadata_"] = metadata
         if specs is not None:
             values["specs"] = specs
-        if access_blob is not None:
-            values["access_blob"] = access_blob
         async with self.context.session() as db:
             if not drop_revision:
                 current = (
@@ -1529,9 +1529,17 @@ class CatalogNodeAdapter:
                     revision_number=next_revision_number,
                 )
                 db.add(revision)
-            await db.execute(
-                update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
-            )
+            if values:
+                await db.execute(
+                    update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
+                )
+            if access_blob is not None:
+                await db.execute(
+                    delete(orm.AccessBlob).where(orm.AccessBlob.node_id == self.node.id)
+                )
+                access_blob_orm = _access_blob_to_orm(access_blob)
+                access_blob_orm.node_id = self.node.id
+                db.add(access_blob_orm)
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2555,7 +2563,6 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
     from sqlalchemy import insert
 
     specs = specs or []
-    access_blob = access_blob or {}
     async with engine.begin() as conn:
         parent_id = 0  # root node id
         for i, segment in enumerate(mount_path):
@@ -2576,10 +2583,19 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                         structure_family=StructureFamily.container,
                         metadata_={},
                         specs=specs if is_leaf else [],
-                        access_blob=access_blob if is_leaf else {},
                     )
                 )
                 node_id = result.inserted_primary_key[0]
+                node_access_blob = access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
+                access_blob_orm = _access_blob_to_orm(node_access_blob)
+                await conn.execute(
+                    insert(orm.AccessBlob).values(
+                        node_id=node_id,
+                        kind=access_blob_orm.kind,
+                        username=access_blob_orm.username,
+                        tags=access_blob_orm.tags,
+                    )
+                )
                 logger.info(
                     "Created container node %r (id=%d) under parent_id=%d.",
                     segment,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1539,18 +1539,19 @@ class CatalogNodeAdapter:
                     update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
                 )
             if access_blob is not None:
-                await db.execute(
-                    delete(orm.NodeAccessBlob).where(
-                        orm.NodeAccessBlob.node_id == self.node.id
-                    )
-                )
                 access_blob_orm = _access_blob_to_orm(access_blob)
-                db.add(access_blob_orm)
-                await db.flush()
-                db.add(
-                    orm.NodeAccessBlob(
-                        node_id=self.node.id,
-                        access_blob_id=access_blob_orm.id,
+                await db.execute(
+                    update(orm.AccessBlob)
+                    .where(
+                        orm.AccessBlob.id
+                        == select(orm.NodeAccessBlob.access_blob_id)
+                        .where(orm.NodeAccessBlob.node_id == self.node.id)
+                        .scalar_subquery()
+                    )
+                    .values(
+                        kind=access_blob_orm.kind,
+                        username=access_blob_orm.username,
+                        tags=access_blob_orm.tags,
                     )
                 )
             await db.commit()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -2406,21 +2406,23 @@ def access_blob_filter(query, tree):
                     "value"
                 )
                 tags_match = select(orm.AccessBlob.node_id).where(
+                    orm.AccessBlob.kind == "tags",
                     select(1)
                     .select_from(access_tags_json)
                     .where(access_tags_json.c.value.in_(query.tags))
-                    .exists()
+                    .exists(),
                 )
             elif dialect_name == "postgresql":
                 tags_match = select(orm.AccessBlob.node_id).where(
-                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT)))
+                    orm.AccessBlob.kind == "tags",
+                    orm.AccessBlob.tags.has_any(sql_cast(query.tags, ARRAY(TEXT))),
                 )
             else:
                 raise UnsupportedQueryType("access_blob_filter")
             filters.append(orm.Node.id.in_(tags_match))
         if query.user_id is not None:
             user_match = select(orm.AccessBlob.node_id).where(
-                orm.AccessBlob.username == query.user_id
+                orm.AccessBlob.kind == "user", orm.AccessBlob.username == query.user_id
             )
             filters.append(orm.Node.id.in_(user_match))
         condition = or_(*filters) if filters else false()

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -30,7 +30,6 @@ from urllib.parse import urlparse
 import anyio
 from fastapi import HTTPException
 from sqlalchemy import (
-    String,
     delete,
     exists,
     false,
@@ -125,7 +124,6 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
-from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -2422,16 +2422,16 @@ def access_tags_filter(query, tree):
         # there are no rows returned.
         condition = false()
     else:
-        # Nodes carrying at least one of the given tags. Portable across
-        # SQLite and PostgreSQL: resolves names via the unique index on
-        # access_tags.name, then finds nodes via the covering
-        # (tag_id, node_id) index on node_access_tags.
-        tags_match = (
+        # Nodes carrying at least one of the given access tags.
+        # EXISTS is used (vs IN) as it is much more preformant in SQLite,
+        # though performance in Postgres appears similar for both.
+        condition = (
             select(orm.NodeAccessTag.node_id)
             .join(orm.AccessTag, orm.AccessTag.id == orm.NodeAccessTag.tag_id)
+            .where(orm.NodeAccessTag.node_id == orm.Node.id)
             .where(orm.AccessTag.name.in_(query.tags))
+            .exists()
         )
-        condition = orm.Node.id.in_(tags_match)
 
     return tree.new_variation(conditions=tree.conditions + [condition])
 

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -72,6 +72,7 @@ from tiled.queries import (
     StructureFamilyQuery,
 )
 
+from ..access_control.protocols import AccessTags
 from ..adapters.utils import DataNotReadyError, IncompatibleShapeError
 from ..mimetypes import (
     APACHE_ARROW_FILE_MIME_TYPE,
@@ -113,7 +114,6 @@ from ..storage import (
     register_storage,
 )
 from ..structures.core import Spec, StructureFamily
-from ..access_control.protocols import AccessTags
 from ..utils import (
     UNCHANGED,
     Conflicts,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -50,10 +50,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.sql.expression import cast as sql_cast
 from sqlalchemy.sql.sqltypes import MatchType
-from starlette.status import HTTP_404_NOT_FOUND, HTTP_415_UNSUPPORTED_MEDIA_TYPE
+from starlette.status import (
+    HTTP_403_FORBIDDEN,
+    HTTP_404_NOT_FOUND,
+    HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+)
 
 from tiled.queries import (
-    AccessBlobFilter,
+    AccessTagsFilter,
     Comparison,
     Contains,
     Eq,
@@ -110,7 +114,7 @@ from ..storage import (
     register_storage,
 )
 from ..structures.core import Spec, StructureFamily
-from ..type_aliases import AccessBlob
+from ..access_control.protocols import AccessTags
 from ..utils import (
     UNCHANGED,
     Conflicts,
@@ -194,7 +198,7 @@ class RootNode:
 
     structure_family = StructureFamily.container
 
-    def __init__(self, metadata, specs, top_level_access_blob):
+    def __init__(self, metadata, specs, top_level_access_tags):
         self.id = 0
         self.parent = None
         self.metadata_ = metadata or {}
@@ -202,22 +206,36 @@ class RootNode:
         self.key = ""
         self.data_sources = None
 
-        if top_level_access_blob is None:
-            self.access_blob = AccessBlob(tags=[])
-        elif "user" in top_level_access_blob:
-            self.access_blob = AccessBlob(username=top_level_access_blob["user"])
-        else:
-            self.access_blob = AccessBlob(tags=top_level_access_blob["tags"])
+        self.access_tags = AccessTags(top_level_access_tags or [])
 
 
-def _access_blob_to_orm(access_blob: AccessBlob | None) -> orm.AccessBlob:
-    if access_blob is None:
-        return orm.AccessBlob(kind="tags", tags=[])
-    if access_blob.username is not None:
-        return orm.AccessBlob(kind="user", username=access_blob.username)
-    if access_blob.tags is not None:
-        return orm.AccessBlob(kind="tags", tags=access_blob.tags)
-    return orm.AccessBlob(kind="tags", tags=[])
+async def _resolve_access_tags(db, tag_names):
+    """
+    Resolve tag names to orm.AccessTag rows in the given session.
+
+    Fetches only the requested names (an indexed IN lookup, not a scan of
+    the tags table). A node cannot be associated with a tag that has no
+    row, so unknown names raise. Normally the access policy has already
+    validated the tags; this fires only for requests that bypassed the
+    policy or raced a tag-definition resync, and it uses the same status
+    code that the policy check produces (403).
+    """
+    tag_rows = (
+        (
+            await db.execute(
+                select(orm.AccessTag).where(orm.AccessTag.name.in_(tag_names))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    missing = set(tag_names) - {tag.name for tag in tag_rows}
+    if missing:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail=f"Cannot apply access tags that are not defined: {sorted(missing)}",
+        )
+    return list(tag_rows)
 
 
 class Context:
@@ -357,7 +375,7 @@ class CatalogNodeAdapter:
                     mount_path,
                     create_if_not_exist=create_mount_nodes_if_not_exist,
                     specs=node.specs,
-                    access_blob=node.access_blob,
+                    access_tags=node.access_tags,
                 )
             )
         self.shutdown_tasks = [self.shutdown]
@@ -375,8 +393,12 @@ class CatalogNodeAdapter:
             return (await db.execute(statement)).scalars().all()
 
     @property
-    def access_blob(self):
-        return self.node.access_blob
+    def access_tags(self):
+        if isinstance(self.node, RootNode):
+            # Configured at server startup, not stored in the database;
+            # already an AccessTags frozenset of names.
+            return self.node.access_tags
+        return AccessTags(tag.name for tag in self.node.access_tags)
 
     def metadata(self):
         return self.node.metadata_
@@ -390,7 +412,7 @@ class CatalogNodeAdapter:
         *,
         create_if_not_exist=False,
         specs=None,
-        access_blob=None,
+        access_tags=None,
     ):
         statement = node_from_segments(mount_path).with_only_columns(orm.Node.id)
         async with self.context.engine.connect() as conn:
@@ -407,7 +429,7 @@ class CatalogNodeAdapter:
                     self.context.engine,
                     mount_path,
                     specs=specs,
-                    access_blob=access_blob,
+                    access_tags=access_tags,
                 )
                 # Re-query to get the id of the newly created node.
                 async with self.context.engine.connect() as conn:
@@ -938,10 +960,9 @@ class CatalogNodeAdapter:
         key=None,
         specs=None,
         data_sources=None,
-        access_blob=None,
+        access_tags=None,
     ):
-        if access_blob is None:
-            access_blob = AccessBlob(tags=[])
+        access_tags = AccessTags(access_tags or [])
         key = key or self.context.key_maker()
         data_sources = data_sources or []
 
@@ -952,8 +973,11 @@ class CatalogNodeAdapter:
             structure_family=structure_family,
             specs=specs or [],
         )
-        node.access_blob = _access_blob_to_orm(access_blob)
         async with self.context.session() as db:
+            if access_tags:
+                # Assigning AccessTag rows to the (many-to-many) relationship
+                # creates the node_access_tags association rows on flush.
+                node.access_tags = await _resolve_access_tags(db, access_tags)
             # TODO Consider using nested transitions to ensure that
             # both the node is created (name not already taken)
             # and the directory/file is created---or neither are.
@@ -1087,11 +1111,8 @@ class CatalogNodeAdapter:
                     "specs": [spec.model_dump() for spec in (specs or [])],
                     "metadata": metadata,
                     "data_sources": [d.model_dump() for d in data_sources_with_ids],
-                    "access_blob": (
-                        {"user": refreshed_node.access_blob.username}
-                        if refreshed_node.access_blob.username is not None
-                        else {"tags": refreshed_node.access_blob.tags}
-                    ),
+                    # JSON-serializable list of tag names.
+                    "access_tags": [tag.name for tag in refreshed_node.access_tags],
                 }
 
                 # Cache data in Redis with a TTL, and publish
@@ -1500,7 +1521,7 @@ class CatalogNodeAdapter:
             await db.commit()
 
     async def replace_metadata(
-        self, metadata=None, specs=None, access_blob=None, *, drop_revision=False
+        self, metadata=None, specs=None, access_tags=None, *, drop_revision=False
     ):
         values = {}
         if metadata is not None:
@@ -1539,22 +1560,16 @@ class CatalogNodeAdapter:
                 await db.execute(
                     update(orm.Node).where(orm.Node.id == self.node.id).values(**values)
                 )
-            if access_blob is not None:
-                access_blob_orm = _access_blob_to_orm(access_blob)
+            if access_tags is not None:
+                # Replace the node's tag set: drop existing association rows
+                # and insert one per (deduplicated) tag name.
                 await db.execute(
-                    update(orm.AccessBlob)
-                    .where(
-                        orm.AccessBlob.id
-                        == select(orm.NodeAccessBlob.access_blob_id)
-                        .where(orm.NodeAccessBlob.node_id == self.node.id)
-                        .scalar_subquery()
-                    )
-                    .values(
-                        kind=access_blob_orm.kind,
-                        username=access_blob_orm.username,
-                        tags=access_blob_orm.tags,
+                    delete(orm.NodeAccessTag).where(
+                        orm.NodeAccessTag.node_id == self.node.id
                     )
                 )
+                for tag in await _resolve_access_tags(db, AccessTags(access_tags)):
+                    db.add(orm.NodeAccessTag(node_id=self.node.id, tag_id=tag.id))
             await db.commit()
             # Upon successful update, inform websocket subscribers through redis
             if self.context.streaming_cache:
@@ -2402,56 +2417,23 @@ def specs(query, tree):
     return tree.new_variation(conditions=tree.conditions + conditions)
 
 
-def access_blob_filter(query, tree):
-    dialect_name = tree.context.engine.url.get_dialect().name
-    if not (query.user_id or query.tags):
-        # Results cannot possibly match an empty value or list,
+def access_tags_filter(query, tree):
+    if not query.tags:
+        # Results cannot possibly match an empty list,
         # so put a False condition in the list ensuring that
         # there are no rows returned.
         condition = false()
     else:
-        filters = []
-        if query.tags:
-            if dialect_name == "sqlite":
-                access_tags_json = func.json_each(orm.AccessBlob.tags).table_valued(
-                    "value"
-                )
-                tags_match = (
-                    select(orm.NodeAccessBlob.node_id)
-                    .join(orm.AccessBlob)
-                    .where(
-                        orm.AccessBlob.kind == "tags",
-                        select(1)
-                        .select_from(access_tags_json)
-                        .where(access_tags_json.c.value.in_(query.tags))
-                        .exists(),
-                    )
-                )
-            elif dialect_name == "postgresql":
-                tags_match = (
-                    select(orm.NodeAccessBlob.node_id)
-                    .join(orm.AccessBlob)
-                    .where(
-                        orm.AccessBlob.kind == "tags",
-                        type_coerce(orm.AccessBlob.tags, ARRAY(String())).overlap(
-                            sql_cast(query.tags, ARRAY(String()))
-                        ),
-                    )
-                )
-            else:
-                raise UnsupportedQueryType("access_blob_filter")
-            filters.append(orm.Node.id.in_(tags_match))
-        if query.user_id is not None:
-            user_match = (
-                select(orm.NodeAccessBlob.node_id)
-                .join(orm.AccessBlob)
-                .where(
-                    orm.AccessBlob.kind == "user",
-                    orm.AccessBlob.username == query.user_id,
-                )
-            )
-            filters.append(orm.Node.id.in_(user_match))
-        condition = or_(*filters) if filters else false()
+        # Nodes carrying at least one of the given tags. Portable across
+        # SQLite and PostgreSQL: resolves names via the unique index on
+        # access_tags.name, then finds nodes via the covering
+        # (tag_id, node_id) index on node_access_tags.
+        tags_match = (
+            select(orm.NodeAccessTag.node_id)
+            .join(orm.AccessTag, orm.AccessTag.id == orm.NodeAccessTag.tag_id)
+            .where(orm.AccessTag.name.in_(query.tags))
+        )
+        condition = orm.Node.id.in_(tags_match)
 
     return tree.new_variation(conditions=tree.conditions + [condition])
 
@@ -2549,7 +2531,7 @@ CatalogNodeAdapter.register_query(KeyPresent, key_present)
 CatalogNodeAdapter.register_query(KeysFilter, keys_filter)
 CatalogNodeAdapter.register_query(StructureFamilyQuery, structure_family)
 CatalogNodeAdapter.register_query(SpecsQuery, specs)
-CatalogNodeAdapter.register_query(AccessBlobFilter, access_blob_filter)
+CatalogNodeAdapter.register_query(AccessTagsFilter, access_tags_filter)
 CatalogNodeAdapter.register_query(FullText, full_text)
 CatalogNodeAdapter.register_query(Like, like)
 
@@ -2562,7 +2544,7 @@ def in_memory(
     writable_storage=None,
     readable_storage=None,
     adapters_by_mimetype=None,
-    top_level_access_blob=None,
+    top_level_access_tags=None,
     cache_config=None,
     webhook_secret_keys: Optional[List[str]] = None,
 ):
@@ -2580,23 +2562,24 @@ def in_memory(
         readable_storage=readable_storage,
         init_if_not_exists=True,
         adapters_by_mimetype=adapters_by_mimetype,
-        top_level_access_blob=top_level_access_blob,
+        top_level_access_tags=top_level_access_tags,
         cache_config=cache_config,
         webhook_secret_keys=webhook_secret_keys,
     )
 
 
-async def _create_mount_node_segments(engine, mount_path, specs=None, access_blob=None):
+async def _create_mount_node_segments(engine, mount_path, specs=None, access_tags=None):
     """Create missing intermediate container nodes for a mount path.
 
     Walks the path segments, creating any that don't exist yet.
     DB triggers automatically maintain the nodes_closure table.
-    The leaf node (last segment) receives the given specs and access_blob;
+    The leaf node (last segment) receives the given specs and access_tags;
     intermediate nodes get empty defaults.
     """
     from sqlalchemy import insert
 
     specs = specs or []
+    access_tags = AccessTags(access_tags or [])
     async with engine.begin() as conn:
         parent_id = 0  # root node id
         for i, segment in enumerate(mount_path):
@@ -2620,23 +2603,30 @@ async def _create_mount_node_segments(engine, mount_path, specs=None, access_blo
                     )
                 )
                 node_id = result.inserted_primary_key[0]
-                node_access_blob = (
-                    access_blob if (is_leaf and access_blob) else AccessBlob(tags=[])
-                )
-                access_blob_orm = _access_blob_to_orm(node_access_blob)
-                access_blob_result = await conn.execute(
-                    insert(orm.AccessBlob).values(
-                        kind=access_blob_orm.kind,
-                        username=access_blob_orm.username,
-                        tags=access_blob_orm.tags,
+                node_access_tags = access_tags if is_leaf else AccessTags([])
+                if node_access_tags:
+                    # Resolve tag names to ids; raise on any undefined tag.
+                    rows = (
+                        await conn.execute(
+                            select(orm.AccessTag.id, orm.AccessTag.name).where(
+                                orm.AccessTag.name.in_(node_access_tags)
+                            )
+                        )
+                    ).all()
+                    missing = set(node_access_tags) - {name for _, name in rows}
+                    if missing:
+                        raise ValueError(
+                            "Cannot apply access tags that are not defined: "
+                            f"{sorted(missing)}"
+                        )
+                    await conn.execute(
+                        insert(orm.NodeAccessTag).values(
+                            [
+                                {"node_id": node_id, "tag_id": tag_id}
+                                for tag_id, _ in rows
+                            ]
+                        )
                     )
-                )
-                await conn.execute(
-                    insert(orm.NodeAccessBlob).values(
-                        node_id=node_id,
-                        access_blob_id=access_blob_result.inserted_primary_key[0],
-                    )
-                )
                 logger.info(
                     "Created container node %r (id=%d) under parent_id=%d.",
                     segment,
@@ -2655,7 +2645,7 @@ def from_uri(
     readable_storage=None,
     init_if_not_exists=False,
     adapters_by_mimetype=None,
-    top_level_access_blob=None,
+    top_level_access_tags=None,
     mount_node: Optional[Union[str, List[str]]] = None,
     create_mount_nodes_if_not_exist=False,
     cache_config=None,
@@ -2703,7 +2693,7 @@ def from_uri(
         storage_max_overflow=storage_max_overflow,
         webhook_secret_keys=webhook_secret_keys,
     )
-    node = RootNode(metadata, specs, top_level_access_blob)
+    node = RootNode(metadata, specs, top_level_access_tags)
     mount_path = (
         [segment for segment in mount_node.split("/") if segment]
         if isinstance(mount_node, str)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -211,31 +211,31 @@ class RootNode:
         self.access_tags = AccessTags(top_level_access_tags or [])
 
 
-async def _resolve_access_tags(db, tag_names):
+async def _resolve_access_tags(db, access_tag_names):
     """
-    Resolve tag names to orm.AccessTag rows in the given session.
+    Resolve access tag names to orm.AccessTag rows in the given session.
 
     Fetches only the requested names (an indexed IN lookup, not a scan of
-    the tags table). A node cannot be associated with a tag that has no
-    row, so unknown names raise. Normally the access policy has already
+    the access_tags table). A node cannot be associated with a tag that has
+    no row, so unknown names raise. Normally the access policy has already
     validated the tags; this fires only for requests that bypassed the
     policy or raced a tag-definition resync, and it uses the same status
     code that the policy check produces (403).
 
     Principal tags are slightly different: these need to exist at write,
-    possibly before the tags compiler has been able to create them.
+    possibly before the access tags compiler has been able to create them.
     """
-    await register_principal_tag_rows(await db.connection(), tag_names)
+    await register_principal_tag_rows(await db.connection(), access_tag_names)
     tag_rows = (
         (
             await db.execute(
-                select(orm.AccessTag).where(orm.AccessTag.name.in_(tag_names))
+                select(orm.AccessTag).where(orm.AccessTag.name.in_(access_tag_names))
             )
         )
         .scalars()
         .all()
     )
-    missing = set(tag_names) - {tag.name for tag in tag_rows}
+    missing = set(access_tag_names) - {tag.name for tag in tag_rows}
     if missing:
         raise HTTPException(
             status_code=HTTP_403_FORBIDDEN,

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -121,6 +121,7 @@ from ..utils import (
     import_object,
     path_from_uri,
 )
+from ..type_aliases import AccessBlob
 from . import orm
 from .core import check_catalog_database, initialize_database
 from .explain import ExplainAsyncSession

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -125,7 +125,11 @@ from ..utils import (
     path_from_uri,
 )
 from . import orm
-from .core import check_catalog_database, initialize_database
+from .core import (
+    check_catalog_database,
+    initialize_database,
+    register_principal_tag_rows,
+)
 from .explain import ExplainAsyncSession
 from .utils import compute_structure_id
 
@@ -217,7 +221,11 @@ async def _resolve_access_tags(db, tag_names):
     validated the tags; this fires only for requests that bypassed the
     policy or raced a tag-definition resync, and it uses the same status
     code that the policy check produces (403).
+
+    Principal tags are slightly different: these need to exist at write,
+    possibly before the tags compiler has been able to create them.
     """
+    await register_principal_tag_rows(await db.connection(), tag_names)
     tag_rows = (
         (
             await db.execute(

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -1,4 +1,4 @@
-from sqlalchemy import text
+from sqlalchemy import insert, select, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..alembic_utils import DatabaseUpgradeNeeded, UninitializedDatabase, check_database
@@ -49,6 +49,21 @@ async def initialize_database(engine: AsyncEngine):
             await connection.execute(text("create extension btree_gin;"))
         # Create all tables.
         await connection.run_sync(Base.metadata.create_all)
+        root_access_blob_id = await connection.scalar(
+            select(orm.NodeAccessBlob.access_blob_id).where(
+                orm.NodeAccessBlob.node_id == 0
+            )
+        )
+        if root_access_blob_id is None:
+            result = await connection.execute(
+                insert(orm.AccessBlob).values(kind="tags", tags=["public"])
+            )
+            await connection.execute(
+                insert(orm.NodeAccessBlob).values(
+                    node_id=0,
+                    access_blob_id=result.inserted_primary_key[0],
+                )
+            )
         if engine.dialect.name == "sqlite":
             # Use write-ahead log mode. This persists across all future connections
             # until/unless manually switched.

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "de302a096358",
     "c31f6a1d7e20",
     "9bc9b57294b9",
     "b93c79d197f4",

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -51,8 +51,9 @@ async def initialize_database(engine: AsyncEngine):
         # tag-based access control, a node with no tags is inaccessible, and
         # the root must never block traversal to its children. The
         # association requires the 'public' tag row to exist (foreign key),
-        # so it is created here if missing. This is the only place outside of
-        # the access tags compiler that inserts an access tag.
+        # so it is created here if missing. Besides the access tags compiler,
+        # tag rows are inserted only here and by the storage layers'
+        # auto-registration of principal tags (register_principal_tag_rows).
         # On a server without an access policy, tags are ignored and
         # these rows are inert.
         public_tag_id = await connection.scalar(
@@ -79,6 +80,38 @@ async def initialize_database(engine: AsyncEngine):
             # https://www.sqlite.org/wal.html
             await connection.execute(text("PRAGMA journal_mode=WAL;"))
         await connection.commit()
+
+
+async def register_principal_tag_rows(connection, tag_names):
+    """
+    Auto-register bare access tag rows for any principal tags in tag_names.
+    Principal tags need to exist at write, possibly before the tags compiler
+    has been able to create them.
+
+    Call this on the same connection/transaction as the tag assignment, so
+    that the row is never observed unassigned and the compiler's retention
+    rules will never delete it. (An AsyncSession caller can pass
+    `await session.connection()`.)
+    """
+    from ..access_control.protocols import PRINCIPAL_TAG_PREFIXES
+    from . import orm
+
+    principal_tags = {
+        name for name in tag_names if name.startswith(PRINCIPAL_TAG_PREFIXES)
+    }
+    if not principal_tags:
+        return
+    if connection.dialect.name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as upsert
+    else:
+        from sqlalchemy.dialects.sqlite import insert as upsert
+    await connection.execute(
+        upsert(orm.AccessTag.__table__)
+        .values(
+            [{"name": name, "is_public": False} for name in sorted(principal_tags)]
+        )
+        .on_conflict_do_nothing(index_elements=["name"])
+    )
 
 
 async def check_catalog_database(engine: AsyncEngine):

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -6,6 +6,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "3bc110ce44e9",
     "de302a096358",
     "c31f6a1d7e20",
     "9bc9b57294b9",
@@ -35,14 +36,8 @@ REQUIRED_REVISION = ALL_REVISIONS[0]
 
 
 async def initialize_database(engine: AsyncEngine):
-    # The definitions in .orm alter Base.metadata.
-    # TODO(access-tags): The graph (splash-links) tables also live in the
-    # catalog database and attach to Base.metadata. They have not yet been
-    # converted to the access_tags schema, so importing tiled.graph.orm here
-    # would make create_all fail (its tables hold foreign keys into a table
-    # that no longer exists). Restore this import once the graph ORM is
-    # converted:
-    #     from ..graph import orm as graph_orm  # noqa: F401
+    from ..graph import orm as graph_orm  # noqa: F401
+
     from . import orm  # noqa: F401
 
     async with engine.connect() as connection:

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -81,11 +81,11 @@ async def initialize_database(engine: AsyncEngine):
         await connection.commit()
 
 
-async def register_principal_tag_rows(connection, tag_names):
+async def register_principal_tag_rows(connection, access_tag_names):
     """
-    Auto-register bare access tag rows for any principal tags in tag_names.
-    Principal tags need to exist at write, possibly before the tags compiler
-    has been able to create them.
+    Auto-register bare access tag rows for any principal tags in
+    access_tag_names. Principal tags need to exist at write, possibly before
+    the access tags compiler has been able to create them.
 
     Call this on the same connection/transaction as the tag assignment, so
     that the row is never observed unassigned and the compiler's retention
@@ -96,7 +96,7 @@ async def register_principal_tag_rows(connection, tag_names):
     from . import orm
 
     principal_tags = {
-        name for name in tag_names if name.startswith(PRINCIPAL_TAG_PREFIXES)
+        name for name in access_tag_names if name.startswith(PRINCIPAL_TAG_PREFIXES)
     }
     if not principal_tags:
         return

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -37,7 +37,6 @@ REQUIRED_REVISION = ALL_REVISIONS[0]
 
 async def initialize_database(engine: AsyncEngine):
     from ..graph import orm as graph_orm  # noqa: F401
-
     from . import orm  # noqa: F401
 
     async with engine.connect() as connection:
@@ -107,9 +106,7 @@ async def register_principal_tag_rows(connection, tag_names):
         from sqlalchemy.dialects.sqlite import insert as upsert
     await connection.execute(
         upsert(orm.AccessTag.__table__)
-        .values(
-            [{"name": name, "is_public": False} for name in sorted(principal_tags)]
-        )
+        .values([{"name": name, "is_public": False} for name in sorted(principal_tags)])
         .on_conflict_do_nothing(index_elements=["name"])
     )
 

--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -36,11 +36,13 @@ REQUIRED_REVISION = ALL_REVISIONS[0]
 
 async def initialize_database(engine: AsyncEngine):
     # The definitions in .orm alter Base.metadata.
-    # The graph (splash-links) tables also live in the catalog database and
-    # attach to Base.metadata, so importing them here ensures create_all
-    # provisions them on fresh databases (existing databases get them via the
-    # Alembic migration c31f6a1d7e20).
-    from ..graph import orm as graph_orm  # noqa: F401
+    # TODO(access-tags): The graph (splash-links) tables also live in the
+    # catalog database and attach to Base.metadata. They have not yet been
+    # converted to the access_tags schema, so importing tiled.graph.orm here
+    # would make create_all fail (its tables hold foreign keys into a table
+    # that no longer exists). Restore this import once the graph ORM is
+    # converted:
+    #     from ..graph import orm as graph_orm  # noqa: F401
     from . import orm  # noqa: F401
 
     async with engine.connect() as connection:
@@ -49,20 +51,32 @@ async def initialize_database(engine: AsyncEngine):
             await connection.execute(text("create extension btree_gin;"))
         # Create all tables.
         await connection.run_sync(Base.metadata.create_all)
-        root_access_blob_id = await connection.scalar(
-            select(orm.NodeAccessBlob.access_blob_id).where(
-                orm.NodeAccessBlob.node_id == 0
+        # The persisted catalog root node (nodes.id = 0, inserted by the
+        # nodes_closure DDL listener) is always tagged 'public': under
+        # tag-based access control, a node with no tags is inaccessible, and
+        # the root must never block traversal to its children. The
+        # association requires the 'public' tag row to exist (foreign key),
+        # so it is created here if missing. This is the only place outside of
+        # the access tags compiler that inserts an access tag.
+        # On a server without an access policy, tags are ignored and
+        # these rows are inert.
+        public_tag_id = await connection.scalar(
+            select(orm.AccessTag.id).where(orm.AccessTag.name == "public")
+        )
+        if public_tag_id is None:
+            result = await connection.execute(
+                insert(orm.AccessTag).values(name="public", is_public=True)
+            )
+            public_tag_id = result.inserted_primary_key[0]
+        root_is_tagged = await connection.scalar(
+            select(orm.NodeAccessTag.tag_id).where(
+                orm.NodeAccessTag.node_id == 0,
+                orm.NodeAccessTag.tag_id == public_tag_id,
             )
         )
-        if root_access_blob_id is None:
-            result = await connection.execute(
-                insert(orm.AccessBlob).values(kind="tags", tags=["public"])
-            )
+        if root_is_tagged is None:
             await connection.execute(
-                insert(orm.NodeAccessBlob).values(
-                    node_id=0,
-                    access_blob_id=result.inserted_primary_key[0],
-                )
+                insert(orm.NodeAccessTag).values(node_id=0, tag_id=public_tag_id)
             )
         if engine.dialect.name == "sqlite":
             # Use write-ahead log mode. This persists across all future connections

--- a/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
+++ b/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
@@ -1,0 +1,972 @@
+"""Convert access blobs to access tags
+
+Revision ID: 3bc110ce44e9
+Revises: de302a096358
+Create Date: 2026-09-04
+
+Replaces the ``access_blobs`` table (and its per-owner association tables
+``node_access_blobs``, ``entity_access_blobs``, ``link_access_blobs``) with
+named, deduplicated access tags:
+
+* ``access_tags`` holds one row per distinct tag name. Every owner carrying a
+  given tag points at the same deduplicated row. The ``public`` tag is marked
+  ``is_public``.
+* ``node_access_tags``, ``entity_access_tags``, and ``link_access_tags`` are
+  many-to-many association tables (an owner may carry several tags; a tag may
+  be carried by many owners).
+* A blob of kind ``user`` (a principal-owned node/entity/link) becomes the tag
+  ``user:<username>``. The blob world stored service principals the same way
+  (``username`` held the service's uuid), and the catalog database has no
+  local way to tell the two apart, so they too become ``user:<uuid>`` here.
+  The access tags compiler later adds a ``service:<uuid>`` tag definition for
+  each service principal (with stable IDs, matching either form) so that data
+  migrated as ``user:<uuid>`` and data tagged ``service:<uuid>`` going forward
+  both resolve; each owner still carries exactly one principal tag.
+* Entities that reference a catalog node (``node_id`` set) had no blob and get
+  no tags: they assume the access tags of the referenced node. Database
+  triggers enforcing that invariant are recreated in tag form.
+* The supporting tables for tag definitions -- ``access_tags_principals``,
+  ``scopes``, ``access_tag_principal_scopes``, ``access_tag_owners`` -- are
+  created empty. They are populated for the first time by the access tags
+  compiler, not by this migration.
+
+The downgrade reconstructs one blob per owner from its tags before dropping
+the tag tables: an owner whose only tag is a principal tag (``user:<name>``
+or ``service:<uuid>``) becomes a kind ``user`` blob again, with the username
+taken from either prefix; anything else becomes a kind ``tags`` blob.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3bc110ce44e9"
+down_revision = "de302a096358"
+branch_labels = None
+depends_on = None
+
+ENTITY_NODE_ACCESS_TAGS_ERROR = (
+    "An entity with node_id set must not have its own access tags; "
+    "access is controlled by the referenced node."
+)
+
+# (owner table, tag association table, owner id column, blob association table)
+OWNERS = (
+    ("nodes", "node_access_tags", "node_id", "node_access_blobs"),
+    ("entities", "entity_access_tags", "entity_id", "entity_access_blobs"),
+    ("links", "link_access_tags", "link_id", "link_access_blobs"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema pieces
+# ---------------------------------------------------------------------------
+
+
+def _create_tag_tables():
+    """Create the tag tables and indexes, mirroring tiled.catalog.orm and
+    tiled.graph.orm exactly."""
+    op.create_table(
+        "access_tags",
+        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column(
+            "time_updated",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+        ),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
+        sa.Column(
+            "is_public",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # Partial + covering, matching the ORM: index-only scan for
+    # "SELECT name WHERE is_public", zero maintenance for non-public rows.
+    op.create_index(
+        "idx_access_tags_is_public",
+        "access_tags",
+        ["name"],
+        postgresql_where=sa.text("is_public"),
+        sqlite_where=sa.text("is_public"),
+    )
+
+    op.create_table(
+        "node_access_tags",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "nodes.id", name="fk_node_access_tags_node", ondelete="CASCADE"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags.id", name="fk_node_access_tags_tag", ondelete="CASCADE"
+            ),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("node_id", "tag_id", name="node_access_tags_pkey"),
+    )
+    op.create_index(
+        "idx_node_access_tags_tag_id_node_id",
+        "node_access_tags",
+        ["tag_id", "node_id"],
+    )
+
+    op.create_table(
+        "entity_access_tags",
+        sa.Column(
+            "entity_id",
+            sa.String(),
+            sa.ForeignKey(
+                "entities.id", name="fk_entity_access_tags_entity", ondelete="CASCADE"
+            ),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags.id", name="fk_entity_access_tags_tag", ondelete="CASCADE"
+            ),
+            primary_key=True,
+        ),
+    )
+    op.create_index(
+        "idx_entity_access_tags_tag_id_entity_id",
+        "entity_access_tags",
+        ["tag_id", "entity_id"],
+    )
+
+    op.create_table(
+        "link_access_tags",
+        sa.Column(
+            "link_id",
+            sa.String(),
+            sa.ForeignKey(
+                "links.id", name="fk_link_access_tags_link", ondelete="CASCADE"
+            ),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags.id", name="fk_link_access_tags_tag", ondelete="CASCADE"
+            ),
+            primary_key=True,
+        ),
+    )
+    op.create_index(
+        "idx_link_access_tags_tag_id_link_id",
+        "link_access_tags",
+        ["tag_id", "link_id"],
+    )
+
+    # Tag-definition support tables. Created empty: they are populated for the
+    # first time by the access tags compiler, never by this migration.
+    op.create_table(
+        "access_tags_principals",
+        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("time_updated", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
+    )
+    op.create_table(
+        "scopes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
+    )
+    op.create_table(
+        "access_tag_principal_scopes",
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags.id",
+                name="fk_access_tag_principal_scopes_access_tag",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "principal_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags_principals.id",
+                name="fk_access_tag_principal_scopes_principal",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "scope_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "scopes.id",
+                name="fk_access_tag_principal_scopes_scope",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint(
+            "tag_id",
+            "principal_id",
+            "scope_id",
+            name="access_tag_principal_scopes_pkey",
+        ),
+    )
+    op.create_index(
+        "idx_access_tag_principal_scopes_principal_scope",
+        "access_tag_principal_scopes",
+        ["principal_id", "scope_id", "tag_id"],
+    )
+    op.create_index(
+        "idx_access_tag_principal_scopes_scope_id",
+        "access_tag_principal_scopes",
+        ["scope_id"],
+    )
+    op.create_table(
+        "access_tag_owners",
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags.id",
+                name="fk_access_tag_owners_access_tag",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "principal_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "access_tags_principals.id",
+                name="fk_access_tag_owners_principal",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint(
+            "tag_id", "principal_id", name="access_tag_owners_pkey"
+        ),
+    )
+    op.create_index(
+        "idx_access_tag_owners_principal_id",
+        "access_tag_owners",
+        ["principal_id"],
+    )
+
+
+def _drop_tag_tables():
+    """Drop the tag tables, dependents before their referents."""
+    op.drop_table("access_tag_principal_scopes")
+    op.drop_table("access_tag_owners")
+    op.drop_table("access_tags_principals")
+    op.drop_table("scopes")
+    op.drop_table("node_access_tags")
+    op.drop_table("entity_access_tags")
+    op.drop_table("link_access_tags")
+    op.drop_table("access_tags")
+
+
+# ---------------------------------------------------------------------------
+# Data: blobs -> tags (upgrade)
+# ---------------------------------------------------------------------------
+
+
+def _populate_tags_from_blobs(connection):
+    """
+    Populate access_tags with one row per distinct tag name across all blobs
+    (deduplicated), then point each owner's association rows at those shared
+    rows. Blobs of kind 'user' become 'user:<username>' tags.
+    """
+    dialect_name = connection.engine.dialect.name
+    if dialect_name == "sqlite":
+        # Deduplicated tag names: UNION removes duplicates across and within
+        # sources. json_each explodes the JSON array of kind='tags' blobs.
+        connection.execute(
+            sa.text(
+                """
+INSERT INTO access_tags (name, is_public)
+SELECT tag_name, (tag_name = 'public') FROM (
+    SELECT je.value AS tag_name
+    FROM access_blobs ab, json_each(ab.tags) je
+    WHERE ab.kind = 'tags'
+    UNION
+    SELECT 'user:' || ab.username AS tag_name
+    FROM access_blobs ab
+    WHERE ab.kind = 'user'
+)
+"""
+            )
+        )
+        for _, tag_assoc, owner_column, blob_assoc in OWNERS:
+            # DISTINCT guards against duplicate names within one blob's array,
+            # which would violate the association's composite primary key.
+            connection.execute(
+                sa.text(
+                    f"""
+INSERT INTO {tag_assoc} ({owner_column}, tag_id)
+SELECT DISTINCT assoc.{owner_column}, at.id
+FROM {blob_assoc} assoc
+JOIN access_blobs ab ON ab.id = assoc.access_blob_id, json_each(ab.tags) je
+JOIN access_tags at ON at.name = je.value
+WHERE ab.kind = 'tags'
+"""
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"""
+INSERT INTO {tag_assoc} ({owner_column}, tag_id)
+SELECT assoc.{owner_column}, at.id
+FROM {blob_assoc} assoc
+JOIN access_blobs ab ON ab.id = assoc.access_blob_id
+JOIN access_tags at ON at.name = 'user:' || ab.username
+WHERE ab.kind = 'user'
+"""
+                )
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                """
+INSERT INTO access_tags (name, is_public)
+SELECT tag_name, (tag_name = 'public') FROM (
+    SELECT unnest(ab.tags) AS tag_name
+    FROM access_blobs ab
+    WHERE ab.kind = 'tags'
+    UNION
+    SELECT 'user:' || ab.username AS tag_name
+    FROM access_blobs ab
+    WHERE ab.kind = 'user'
+) tag_names
+"""
+            )
+        )
+        for _, tag_assoc, owner_column, blob_assoc in OWNERS:
+            connection.execute(
+                sa.text(
+                    f"""
+INSERT INTO {tag_assoc} ({owner_column}, tag_id)
+SELECT DISTINCT assoc.{owner_column}, at.id
+FROM {blob_assoc} assoc
+JOIN access_blobs ab ON ab.id = assoc.access_blob_id
+CROSS JOIN LATERAL unnest(ab.tags) AS tag_name
+JOIN access_tags at ON at.name = tag_name
+WHERE ab.kind = 'tags'
+"""
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"""
+INSERT INTO {tag_assoc} ({owner_column}, tag_id)
+SELECT assoc.{owner_column}, at.id
+FROM {blob_assoc} assoc
+JOIN access_blobs ab ON ab.id = assoc.access_blob_id
+JOIN access_tags at ON at.name = 'user:' || ab.username
+WHERE ab.kind = 'user'
+"""
+                )
+            )
+    else:
+        raise RuntimeError(f"Unsupported dialect for migration: {dialect_name}")
+
+
+# ---------------------------------------------------------------------------
+# Data: tags -> blobs (downgrade)
+# ---------------------------------------------------------------------------
+
+
+def _reconstruct_blobs_from_tags(
+    connection, owner_table, tag_assoc, owner_column, blob_assoc, where=""
+):
+    """
+    Reconstruct one access_blobs row per owner from its tags, restoring the
+    blob world's 1:1 owner->blob shape:
+
+    * an owner whose only tag is a principal tag -- 'user:<username>' or
+      'service:<uuid>' (the access policy applies exactly one, never both) --
+      -> kind='user' blob, with the username taken from whichever prefix is
+      present (the blob world stored service principals as kind='user' with
+      the uuid in the username column);
+    * anything else (including zero tags) -> kind='tags' blob with the
+      aggregated tag names ('[]' for untagged owners).
+
+    Correlation between a newly inserted access_blobs row and its owner is
+    done through a temporary _migrate_owner column (dropped at the end),
+    following the pattern of revision de302a096358.
+    """
+    dialect_name = connection.engine.dialect.name
+    owner_type = "INTEGER" if owner_column == "node_id" else "VARCHAR"
+    connection.execute(
+        sa.text(f"ALTER TABLE access_blobs ADD COLUMN _migrate_owner {owner_type}")
+    )
+    # 'user:' is 5 characters and 'service:' is 8, so the identifier starts at
+    # (1-indexed) position 6 and 9 respectively. substr() is available on both
+    # SQLite and PostgreSQL.
+    is_user_blob = "agg.n_tags = 1 AND agg.n_user + agg.n_service = 1"
+    if dialect_name == "sqlite":
+        empty_tags = "json('[]')"
+        tags_agg = (
+            "CASE WHEN COUNT(t.id) = 0 THEN json('[]') "
+            "ELSE json_group_array(t.name) END"
+        )
+        kind_expr = f"CASE WHEN {is_user_blob} THEN 'user' ELSE 'tags' END"
+    elif dialect_name == "postgresql":
+        empty_tags = "ARRAY[]::varchar[]"
+        tags_agg = (
+            "CASE WHEN COUNT(t.id) = 0 THEN ARRAY[]::varchar[] "
+            "ELSE array_agg(t.name)::varchar[] END"
+        )
+        kind_expr = (
+            f"(CASE WHEN {is_user_blob} THEN 'user' ELSE 'tags' END)::access_kind"
+        )
+    else:
+        raise RuntimeError(f"Unsupported dialect for migration: {dialect_name}")
+
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO access_blobs (kind, username, tags, _migrate_owner)
+SELECT
+    {kind_expr},
+    CASE WHEN {is_user_blob}
+         THEN COALESCE(agg.user_name, agg.service_name) ELSE NULL END,
+    CASE WHEN {is_user_blob} THEN NULL ELSE COALESCE(agg.tag_names, {empty_tags}) END,
+    agg.owner
+FROM (
+    SELECT
+        owner_table.id AS owner,
+        COUNT(t.id) AS n_tags,
+        COALESCE(
+            SUM(CASE WHEN t.name LIKE 'user:%' THEN 1 ELSE 0 END), 0
+        ) AS n_user,
+        COALESCE(
+            SUM(CASE WHEN t.name LIKE 'service:%' THEN 1 ELSE 0 END), 0
+        ) AS n_service,
+        MAX(CASE WHEN t.name LIKE 'user:%'
+                 THEN substr(t.name, 6) END) AS user_name,
+        MAX(CASE WHEN t.name LIKE 'service:%'
+                 THEN substr(t.name, 9) END) AS service_name,
+        {tags_agg} AS tag_names
+    FROM {owner_table} owner_table
+    LEFT JOIN {tag_assoc} assoc ON assoc.{owner_column} = owner_table.id
+    LEFT JOIN access_tags t ON t.id = assoc.tag_id
+    {where}
+    GROUP BY owner_table.id
+) agg
+"""
+        )
+    )
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO {blob_assoc} ({owner_column}, access_blob_id)
+SELECT _migrate_owner, id
+FROM access_blobs
+WHERE _migrate_owner IS NOT NULL
+"""
+        )
+    )
+    # Use a native ALTER rather than Alembic's batch mode, which would rebuild
+    # the access_blobs table and disturb the foreign keys the association
+    # tables hold against it (see de302a096358).
+    connection.execute(sa.text("ALTER TABLE access_blobs DROP COLUMN _migrate_owner"))
+
+
+# ---------------------------------------------------------------------------
+# Triggers: node-backed entities must not carry their own access tags
+# ---------------------------------------------------------------------------
+
+
+def _create_entity_tag_triggers(connection):
+    """Create the delegation-invariant triggers, mirroring tiled.graph.orm."""
+    dialect_name = connection.engine.dialect.name
+    if dialect_name == "sqlite":
+        connection.execute(
+            sa.text(
+                f"""
+CREATE TRIGGER entities_node_access_tags_update
+BEFORE UPDATE OF node_id ON entities
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_tags WHERE entity_id = NEW.id
+))
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_TAGS_ERROR}');
+END"""
+            )
+        )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entity_access_tags_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_tags
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_TAGS_ERROR}');
+END"""
+                )
+            )
+    elif dialect_name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute, so
+        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
+        # PostgreSQL does not allow subqueries in a trigger WHEN clause, so
+        # the EXISTS checks live in the function bodies.
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_tags()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM entity_access_tags WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_TAGS_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entities_node_access_tags_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW
+WHEN (NEW.node_id IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_tags();"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION entity_access_tags_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_TAGS_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entity_access_tags_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_tags
+FOR EACH ROW EXECUTE FUNCTION entity_access_tags_reject_node_backed_entity();"""
+            )
+        )
+
+
+def _drop_entity_tag_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    if dialect_name == "sqlite":
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS entities_node_access_tags_update")
+        )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS entity_access_tags_{operation}_reject_node_backed_entity"
+                )
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entities_node_access_tags_check ON entities"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entity_access_tags_reject_node_backed_entity "
+                "ON entity_access_tags"
+            )
+        )
+        for function in (
+            "entities_reject_node_access_tags",
+            "entity_access_tags_reject_node_backed_entity",
+        ):
+            connection.execute(sa.text(f"DROP FUNCTION IF EXISTS {function}"))
+
+
+# ---------------------------------------------------------------------------
+# Blob-era triggers (recreated on downgrade; dropped on upgrade). These are
+# copied verbatim from revision de302a096358 so that a downgraded database is
+# indistinguishable from one sitting at that revision.
+# ---------------------------------------------------------------------------
+
+BLOB_ASSOC_TABLES = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+ENTITY_NODE_ACCESS_BLOB_ERROR = (
+    "An entity with node_id set must not have its own access_blob; "
+    "access is controlled by the referenced node."
+)
+
+
+def _create_blob_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    if dialect_name == "sqlite":
+        for table in BLOB_ASSOC_TABLES:
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+                )
+            )
+            others = " OR ".join(
+                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
+                for other in BLOB_ASSOC_TABLES
+                if other != table
+            )
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    sa.text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN {others}
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
+END"""
+                    )
+                )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_blobs
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+                )
+            )
+        connection.execute(
+            sa.text(
+                f"""
+CREATE TRIGGER entities_node_access_blob_update
+BEFORE UPDATE OF node_id ON entities
+WHEN NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+            )
+        )
+    elif dialect_name == "postgresql":
+        for table in BLOB_ASSOC_TABLES:
+            singular = table.replace("_access_blobs", "")
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE OR REPLACE FUNCTION delete_{singular}_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;"""
+                )
+            )
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        for table in BLOB_ASSOC_TABLES:
+            singular = table.replace("_access_blobs", "")
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+FOR EACH ROW EXECUTE FUNCTION delete_{singular}_access_blob();"""
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
+                )
+            )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entities_node_access_blob_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
+            )
+        )
+
+
+def _drop_blob_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    if dialect_name == "sqlite":
+        for table in BLOB_ASSOC_TABLES:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup")
+            )
+            for operation in ("insert", "update"):
+                connection.execute(
+                    sa.text(
+                        f"DROP TRIGGER IF EXISTS {table}_{operation}_reject_shared_access_blob"
+                    )
+                )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS entity_access_blobs_{operation}_reject_node_backed_entity"
+                )
+            )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS entities_node_access_blob_update")
+        )
+    elif dialect_name == "postgresql":
+        for table in BLOB_ASSOC_TABLES:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup ON {table}")
+            )
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
+                )
+            )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entity_access_blobs_reject_node_backed_entity "
+                "ON entity_access_blobs"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entities_node_access_blob_check ON entities"
+            )
+        )
+        for function in (
+            "delete_node_access_blob",
+            "delete_entity_access_blob",
+            "delete_link_access_blob",
+            "reject_shared_access_blob",
+            "entities_reject_node_access_blob",
+            "entity_access_blob_reject_node_backed_entity",
+        ):
+            connection.execute(sa.text(f"DROP FUNCTION IF EXISTS {function}"))
+
+
+# ---------------------------------------------------------------------------
+# upgrade / downgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+
+    _create_tag_tables()
+    _populate_tags_from_blobs(connection)
+
+    # The blob-era delete-cleanup triggers on the association tables would
+    # cascade into access_blobs while the association tables are dropped;
+    # remove all blob triggers (and, on PostgreSQL, their functions) first.
+    _drop_blob_triggers(connection)
+    op.drop_table("node_access_blobs")
+    op.drop_table("entity_access_blobs")
+    op.drop_table("link_access_blobs")
+    # Dropping access_blobs also drops its indexes (ix_access_blobs_username_user,
+    # ix_access_blobs_kind_id, and on PostgreSQL ix_access_blobs_tags_gin).
+    op.drop_table("access_blobs")
+    if dialect_name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS access_kind")
+
+    _create_entity_tag_triggers(connection)
+
+
+def downgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+
+    _drop_entity_tag_triggers(connection)
+
+    # Recreate the blob tables exactly as revision de302a096358 created them.
+    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
+        sa.ARRAY(sa.String()), "postgresql"
+    )
+    op.create_table(
+        "access_blobs",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("kind", sa.Enum("user", "tags", name="access_kind"), nullable=False),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("tags", access_tags_variant, nullable=True),
+        sa.CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
+    )
+    op.create_index(
+        "ix_access_blobs_username_user",
+        "access_blobs",
+        ["username"],
+        sqlite_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+        postgresql_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+    )
+    op.create_index("ix_access_blobs_kind_id", "access_blobs", ["kind", "id"])
+    op.create_table(
+        "node_access_blobs",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
+    op.create_table(
+        "link_access_blobs",
+        sa.Column(
+            "link_id",
+            sa.String(),
+            sa.ForeignKey("links.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
+    op.create_table(
+        "entity_access_blobs",
+        sa.Column(
+            "entity_id",
+            sa.String(),
+            sa.ForeignKey("entities.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
+    if dialect_name == "postgresql":
+        op.create_index(
+            "ix_access_blobs_tags_gin",
+            "access_blobs",
+            ["tags"],
+            postgresql_using="gin",
+            postgresql_where=sa.text("kind = 'tags' AND tags IS NOT NULL"),
+        )
+
+    # Reconstruct blobs before dropping the tag tables. Every node and link
+    # owns a blob in the blob world; entities only when standalone (an entity
+    # with node_id set delegates access control to the referenced node).
+    _reconstruct_blobs_from_tags(
+        connection, "nodes", "node_access_tags", "node_id", "node_access_blobs"
+    )
+    _reconstruct_blobs_from_tags(
+        connection,
+        "entities",
+        "entity_access_tags",
+        "entity_id",
+        "entity_access_blobs",
+        where="WHERE owner_table.node_id IS NULL",
+    )
+    _reconstruct_blobs_from_tags(
+        connection, "links", "link_access_tags", "link_id", "link_access_blobs"
+    )
+
+    _create_blob_triggers(connection)
+
+    _drop_tag_tables()

--- a/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
+++ b/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
@@ -65,14 +65,10 @@ OWNERS = (
 def _create_tag_tables():
     """Create the tag tables and indexes, mirroring tiled.catalog.orm and
     tiled.graph.orm exactly."""
+    # Column order matters for parity with create_all: the Timestamped mixin
+    # columns come last in the ORM-rendered DDL.
     op.create_table(
         "access_tags",
-        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
-        sa.Column(
-            "time_updated",
-            sa.DateTime(),
-            server_default=sa.func.now(),
-        ),
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
         sa.Column(
@@ -81,6 +77,8 @@ def _create_tag_tables():
             nullable=False,
             server_default=sa.text("false"),
         ),
+        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("time_updated", sa.DateTime(), server_default=sa.func.now()),
     )
     # Partial + covering, matching the ORM: index-only scan for
     # "SELECT name WHERE is_public", zero maintenance for non-public rows.
@@ -172,10 +170,10 @@ def _create_tag_tables():
     # first time by the access tags compiler, never by this migration.
     op.create_table(
         "access_tags_principals",
-        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
-        sa.Column("time_updated", sa.DateTime(), server_default=sa.func.now()),
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
+        sa.Column("time_created", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("time_updated", sa.DateTime(), server_default=sa.func.now()),
     )
     op.create_table(
         "scopes",

--- a/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
+++ b/tiled/catalog/migrations/versions/3bc110ce44e9_convert_access_blobs_to_access_tags.py
@@ -44,6 +44,30 @@ down_revision = "de302a096358"
 branch_labels = None
 depends_on = None
 
+# The scopes.name column is a native enum (scope_name on PostgreSQL). The
+# values are frozen here at this revision's authorship; the live set of valid
+# scopes is the ScopeName enum in tiled.access_control.scopes, but migrations
+# must not import application code that may change out from under them.
+SCOPE_NAME_ENUM = sa.Enum(
+    "read:metadata",
+    "read:data",
+    "write:metadata",
+    "write:data",
+    "delete:revision",
+    "delete:node",
+    "create:node",
+    "register",
+    "metrics",
+    "create:apikeys",
+    "revoke:apikeys",
+    "admin:apikeys",
+    "read:principals",
+    "write:principals",
+    "read:webhooks",
+    "write:webhooks",
+    name="scope_name",
+)
+
 ENTITY_NODE_ACCESS_TAGS_ERROR = (
     "An entity with node_id set must not have its own access tags; "
     "access is controlled by the referenced node."
@@ -178,7 +202,7 @@ def _create_tag_tables():
     op.create_table(
         "scopes",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
-        sa.Column("name", sa.Unicode(255), nullable=False, unique=True),
+        sa.Column("name", SCOPE_NAME_ENUM, nullable=False, unique=True),
     )
     op.create_table(
         "access_tag_principal_scopes",
@@ -968,3 +992,5 @@ def downgrade():
     _create_blob_triggers(connection)
 
     _drop_tag_tables()
+    if dialect_name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS scope_name")

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -311,21 +311,33 @@ def downgrade():
     dialect_name = connection.engine.dialect.name
 
     if dialect_name == "sqlite":
-        connection.execute(sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup"))
-        connection.execute(sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup"))
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup")
+        )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup")
+        )
         for table in ("node_access_blobs", "link_access_blobs"):
             connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob")
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob"
+                )
             )
             connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob")
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob"
+                )
             )
     elif dialect_name == "postgresql":
         connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs")
+            sa.text(
+                "DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs"
+            )
         )
         connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs")
+            sa.text(
+                "DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs"
+            )
         )
         for table in ("node_access_blobs", "link_access_blobs"):
             connection.execute(
@@ -333,7 +345,9 @@ def downgrade():
                     f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
                 )
             )
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob"))
+        connection.execute(
+            sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob")
+        )
         connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
         connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
         connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -5,8 +5,6 @@ Revises: c31f6a1d7e20
 Create Date: 2026-07-03 14:27:39.197261
 
 """
-import json
-
 import sqlalchemy as sa
 from alembic import op
 
@@ -22,48 +20,115 @@ depends_on = None
 def _copy_access_blobs(
     connection, source_table, association_table, owner_column, where=""
 ):
-    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
-        sa.ARRAY(sa.String()), "postgresql"
+    """Convert a JSON ``access_blob`` column into ``access_blobs`` rows plus an
+    association row per owner, using set-based SQL so the migration scales to
+    very large catalogs.
+
+    Correlation between a newly inserted ``access_blobs`` row and its owner is
+    done through a temporary ``_migrate_owner`` column (dropped at the end),
+    which avoids needing per-row ``RETURNING``.
+
+    * a blob containing a ``"user"`` key becomes ``kind='user'``;
+    * otherwise ``kind='tags'`` with ``tags`` taken from the ``"tags"`` key,
+      defaulting to an empty list;
+    * the root node (``nodes.id = 0``) with an empty blob or ``tags == []`` is
+      promoted to ``{"tags": ["public"]}``.
+    """
+    dialect_name = connection.engine.dialect.name
+
+    # Add a temporary column to correlate each access_blobs row to its owner.
+    owner_type = "INTEGER" if owner_column == "node_id" else "VARCHAR"
+    connection.execute(
+        sa.text(f"ALTER TABLE access_blobs ADD COLUMN _migrate_owner {owner_type}")
     )
-    access_blobs = sa.table(
-        "access_blobs",
-        sa.column("id", sa.Integer),
-        sa.column("kind", sa.Enum("user", "tags", name="access_kind")),
-        sa.column("username", sa.String),
-        sa.column("tags", access_tags_variant),
-    )
-    associations = sa.table(
-        association_table,
-        sa.column(owner_column),
-        sa.column("access_blob_id", sa.Integer),
-    )
-    rows = connection.execute(
-        sa.text(f"SELECT id, access_blob FROM {source_table} {where}")
-    )
-    for row in rows:
-        access_blob = row.access_blob
-        if isinstance(access_blob, str):
-            access_blob = json.loads(access_blob)
-        access_blob = access_blob or {}
-        if (
-            source_table == "nodes"
-            and row.id == 0
-            and (not access_blob or access_blob.get("tags") == [])
-        ):
-            access_blob = {"tags": ["public"]}
-        values = (
-            {"kind": "user", "username": access_blob["user"], "tags": None}
-            if "user" in access_blob
-            else {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
-        )
-        access_blob_id = connection.execute(
-            access_blobs.insert().values(**values).returning(access_blobs.c.id)
-        ).scalar_one()
-        connection.execute(
-            associations.insert().values(
-                **{owner_column: row.id, "access_blob_id": access_blob_id}
+
+    # Per-dialect JSON extraction. Both branches must yield, per source row:
+    #   kind      -> 'user' when a "user" key is present, else 'tags'
+    #   username  -> the "user" value when kind='user', else NULL
+    #   tags      -> the "tags" array when kind='tags', else NULL
+    # honoring the root-node "public" promotion and (for entities) the
+    # caller-supplied WHERE clause that skips node-delegated rows.
+    root_public = source_table == "nodes"
+    if dialect_name == "sqlite":
+        # In SQLite the column is TEXT; treat SQL NULL / JSON 'null' as '{}'.
+        blob = "COALESCE(NULLIF(access_blob, 'null'), '{}')"
+        has_user = f"json_extract({blob}, '$.user') IS NOT NULL"
+        user_val = f"json_extract({blob}, '$.user')"
+        # json_extract of a missing/absent "tags" yields NULL; default to [].
+        tags_val = f"COALESCE(json_extract({blob}, '$.tags'), json('[]'))"
+        if root_public:
+            # Root node with empty tags or empty blob -> ["public"].
+            is_empty_root = (
+                f"id = 0 AND ("
+                f"json_extract({blob}, '$.user') IS NULL AND ("
+                f"json_extract({blob}, '$.tags') IS NULL OR "
+                f"json_array_length(json_extract({blob}, '$.tags')) = 0))"
             )
+            tags_val = (
+                f"CASE WHEN {is_empty_root} THEN json('[\"public\"]') "
+                f"ELSE {tags_val} END"
+            )
+        kind_expr = f"CASE WHEN {has_user} THEN 'user' ELSE 'tags' END"
+        username_expr = f"CASE WHEN {has_user} THEN {user_val} ELSE NULL END"
+        tags_expr = f"CASE WHEN {has_user} THEN NULL ELSE {tags_val} END"
+    elif dialect_name == "postgresql":
+        # nodes.access_blob is jsonb but the c31-era entities/links access_blob
+        # columns are plain json; cast so COALESCE unifies on jsonb either way.
+        blob = "COALESCE(access_blob::jsonb, '{}'::jsonb)"
+        has_user = f"({blob} ? 'user')"
+        user_val = f"{blob} ->> 'user'"
+        # Build a text[] from the JSON "tags" array; default to empty array.
+        tags_val = (
+            f"COALESCE("
+            f"ARRAY(SELECT jsonb_array_elements_text({blob} -> 'tags')), "
+            f"ARRAY[]::varchar[])"
         )
+        if root_public:
+            is_empty_root = (
+                f"id = 0 AND NOT ({blob} ? 'user') AND ("
+                f"NOT ({blob} ? 'tags') OR "
+                f"jsonb_array_length(COALESCE({blob} -> 'tags', '[]'::jsonb)) = 0)"
+            )
+            tags_val = (
+                f"CASE WHEN {is_empty_root} THEN ARRAY['public']::varchar[] "
+                f"ELSE {tags_val} END"
+            )
+        # The CASE yields text; the target column is the access_kind enum and
+        # INSERT ... SELECT does not implicitly cast, so cast explicitly.
+        kind_expr = f"(CASE WHEN {has_user} THEN 'user' ELSE 'tags' END)::access_kind"
+        username_expr = f"CASE WHEN {has_user} THEN {user_val} ELSE NULL END"
+        # Likewise cast to the column's varchar[] type: jsonb_array_elements_text
+        # produces text[], and mixed CASE/COALESCE branches resolve to text[].
+        tags_expr = f"(CASE WHEN {has_user} THEN NULL ELSE {tags_val} END)::varchar[]"
+    else:
+        raise RuntimeError(f"Unsupported dialect for migration: {dialect_name}")
+
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO access_blobs (kind, username, tags, _migrate_owner)
+SELECT {kind_expr}, {username_expr}, {tags_expr}, id
+FROM {source_table}
+{where}
+"""
+        )
+    )
+    connection.execute(
+        sa.text(
+            f"""
+INSERT INTO {association_table} ({owner_column}, access_blob_id)
+SELECT _migrate_owner, id
+FROM access_blobs
+WHERE _migrate_owner IS NOT NULL
+"""
+        )
+    )
+    # Drop the temporary correlation column now that associations are populated.
+    # Use a native ALTER rather than Alembic's batch mode, which would rebuild
+    # the access_blobs table and disturb the foreign keys the association tables
+    # hold against it.
+    # ALTER TABLE ... DROP COLUMN requires SQLite >= 3.35 (2021).
+    connection.execute(sa.text("ALTER TABLE access_blobs DROP COLUMN _migrate_owner"))
 
 
 def _restore_access_blobs(
@@ -100,7 +165,9 @@ def _restore_access_blobs(
                     SELECT CASE
                         WHEN access_blobs.kind = 'user' THEN
                             json_object('user', access_blobs.username)
-                        ELSE json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                        ELSE json_object(
+                            'tags', json(COALESCE(access_blobs.tags, '[]'))
+                        )
                     END FROM {source_table}
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
@@ -117,7 +184,7 @@ def _create_association_triggers(connection):
     dialect_name = connection.engine.dialect.name
     tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
     error_message = (
-        "An entity with node_id set must not have its own access blob; "
+        "An entity with node_id set must not have its own access_blob; "
         "access is controlled by the referenced node."
     )
     if dialect_name == "sqlite":
@@ -161,35 +228,47 @@ BEGIN
 END"""
                 )
             )
-        for operation in ("INSERT", "UPDATE OF node_id"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER entities_node_access_blob_{operation.split()[0].lower()}
-BEFORE {operation} ON entities
+        # Only guard UPDATE OF node_id: the INSERT case cannot occur in a
+        # single statement (an entities INSERT sets only node_id, while the
+        # blob lives in a separate entity_access_blobs row guarded by
+        # entity_access_blobs_insert_reject_node_backed_entity). This mirrors
+        # the PostgreSQL branch and tiled.graph.orm's create_all path.
+        connection.execute(
+            sa.text(
+                f"""
+CREATE TRIGGER entities_node_access_blob_update
+BEFORE UPDATE OF node_id ON entities
 WHEN NEW.node_id IS NOT NULL AND EXISTS (
     SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
 )
 BEGIN
     SELECT RAISE(ABORT, '{error_message}');
 END"""
-                )
             )
+        )
     elif dialect_name == "postgresql":
         # asyncpg cannot run multiple statements in one prepared execute, so
         # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
+        # One cleanup function per association table, matching the objects
+        # created by the create_all path (node's lives in tiled.catalog.orm,
+        # entity's and link's in tiled.graph.orm). Keeping them per-table -
+        # rather than a single shared function - keeps each feature's DDL
+        # self-contained and avoids graph objects depending on a catalog-owned
+        # function (or vice versa).
+        for table in tables:
+            singular = table.replace("_access_blobs", "")
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE OR REPLACE FUNCTION delete_{singular}_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;"""
+                )
             )
-        )
         connection.execute(
             sa.text(
                 """
@@ -213,13 +292,22 @@ END;
 $$ LANGUAGE plpgsql;"""
             )
         )
+        # PostgreSQL does not allow subqueries in a trigger WHEN clause
+        # ("cannot use subquery in trigger WHEN condition"), so the EXISTS
+        # check against entity_access_blobs lives in the function body; the
+        # trigger WHEN clause keeps only the cheap scalar column test.
         connection.execute(
             sa.text(
                 f"""
 CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
-    RAISE EXCEPTION '{error_message}';
+    IF EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{error_message}';
+    END IF;
+    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;"""
             )
@@ -239,12 +327,13 @@ $$ LANGUAGE plpgsql;"""
             )
         )
         for table in tables:
+            singular = table.replace("_access_blobs", "")
             connection.execute(
                 sa.text(
                     f"""
 CREATE TRIGGER {table}_delete_cleanup
 AFTER DELETE ON {table}
-FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();"""
+FOR EACH ROW EXECUTE FUNCTION delete_{singular}_access_blob();"""
                 )
             )
             connection.execute(
@@ -268,9 +357,7 @@ FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
                 """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE UPDATE OF node_id ON entities
-FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL)
 EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
@@ -296,10 +383,9 @@ def _drop_association_triggers(connection):
                     f"DROP TRIGGER IF EXISTS entity_access_blobs_{operation}_reject_node_backed_entity"
                 )
             )
-        for operation in ("insert", "update"):
-            connection.execute(
-                sa.text(f"DROP TRIGGER IF EXISTS entities_node_access_blob_{operation}")
-            )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS entities_node_access_blob_update")
+        )
     elif dialect_name == "postgresql":
         for table in tables:
             connection.execute(
@@ -321,7 +407,9 @@ def _drop_association_triggers(connection):
             )
         )
         for function in (
-            "delete_orphaned_access_blob",
+            "delete_node_access_blob",
+            "delete_entity_access_blob",
+            "delete_link_access_blob",
             "reject_shared_access_blob",
             "entities_reject_node_access_blob",
             "entity_access_blob_reject_node_backed_entity",
@@ -453,6 +541,11 @@ def upgrade():
         batch_op.drop_column("access_blob")
     with op.batch_alter_table("entities") as batch_op:
         batch_op.drop_column("access_blob")
+    # The Revision model no longer tracks access_blob; drop the column so that
+    # inserting a revision (on metadata update) does not violate its former
+    # NOT NULL constraint now that the ORM stops populating it.
+    with op.batch_alter_table("revisions") as batch_op:
+        batch_op.drop_column("access_blob")
     op.create_index(
         "top_level_metadata",
         "nodes",
@@ -467,6 +560,15 @@ def downgrade():
     dialect_name = connection.engine.dialect.name
 
     _drop_association_triggers(connection)
+
+    # Restore the revisions.access_blob column dropped on upgrade. The former
+    # data is not recoverable (revisions no longer carried it), so recreate it
+    # with the same NOT NULL + server_default('{}') shape as migration
+    # a963a6c32a0c, which is what a database at that revision would have.
+    with op.batch_alter_table("revisions") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
 
     with op.batch_alter_table("entities") as batch_op:
         batch_op.add_column(sa.Column("access_blob", JSONVariant, nullable=True))

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,10 +1,12 @@
-"""Convert access_blob column to assoc. table
+"""Convert node and link access_blob columns to assoc. tables
 
 Revision ID: de302a096358
-Revises: b93c79d197f4
+Revises: c31f6a1d7e20
 Create Date: 2026-07-03 14:27:39.197261
 
 """
+import json
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -12,25 +14,111 @@ from tiled.catalog.orm import JSONVariant
 
 # revision identifiers, used by Alembic.
 revision = "de302a096358"
-down_revision = "b93c79d197f4"
+down_revision = "c31f6a1d7e20"
 branch_labels = None
 depends_on = None
+
+
+def _copy_access_blobs(connection, source_table, association_table, owner_column):
+    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
+        sa.ARRAY(sa.String()), "postgresql"
+    )
+    access_blobs = sa.table(
+        "access_blobs",
+        sa.column("id", sa.Integer),
+        sa.column("kind", sa.Enum("user", "tags", name="access_kind")),
+        sa.column("username", sa.String),
+        sa.column("tags", access_tags_variant),
+    )
+    associations = sa.table(
+        association_table,
+        sa.column(owner_column),
+        sa.column("access_blob_id", sa.Integer),
+    )
+    rows = connection.execute(sa.text(f"SELECT id, access_blob FROM {source_table}"))
+    for row in rows:
+        access_blob = row.access_blob
+        if isinstance(access_blob, str):
+            access_blob = json.loads(access_blob)
+        access_blob = access_blob or {}
+        if (
+            source_table == "nodes"
+            and row.id == 0
+            and (not access_blob or access_blob.get("tags") == [])
+        ):
+            access_blob = {"tags": ["public"]}
+        values = (
+            {"kind": "user", "username": access_blob["user"], "tags": None}
+            if "user" in access_blob
+            else {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
+        )
+        access_blob_id = connection.execute(
+            access_blobs.insert().values(**values).returning(access_blobs.c.id)
+        ).scalar_one()
+        connection.execute(
+            associations.insert().values(
+                **{owner_column: row.id, "access_blob_id": access_blob_id}
+            )
+        )
+
+
+def _restore_access_blobs(dialect_name, source_table, id_column, destination_table):
+    if dialect_name == "postgresql":
+        op.execute(
+            f"""
+            UPDATE {destination_table}
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            jsonb_build_object('user', access_blobs.username)
+                        ELSE jsonb_build_object(
+                            'tags', to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
+                        )
+                    END FROM {source_table}
+                    JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
+                    WHERE {source_table}.{id_column} = {destination_table}.id
+                ),
+                '{{}}'::jsonb
+            )
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            f"""
+            UPDATE {destination_table}
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            json_object('user', access_blobs.username)
+                        ELSE json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                    END FROM {source_table}
+                    JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
+                    WHERE {source_table}.{id_column} = {destination_table}.id
+                ),
+                json('{{}}')
+            )
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
 
 
 def upgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
-    access_tags_variant = sa.JSON().with_variant(sa.ARRAY(sa.String()), "postgresql")
+    access_tags_variant = sa.JSON(none_as_null=True).with_variant(
+        sa.ARRAY(sa.String()), "postgresql"
+    )
 
     op.create_table(
         "access_blobs",
         sa.Column(
-            "node_id",
+            "id",
             sa.Integer(),
-            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
             nullable=False,
             primary_key=True,
-            unique=True,
         ),
         sa.Column("kind", sa.Enum("user", "tags", name="access_kind"), nullable=False),
         sa.Column("username", sa.String(), nullable=True),
@@ -49,9 +137,44 @@ def upgrade():
         postgresql_where=sa.text("kind = 'user' AND username IS NOT NULL"),
     )
     op.create_index(
-        "ix_access_blobs_kind_node_id",
+        "ix_access_blobs_kind_id",
         "access_blobs",
-        ["kind", "node_id"],
+        ["kind", "id"],
+    )
+
+    op.create_table(
+        "node_access_blobs",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
+    op.create_table(
+        "link_access_blobs",
+        sa.Column(
+            "link_id",
+            sa.String(),
+            sa.ForeignKey("links.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
     )
     if dialect_name == "postgresql":
         op.create_index(
@@ -61,49 +184,116 @@ def upgrade():
             postgresql_using="gin",
             postgresql_where=sa.text("kind = 'tags' AND tags IS NOT NULL"),
         )
+    _copy_access_blobs(connection, "nodes", "node_access_blobs", "node_id")
+    _copy_access_blobs(connection, "links", "link_access_blobs", "link_id")
 
-    if dialect_name == "postgresql":
-        op.execute(
-            """
-            INSERT INTO access_blobs (node_id, kind, username, tags)
-            SELECT
-                id AS node_id,
-                CASE
-                    WHEN access_blob ? 'user' THEN 'user'::access_kind
-                    ELSE 'tags'::access_kind
-                END AS kind,
-                access_blob ->> 'user' AS username,
-                CASE
-                    WHEN access_blob ? 'user' THEN NULL
-                    WHEN access_blob ? 'tags' THEN ARRAY(
-                        SELECT jsonb_array_elements_text(access_blob -> 'tags')
-                    )::varchar[]
-                    ELSE ARRAY[]::varchar[]
-                END AS tags
-            FROM nodes
-            """
+    if dialect_name == "sqlite":
+        for association_table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {association_table}_delete_cleanup
+AFTER DELETE ON {association_table}
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+                )
+            )
+        for table, other_table in (
+            ("node_access_blobs", "link_access_blobs"),
+            ("link_access_blobs", "node_access_blobs"),
+        ):
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    sa.text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
+END"""
+                    )
+                )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION delete_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
         )
-    elif dialect_name == "sqlite":
-        op.execute(
-            """
-            INSERT INTO access_blobs (node_id, kind, username, tags)
-            SELECT
-                id AS node_id,
-                CASE
-                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN 'user'
-                    ELSE 'tags'
-                END AS kind,
-                json_extract(access_blob, '$.user') AS username,
-                CASE
-                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN NULL
-                    WHEN json_type(access_blob, '$.tags') IS NOT NULL THEN json_extract(access_blob, '$.tags')
-                    ELSE json('[]')
-                END AS tags
-            FROM nodes
-            """
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
+"""
+            )
         )
-    else:
-        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION delete_link_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
+"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
+"""
+                )
+            )
+
+    with op.batch_alter_table("links") as batch_op:
+        batch_op.drop_column("access_blob")
 
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
@@ -120,6 +310,43 @@ def downgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
 
+    if dialect_name == "sqlite":
+        connection.execute(sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup"))
+        connection.execute(sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup"))
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob")
+            )
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob")
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs")
+        )
+        connection.execute(
+            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs")
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
+                )
+            )
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
+        connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))
+
+    with op.batch_alter_table("links") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
+
+    _restore_access_blobs(dialect_name, "link_access_blobs", "link_id", "links")
+
+    op.drop_table("link_access_blobs")
+
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
         batch_op.add_column(
@@ -132,52 +359,9 @@ def downgrade():
         postgresql_using="gin",
     )
 
-    if dialect_name == "postgresql":
-        op.execute(
-            """
-            UPDATE nodes
-            SET access_blob = COALESCE(
-                (
-                    SELECT CASE
-                        WHEN access_blobs.kind = 'user' THEN
-                            jsonb_build_object('user', access_blobs.username)
-                        WHEN access_blobs.kind = 'tags' THEN
-                            jsonb_build_object(
-                                'tags',
-                                to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
-                            )
-                        ELSE '{}'::jsonb
-                    END
-                    FROM access_blobs
-                    WHERE access_blobs.node_id = nodes.id
-                ),
-                '{}'::jsonb
-            )
-            """
-        )
-    elif dialect_name == "sqlite":
-        op.execute(
-            """
-            UPDATE nodes
-            SET access_blob = COALESCE(
-                (
-                    SELECT CASE
-                        WHEN access_blobs.kind = 'user' THEN
-                            json_object('user', access_blobs.username)
-                        WHEN access_blobs.kind = 'tags' THEN
-                            json_object('tags', COALESCE(access_blobs.tags, json('[]')))
-                        ELSE json('{}')
-                    END
-                    FROM access_blobs
-                    WHERE access_blobs.node_id = nodes.id
-                ),
-                json('{}')
-            )
-            """
-        )
-    else:
-        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+    _restore_access_blobs(dialect_name, "node_access_blobs", "node_id", "nodes")
 
+    op.drop_table("node_access_blobs")
     op.drop_table("access_blobs")
     if dialect_name == "postgresql":
         op.execute("DROP TYPE IF EXISTS access_kind")

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -91,7 +91,7 @@ def _restore_access_blobs(
             """
         )
     elif dialect_name == "sqlite":
-        fallback = "json('{{}}')" if default_empty else "NULL"
+        fallback = "json('{}')" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -176,16 +176,23 @@ END"""
                 )
             )
     elif dialect_name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute, so
+        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
         connection.execute(
             sa.text(
-                f"""
+                """
 CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -203,13 +210,23 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
 CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '{error_message}';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                f"""
 CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -227,7 +244,12 @@ $$ LANGUAGE plpgsql;"""
                     f"""
 CREATE TRIGGER {table}_delete_cleanup
 AFTER DELETE ON {table}
-FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();
+FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();"""
+                )
+            )
+            connection.execute(
+                sa.text(
+                    f"""
 CREATE TRIGGER {table}_reject_shared_access_blob
 BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
 FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
@@ -238,7 +260,12 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
                 """
 CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
 BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE UPDATE OF node_id ON entities
 FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
@@ -471,6 +498,7 @@ END"""
                 )
             )
     elif dialect_name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute.
         connection.execute(
             sa.text(
                 f"""
@@ -479,7 +507,12 @@ RETURNS TRIGGER AS $$
 BEGIN
     RAISE EXCEPTION '{error_message}';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
 CREATE TRIGGER entities_node_access_blob_check
 BEFORE INSERT OR UPDATE ON entities
 FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,7 +1,7 @@
 """Convert access_blob column to assoc. table
 
 Revision ID: de302a096358
-Revises: e8956581ecd5
+Revises: b93c79d197f4
 Create Date: 2026-07-03 14:27:39.197261
 
 """
@@ -12,7 +12,7 @@ from tiled.catalog.orm import JSONVariant
 
 # revision identifiers, used by Alembic.
 revision = "de302a096358"
-down_revision = "e8956581ecd5"
+down_revision = "b93c79d197f4"
 branch_labels = None
 depends_on = None
 

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,0 +1,163 @@
+"""Convert access_blob column to assoc. table
+
+Revision ID: de302a096358
+Revises: e8956581ecd5
+Create Date: 2026-07-03 14:27:39.197261
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.catalog.orm import JSONVariant
+
+# revision identifiers, used by Alembic.
+revision = "de302a096358"
+down_revision = "e8956581ecd5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+    access_tags_variant = sa.JSON().with_variant(sa.ARRAY(sa.String()), "postgresql")
+
+    op.create_table(
+        "access_blobs",
+        sa.Column(
+            "node_id",
+            sa.Integer(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+            unique=True,
+        ),
+        sa.Column("kind", sa.Enum("user", "tags", name="access_kind"), nullable=False),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("tags", access_tags_variant, nullable=True),
+        sa.CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
+    )
+
+    if dialect_name == "postgresql":
+        op.execute(
+            """
+            INSERT INTO access_blobs (node_id, kind, username, tags)
+            SELECT
+                id AS node_id,
+                CASE
+                    WHEN access_blob ? 'user' THEN 'user'::access_kind
+                    ELSE 'tags'::access_kind
+                END AS kind,
+                access_blob ->> 'user' AS username,
+                CASE
+                    WHEN access_blob ? 'user' THEN NULL
+                    WHEN access_blob ? 'tags' THEN ARRAY(
+                        SELECT jsonb_array_elements_text(access_blob -> 'tags')
+                    )::varchar[]
+                    ELSE ARRAY[]::varchar[]
+                END AS tags
+            FROM nodes
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            """
+            INSERT INTO access_blobs (node_id, kind, username, tags)
+            SELECT
+                id AS node_id,
+                CASE
+                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN 'user'
+                    ELSE 'tags'
+                END AS kind,
+                json_extract(access_blob, '$.user') AS username,
+                CASE
+                    WHEN json_type(access_blob, '$.user') IS NOT NULL THEN NULL
+                    WHEN json_type(access_blob, '$.tags') IS NOT NULL THEN json_extract(access_blob, '$.tags')
+                    ELSE json('[]')
+                END AS tags
+            FROM nodes
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+    op.drop_index("top_level_metadata", table_name="nodes")
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.drop_column("access_blob")
+    op.create_index(
+        "top_level_metadata",
+        "nodes",
+        ["parent", "time_created", "id", "metadata"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+    dialect_name = connection.engine.dialect.name
+
+    op.drop_index("top_level_metadata", table_name="nodes")
+    with op.batch_alter_table("nodes") as batch_op:
+        batch_op.add_column(
+            sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}")
+        )
+    op.create_index(
+        "top_level_metadata",
+        "nodes",
+        ["parent", "time_created", "id", "metadata", "access_blob"],
+        postgresql_using="gin",
+    )
+
+    if dialect_name == "postgresql":
+        op.execute(
+            """
+            UPDATE nodes
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            jsonb_build_object('user', access_blobs.username)
+                        WHEN access_blobs.kind = 'tags' THEN
+                            jsonb_build_object(
+                                'tags',
+                                to_jsonb(COALESCE(access_blobs.tags, ARRAY[]::varchar[]))
+                            )
+                        ELSE '{}'::jsonb
+                    END
+                    FROM access_blobs
+                    WHERE access_blobs.node_id = nodes.id
+                ),
+                '{}'::jsonb
+            )
+            """
+        )
+    elif dialect_name == "sqlite":
+        op.execute(
+            """
+            UPDATE nodes
+            SET access_blob = COALESCE(
+                (
+                    SELECT CASE
+                        WHEN access_blobs.kind = 'user' THEN
+                            json_object('user', access_blobs.username)
+                        WHEN access_blobs.kind = 'tags' THEN
+                            json_object('tags', COALESCE(access_blobs.tags, json('[]')))
+                        ELSE json('{}')
+                    END
+                    FROM access_blobs
+                    WHERE access_blobs.node_id = nodes.id
+                ),
+                json('{}')
+            )
+            """
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+    op.drop_table("access_blobs")
+    if dialect_name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS access_kind")

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -1,4 +1,4 @@
-"""Convert node and link access_blob columns to assoc. tables
+"""Convert node, entity, and link access_blob columns to assoc. tables
 
 Revision ID: de302a096358
 Revises: c31f6a1d7e20
@@ -19,7 +19,9 @@ branch_labels = None
 depends_on = None
 
 
-def _copy_access_blobs(connection, source_table, association_table, owner_column):
+def _copy_access_blobs(
+    connection, source_table, association_table, owner_column, where=""
+):
     access_tags_variant = sa.JSON(none_as_null=True).with_variant(
         sa.ARRAY(sa.String()), "postgresql"
     )
@@ -35,7 +37,9 @@ def _copy_access_blobs(connection, source_table, association_table, owner_column
         sa.column(owner_column),
         sa.column("access_blob_id", sa.Integer),
     )
-    rows = connection.execute(sa.text(f"SELECT id, access_blob FROM {source_table}"))
+    rows = connection.execute(
+        sa.text(f"SELECT id, access_blob FROM {source_table} {where}")
+    )
     for row in rows:
         access_blob = row.access_blob
         if isinstance(access_blob, str):
@@ -62,8 +66,11 @@ def _copy_access_blobs(connection, source_table, association_table, owner_column
         )
 
 
-def _restore_access_blobs(dialect_name, source_table, id_column, destination_table):
+def _restore_access_blobs(
+    dialect_name, source_table, id_column, destination_table, default_empty=True
+):
     if dialect_name == "postgresql":
+        fallback = "'{}'::jsonb" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -79,11 +86,12 @@ def _restore_access_blobs(dialect_name, source_table, id_column, destination_tab
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
                 ),
-                '{{}}'::jsonb
+                {fallback}
             )
             """
         )
     elif dialect_name == "sqlite":
+        fallback = "json('{{}}')" if default_empty else "NULL"
         op.execute(
             f"""
             UPDATE {destination_table}
@@ -97,12 +105,201 @@ def _restore_access_blobs(dialect_name, source_table, id_column, destination_tab
                     JOIN access_blobs ON access_blobs.id = {source_table}.access_blob_id
                     WHERE {source_table}.{id_column} = {destination_table}.id
                 ),
-                json('{{}}')
+                {fallback}
             )
             """
         )
     else:
         raise NotImplementedError(f"Unsupported dialect: {dialect_name}")
+
+
+def _create_association_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    error_message = (
+        "An entity with node_id set must not have its own access blob; "
+        "access is controlled by the referenced node."
+    )
+    if dialect_name == "sqlite":
+        for table in tables:
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+                )
+            )
+            others = " OR ".join(
+                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
+                for other in tables
+                if other != table
+            )
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    sa.text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN {others}
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
+END"""
+                    )
+                )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_blobs
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
+                )
+            )
+        for operation in ("INSERT", "UPDATE OF node_id"):
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER entities_node_access_blob_{operation.split()[0].lower()}
+BEFORE {operation} ON entities
+WHEN NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+)
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
+                )
+            )
+    elif dialect_name == "postgresql":
+        connection.execute(
+            sa.text(
+                f"""
+CREATE OR REPLACE FUNCTION delete_orphaned_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '{error_message}';
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{error_message}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        for table in tables:
+            connection.execute(
+                sa.text(
+                    f"""
+CREATE TRIGGER {table}_delete_cleanup
+AFTER DELETE ON {table}
+FOR EACH ROW EXECUTE FUNCTION delete_orphaned_access_blob();
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
+                )
+            )
+        connection.execute(
+            sa.text(
+                """
+CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+CREATE TRIGGER entities_node_access_blob_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
+            )
+        )
+
+
+def _drop_association_triggers(connection):
+    dialect_name = connection.engine.dialect.name
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    if dialect_name == "sqlite":
+        for table in tables:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup")
+            )
+            for operation in ("insert", "update"):
+                connection.execute(
+                    sa.text(
+                        f"DROP TRIGGER IF EXISTS {table}_{operation}_reject_shared_access_blob"
+                    )
+                )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS entity_access_blobs_{operation}_reject_node_backed_entity"
+                )
+            )
+        for operation in ("insert", "update"):
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS entities_node_access_blob_{operation}")
+            )
+    elif dialect_name == "postgresql":
+        for table in tables:
+            connection.execute(
+                sa.text(f"DROP TRIGGER IF EXISTS {table}_delete_cleanup ON {table}")
+            )
+            connection.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
+                )
+            )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entity_access_blobs_reject_node_backed_entity ON entity_access_blobs"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "DROP TRIGGER IF EXISTS entities_node_access_blob_check ON entities"
+            )
+        )
+        for function in (
+            "delete_orphaned_access_blob",
+            "reject_shared_access_blob",
+            "entities_reject_node_access_blob",
+            "entity_access_blob_reject_node_backed_entity",
+        ):
+            connection.execute(sa.text(f"DROP FUNCTION IF EXISTS {function}"))
 
 
 def upgrade():
@@ -176,6 +373,23 @@ def upgrade():
             unique=True,
         ),
     )
+    op.create_table(
+        "entity_access_blobs",
+        sa.Column(
+            "entity_id",
+            sa.String(),
+            sa.ForeignKey("entities.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "access_blob_id",
+            sa.Integer(),
+            sa.ForeignKey("access_blobs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+    )
     if dialect_name == "postgresql":
         op.create_index(
             "ix_access_blobs_tags_gin",
@@ -186,111 +400,23 @@ def upgrade():
         )
     _copy_access_blobs(connection, "nodes", "node_access_blobs", "node_id")
     _copy_access_blobs(connection, "links", "link_access_blobs", "link_id")
+    _copy_access_blobs(
+        connection,
+        "entities",
+        "entity_access_blobs",
+        "entity_id",
+        "WHERE access_blob IS NOT NULL",
+    )
 
+    # Replace c31's JSON-column delegation checks before dropping that column.
     if dialect_name == "sqlite":
-        for association_table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER {association_table}_delete_cleanup
-AFTER DELETE ON {association_table}
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-END"""
-                )
-            )
-        for table, other_table in (
-            ("node_access_blobs", "link_access_blobs"),
-            ("link_access_blobs", "node_access_blobs"),
-        ):
-            for operation in ("INSERT", "UPDATE OF access_blob_id"):
-                connection.execute(
-                    sa.text(
-                        f"""
-CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
-BEFORE {operation} ON {table}
-WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
-BEGIN
-    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
-END"""
-                    )
-                )
+        connection.execute(sa.text("DROP TRIGGER entities_node_access_blob_insert"))
+        connection.execute(sa.text("DROP TRIGGER entities_node_access_blob_update"))
     elif dialect_name == "postgresql":
         connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_node_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
+            sa.text("DROP TRIGGER entities_node_access_blob_check ON entities")
         )
-        connection.execute(
-            sa.text(
-                """
-CREATE TRIGGER node_access_blobs_delete_cleanup
-AFTER DELETE ON node_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION delete_link_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE TRIGGER link_access_blobs_delete_cleanup
-AFTER DELETE ON link_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
-"""
-            )
-        )
-        connection.execute(
-            sa.text(
-                """
-CREATE OR REPLACE FUNCTION reject_shared_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
-        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
-        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"""
-CREATE TRIGGER {table}_reject_shared_access_blob
-BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
-FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
-"""
-                )
-            )
+        connection.execute(sa.text("DROP FUNCTION entities_reject_node_access_blob"))
 
     with op.batch_alter_table("links") as batch_op:
         batch_op.drop_column("access_blob")
@@ -298,59 +424,68 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
     op.drop_index("top_level_metadata", table_name="nodes")
     with op.batch_alter_table("nodes") as batch_op:
         batch_op.drop_column("access_blob")
+    with op.batch_alter_table("entities") as batch_op:
+        batch_op.drop_column("access_blob")
     op.create_index(
         "top_level_metadata",
         "nodes",
         ["parent", "time_created", "id", "metadata"],
         postgresql_using="gin",
     )
+    _create_association_triggers(connection)
 
 
 def downgrade():
     connection = op.get_bind()
     dialect_name = connection.engine.dialect.name
 
+    _drop_association_triggers(connection)
+
+    with op.batch_alter_table("entities") as batch_op:
+        batch_op.add_column(sa.Column("access_blob", JSONVariant, nullable=True))
+    _restore_access_blobs(
+        dialect_name,
+        "entity_access_blobs",
+        "entity_id",
+        "entities",
+        default_empty=False,
+    )
+    op.drop_table("entity_access_blobs")
+
+    # Restore c31's JSON-column delegation checks.
+    error_message = (
+        "An entity with node_id set must not have its own access_blob; "
+        "access is controlled by the referenced node."
+    )
     if dialect_name == "sqlite":
-        connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup")
-        )
-        connection.execute(
-            sa.text("DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup")
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
+        for operation in ("INSERT", "UPDATE"):
             connection.execute(
                 sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_insert_reject_shared_access_blob"
-                )
-            )
-            connection.execute(
-                sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_update_reject_shared_access_blob"
+                    f"""
+CREATE TRIGGER entities_node_access_blob_{operation.lower()}
+BEFORE {operation} ON entities
+WHEN NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, '{error_message}');
+END"""
                 )
             )
     elif dialect_name == "postgresql":
         connection.execute(
             sa.text(
-                "DROP TRIGGER IF EXISTS node_access_blobs_delete_cleanup ON node_access_blobs"
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION '{error_message}';
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entities_node_access_blob_check
+BEFORE INSERT OR UPDATE ON entities
+FOR EACH ROW WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
-        connection.execute(
-            sa.text(
-                "DROP TRIGGER IF EXISTS link_access_blobs_delete_cleanup ON link_access_blobs"
-            )
-        )
-        for table in ("node_access_blobs", "link_access_blobs"):
-            connection.execute(
-                sa.text(
-                    f"DROP TRIGGER IF EXISTS {table}_reject_shared_access_blob ON {table}"
-                )
-            )
-        connection.execute(
-            sa.text("DROP FUNCTION IF EXISTS delete_orphaned_access_blob")
-        )
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_node_access_blob"))
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS delete_link_access_blob"))
-        connection.execute(sa.text("DROP FUNCTION IF EXISTS reject_shared_access_blob"))
 
     with op.batch_alter_table("links") as batch_op:
         batch_op.add_column(

--- a/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
+++ b/tiled/catalog/migrations/versions/de302a096358_convert_access_blob_column_to_assoc_.py
@@ -41,6 +41,26 @@ def upgrade():
             name="ck_access_blob_user_xor_tags",
         ),
     )
+    op.create_index(
+        "ix_access_blobs_username_user",
+        "access_blobs",
+        ["username"],
+        sqlite_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+        postgresql_where=sa.text("kind = 'user' AND username IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_access_blobs_kind_node_id",
+        "access_blobs",
+        ["kind", "node_id"],
+    )
+    if dialect_name == "postgresql":
+        op.create_index(
+            "ix_access_blobs_tags_gin",
+            "access_blobs",
+            ["tags"],
+            postgresql_using="gin",
+            postgresql_where=sa.text("kind = 'tags' AND tags IS NOT NULL"),
+        )
 
     if dialect_name == "postgresql":
         op.execute(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
+from sqlalchemy.schema import CheckConstraint, PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -201,6 +201,44 @@ class NodeAccessBlob(Base):
     )
 
 
+@event.listens_for(NodeAccessBlob.__table__, "after_create")
+def create_node_access_blob_cleanup_trigger(target, connection, **kw):
+    if connection.engine.dialect.name == "sqlite":
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION delete_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER node_access_blobs_delete_cleanup
+AFTER DELETE ON node_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
+"""
+            )
+        )
+
+
 class DataSourceAssetAssociation(Base):
     """
     This describes which Assets are used by which DataSources, and how.

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from sqlalchemy import (
+    ARRAY,
     JSON,
     BigInteger,
     Boolean,
@@ -10,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    String,
     Table,
     Unicode,
     event,
@@ -19,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint, CheckConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management
@@ -28,6 +30,7 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
+AccessTagsVariant = JSON().with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -92,6 +95,7 @@ class Node(Timestamped, Base):
     access_blob = relationship(
         "AccessBlob",
         uselist=False,
+        lazy="selectin",
         passive_deletes=True,
         cascade="all, delete-orphan",
         single_parent=True,
@@ -160,7 +164,7 @@ class AccessBlob(Base):
     )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
-    tags = Column(ARRAY(String), nullable=True)
+    tags = Column(AccessTagsVariant, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -172,6 +172,23 @@ class AccessBlob(Base):
             "(username IS NULL AND tags IS NOT NULL)",
             name="ck_access_blob_user_xor_tags",
         ),
+        # Tight partial index for owner lookups used by access_blob_filter.
+        Index(
+            "ix_access_blobs_username_user",
+            "username",
+            postgresql_where=text("kind = 'user' AND username IS NOT NULL"),
+            sqlite_where=text("kind = 'user' AND username IS NOT NULL"),
+        ),
+        # Helps narrow to the relevant subset for tags/user branches quickly,
+        # including SQLite where tags membership itself is not index-friendly.
+        Index("ix_access_blobs_kind_node_id", "kind", "node_id"),
+        # PostgreSQL can index array overlap checks directly.
+        Index(
+            "ix_access_blobs_tags_gin",
+            "tags",
+            postgresql_using="gin",
+            postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
+        ),
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -76,7 +76,6 @@ class Node(Timestamped, Base):
     structure_family = Column(Enum(StructureFamily), nullable=False)
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     data_sources = relationship(
         "DataSource",
@@ -88,6 +87,11 @@ class Node(Timestamped, Base):
     revisions = relationship(
         "Revision",
         backref="node",
+        passive_deletes=True,
+    )
+    access_blob = relationship(
+        "AccessBlob",
+        uselist=False,
         passive_deletes=True,
     )
 
@@ -107,7 +111,6 @@ class Node(Timestamped, Base):
             "time_created",
             "id",
             "metadata",
-            "access_blob",
             postgresql_using="gin",
         ),
         # B-tree index supporting cursor-based pagination (WHERE parent = ?
@@ -134,6 +137,30 @@ class NodesClosure(Base):
     __table_args__ = (
         Index("idx_nodes_closure_ancestor", "ancestor"),
         Index("idx_nodes_closure_descendant", "descendant"),
+    )
+
+
+class AccessBlob(Base):
+    """
+    An access blob contains a set of tags that are used to control access to nodes.
+    May otherwise contain information indicating that a node is "user-owned".
+
+    Relationship is one-to-one with the nodes table.
+    """
+
+    __tablename__ = "access_blobs"
+
+    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
+    username = Column(String, nullable=True)
+    tags = Column(ARRAY(String), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "(username IS NOT NULL AND tags IS NULL) OR "
+            "(username IS NULL AND tags IS NOT NULL)",
+            name="ck_access_blob_user_xor_tags",
+        ),
     )
 
 
@@ -373,8 +400,8 @@ EXECUTE FUNCTION update_closure_table_when_inserting();
     connection.execute(
         text(
             """
-INSERT INTO nodes(id, key, parent, structure_family, metadata, specs, access_blob)
-SELECT 0, '', NULL, 'container', '{}', '[]', '{}';
+INSERT INTO nodes(id, key, parent, structure_family, metadata, specs)
+SELECT 0, '', NULL, 'container', '{}', '[]';
 """
         )
     )
@@ -551,7 +578,7 @@ class Asset(Timestamped, Base):
 
 class Revision(Timestamped, Base):
     """
-    This tracks history of metadata, specs, and access_blob supporting 'undo' functionality.
+    This tracks history of metadata and specs supporting 'undo' functionality.
     """
 
     __tablename__ = "revisions"
@@ -567,7 +594,6 @@ class Revision(Timestamped, Base):
 
     metadata_ = Column("metadata", JSONVariant, nullable=False)
     specs = Column(JSONVariant, nullable=False)
-    access_blob = Column("access_blob", JSONVariant, nullable=False)
 
     __table_args__ = (
         UniqueConstraint(

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -30,7 +30,7 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
-AccessTagsVariant = JSON().with_variant(ARRAY(String()), "postgresql")
+AccessTagsVariant = JSON(none_as_null=True).with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -94,11 +94,10 @@ class Node(Timestamped, Base):
     )
     access_blob = relationship(
         "AccessBlob",
+        secondary="node_access_blobs",
         uselist=False,
         lazy="selectin",
         passive_deletes=True,
-        cascade="all, delete-orphan",
-        single_parent=True,
     )
 
     # This is a self-referencing relationship between parent and children
@@ -151,17 +150,13 @@ class AccessBlob(Base):
     An access blob contains a set of tags that are used to control access to nodes.
     May otherwise contain information indicating that a node is "user-owned".
 
-    Relationship is one-to-one with the nodes table.
+    Associated with catalog nodes and graph links through separate association
+    tables.
     """
 
     __tablename__ = "access_blobs"
 
-    node_id = Column(
-        ForeignKey("nodes.id", ondelete="CASCADE"),
-        primary_key=True,
-        unique=True,
-        nullable=False,
-    )
+    id = Column(Integer, primary_key=True, autoincrement=True)
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
     tags = Column(AccessTagsVariant, nullable=True)
@@ -181,7 +176,7 @@ class AccessBlob(Base):
         ),
         # Helps narrow to the relevant subset for tags/user branches quickly,
         # including SQLite where tags membership itself is not index-friendly.
-        Index("ix_access_blobs_kind_node_id", "kind", "node_id"),
+        Index("ix_access_blobs_kind_id", "kind", "id"),
         # PostgreSQL can index array overlap checks directly.
         Index(
             "ix_access_blobs_tags_gin",
@@ -189,6 +184,20 @@ class AccessBlob(Base):
             postgresql_using="gin",
             postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
         ),
+    )
+
+
+class NodeAccessBlob(Base):
+    __tablename__ = "node_access_blobs"
+
+    node_id = Column(
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    access_blob_id = Column(
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -93,6 +93,8 @@ class Node(Timestamped, Base):
         "AccessBlob",
         uselist=False,
         passive_deletes=True,
+        cascade="all, delete-orphan",
+        single_parent=True,
     )
 
     # This is a self-referencing relationship between parent and children
@@ -150,7 +152,12 @@ class AccessBlob(Base):
 
     __tablename__ = "access_blobs"
 
-    node_id = Column(ForeignKey("nodes.id", ondelete="CASCADE"), unique=True, nullable=False)
+    node_id = Column(
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        primary_key=True,
+        unique=True,
+        nullable=False,
+    )
     kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
     username = Column(String, nullable=True)
     tags = Column(ARRAY(String), nullable=True)

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.sql import func
 
+from ..access_control.scopes import ScopeName
 from ..server.schemas import Management
 from ..structures.core import StructureFamily
 from .base import Base
@@ -252,15 +253,22 @@ class Scope(Base):
     """
     A named permission scope (e.g. 'read:data', 'write:data', 'create:node').
 
-    The set of valid scopes is defined by the server configuration.  A Scope
-    row is created the first time a scope name appears in a tag definition so
-    that AccessTagPrincipalScope can reference it by ID.
+    The set of valid scope names is the closed ScopeName enum. A Scope row is
+    created the first time a scope name appears in a tag definition.
     """
 
     __tablename__ = "scopes"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(Unicode(255), nullable=False, unique=True)
+    name = Column(
+        Enum(
+            ScopeName,
+            name="scope_name",
+            values_callable=lambda enum: [member.value for member in enum],
+        ),
+        nullable=False,
+        unique=True,
+    )
 
     principal_tags: Mapped[List["AccessTagPrincipalScope"]] = relationship(
         back_populates="scope",

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from sqlalchemy import (
-    ARRAY,
     JSON,
     BigInteger,
     Boolean,
@@ -11,7 +10,6 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
-    String,
     Table,
     Unicode,
     event,
@@ -21,7 +19,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.schema import CheckConstraint, PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy.schema import PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.sql import func
 
 from ..server.schemas import Management
@@ -30,7 +28,6 @@ from .base import Base
 
 # Use JSON with SQLite and JSONB with PostgreSQL.
 JSONVariant = JSON().with_variant(JSONB(), "postgresql")
-AccessTagsVariant = JSON(none_as_null=True).with_variant(ARRAY(String()), "postgresql")
 
 
 class Timestamped:
@@ -92,10 +89,13 @@ class Node(Timestamped, Base):
         backref="node",
         passive_deletes=True,
     )
-    access_blob = relationship(
-        "AccessBlob",
-        secondary="node_access_blobs",
-        uselist=False,
+    # Many-to-many relationship to AccessTag through the node_access_tags
+    # association table. Writable: assigning/appending AccessTag objects
+    # inserts/deletes rows in node_access_tags (never in access_tags itself).
+    # passive_deletes defers cleanup of association rows to the DB-level
+    # ON DELETE CASCADE when a node is deleted.
+    access_tags: Mapped[List["AccessTag"]] = relationship(
+        secondary="node_access_tags",
         lazy="selectin",
         passive_deletes=True,
     )
@@ -145,45 +145,228 @@ class NodesClosure(Base):
     )
 
 
-class AccessBlob(Base):
+class AccessTag(Timestamped, Base):
     """
-    An access blob contains a set of tags that are used to control access to nodes.
-    May otherwise contain information indicating that a node is "user-owned".
+    A named access tag.
 
-    Associated with catalog nodes and graph links through separate association
-    tables.
+    AccessTags are the unit of access control: nodes carry a set of tags, and
+    principals are granted access by being associated with one or more tags.
+    The allowed operations for a principal on a node are determined by the
+    scopes bound to their AccessTagPrincipalScope rows.
+
+    A tag with is_public=True grants read access to unauthenticated requests.
+
+    Ownership is tracked via AccessTagOwner rows; tag owners may apply tags
+    without being a server administrator.
     """
 
-    __tablename__ = "access_blobs"
+    __tablename__ = "access_tags"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    kind = Column(Enum("user", "tags", name="access_kind"), nullable=False)
-    username = Column(String, nullable=True)
-    tags = Column(AccessTagsVariant, nullable=True)
+    name = Column(Unicode(255), nullable=False, unique=True)
+    is_public = Column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
+    principal_scopes: Mapped[List["AccessTagPrincipalScope"]] = relationship(
+        back_populates="tag",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    owners: Mapped[List["AccessTagOwner"]] = relationship(
+        back_populates="tag",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
     __table_args__ = (
-        CheckConstraint(
-            "(username IS NOT NULL AND tags IS NULL) OR "
-            "(username IS NULL AND tags IS NOT NULL)",
-            name="ck_access_blob_user_xor_tags",
+        # Supports enumerating/filtering public tags for unauthenticated requests.
+        Index("idx_access_tags_is_public", "is_public"),
+    )
+
+
+class NodeAccessTag(Base):
+    """
+    Association table mapping Nodes to Access Tags (many-to-many).
+    Used to perform lookups in both directions, i.e.:
+        - Which tags are on this node? (served by the primary key)
+        - Which nodes have this tag? (served by the secondary index)
+    """
+
+    __tablename__ = "node_access_tags"
+
+    node_id = Column(
+        Integer,
+        ForeignKey("nodes.id", name="fk_node_access_tags_node", ondelete="CASCADE"),
+        nullable=False,
+    )
+    tag_id = Column(
+        Integer,
+        ForeignKey(
+            "access_tags.id", name="fk_node_access_tags_tag", ondelete="CASCADE"
         ),
-        # Tight partial index for owner lookups used by access_blob_filter.
+        nullable=False,
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("node_id", "tag_id", name="node_access_tags_pkey"),
+        # Covering index for the reverse (tag -> nodes) direction.
+        Index("idx_node_access_tags_tag_id_node_id", "tag_id", "node_id"),
+    )
+
+
+class AccessTagsPrincipal(Timestamped, Base):
+    """
+    A principal (human user or service account) that can be granted access
+    via AccessTags.
+
+    The name is the canonical identifier used in authentication tokens and group
+    memberships.  Scopes granted to this principal for a given tag are stored in
+    AccessTagPrincipalScope rows; ownership of a tag is stored in AccessTagOwner
+    rows.
+    """
+
+    __tablename__ = "access_tags_principals"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(Unicode(255), nullable=False, unique=True)
+
+    tag_scopes: Mapped[List["AccessTagPrincipalScope"]] = relationship(
+        back_populates="principal",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    owned_tags: Mapped[List["AccessTagOwner"]] = relationship(
+        back_populates="principal",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class Scope(Base):
+    """
+    A named permission scope (e.g. 'read:data', 'write:data', 'create:node').
+
+    The set of valid scopes is defined by the server configuration.  A Scope
+    row is created the first time a scope name appears in a tag definition so
+    that AccessTagPrincipalScope can reference it by ID.
+    """
+
+    __tablename__ = "scopes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(Unicode(255), nullable=False, unique=True)
+
+    principal_tags: Mapped[List["AccessTagPrincipalScope"]] = relationship(
+        back_populates="scope",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class AccessTagPrincipalScope(Base):
+    """
+    Three-way junction (association table): a Principal is granted a Scope on
+    all nodes carrying an AccessTag.
+
+    Used to check:
+        - What scopes does a principal have on a given node per the node's tags?
+        - What tags does a principal have a given scope on, and thus how should
+          nodes be filtered for that principal?
+    """
+
+    __tablename__ = "access_tag_principal_scopes"
+
+    tag_id = Column(
+        Integer,
+        ForeignKey(
+            "access_tags.id",
+            name="fk_access_tag_principal_scopes_access_tag",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    principal_id = Column(
+        Integer,
+        ForeignKey(
+            "access_tags_principals.id",
+            name="fk_access_tag_principal_scopes_principal",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    scope_id = Column(
+        Integer,
+        ForeignKey(
+            "scopes.id",
+            name="fk_access_tag_principal_scopes_scope",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+
+    tag: Mapped["AccessTag"] = relationship(back_populates="principal_scopes")
+    principal: Mapped["AccessTagsPrincipal"] = relationship(
+        back_populates="tag_scopes"
+    )
+    scope: Mapped["Scope"] = relationship(back_populates="principal_tags")
+
+    __table_args__ = (
+        # Serves '(tag, principal) -> scopes' probes, e.g. checking scopes on a
+        # node given its tags.
+        PrimaryKeyConstraint(
+            "tag_id", "principal_id", "scope_id", name="access_tag_principal_scopes_pkey"
+        ),
+        # Covering index serving '(principal, scope) -> tags' lookups, used to
+        # filter nodes visible to a principal.
         Index(
-            "ix_access_blobs_username_user",
-            "username",
-            postgresql_where=text("kind = 'user' AND username IS NOT NULL"),
-            sqlite_where=text("kind = 'user' AND username IS NOT NULL"),
+            "idx_access_tag_principal_scopes_principal_scope",
+            "principal_id",
+            "scope_id",
+            "tag_id",
         ),
-        # Helps narrow to the relevant subset for tags/user branches quickly,
-        # including SQLite where tags membership itself is not index-friendly.
-        Index("ix_access_blobs_kind_id", "kind", "id"),
-        # PostgreSQL can index array overlap checks directly.
-        Index(
-            "ix_access_blobs_tags_gin",
-            "tags",
-            postgresql_using="gin",
-            postgresql_where=text("kind = 'tags' AND tags IS NOT NULL"),
+        # Supports FK cascade when a Scope row is deleted (e.g. during
+        # reconciliation of the configured scope set).
+        Index("idx_access_tag_principal_scopes_scope_id", "scope_id"),
+    )
+
+
+class AccessTagOwner(Base):
+    """
+    Association table which records that a Principal owns an AccessTag and may
+    apply that tag to a node (if scopes permit).
+    """
+
+    __tablename__ = "access_tag_owners"
+
+    tag_id = Column(
+        Integer,
+        ForeignKey(
+            "access_tags.id", name="fk_access_tag_owners_access_tag", ondelete="CASCADE"
         ),
+        nullable=False,
+    )
+    principal_id = Column(
+        Integer,
+        ForeignKey(
+            "access_tags_principals.id",
+            name="fk_access_tag_owners_principal",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+
+    tag: Mapped["AccessTag"] = relationship(back_populates="owners")
+    principal: Mapped["AccessTagsPrincipal"] = relationship(
+        back_populates="owned_tags"
+    )
+
+    __table_args__ = (
+        # Serves 'owners of a tag' and exact (tag, principal) membership probes.
+        PrimaryKeyConstraint("tag_id", "principal_id", name="access_tag_owners_pkey"),
+        # Serves 'tags owned by a principal' lookups and FK cascade on
+        # principal deletion.
+        Index("idx_access_tag_owners_principal_id", "principal_id"),
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -180,8 +180,13 @@ class AccessTag(Timestamped, Base):
     )
 
     __table_args__ = (
-        # Supports enumerating/filtering public tags for unauthenticated requests.
-        Index("idx_access_tags_is_public", "is_public"),
+        # Partial index for public tags only, covering name-only queries
+        Index(
+            "idx_access_tags_is_public",
+            "name",
+            postgresql_where=text("is_public"),
+            sqlite_where=text("is_public"),
+        ),
     )
 
 

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -319,16 +319,17 @@ class AccessTagPrincipalScope(Base):
     )
 
     tag: Mapped["AccessTag"] = relationship(back_populates="principal_scopes")
-    principal: Mapped["AccessTagsPrincipal"] = relationship(
-        back_populates="tag_scopes"
-    )
+    principal: Mapped["AccessTagsPrincipal"] = relationship(back_populates="tag_scopes")
     scope: Mapped["Scope"] = relationship(back_populates="principal_tags")
 
     __table_args__ = (
         # Serves '(tag, principal) -> scopes' probes, e.g. checking scopes on a
         # node given its tags.
         PrimaryKeyConstraint(
-            "tag_id", "principal_id", "scope_id", name="access_tag_principal_scopes_pkey"
+            "tag_id",
+            "principal_id",
+            "scope_id",
+            name="access_tag_principal_scopes_pkey",
         ),
         # Covering index serving '(principal, scope) -> tags' lookups, used to
         # filter nodes visible to a principal.
@@ -370,9 +371,7 @@ class AccessTagOwner(Base):
     )
 
     tag: Mapped["AccessTag"] = relationship(back_populates="owners")
-    principal: Mapped["AccessTagsPrincipal"] = relationship(
-        back_populates="owned_tags"
-    )
+    principal: Mapped["AccessTagsPrincipal"] = relationship(back_populates="owned_tags")
 
     __table_args__ = (
         # Serves 'owners of a tag' and exact (tag, principal) membership probes.

--- a/tiled/catalog/orm.py
+++ b/tiled/catalog/orm.py
@@ -370,58 +370,6 @@ class AccessTagOwner(Base):
     )
 
 
-class NodeAccessBlob(Base):
-    __tablename__ = "node_access_blobs"
-
-    node_id = Column(
-        ForeignKey("nodes.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    access_blob_id = Column(
-        ForeignKey("access_blobs.id", ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
-    )
-
-
-@event.listens_for(NodeAccessBlob.__table__, "after_create")
-def create_node_access_blob_cleanup_trigger(target, connection, **kw):
-    if connection.engine.dialect.name == "sqlite":
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER node_access_blobs_delete_cleanup
-AFTER DELETE ON node_access_blobs
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-END"""
-            )
-        )
-    elif connection.engine.dialect.name == "postgresql":
-        connection.execute(
-            text(
-                """
-CREATE OR REPLACE FUNCTION delete_node_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER node_access_blobs_delete_cleanup
-AFTER DELETE ON node_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_node_access_blob();
-"""
-            )
-        )
-
-
 class DataSourceAssetAssociation(Base):
     """
     This describes which Assets are used by which DataSources, and how.

--- a/tiled/client/base.py
+++ b/tiled/client/base.py
@@ -260,7 +260,7 @@ class BaseClient:
         """
         metadata = deepcopy(self._item["attributes"]["metadata"])
         specs = [Spec.from_json(spec) for spec in self._item["attributes"]["specs"]]
-        access_tags = deepcopy(self._item["attributes"]["access_blob"].get("tags", []))
+        access_tags = list(self._item["attributes"]["access_tags"])
         return [
             md for md in [metadata, specs, access_tags] if md is not None
         ]  # returning as list of mutable items
@@ -273,15 +273,15 @@ class BaseClient:
         )
 
     @property
-    def access_blob(self) -> DictView[str, JSON_ITEM]:
-        "Authorization information about this node, in blob form"
-        access_blob = self._item["attributes"]["access_blob"]
-        if access_blob is None:
-            raise AttributeError("Node has no attribute 'access_blob'")
+    def access_tags(self) -> ListView[str]:
+        "Authorization information about this node, encoded as access tags."
+        access_tags = self._item["attributes"]["access_tags"]
+        if access_tags is None:
+            raise AttributeError("Node has no attribute 'access_tags'")
         # Ensure this is immutable (at the top level) to help the user avoid
         # getting the wrong impression that editing this would update anything
         # persistent.
-        return DictView(access_blob)
+        return ListView(access_tags)
 
     @property
     def uri(self):
@@ -595,7 +595,7 @@ class BaseClient:
         >>> md['unwanted_key'] = DELETE_KEY
         >>> node.update_metadata(metadata=md)  # Update the copy on the server
         """
-        metadata_patch, specs_patch, access_blob_patch = self.build_metadata_patches(
+        metadata_patch, specs_patch, access_tags_patch = self.build_metadata_patches(
             metadata=metadata,
             specs=specs,
             access_tags=access_tags,
@@ -603,7 +603,7 @@ class BaseClient:
         self.patch_metadata(
             metadata_patch=metadata_patch,
             specs_patch=specs_patch,
-            access_blob_patch=access_blob_patch,
+            access_tags_patch=access_tags_patch,
             drop_revision=drop_revision,
         )
 
@@ -632,9 +632,9 @@ class BaseClient:
         specs_patch : list[dict]
             A JSON serializable object representing a valid JSON patch (RFC6902)
             for metadata validation specifications.
-        access_blob_patch : list[dict]
+        access_tags_patch : list[dict]
             A JSON serializable object representing a valid JSON patch (RFC6902)
-            for access control fields that are stored in the access_blob.
+            for access tags
 
         See Also
         --------
@@ -703,17 +703,14 @@ class BaseClient:
 
         if not access_tags:
             # empty list of access_tags should be a no-op
-            access_blob_patch = None
+            access_tags_patch = None
         else:
-            ab_copy = deepcopy(self._item["attributes"]["access_blob"])
-            access_blob = {"tags": access_tags}
-            access_blob_patch = jsonpatch.JsonPatch.from_diff(
-                self._item["attributes"]["access_blob"],
-                apply_update_patch(ab_copy, access_blob),
-                dumps=orjson.dumps,
+            access_tags_copy = list(self._item["attributes"]["access_tags"])
+            access_tags_patch = jsonpatch.JsonPatch.from_diff(
+                access_tags_copy, access_tags, dumps=orjson.dumps
             ).patch
 
-        return metadata_patch, specs_patch, access_blob_patch
+        return metadata_patch, specs_patch, access_tags_patch
 
     def _build_json_patch(self, origin, update_patch):
         """
@@ -739,7 +736,7 @@ class BaseClient:
         self,
         metadata_patch=None,
         specs_patch=None,
-        access_blob_patch=None,
+        access_tags_patch=None,
         content_type=patch_mimetypes.JSON_PATCH,
         drop_revision=False,
     ):
@@ -755,8 +752,8 @@ class BaseClient:
         specs_patch : List[dict], optional
             JSON-serializable patch to be applied to metadata validation
             specifications list
-        access_blob_patch : List[dict], optional
-            JSON-serializable patch to be applied to the access_blob
+        access_tags_patch : List[dict], optional
+            JSON-serializable patch to be applied to the access_tags
         content_type : str
             Mimetype of the patches. Acceptable values are:
 
@@ -816,7 +813,7 @@ class BaseClient:
             "content-type": content_type,
             "metadata": metadata_patch,
             "specs": normalized_specs_patch,
-            "access_blob": access_blob_patch,
+            "access_tags": access_tags_patch,
         }
         params = {}
         if drop_revision:
@@ -850,12 +847,12 @@ class BaseClient:
             patched_specs = patcher(current_specs, normalized_specs_patch, content_type)
             self._item["attributes"]["specs"] = patched_specs
 
-        if access_blob_patch is not None:
-            if "access_blob" in content:
-                self._item["attributes"]["access_blob"] = content["access_blob"]
+        if access_tags_patch is not None:
+            if "access_tags" in content:
+                self._item["attributes"]["access_tags"] = content["access_tags"]
             else:
-                self._item["attributes"]["access_blob"] = patcher(
-                    dict(self.access_blob), access_blob_patch, content_type
+                self._item["attributes"]["access_tags"] = patcher(
+                    list(self.access_tags), access_tags_patch, content_type
                 )
 
     def replace_metadata(
@@ -888,15 +885,10 @@ class BaseClient:
 
         self._cached_len = None
 
-        if access_tags is None:
-            access_blob = None
-        else:
-            access_blob = {"tags": access_tags}
-
         data = {
             "metadata": metadata,
             "specs": normalize_specs(specs),
-            "access_blob": access_blob,
+            "access_tags": access_tags,
         }
         params = {}
         if drop_revision:
@@ -926,11 +918,11 @@ class BaseClient:
         if specs is not None:
             self._item["attributes"]["specs"] = normalize_specs(specs)
 
-        if access_blob is not None:
-            if "access_blob" in content:
-                self._item["attributes"]["access_blob"] = content["access_blob"]
+        if access_tags is not None:
+            if "access_tags" in content:
+                self._item["attributes"]["access_tags"] = content["access_tags"]
             else:
-                self._item["attributes"]["access_blob"] = access_blob
+                self._item["attributes"]["access_tags"] = access_tags
 
     @property
     def metadata_revisions(self):

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -701,7 +701,6 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         self._cached_len = None
         metadata = metadata or {}
-        access_tags = access_tags or []
 
         # Backompatibility: if the server is older than 0.2.4,
         # it can not accept the "properties" field in the data source.

--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -701,7 +701,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
 
         self._cached_len = None
         metadata = metadata or {}
-        access_blob = {"tags": access_tags} if access_tags is not None else {}
+        access_tags = access_tags or []
 
         # Backompatibility: if the server is older than 0.2.4,
         # it can not accept the "properties" field in the data source.
@@ -721,7 +721,7 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 "structure_family": StructureFamily(structure_family),
                 "specs": normalize_specs(specs or []),
                 "data_sources": data_sources_as_dicts,
-                "access_blob": access_blob,
+                "access_tags": access_tags,
             }
         }
         body = dict(item["attributes"])
@@ -778,9 +778,9 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 ds for ds in document.pop("data_sources")
             ]
 
-        # And for access_blob
-        if "access_blob" in document:
-            item["attributes"]["access_blob"] = document.pop("access_blob")
+        # And for access_tags
+        if "access_tags" in document:
+            item["attributes"]["access_tags"] = document.pop("access_tags")
 
         # Merge in "id" and "links" returned by the server.
         item.update(document)

--- a/tiled/client/stream.py
+++ b/tiled/client/stream.py
@@ -690,7 +690,7 @@ class LiveChildCreated(ChildCreated):
                 "structure_family": self.structure_family,
                 "specs": normalize_specs(self.specs or []),
                 "data_sources": self.data_sources,
-                "access_blob": self.access_blob,
+                "access_tags": self.access_tags,
             },
         }
         if self.structure_family == StructureFamily.container:

--- a/tiled/config.py
+++ b/tiled/config.py
@@ -65,7 +65,7 @@ class CatalogConfig(BaseSettings):
     readable_storage: Optional[list[str]] = None
     init_if_not_exists: bool = False
     adapters_by_mimetype: Optional[dict[str, EntryPointString]] = None
-    top_level_access_blob: Optional[dict] = None
+    top_level_access_tags: Optional[list[str]] = None
     mount_node: Optional[Union[str, list[str]]] = None
     catalog_pool_size: int = 5
     storage_pool_size: int = 5

--- a/tiled/config_schemas/service_configuration.yml
+++ b/tiled/config_schemas/service_configuration.yml
@@ -410,8 +410,7 @@ properties:
           access_policy: "tiled.access_control.access_policies:TagBasedAccessPolicy"
           args:
             provider: "pam"
-            tags_db:
-              uri: "file:compiled_tags.sqlite"
+            # Access tag definitions are read from the catalog database.
             access_tags_parser: "tiled.access_control.access_tags:AccessTagsParser"
           ```
       args:

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -19,12 +19,12 @@ is declared as a Core table on ``Base.metadata`` in ``tiled.catalog.orm``.
 from __future__ import annotations
 
 from sqlalchemy import (
-    JSON,
     Column,
     DateTime,
     ForeignKey,
     Index,
     Integer,
+    JSON,
     String,
     Table,
     event,
@@ -146,12 +146,115 @@ links = Table(
         nullable=False,
     ),
     Column("properties", JSON, nullable=False),
-    Column("access_blob", JSON, nullable=False),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Index("links_subject_predicate_idx", "subject_id", "predicate"),
     Index("links_predicate_object_idx", "predicate", "object_id"),
     Index("links_triple_idx", "subject_id", "predicate", "object_id"),
 )
+
+link_access_blobs = Table(
+    "link_access_blobs",
+    metadata,
+    Column(
+        "link_id",
+        String,
+        ForeignKey("links.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "access_blob_id",
+        Integer,
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    ),
+)
+
+
+@event.listens_for(link_access_blobs, "after_create")
+def _create_access_blob_cleanup_triggers(target, connection, **kw):
+    if connection.engine.dialect.name == "sqlite":
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+        for table, other_table in (
+            ("node_access_blobs", "link_access_blobs"),
+            ("link_access_blobs", "node_access_blobs"),
+        ):
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                trigger_operation = operation.split()[0].lower()
+                connection.execute(
+                    text(
+                        f"""
+CREATE TRIGGER {table}_{trigger_operation}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
+END"""
+                    )
+                )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION delete_link_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE TRIGGER link_access_blobs_delete_cleanup
+AFTER DELETE ON link_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
+"""
+            )
+        )
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE FUNCTION reject_shared_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    ) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+            )
+        )
+        for table in ("node_access_blobs", "link_access_blobs"):
+            connection.execute(
+                text(
+                    f"""
+CREATE TRIGGER {table}_reject_shared_access_blob
+BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
+"""
+                )
+            )
 
 namespaces = Table(
     "namespaces",

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -61,71 +61,6 @@ ENTITY_NODE_ACCESS_BLOB_ERROR = (
 )
 
 
-@event.listens_for(metadata, "after_create")
-def _create_entities_node_access_blob_trigger(target, connection, **kw):
-    """
-    Enforce, at the database level, that an entity pointing to a catalog
-    node (node_id set) does not also carry its own access_blob. This
-    mirrors the trigger created by the
-    de302a096358_convert_access_blob_column_to_assoc_ alembic migration,
-    which applies the same DDL for databases provisioned via `alembic
-    upgrade` rather than `create_all` (e.g.
-    tiled.catalog.core.initialize_database, which is what the test suite
-    exercises).
-    """
-    if connection.engine.dialect.name == "sqlite":
-        connection.execute(
-            text(
-                f"""
-CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_insert
-BEFORE INSERT ON entities
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
-END"""
-            )
-        )
-        connection.execute(
-            text(
-                f"""
-CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
-BEFORE UPDATE ON entities
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
-END"""
-            )
-        )
-    elif connection.engine.dialect.name == "postgresql":
-        connection.execute(
-            text(
-                f"""
-CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
-END;
-$$ LANGUAGE plpgsql;"""
-            )
-        )
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER entities_node_access_blob_check
-BEFORE UPDATE OF node_id ON entities
-FOR EACH ROW
-WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
-))
-EXECUTE FUNCTION entities_reject_node_access_blob();"""
-            )
-        )
-
-
 links = Table(
     "links",
     metadata,
@@ -185,6 +120,68 @@ entity_access_blobs = Table(
         unique=True,
     ),
 )
+
+
+@event.listens_for(entity_access_blobs, "after_create")
+def _create_entities_node_access_blob_trigger(target, connection, **kw):
+    """
+    Enforce, at the database level, that an entity pointing to a catalog
+    node (node_id set) does not also carry its own access_blob.
+    """
+    if connection.engine.dialect.name == "sqlite":
+        # Only an UPDATE that sets node_id can turn an existing blob-bearing
+        # entity into an illegal node-backed-with-blob row. The INSERT case
+        # cannot occur in a single statement: an entities INSERT sets only
+        # node_id, while the blob lives in a separate entity_access_blobs row
+        # written by a separate INSERT -- which is itself guarded by
+        # entity_access_blobs_insert_reject_node_backed_entity. This mirrors
+        # the PostgreSQL branch, which likewise only guards UPDATE OF node_id.
+        connection.execute(
+            text(
+                f"""
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
+BEFORE UPDATE OF node_id ON entities
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+            )
+        )
+    elif connection.engine.dialect.name == "postgresql":
+        # PostgreSQL does not allow subqueries in a trigger WHEN clause
+        # ("cannot use subquery in trigger WHEN condition"), so the EXISTS
+        # check against entity_access_blobs lives in the function body; the
+        # trigger WHEN clause keeps only the cheap scalar column test.
+        connection.execute(
+            text(
+                f"""
+CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    ) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        # OR REPLACE keeps this belt-and-suspenders idempotent even though the
+        # table-level listener already fires only once (PostgreSQL 14+).
+        connection.execute(
+            text(
+                """
+CREATE OR REPLACE TRIGGER entities_node_access_blob_check
+BEFORE UPDATE OF node_id ON entities
+FOR EACH ROW
+WHEN (NEW.node_id IS NOT NULL)
+EXECUTE FUNCTION entities_reject_node_access_blob();"""
+            )
+        )
 
 
 @event.listens_for(link_access_blobs, "after_create")

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -270,20 +270,31 @@ END"""
                     )
                 )
     elif connection.engine.dialect.name == "postgresql":
+        # asyncpg cannot run multiple statements in one prepared execute, so
+        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
         connection.execute(
             text(
-                f"""
+                """
 CREATE OR REPLACE FUNCTION delete_entity_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
     DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
     RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE TRIGGER entity_access_blobs_delete_cleanup
 AFTER DELETE ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();
-
+FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();"""
+            )
+        )
+        connection.execute(
+            text(
+                f"""
 CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -292,11 +303,20 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
 BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
-
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+            )
+        )
+        connection.execute(
+            text(
+                """
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -314,8 +334,7 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
-"""
+$$ LANGUAGE plpgsql;"""
             )
         )
         for table in tables:

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -49,14 +49,6 @@ entities = Table(
     Column("name", String, nullable=False),
     Column("uri", String, nullable=True),
     Column("properties", JSON, nullable=False),
-    # Nullable: an entity with node_id set must not have its own
-    # access_blob (enforced by the trigger below and in
-    # tiled.graph.schema); access control for such an entity is delegated
-    # to the node it points to. none_as_null=True: without it, SQLAlchemy's
-    # JSON type stores Python None as the JSON literal 'null' (a non-NULL
-    # string), which would defeat both the trigger's and our own
-    # IS NULL / IS NOT NULL checks.
-    Column("access_blob", JSON(none_as_null=True), nullable=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Index("entities_node_id_idx", "node_id"),
     Index("entities_type_created_idx", "entity_type", "created_at"),
@@ -69,13 +61,13 @@ ENTITY_NODE_ACCESS_BLOB_ERROR = (
 )
 
 
-@event.listens_for(entities, "after_create")
+@event.listens_for(metadata, "after_create")
 def _create_entities_node_access_blob_trigger(target, connection, **kw):
     """
     Enforce, at the database level, that an entity pointing to a catalog
     node (node_id set) does not also carry its own access_blob. This
     mirrors the trigger created by the
-    c31f6a1d7e20_add_graph_entities_and_links_tables alembic migration,
+    de302a096358_convert_access_blob_column_to_assoc_ alembic migration,
     which applies the same DDL for databases provisioned via `alembic
     upgrade` rather than `create_all` (e.g.
     tiled.catalog.core.initialize_database, which is what the test suite
@@ -85,9 +77,11 @@ def _create_entities_node_access_blob_trigger(target, connection, **kw):
         connection.execute(
             text(
                 f"""
-CREATE TRIGGER entities_node_access_blob_insert
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_insert
 BEFORE INSERT ON entities
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 BEGIN
     SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
 END"""
@@ -96,9 +90,11 @@ END"""
         connection.execute(
             text(
                 f"""
-CREATE TRIGGER entities_node_access_blob_update
+CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
 BEFORE UPDATE ON entities
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 BEGIN
     SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
 END"""
@@ -120,9 +116,11 @@ $$ LANGUAGE plpgsql;"""
             text(
                 """
 CREATE TRIGGER entities_node_access_blob_check
-BEFORE INSERT OR UPDATE ON entities
+BEFORE UPDATE OF node_id ON entities
 FOR EACH ROW
-WHEN (NEW.node_id IS NOT NULL AND NEW.access_blob IS NOT NULL)
+WHEN (NEW.node_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+))
 EXECUTE FUNCTION entities_reject_node_access_blob();"""
             )
         )
@@ -170,9 +168,27 @@ link_access_blobs = Table(
     ),
 )
 
+entity_access_blobs = Table(
+    "entity_access_blobs",
+    metadata,
+    Column(
+        "entity_id",
+        String,
+        ForeignKey("entities.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "access_blob_id",
+        Integer,
+        ForeignKey("access_blobs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    ),
+)
+
 
 @event.listens_for(link_access_blobs, "after_create")
-def _create_access_blob_cleanup_triggers(target, connection, **kw):
+def _create_link_access_blob_cleanup_trigger(target, connection, **kw):
     if connection.engine.dialect.name == "sqlite":
         connection.execute(
             text(
@@ -184,23 +200,6 @@ BEGIN
 END"""
             )
         )
-        for table, other_table in (
-            ("node_access_blobs", "link_access_blobs"),
-            ("link_access_blobs", "node_access_blobs"),
-        ):
-            for operation in ("INSERT", "UPDATE OF access_blob_id"):
-                trigger_operation = operation.split()[0].lower()
-                connection.execute(
-                    text(
-                        f"""
-CREATE TRIGGER {table}_{trigger_operation}_reject_shared_access_blob
-BEFORE {operation} ON {table}
-WHEN EXISTS (SELECT 1 FROM {other_table} WHERE access_blob_id = NEW.access_blob_id)
-BEGIN
-    SELECT RAISE(ABORT, 'An access blob may belong to only one node or link');
-END"""
-                    )
-                )
     elif connection.engine.dialect.name == "postgresql":
         connection.execute(
             text(
@@ -224,20 +223,94 @@ FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
 """
             )
         )
+
+
+@event.listens_for(link_access_blobs, "after_create")
+def _create_access_blob_association_triggers(target, connection, **kw):
+    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
+    if connection.engine.dialect.name == "sqlite":
         connection.execute(
             text(
                 """
+CREATE TRIGGER entity_access_blobs_delete_cleanup
+AFTER DELETE ON entity_access_blobs
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+END"""
+            )
+        )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                text(
+                    f"""
+CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_blobs
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+END"""
+                )
+            )
+        for table in tables:
+            others = " OR ".join(
+                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
+                for other in tables
+                if other != table
+            )
+            for operation in ("INSERT", "UPDATE OF access_blob_id"):
+                connection.execute(
+                    text(
+                        f"""
+CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
+BEFORE {operation} ON {table}
+WHEN {others}
+BEGIN
+    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
+END"""
+                    )
+                )
+    elif connection.engine.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                f"""
+CREATE OR REPLACE FUNCTION delete_entity_access_blob()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entity_access_blobs_delete_cleanup
+AFTER DELETE ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();
+
+CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
+FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();
+
 CREATE OR REPLACE FUNCTION reject_shared_access_blob()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
-        SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
-    ELSIF TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
+        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
         SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    ) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node or link';
+        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
+        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
+        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
+    )) THEN
+        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
     END IF;
     RETURN NEW;
 END;
@@ -245,14 +318,13 @@ $$ LANGUAGE plpgsql;
 """
             )
         )
-        for table in ("node_access_blobs", "link_access_blobs"):
+        for table in tables:
             connection.execute(
                 text(
                     f"""
 CREATE TRIGGER {table}_reject_shared_access_blob
 BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
-FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
-"""
+FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
                 )
             )
 

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -19,12 +19,12 @@ is declared as a Core table on ``Base.metadata`` in ``tiled.catalog.orm``.
 from __future__ import annotations
 
 from sqlalchemy import (
+    JSON,
     Column,
     DateTime,
     ForeignKey,
     Index,
     Integer,
-    JSON,
     String,
     Table,
     event,
@@ -255,6 +255,7 @@ FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();
 """
                 )
             )
+
 
 namespaces = Table(
     "namespaces",

--- a/tiled/graph/orm.py
+++ b/tiled/graph/orm.py
@@ -8,12 +8,18 @@ of provisioning a catalog database both include them:
 
 * a fresh database created by ``tiled.catalog.core.initialize_database``
   (which runs ``Base.metadata.create_all``), and
-* an existing database upgraded through the Alembic migration
-  ``c31f6a1d7e20``.
+* an existing database upgraded through Alembic migrations.
 
 The store (``tiled.graph.store``) uses these ``Table`` objects to read and
 write rows; it does not create them itself. This mirrors how ``metadata_fts5``
 is declared as a Core table on ``Base.metadata`` in ``tiled.catalog.orm``.
+
+Access control: entities and links carry access tags drawn from the same
+catalog ``access_tags`` table that nodes use. The ``entity_access_tags`` and
+``link_access_tags`` association tables mirror the catalog's
+``node_access_tags`` table. An entity that points to a catalog node
+(``node_id`` set) must not carry its own access tags -- it assumes the tags of
+the referenced node -- and this is enforced at the database level by triggers.
 """
 
 from __future__ import annotations
@@ -55,8 +61,8 @@ entities = Table(
     Index("entities_uri_idx", "uri"),
 )
 
-ENTITY_NODE_ACCESS_BLOB_ERROR = (
-    "An entity with node_id set must not have its own access_blob; "
+ENTITY_NODE_ACCESS_TAGS_ERROR = (
+    "An entity with node_id set must not have its own access tags; "
     "access is controlled by the referenced node."
 )
 
@@ -85,85 +91,106 @@ links = Table(
     Index("links_triple_idx", "subject_id", "predicate", "object_id"),
 )
 
-link_access_blobs = Table(
-    "link_access_blobs",
-    metadata,
-    Column(
-        "link_id",
-        String,
-        ForeignKey("links.id", ondelete="CASCADE"),
-        primary_key=True,
-    ),
-    Column(
-        "access_blob_id",
-        Integer,
-        ForeignKey("access_blobs.id", ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
-    ),
-)
+# Association tables mapping entities/links to catalog access tags
+# (many-to-many), mirroring the catalog's node_access_tags table. Both
+# directions of lookup are served: "which tags are on this entity/link?"
+# by the composite primary key, and "which entities/links have this tag?"
+# by the covering reverse index. Deleting an entity, link, or tag cascades
+# to its association rows via the foreign keys.
 
-entity_access_blobs = Table(
-    "entity_access_blobs",
+entity_access_tags = Table(
+    "entity_access_tags",
     metadata,
     Column(
         "entity_id",
         String,
-        ForeignKey("entities.id", ondelete="CASCADE"),
+        ForeignKey(
+            "entities.id", name="fk_entity_access_tags_entity", ondelete="CASCADE"
+        ),
         primary_key=True,
     ),
     Column(
-        "access_blob_id",
+        "tag_id",
         Integer,
-        ForeignKey("access_blobs.id", ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
+        ForeignKey(
+            "access_tags.id", name="fk_entity_access_tags_tag", ondelete="CASCADE"
+        ),
+        primary_key=True,
     ),
+    Index("idx_entity_access_tags_tag_id_entity_id", "tag_id", "entity_id"),
+)
+
+link_access_tags = Table(
+    "link_access_tags",
+    metadata,
+    Column(
+        "link_id",
+        String,
+        ForeignKey("links.id", name="fk_link_access_tags_link", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "tag_id",
+        Integer,
+        ForeignKey(
+            "access_tags.id", name="fk_link_access_tags_tag", ondelete="CASCADE"
+        ),
+        primary_key=True,
+    ),
+    Index("idx_link_access_tags_tag_id_link_id", "tag_id", "link_id"),
 )
 
 
-@event.listens_for(entity_access_blobs, "after_create")
-def _create_entities_node_access_blob_trigger(target, connection, **kw):
+@event.listens_for(entity_access_tags, "after_create")
+def _create_entities_node_access_tags_triggers(target, connection, **kw):
     """
     Enforce, at the database level, that an entity pointing to a catalog
-    node (node_id set) does not also carry its own access_blob.
+    node (node_id set) does not also carry its own access tags. Two paths
+    could violate this: an UPDATE that sets node_id on an entity that has
+    tag associations, and an INSERT/UPDATE on entity_access_tags that
+    references a node-backed entity.
     """
     if connection.engine.dialect.name == "sqlite":
-        # Only an UPDATE that sets node_id can turn an existing blob-bearing
-        # entity into an illegal node-backed-with-blob row. The INSERT case
-        # cannot occur in a single statement: an entities INSERT sets only
-        # node_id, while the blob lives in a separate entity_access_blobs row
-        # written by a separate INSERT -- which is itself guarded by
-        # entity_access_blobs_insert_reject_node_backed_entity. This mirrors
-        # the PostgreSQL branch, which likewise only guards UPDATE OF node_id.
         connection.execute(
             text(
                 f"""
-CREATE TRIGGER IF NOT EXISTS entities_node_access_blob_update
+CREATE TRIGGER IF NOT EXISTS entities_node_access_tags_update
 BEFORE UPDATE OF node_id ON entities
 WHEN (NEW.node_id IS NOT NULL AND EXISTS (
-    SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+    SELECT 1 FROM entity_access_tags WHERE entity_id = NEW.id
 ))
 BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_TAGS_ERROR}');
 END"""
             )
         )
+        for operation in ("INSERT", "UPDATE OF entity_id"):
+            connection.execute(
+                text(
+                    f"""
+CREATE TRIGGER IF NOT EXISTS entity_access_tags_{operation.split()[0].lower()}_reject_node_backed_entity
+BEFORE {operation} ON entity_access_tags
+WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
+BEGIN
+    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_TAGS_ERROR}');
+END"""
+                )
+            )
     elif connection.engine.dialect.name == "postgresql":
         # PostgreSQL does not allow subqueries in a trigger WHEN clause
         # ("cannot use subquery in trigger WHEN condition"), so the EXISTS
-        # check against entity_access_blobs lives in the function body; the
-        # trigger WHEN clause keeps only the cheap scalar column test.
+        # checks live in the function bodies; the trigger WHEN clause keeps
+        # only the cheap scalar column test.
         connection.execute(
             text(
                 f"""
-CREATE OR REPLACE FUNCTION entities_reject_node_access_blob()
+CREATE OR REPLACE FUNCTION entities_reject_node_access_tags()
 RETURNS TRIGGER AS $$
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM entity_access_blobs WHERE entity_id = NEW.id
+        SELECT 1 FROM entity_access_tags WHERE entity_id = NEW.id
     ) THEN
-        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_TAGS_ERROR}';
     END IF;
     RETURN NEW;
 END;
@@ -175,128 +202,21 @@ $$ LANGUAGE plpgsql;"""
         connection.execute(
             text(
                 """
-CREATE OR REPLACE TRIGGER entities_node_access_blob_check
+CREATE OR REPLACE TRIGGER entities_node_access_tags_check
 BEFORE UPDATE OF node_id ON entities
 FOR EACH ROW
 WHEN (NEW.node_id IS NOT NULL)
-EXECUTE FUNCTION entities_reject_node_access_blob();"""
-            )
-        )
-
-
-@event.listens_for(link_access_blobs, "after_create")
-def _create_link_access_blob_cleanup_trigger(target, connection, **kw):
-    if connection.engine.dialect.name == "sqlite":
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER link_access_blobs_delete_cleanup
-AFTER DELETE ON link_access_blobs
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-END"""
-            )
-        )
-    elif connection.engine.dialect.name == "postgresql":
-        connection.execute(
-            text(
-                """
-CREATE OR REPLACE FUNCTION delete_link_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-"""
-            )
-        )
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER link_access_blobs_delete_cleanup
-AFTER DELETE ON link_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_link_access_blob();
-"""
-            )
-        )
-
-
-@event.listens_for(link_access_blobs, "after_create")
-def _create_access_blob_association_triggers(target, connection, **kw):
-    tables = ("node_access_blobs", "entity_access_blobs", "link_access_blobs")
-    if connection.engine.dialect.name == "sqlite":
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER entity_access_blobs_delete_cleanup
-AFTER DELETE ON entity_access_blobs
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-END"""
-            )
-        )
-        for operation in ("INSERT", "UPDATE OF entity_id"):
-            connection.execute(
-                text(
-                    f"""
-CREATE TRIGGER entity_access_blobs_{operation.split()[0].lower()}_reject_node_backed_entity
-BEFORE {operation} ON entity_access_blobs
-WHEN EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL)
-BEGIN
-    SELECT RAISE(ABORT, '{ENTITY_NODE_ACCESS_BLOB_ERROR}');
-END"""
-                )
-            )
-        for table in tables:
-            others = " OR ".join(
-                f"EXISTS (SELECT 1 FROM {other} WHERE access_blob_id = NEW.access_blob_id)"
-                for other in tables
-                if other != table
-            )
-            for operation in ("INSERT", "UPDATE OF access_blob_id"):
-                connection.execute(
-                    text(
-                        f"""
-CREATE TRIGGER {table}_{operation.split()[0].lower()}_reject_shared_access_blob
-BEFORE {operation} ON {table}
-WHEN {others}
-BEGIN
-    SELECT RAISE(ABORT, 'An access blob may belong to only one node, entity, or link');
-END"""
-                    )
-                )
-    elif connection.engine.dialect.name == "postgresql":
-        # asyncpg cannot run multiple statements in one prepared execute, so
-        # each CREATE FUNCTION / CREATE TRIGGER is issued individually.
-        connection.execute(
-            text(
-                """
-CREATE OR REPLACE FUNCTION delete_entity_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    DELETE FROM access_blobs WHERE id = OLD.access_blob_id;
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;"""
-            )
-        )
-        connection.execute(
-            text(
-                """
-CREATE TRIGGER entity_access_blobs_delete_cleanup
-AFTER DELETE ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION delete_entity_access_blob();"""
+EXECUTE FUNCTION entities_reject_node_access_tags();"""
             )
         )
         connection.execute(
             text(
                 f"""
-CREATE OR REPLACE FUNCTION entity_access_blob_reject_node_backed_entity()
+CREATE OR REPLACE FUNCTION entity_access_tags_reject_node_backed_entity()
 RETURNS TRIGGER AS $$
 BEGIN
     IF EXISTS (SELECT 1 FROM entities WHERE id = NEW.entity_id AND node_id IS NOT NULL) THEN
-        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_BLOB_ERROR}';
+        RAISE EXCEPTION '{ENTITY_NODE_ACCESS_TAGS_ERROR}';
     END IF;
     RETURN NEW;
 END;
@@ -306,43 +226,11 @@ $$ LANGUAGE plpgsql;"""
         connection.execute(
             text(
                 """
-CREATE TRIGGER entity_access_blobs_reject_node_backed_entity
-BEFORE INSERT OR UPDATE OF entity_id ON entity_access_blobs
-FOR EACH ROW EXECUTE FUNCTION entity_access_blob_reject_node_backed_entity();"""
+CREATE OR REPLACE TRIGGER entity_access_tags_reject_node_backed_entity
+BEFORE INSERT OR UPDATE OF entity_id ON entity_access_tags
+FOR EACH ROW EXECUTE FUNCTION entity_access_tags_reject_node_backed_entity();"""
             )
         )
-        connection.execute(
-            text(
-                """
-CREATE OR REPLACE FUNCTION reject_shared_access_blob()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF (TG_TABLE_NAME = 'node_access_blobs' AND EXISTS (
-        SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
-        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    )) OR (TG_TABLE_NAME = 'entity_access_blobs' AND EXISTS (
-        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-        UNION ALL SELECT 1 FROM link_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    )) OR (TG_TABLE_NAME = 'link_access_blobs' AND EXISTS (
-        SELECT 1 FROM node_access_blobs WHERE access_blob_id = NEW.access_blob_id
-        UNION ALL SELECT 1 FROM entity_access_blobs WHERE access_blob_id = NEW.access_blob_id
-    )) THEN
-        RAISE EXCEPTION 'An access blob may belong to only one node, entity, or link';
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;"""
-            )
-        )
-        for table in tables:
-            connection.execute(
-                text(
-                    f"""
-CREATE TRIGGER {table}_reject_shared_access_blob
-BEFORE INSERT OR UPDATE OF access_blob_id ON {table}
-FOR EACH ROW EXECUTE FUNCTION reject_shared_access_blob();"""
-                )
-            )
 
 
 namespaces = Table(

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -21,6 +21,11 @@ Mutations:
 Property keys and link predicates are expanded against the namespace
 registry when written and compacted back to CURIEs when read, so a
 prefix registered through `upsertNamespace` is resolved consistently.
+
+Access control: entities and links carry access tags (the same tags that
+catalog nodes use). An entity that points to a catalog node (nodeId set)
+carries no tags of its own; it assumes the access tags of the referenced
+node.
 """
 
 from __future__ import annotations
@@ -36,11 +41,11 @@ from strawberry.types import Info
 from strawberry.types.unset import UNSET, UnsetType
 
 from tiled.access_control.access_policies import NO_ACCESS
-from tiled.queries import AccessBlobFilter
-from tiled.type_aliases import AccessBlob
+from tiled.access_control.protocols import AccessTags
+from tiled.queries import AccessTagsFilter
 
 from .curie import compact_term, compact_value, expand_term, expand_value
-from .orm import ENTITY_NODE_ACCESS_BLOB_ERROR
+from .orm import ENTITY_NODE_ACCESS_TAGS_ERROR
 from .store import UNSET as STORE_UNSET
 from .store import EntityRecord, GraphSQLAlchemyStore, LinkRecord
 
@@ -93,12 +98,12 @@ async def _resolve_node_binding(
 
 
 class _PolicyNode:
-    def __init__(self, access_blob: Optional[AccessBlob]):
-        self.access_blob = access_blob or AccessBlob(tags=[])
+    def __init__(self, access_tags: Optional[AccessTags]):
+        self.access_tags = AccessTags(access_tags or ())
 
 
 async def _is_allowed(
-    info: Info, access_blob: Optional[AccessBlob], scope: str
+    info: Info, access_tags: Optional[AccessTags], scope: str
 ) -> bool:
     authn_scopes = info.context["authn_scopes"]
     if scope not in authn_scopes:
@@ -107,7 +112,7 @@ async def _is_allowed(
     if policy is None or not hasattr(policy, "allowed_scopes"):
         return True
     allowed = await policy.allowed_scopes(
-        _PolicyNode(access_blob),
+        _PolicyNode(access_tags),
         info.context["principal"],
         info.context["authn_access_tags"],
         authn_scopes,
@@ -116,24 +121,24 @@ async def _is_allowed(
 
 
 async def _assert_allowed(
-    info: Info, access_blob: Optional[AccessBlob], scope: str
+    info: Info, access_tags: Optional[AccessTags], scope: str
 ) -> None:
-    if not await _is_allowed(info, access_blob, scope):
+    if not await _is_allowed(info, access_tags, scope):
         raise GraphQLError("Not permitted")
 
 
-async def _effective_access_blob(info: Info, record: EntityRecord) -> AccessBlob:
+async def _effective_access_tags(info: Info, record: EntityRecord) -> AccessTags:
     """
     An entity that points to a catalog node (node_id set) delegates its
-    access control to that node, rather than carrying its own access_blob
-    (which is NULL in that case; see the entities_node_access_blob_*
-    trigger in tiled.graph.store). Resolve whichever one is authoritative.
+    access control to that node, rather than carrying its own access tags
+    (it has none in that case; see the entities_node_access_tags_* triggers
+    in tiled.graph.orm). Resolve whichever is authoritative.
     """
     if record.node_id is not None:
-        return await _store(info).get_node_access_blob(record.node_id) or AccessBlob(
-            tags=[]
-        )
-    return record.access_blob or AccessBlob(tags=[])
+        return await _store(info).get_node_access_tags(
+            record.node_id
+        ) or AccessTags()
+    return AccessTags(record.access_tags or ())
 
 
 def _assert_authn_scope(info: Info, scope: str) -> None:
@@ -144,7 +149,7 @@ def _assert_authn_scope(info: Info, scope: str) -> None:
 async def _policy_access_filters(info: Info, scope: str) -> object:
     """
     Return the access-policy filters for a listing query: either a list of
-    AccessBlobFilter (possibly empty, meaning no restriction) or the
+    AccessTagsFilter (possibly empty, meaning no restriction) or the
     NO_ACCESS sentinel. Callers pass the result straight to the store so
     filtering happens in SQL before LIMIT/OFFSET, rather than filtering a
     page of results after the fact (which would return fewer than `limit`
@@ -155,7 +160,7 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
         return []
 
     queries = await policy.filters(
-        _PolicyNode(AccessBlob(tags=[])),
+        _PolicyNode(AccessTags()),
         info.context["principal"],
         info.context["authn_access_tags"],
         info.context["authn_scopes"],
@@ -164,66 +169,66 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
     if queries is NO_ACCESS:
         return NO_ACCESS
     for query in queries:
-        if not isinstance(query, AccessBlobFilter):
+        if not isinstance(query, AccessTagsFilter):
             raise GraphQLError(
                 f"Unsupported access-policy filter in graph queries: {type(query).__name__}"
             )
     return queries
 
 
-def _access_blob_from_input(access_blob: dict) -> AccessBlob:
-    if "user" in access_blob and set(access_blob) == {"user"}:
-        return AccessBlob(username=access_blob["user"])
-    if set(access_blob) <= {"tags"}:
-        return AccessBlob(tags=access_blob.get("tags", []))
-    raise GraphQLError(
-        'access_blob must be either {"user": <username>} or '
-        '{"tags": [<tag>, ...]}. '
-        f"Received {access_blob!r}"
-    )
+def _access_tags_from_input(access_tags: list[str]) -> AccessTags:
+    try:
+        return AccessTags(access_tags)
+    except TypeError as exc:
+        raise GraphQLError(
+            "accessTags must be a list of tag names, e.g. "
+            f'["tag1", "tag2"]. Received {access_tags!r}'
+        ) from exc
 
 
-async def _init_access_blob(
-    info: Info, access_blob: Optional[AccessBlob]
-) -> AccessBlob:
+async def _init_access_tags(
+    info: Info, access_tags: Optional[AccessTags]
+) -> AccessTags:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "init_node"):
         try:
-            _, new_access_blob = await policy.init_node(
+            _, new_access_tags = await policy.init_node(
                 info.context["principal"],
                 info.context["authn_access_tags"],
                 info.context["authn_scopes"],
-                access_blob=access_blob,
+                access_tags=access_tags,
             )
         except ValueError as exc:
-            raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
-        if not isinstance(new_access_blob, AccessBlob):
-            raise TypeError("access policy must return an AccessBlob")
-        return new_access_blob
-    return access_blob or AccessBlob(tags=[])
+            raise GraphQLError(f"Access policy rejects access tags: {exc}") from exc
+        if not isinstance(new_access_tags, AccessTags):
+            raise TypeError("access policy must return an AccessTags")
+        return new_access_tags
+    return access_tags if access_tags is not None else AccessTags()
 
 
-async def _modify_access_blob(
+async def _modify_access_tags(
     info: Info,
-    current_access_blob: Optional[AccessBlob],
-    requested_access_blob: Optional[AccessBlob],
-) -> AccessBlob:
+    current_access_tags: Optional[AccessTags],
+    requested_access_tags: Optional[AccessTags],
+) -> AccessTags:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "modify_node"):
         try:
-            _, new_access_blob = await policy.modify_node(
-                _PolicyNode(current_access_blob),
+            _, new_access_tags = await policy.modify_node(
+                _PolicyNode(current_access_tags),
                 info.context["principal"],
                 info.context["authn_access_tags"],
                 info.context["authn_scopes"],
-                requested_access_blob,
+                requested_access_tags,
             )
         except ValueError as exc:
-            raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
-        if not isinstance(new_access_blob, AccessBlob):
-            raise TypeError("access policy must return an AccessBlob")
-        return new_access_blob
-    return current_access_blob or AccessBlob(tags=[])
+            raise GraphQLError(f"Access policy rejects access tags: {exc}") from exc
+        if not isinstance(new_access_tags, AccessTags):
+            raise TypeError("access policy must return an AccessTags")
+        return new_access_tags
+    if requested_access_tags is not None:
+        return requested_access_tags
+    return AccessTags(current_access_tags or ())
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +298,7 @@ class Link:
     predicate: str
     object_id: strawberry.ID
     properties: Optional[JSON]  # type: ignore[valid-type]
-    access_blob: Optional[JSON]  # type: ignore[valid-type]
+    access_tags: list[str]
     created_at: str
 
     @strawberry.field
@@ -301,8 +306,8 @@ class Link:
         record = await _store(info).get_entity(str(self.subject_id))
         if record is None:
             return None
-        access_blob = await _effective_access_blob(info, record)
-        if not await _is_allowed(info, access_blob, "read:metadata"):
+        access_tags = await _effective_access_tags(info, record)
+        if not await _is_allowed(info, access_tags, "read:metadata"):
             return None
         return _entity_from_record(record, await _namespaces(info))
 
@@ -311,8 +316,8 @@ class Link:
         record = await _store(info).get_entity(str(self.object_id))
         if record is None:
             return None
-        access_blob = await _effective_access_blob(info, record)
-        if not await _is_allowed(info, access_blob, "read:metadata"):
+        access_tags = await _effective_access_tags(info, record)
+        if not await _is_allowed(info, access_tags, "read:metadata"):
             return None
         return _entity_from_record(record, await _namespaces(info))
 
@@ -345,18 +350,13 @@ def _entity_from_record(r: EntityRecord, namespaces: dict[str, str]) -> Entity:
 
 def _link_from_record(r: LinkRecord, namespaces: dict[str, str]) -> Link:
     properties = compact_value(r.properties, namespaces) if r.properties else None
-    access_blob = (
-        {"user": r.access_blob.username}
-        if r.access_blob.username is not None
-        else {"tags": r.access_blob.tags or []}
-    )
     return Link(
         id=strawberry.ID(r.id),
         subject_id=strawberry.ID(r.subject_id),
         predicate=compact_term(r.predicate, namespaces),
         object_id=strawberry.ID(r.object_id),
         properties=properties,
-        access_blob=access_blob,
+        access_tags=sorted(r.access_tags),
         created_at=r.created_at.isoformat(),
     )
 
@@ -374,13 +374,13 @@ class UpdateEntityInput:
     node_path_parts: Optional[list[str]] | UnsetType = UNSET
     uri: Optional[str] | UnsetType = UNSET
     entity_type: Optional[str] = None
-    access_blob: Optional[JSON] | UnsetType = UNSET  # type: ignore[valid-type]
+    access_tags: Optional[list[str]] | UnsetType = UNSET
 
 
 @strawberry.input
 class UpdateLinkInput:
     predicate: Optional[str] | UnsetType = UNSET
-    access_blob: Optional[JSON] | UnsetType = UNSET  # type: ignore[valid-type]
+    access_tags: Optional[list[str]] | UnsetType = UNSET
 
 
 @strawberry.input
@@ -394,7 +394,7 @@ class CreateEntityInput:
     node_path_parts: Optional[list[str]] = None
     uri: Optional[str] = None
     properties: Optional[JSON] = None  # type: ignore[valid-type]
-    access_blob: Optional[JSON] = None  # type: ignore[valid-type]
+    access_tags: Optional[list[str]] = None
 
 
 @strawberry.input
@@ -403,7 +403,7 @@ class CreateLinkInput:
     predicate: str
     object_id: strawberry.ID
     properties: Optional[JSON] = None  # type: ignore[valid-type]
-    access_blob: Optional[JSON] = None  # type: ignore[valid-type]
+    access_tags: Optional[list[str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -418,8 +418,8 @@ class Query:
         record = await _store(info).get_entity(str(id))
         if record is None:
             return None
-        access_blob = await _effective_access_blob(info, record)
-        if not await _is_allowed(info, access_blob, "read:metadata"):
+        access_tags = await _effective_access_tags(info, record)
+        if not await _is_allowed(info, access_tags, "read:metadata"):
             return None
         return _entity_from_record(record, await _namespaces(info))
 
@@ -455,7 +455,7 @@ class Query:
     async def link(self, info: Info, id: strawberry.ID) -> Optional[Link]:
         record = await _store(info).get_link(str(id))
         if not record or not await _is_allowed(
-            info, record.access_blob, "read:metadata"
+            info, AccessTags(record.access_tags), "read:metadata"
         ):
             return None
         return _link_from_record(record, await _namespaces(info))
@@ -505,15 +505,15 @@ class Mutation:
         namespaces = await _namespaces(info)
         node_id = await _resolve_node_binding(info, input.node_path_parts)
         if node_id is not None:
-            if input.access_blob:
-                raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
-            access_blob = None
+            if input.access_tags:
+                raise GraphQLError(ENTITY_NODE_ACCESS_TAGS_ERROR)
+            access_tags = None
         else:
-            access_blob = await _init_access_blob(
+            access_tags = await _init_access_tags(
                 info,
                 (
-                    _access_blob_from_input(input.access_blob)
-                    if input.access_blob is not None
+                    _access_tags_from_input(input.access_tags)
+                    if input.access_tags is not None
                     else None
                 ),
             )
@@ -523,7 +523,7 @@ class Mutation:
             node_id=node_id,
             uri=input.uri,
             properties=expand_value(input.properties or {}, namespaces),
-            access_blob=access_blob,
+            access_tags=access_tags,
         )
         logger.info(
             "Created entity type=%r name=%r id=%s",
@@ -541,19 +541,19 @@ class Mutation:
         if not subject:
             raise GraphQLError(f"Subject entity '{input.subject_id}' not found")
         await _assert_allowed(
-            info, await _effective_access_blob(info, subject), "write:metadata"
+            info, await _effective_access_tags(info, subject), "write:metadata"
         )
         object_ = await _store(info).get_entity(str(input.object_id))
         if not object_:
             raise GraphQLError(f"Object entity '{input.object_id}' not found")
         await _assert_allowed(
-            info, await _effective_access_blob(info, object_), "write:metadata"
+            info, await _effective_access_tags(info, object_), "write:metadata"
         )
-        access_blob = await _init_access_blob(
+        access_tags = await _init_access_tags(
             info,
             (
-                _access_blob_from_input(input.access_blob)
-                if input.access_blob is not None
+                _access_tags_from_input(input.access_tags)
+                if input.access_tags is not None
                 else None
             ),
         )
@@ -562,7 +562,7 @@ class Mutation:
             predicate=expand_term(input.predicate, namespaces),
             object_id=str(input.object_id),
             properties=expand_value(input.properties or {}, namespaces),
-            access_blob=access_blob,
+            access_tags=access_tags,
         )
         logger.info(
             "Created link %s -[%s]-> %s id=%s",
@@ -581,7 +581,7 @@ class Mutation:
         if not record:
             return False
         await _assert_allowed(
-            info, await _effective_access_blob(info, record), "write:metadata"
+            info, await _effective_access_tags(info, record), "write:metadata"
         )
         deleted = await _store(info).delete_entity(str(id))
         if deleted:
@@ -596,7 +596,7 @@ class Mutation:
         if current is None:
             return None
         await _assert_allowed(
-            info, await _effective_access_blob(info, current), "write:metadata"
+            info, await _effective_access_tags(info, current), "write:metadata"
         )
         # Resolve the requested node binding into a tri-state on the internal
         # node id: UNSET (leave), None (detach), or an int (bind).
@@ -609,27 +609,31 @@ class Mutation:
             node_id = await _resolve_node_binding(info, input.node_path_parts)
         node_binding_changed = node_id is not STORE_UNSET
         effective_node_id = current.node_id if node_id is STORE_UNSET else node_id
-        access_blob = UNSET
+        access_tags = UNSET
         if effective_node_id is not None:
-            if input.access_blob is not UNSET and (input.access_blob or {}):
-                raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
-            access_blob = None
-        elif input.access_blob is not UNSET:
-            requested_access_blob = (
-                _access_blob_from_input(input.access_blob)
-                if input.access_blob is not None
+            if input.access_tags is not UNSET and (input.access_tags or []):
+                raise GraphQLError(ENTITY_NODE_ACCESS_TAGS_ERROR)
+            access_tags = None
+        elif input.access_tags is not UNSET:
+            requested_access_tags = (
+                _access_tags_from_input(input.access_tags)
+                if input.access_tags is not None
                 else None
             )
-            access_blob = await _modify_access_blob(
+            access_tags = await _modify_access_tags(
                 info,
-                current.access_blob,
-                requested_access_blob,
+                (
+                    AccessTags(current.access_tags)
+                    if current.access_tags is not None
+                    else None
+                ),
+                requested_access_tags,
             )
-        elif node_binding_changed and current.access_blob is None:
+        elif node_binding_changed and current.access_tags is None:
             # Detaching from a node (node_path_parts set to null) with no
-            # access_blob supplied in the same call: the entity needs its
-            # own access_blob now that it no longer delegates to a node.
-            access_blob = await _init_access_blob(info, None)
+            # access tags supplied in the same call: the entity needs its
+            # own access tags now that it no longer delegates to a node.
+            access_tags = await _init_access_tags(info, None)
         uri = STORE_UNSET if input.uri is UNSET else input.uri
         record = await _store(info).update_entity(
             str(id),
@@ -637,7 +641,7 @@ class Mutation:
             node_id=node_id,
             uri=uri,
             entity_type=input.entity_type,
-            access_blob=access_blob,
+            access_tags=STORE_UNSET if access_tags is UNSET else access_tags,
         )
         if record:
             logger.info("Updated entity id=%s", id)
@@ -648,7 +652,7 @@ class Mutation:
         record = await _store(info).get_link(str(id))
         if not record:
             return False
-        await _assert_allowed(info, record.access_blob, "write:metadata")
+        await _assert_allowed(info, AccessTags(record.access_tags), "write:metadata")
         deleted = await _store(info).delete_link(str(id))
         if deleted:
             logger.info("Deleted link id=%s", id)
@@ -661,17 +665,17 @@ class Mutation:
         current = await _store(info).get_link(str(id))
         if current is None:
             return None
-        await _assert_allowed(info, current.access_blob, "write:metadata")
+        await _assert_allowed(info, AccessTags(current.access_tags), "write:metadata")
         namespaces = await _namespaces(info)
-        access_blob = UNSET
-        if input.access_blob is not UNSET:
-            requested_access_blob = (
-                _access_blob_from_input(input.access_blob)
-                if input.access_blob is not None
+        access_tags = UNSET
+        if input.access_tags is not UNSET:
+            requested_access_tags = (
+                _access_tags_from_input(input.access_tags)
+                if input.access_tags is not None
                 else None
             )
-            access_blob = await _modify_access_blob(
-                info, current.access_blob, requested_access_blob
+            access_tags = await _modify_access_tags(
+                info, AccessTags(current.access_tags), requested_access_tags
             )
         predicate = (
             STORE_UNSET
@@ -681,7 +685,7 @@ class Mutation:
         record = await _store(info).update_link(
             str(id),
             predicate=predicate,
-            access_blob=access_blob,
+            access_tags=STORE_UNSET if access_tags is UNSET else access_tags,
         )
         if record:
             logger.info("Updated link id=%s predicate=%r", id, input.predicate)

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -135,9 +135,8 @@ async def _effective_access_tags(info: Info, record: EntityRecord) -> AccessTags
     in tiled.graph.orm). Resolve whichever is authoritative.
     """
     if record.node_id is not None:
-        return await _store(info).get_node_access_tags(
-            record.node_id
-        ) or AccessTags()
+        node_tags = await _store(info).get_node_access_tags(record.node_id)
+        return AccessTags(node_tags or ())
     return AccessTags(record.access_tags or ())
 
 

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -37,6 +37,7 @@ from strawberry.types.unset import UNSET, UnsetType
 
 from tiled.access_control.access_policies import NO_ACCESS
 from tiled.queries import AccessBlobFilter
+from tiled.type_aliases import AccessBlob
 
 from .curie import compact_term, compact_value, expand_term, expand_value
 from .orm import ENTITY_NODE_ACCESS_BLOB_ERROR
@@ -92,11 +93,13 @@ async def _resolve_node_binding(
 
 
 class _PolicyNode:
-    def __init__(self, access_blob: Optional[dict]):
-        self.access_blob = access_blob or {}
+    def __init__(self, access_blob: Optional[AccessBlob]):
+        self.access_blob = access_blob or AccessBlob(tags=[])
 
 
-async def _is_allowed(info: Info, access_blob: Optional[dict], scope: str) -> bool:
+async def _is_allowed(
+    info: Info, access_blob: Optional[AccessBlob], scope: str
+) -> bool:
     authn_scopes = info.context["authn_scopes"]
     if scope not in authn_scopes:
         return False
@@ -112,12 +115,14 @@ async def _is_allowed(info: Info, access_blob: Optional[dict], scope: str) -> bo
     return scope in allowed
 
 
-async def _assert_allowed(info: Info, access_blob: Optional[dict], scope: str) -> None:
+async def _assert_allowed(
+    info: Info, access_blob: Optional[AccessBlob], scope: str
+) -> None:
     if not await _is_allowed(info, access_blob, scope):
         raise GraphQLError("Not permitted")
 
 
-async def _effective_access_blob(info: Info, record: EntityRecord) -> Optional[dict]:
+async def _effective_access_blob(info: Info, record: EntityRecord) -> AccessBlob:
     """
     An entity that points to a catalog node (node_id set) delegates its
     access control to that node, rather than carrying its own access_blob
@@ -125,8 +130,10 @@ async def _effective_access_blob(info: Info, record: EntityRecord) -> Optional[d
     trigger in tiled.graph.store). Resolve whichever one is authoritative.
     """
     if record.node_id is not None:
-        return await _store(info).get_node_access_blob(record.node_id)
-    return record.access_blob
+        return await _store(info).get_node_access_blob(record.node_id) or AccessBlob(
+            tags=[]
+        )
+    return record.access_blob or AccessBlob(tags=[])
 
 
 def _assert_authn_scope(info: Info, scope: str) -> None:
@@ -148,7 +155,7 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
         return []
 
     queries = await policy.filters(
-        _PolicyNode({}),
+        _PolicyNode(AccessBlob(tags=[])),
         info.context["principal"],
         info.context["authn_access_tags"],
         info.context["authn_scopes"],
@@ -164,7 +171,15 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
     return queries
 
 
-async def _init_access_blob(info: Info, access_blob: Optional[dict]) -> dict:
+def _access_blob_from_input(access_blob: dict) -> AccessBlob:
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    return AccessBlob(tags=access_blob.get("tags", []))
+
+
+async def _init_access_blob(
+    info: Info, access_blob: Optional[AccessBlob]
+) -> AccessBlob:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "init_node"):
         try:
@@ -176,13 +191,17 @@ async def _init_access_blob(info: Info, access_blob: Optional[dict]) -> dict:
             )
         except ValueError as exc:
             raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
+        if not isinstance(new_access_blob, AccessBlob):
+            raise TypeError("access policy must return an AccessBlob")
         return new_access_blob
-    return access_blob or {}
+    return access_blob or AccessBlob(tags=[])
 
 
 async def _modify_access_blob(
-    info: Info, current_access_blob: Optional[dict], requested_access_blob: dict
-) -> dict:
+    info: Info,
+    current_access_blob: Optional[AccessBlob],
+    requested_access_blob: Optional[AccessBlob],
+) -> AccessBlob:
     policy = info.context.get("access_policy")
     if policy is not None and hasattr(policy, "modify_node"):
         try:
@@ -195,8 +214,10 @@ async def _modify_access_blob(
             )
         except ValueError as exc:
             raise GraphQLError(f"Access policy rejects access blob: {exc}") from exc
+        if not isinstance(new_access_blob, AccessBlob):
+            raise TypeError("access policy must return an AccessBlob")
         return new_access_blob
-    return current_access_blob
+    return current_access_blob or AccessBlob(tags=[])
 
 
 # ---------------------------------------------------------------------------
@@ -318,13 +339,18 @@ def _entity_from_record(r: EntityRecord, namespaces: dict[str, str]) -> Entity:
 
 def _link_from_record(r: LinkRecord, namespaces: dict[str, str]) -> Link:
     properties = compact_value(r.properties, namespaces) if r.properties else None
+    access_blob = (
+        {"user": r.access_blob.username}
+        if r.access_blob.username is not None
+        else {"tags": r.access_blob.tags or []}
+    )
     return Link(
         id=strawberry.ID(r.id),
         subject_id=strawberry.ID(r.subject_id),
         predicate=compact_term(r.predicate, namespaces),
         object_id=strawberry.ID(r.object_id),
         properties=properties,
-        access_blob=r.access_blob if r.access_blob else None,
+        access_blob=access_blob,
         created_at=r.created_at.isoformat(),
     )
 
@@ -477,7 +503,14 @@ class Mutation:
                 raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
             access_blob = None
         else:
-            access_blob = await _init_access_blob(info, input.access_blob)
+            access_blob = await _init_access_blob(
+                info,
+                (
+                    _access_blob_from_input(input.access_blob)
+                    if input.access_blob is not None
+                    else None
+                ),
+            )
         record = await _store(info).create_entity(
             entity_type=input.entity_type,
             name=input.name,
@@ -510,7 +543,14 @@ class Mutation:
         await _assert_allowed(
             info, await _effective_access_blob(info, object_), "write:metadata"
         )
-        access_blob = await _init_access_blob(info, input.access_blob)
+        access_blob = await _init_access_blob(
+            info,
+            (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            ),
+        )
         record = await _store(info).create_link(
             subject_id=str(input.subject_id),
             predicate=expand_term(input.predicate, namespaces),
@@ -569,9 +609,15 @@ class Mutation:
                 raise GraphQLError(ENTITY_NODE_ACCESS_BLOB_ERROR)
             access_blob = None
         elif input.access_blob is not UNSET:
-            requested_access_blob = input.access_blob or {}
+            requested_access_blob = (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            )
             access_blob = await _modify_access_blob(
-                info, current.access_blob, requested_access_blob
+                info,
+                current.access_blob,
+                requested_access_blob,
             )
         elif node_binding_changed and current.access_blob is None:
             # Detaching from a node (node_path_parts set to null) with no
@@ -613,7 +659,11 @@ class Mutation:
         namespaces = await _namespaces(info)
         access_blob = UNSET
         if input.access_blob is not UNSET:
-            requested_access_blob = input.access_blob or {}
+            requested_access_blob = (
+                _access_blob_from_input(input.access_blob)
+                if input.access_blob is not None
+                else None
+            )
             access_blob = await _modify_access_blob(
                 info, current.access_blob, requested_access_blob
             )

--- a/tiled/graph/schema.py
+++ b/tiled/graph/schema.py
@@ -172,9 +172,15 @@ async def _policy_access_filters(info: Info, scope: str) -> object:
 
 
 def _access_blob_from_input(access_blob: dict) -> AccessBlob:
-    if "user" in access_blob:
+    if "user" in access_blob and set(access_blob) == {"user"}:
         return AccessBlob(username=access_blob["user"])
-    return AccessBlob(tags=access_blob.get("tags", []))
+    if set(access_blob) <= {"tags"}:
+        return AccessBlob(tags=access_blob.get("tags", []))
+    raise GraphQLError(
+        'access_blob must be either {"user": <username>} or '
+        '{"tags": [<tag>, ...]}. '
+        f"Received {access_blob!r}"
+    )
 
 
 async def _init_access_blob(

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -21,7 +21,6 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
-    JSON,
     String,
     and_,
     delete,
@@ -130,15 +129,20 @@ def _json_access_blob_condition(
 def _json_access_filters_condition(
     dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
 ):
-    condition = _json_access_blob_condition(dialect_name, access_blob_column, queries[0])
+    condition = _json_access_blob_condition(
+        dialect_name, access_blob_column, queries[0]
+    )
     for query in queries[1:]:
         condition = and_(
-            condition, _json_access_blob_condition(dialect_name, access_blob_column, query)
+            condition,
+            _json_access_blob_condition(dialect_name, access_blob_column, query),
         )
     return condition
 
 
-def _access_blob_association_condition(dialect_name: str, table, query: AccessBlobFilter):
+def _access_blob_association_condition(
+    dialect_name: str, table, query: AccessBlobFilter
+):
     if not (query.user_id or query.tags):
         return false()
     tags_match = false()
@@ -147,7 +151,10 @@ def _access_blob_association_condition(dialect_name: str, table, query: AccessBl
             tags = func.json_each(table.c.tags).table_valued("value")
             tags_match = and_(
                 table.c.kind == "tags",
-                select(1).select_from(tags).where(tags.c.value.in_(query.tags)).exists(),
+                select(1)
+                .select_from(tags)
+                .where(tags.c.value.in_(query.tags))
+                .exists(),
             )
         elif dialect_name == "postgresql":
             tags_match = and_(
@@ -309,25 +316,30 @@ class GraphSQLAlchemyStore:
             stmt = stmt.where(_entities.c.node_id == node_id)
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
-            stmt = stmt.outerjoin(
-                _node_access_blobs, _entities.c.node_id == _node_access_blobs.c.node_id
-            ).outerjoin(
-                _access_blobs,
-                _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
-            ).where(
-                or_(
-                    and_(
-                        _entities.c.node_id.is_(None),
-                        _json_access_filters_condition(
-                            dialect_name, _entities.c.access_blob, access_filters
+            stmt = (
+                stmt.outerjoin(
+                    _node_access_blobs,
+                    _entities.c.node_id == _node_access_blobs.c.node_id,
+                )
+                .outerjoin(
+                    _access_blobs,
+                    _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                )
+                .where(
+                    or_(
+                        and_(
+                            _entities.c.node_id.is_(None),
+                            _json_access_filters_condition(
+                                dialect_name, _entities.c.access_blob, access_filters
+                            ),
                         ),
-                    ),
-                    and_(
-                        _entities.c.node_id.isnot(None),
-                        _access_blob_association_filters_condition(
-                            dialect_name, _access_blobs, access_filters
+                        and_(
+                            _entities.c.node_id.isnot(None),
+                            _access_blob_association_filters_condition(
+                                dialect_name, _access_blobs, access_filters
+                            ),
                         ),
-                    ),
+                    )
                 )
             )
         stmt = stmt.limit(limit).offset(offset)

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -30,7 +30,6 @@ from sqlalchemy import and_, delete, false, insert, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ..access_control.protocols import AccessTags
 from ..catalog.orm import AccessTag, Node, NodeAccessTag
 from ..queries import AccessTagsFilter
 from ..server.connection_pool import get_database_engine
@@ -312,11 +311,12 @@ class GraphSQLAlchemyStore:
         async with self._engine.connect() as conn:
             return await self._entity_record(conn, id)
 
-    async def get_node_access_tags(self, node_id: int) -> Optional[AccessTags]:
+    async def get_node_access_tags(self, node_id: int) -> Optional[frozenset[str]]:
         """
         Look up a catalog node's access tags, for resolving the effective
         access control of an entity that points to it (node_id is set).
-        Returns None if the node does not exist.
+        Returns None if the node does not exist. Returns raw stored tag
+        names; the caller converts to the policy-facing AccessTags type.
         """
         async with self._engine.connect() as conn:
             exists = (
@@ -335,7 +335,7 @@ class GraphSQLAlchemyStore:
                     .where(_node_access_tags.c.node_id == node_id)
                 )
             ).all()
-        return AccessTags(row.name for row in rows)
+        return frozenset(row.name for row in rows)
 
     async def list_entities(
         self,

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -30,6 +30,7 @@ from sqlalchemy import and_, delete, false, insert, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from ..catalog.core import register_principal_tag_rows
 from ..catalog.orm import AccessTag, Node, NodeAccessTag
 from ..queries import AccessTagsFilter
 from ..server.connection_pool import get_database_engine
@@ -146,10 +147,14 @@ async def _resolve_tag_ids(conn, tag_names: Iterable[str]) -> list[int]:
     tag that has no row, so unknown names raise. Normally the access policy
     has already validated the tags; this fires only for requests that
     bypassed the policy or raced a tag-definition resync.
+
+    Principal tags are slightly different: these need to exist at write,
+    possibly before the tags compiler has been able to create them.
     """
     names = set(tag_names)
     if not names:
         return []
+    await register_principal_tag_rows(conn, names)
     rows = (
         await conn.execute(
             select(_access_tags.c.id, _access_tags.c.name).where(

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -11,51 +11,43 @@ The graph tables themselves are defined in ``tiled.graph.orm`` (attached to
 the catalog's ``Base.metadata``) and provisioned by the catalog's database
 initialization / Alembic migrations. This store only reads and writes rows; it
 does not create tables.
+
+Access control: entities and links carry access tags drawn from the catalog's
+``access_tags`` table (the same tags nodes use), through the
+``entity_access_tags`` and ``link_access_tags`` association tables. An entity
+that points to a catalog node (``node_id`` set) carries no tags of its own;
+it assumes the access tags of the referenced node.
 """
 
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Iterable, Optional
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import (
-    String,
-    and_,
-    delete,
-    false,
-    func,
-    insert,
-    or_,
-    select,
-    type_coerce,
-    update,
-)
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy import and_, delete, false, insert, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.sql.expression import cast as sql_cast
 
-from ..catalog.orm import AccessBlob as AccessBlobORM
-from ..catalog.orm import Node, NodeAccessBlob
-from ..queries import AccessBlobFilter
+from ..access_control.protocols import AccessTags
+from ..catalog.orm import AccessTag, Node, NodeAccessTag
+from ..queries import AccessTagsFilter
 from ..server.connection_pool import get_database_engine
 from ..server.settings import DatabaseSettings
-from ..type_aliases import AccessBlob
-from ..utils import UnsupportedQueryType
 from .orm import entities as _entities
-from .orm import entity_access_blobs as _entity_access_blobs
-from .orm import link_access_blobs as _link_access_blobs
+from .orm import entity_access_tags as _entity_access_tags
+from .orm import link_access_tags as _link_access_tags
 from .orm import links as _links
 from .orm import namespaces as _namespaces
 
 UNSET = object()
 
-# The catalog ``nodes`` table, used to resolve entities.node_id by catalog path.
+# Catalog tables, used to resolve entities.node_id by catalog path and to
+# resolve/read access tags (shared with catalog nodes).
 _nodes = Node.__table__
-_access_blobs = AccessBlobORM.__table__
-_node_access_blobs = NodeAccessBlob.__table__
+_access_tags = AccessTag.__table__
+_node_access_tags = NodeAccessTag.__table__
 
 # ---------------------------------------------------------------------------
 # Data records
@@ -72,7 +64,7 @@ class EntityRecord(BaseModel):
     uri: Optional[str]
     properties: dict
     # None when node_id is set: access control is delegated to the node.
-    access_blob: Optional[AccessBlob] = None
+    access_tags: Optional[frozenset[str]] = None
     created_at: datetime
 
 
@@ -84,62 +76,94 @@ class LinkRecord(BaseModel):
     predicate: str
     object_id: str
     properties: dict
-    access_blob: AccessBlob
+    access_tags: frozenset[str]
     created_at: datetime
 
 
-def _access_blob_association_condition(
-    dialect_name: str, table, query: AccessBlobFilter
-):
-    if not (query.user_id or query.tags):
+def _access_tags_match_condition(assoc_table, assoc_id_column, owner_column, tags):
+    """
+    Rows tagged with at least one of the given access tags.
+    EXISTS is used (vs IN) as it is much more preformant in SQLite,
+    though performance in Postgres appears similar for both.
+    """
+    return (
+        select(assoc_id_column)
+        .select_from(assoc_table)
+        .join(_access_tags, _access_tags.c.id == assoc_table.c.tag_id)
+        .where(assoc_id_column == owner_column)
+        .where(_access_tags.c.name.in_(tags))
+        .exists()
+    )
+
+
+def _link_access_condition(query: AccessTagsFilter):
+    if not query.tags:
+        # Nothing can match an empty tag list.
         return false()
-    tags_match = false()
-    if query.tags:
-        if dialect_name == "sqlite":
-            tags = func.json_each(table.c.tags).table_valued("value")
-            tags_match = and_(
-                table.c.kind == "tags",
-                select(1)
-                .select_from(tags)
-                .where(tags.c.value.in_(query.tags))
-                .exists(),
-            )
-        elif dialect_name == "postgresql":
-            tags_match = and_(
-                table.c.kind == "tags",
-                type_coerce(table.c.tags, ARRAY(String())).overlap(
-                    sql_cast(query.tags, ARRAY(String()))
-                ),
-            )
-        else:
-            raise UnsupportedQueryType("access_blob_filter")
-    user_match = false()
-    if query.user_id is not None:
-        user_match = and_(table.c.kind == "user", table.c.username == query.user_id)
-    return or_(tags_match, user_match)
+    return _access_tags_match_condition(
+        _link_access_tags, _link_access_tags.c.link_id, _links.c.id, query.tags
+    )
 
 
-def _access_blob_association_filters_condition(
-    dialect_name: str, table, queries: list[AccessBlobFilter]
-):
-    condition = _access_blob_association_condition(dialect_name, table, queries[0])
+def _entity_access_condition(query: AccessTagsFilter):
+    """
+    An entity matches if it carries one of the given tags itself, or, when it
+    is node-backed (node_id set), if the referenced catalog node does.
+    """
+    if not query.tags:
+        return false()
+    return or_(
+        and_(
+            _entities.c.node_id.is_(None),
+            _access_tags_match_condition(
+                _entity_access_tags,
+                _entity_access_tags.c.entity_id,
+                _entities.c.id,
+                query.tags,
+            ),
+        ),
+        and_(
+            _entities.c.node_id.isnot(None),
+            _access_tags_match_condition(
+                _node_access_tags,
+                _node_access_tags.c.node_id,
+                _entities.c.node_id,
+                query.tags,
+            ),
+        ),
+    )
+
+
+def _access_filters_condition(condition_builder, queries: list[AccessTagsFilter]):
+    condition = condition_builder(queries[0])
     for query in queries[1:]:
-        condition = and_(
-            condition, _access_blob_association_condition(dialect_name, table, query)
-        )
+        condition = and_(condition, condition_builder(query))
     return condition
 
 
-def _access_blob_from_association(row) -> AccessBlob:
-    return AccessBlob(username=row.username, tags=row.tags)
-
-
-def _access_blob_values(access_blob: AccessBlob) -> dict:
-    if not isinstance(access_blob, AccessBlob):
-        raise TypeError("access_blob must be an AccessBlob")
-    if access_blob.username is not None:
-        return {"kind": "user", "username": access_blob.username, "tags": None}
-    return {"kind": "tags", "username": None, "tags": access_blob.tags or []}
+async def _resolve_tag_ids(conn, tag_names: Iterable[str]) -> list[int]:
+    """
+    Resolve tag names to access_tags ids. An association cannot reference a
+    tag that has no row, so unknown names raise. Normally the access policy
+    has already validated the tags; this fires only for requests that
+    bypassed the policy or raced a tag-definition resync.
+    """
+    names = set(tag_names)
+    if not names:
+        return []
+    rows = (
+        await conn.execute(
+            select(_access_tags.c.id, _access_tags.c.name).where(
+                _access_tags.c.name.in_(names)
+            )
+        )
+    ).all()
+    missing = names - {row.name for row in rows}
+    if missing:
+        raise ValueError(
+            f"Cannot apply access tags that are not defined: {sorted(missing)}"
+        )
+    return [row.id for row in rows]
 
 
 class GraphSQLAlchemyStore:
@@ -165,7 +189,7 @@ class GraphSQLAlchemyStore:
         return cls(engine, owns_engine=False)
 
     @staticmethod
-    def _to_entity(row) -> EntityRecord:
+    def _to_entity(row, tags: Optional[frozenset[str]]) -> EntityRecord:
         return EntityRecord(
             id=row.id,
             node_id=row.node_id,
@@ -173,52 +197,82 @@ class GraphSQLAlchemyStore:
             name=row.name,
             uri=row.uri,
             properties=row.properties or {},
-            # No association means access control is delegated to node_id.
-            access_blob=(
-                AccessBlob(username=row.access_blob_username, tags=row.access_blob_tags)
-                if row.access_blob_id is not None
-                else None
-            ),
+            # None means access control is delegated to node_id.
+            access_tags=None if row.node_id is not None else (tags or frozenset()),
             created_at=row.created_at,
         )
 
     @staticmethod
-    def _to_link(row) -> LinkRecord:
+    def _to_link(row, tags: Optional[frozenset[str]]) -> LinkRecord:
         return LinkRecord(
             id=row.id,
             subject_id=row.subject_id,
             predicate=row.predicate,
             object_id=row.object_id,
             properties=row.properties or {},
-            access_blob=_access_blob_from_association(row),
+            access_tags=tags or frozenset(),
             created_at=row.created_at,
         )
 
     @staticmethod
-    def _entity_statement(id: Optional[str] = None, entity_access_blobs_value=None):
-        if entity_access_blobs_value is None:
-            entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
-        stmt = (
-            select(
-                _entities,
-                entity_access_blobs_value.c.id.label("access_blob_id"),
-                entity_access_blobs_value.c.username.label("access_blob_username"),
-                entity_access_blobs_value.c.tags.label("access_blob_tags"),
+    async def _tags_by_id(conn, assoc_table, assoc_id_column, ids: list):
+        """Map entity/link id -> frozenset of tag names, one query per page."""
+        if not ids:
+            return {}
+        rows = (
+            await conn.execute(
+                select(assoc_id_column, _access_tags.c.name)
+                .select_from(assoc_table)
+                .join(_access_tags, _access_tags.c.id == assoc_table.c.tag_id)
+                .where(assoc_id_column.in_(ids))
             )
-            .outerjoin(
-                _entity_access_blobs, _entities.c.id == _entity_access_blobs.c.entity_id
-            )
-            .outerjoin(
-                entity_access_blobs_value,
-                _entity_access_blobs.c.access_blob_id == entity_access_blobs_value.c.id,
-            )
-        )
-        if id is not None:
-            stmt = stmt.where(_entities.c.id == id)
-        return stmt
+        ).all()
+        tags_by_id: dict = {}
+        for assoc_id, name in rows:
+            tags_by_id.setdefault(assoc_id, set()).add(name)
+        return {key: frozenset(value) for key, value in tags_by_id.items()}
 
-    async def _entity_row(self, conn, id: str):
-        return (await conn.execute(self._entity_statement(id))).one_or_none()
+    async def _entity_tags(self, conn, ids: list[str]):
+        return await self._tags_by_id(
+            conn, _entity_access_tags, _entity_access_tags.c.entity_id, ids
+        )
+
+    async def _link_tags(self, conn, ids: list[str]):
+        return await self._tags_by_id(
+            conn, _link_access_tags, _link_access_tags.c.link_id, ids
+        )
+
+    async def _entity_record(self, conn, id: str) -> Optional[EntityRecord]:
+        row = (
+            await conn.execute(select(_entities).where(_entities.c.id == id))
+        ).one_or_none()
+        if row is None:
+            return None
+        tags = (await self._entity_tags(conn, [id])).get(id)
+        return self._to_entity(row, tags)
+
+    async def _link_record(self, conn, id: str) -> Optional[LinkRecord]:
+        row = (
+            await conn.execute(select(_links).where(_links.c.id == id))
+        ).one_or_none()
+        if row is None:
+            return None
+        tags = (await self._link_tags(conn, [id])).get(id)
+        return self._to_link(row, tags)
+
+    async def _set_tags(
+        self, conn, assoc_table, assoc_id_column_name: str, id: str, tag_names
+    ) -> None:
+        """Replace the tag associations of an entity or link."""
+        tag_ids = await _resolve_tag_ids(conn, tag_names)
+        await conn.execute(
+            delete(assoc_table).where(getattr(assoc_table.c, assoc_id_column_name) == id)
+        )
+        if tag_ids:
+            await conn.execute(
+                insert(assoc_table),
+                [{assoc_id_column_name: id, "tag_id": tag_id} for tag_id in tag_ids],
+            )
 
     async def create_entity(
         self,
@@ -227,14 +281,12 @@ class GraphSQLAlchemyStore:
         node_id: Optional[int] = None,
         uri: Optional[str] = None,
         properties: Optional[dict] = None,
-        access_blob: Optional[AccessBlob] = None,
+        access_tags: Optional[Iterable[str]] = None,
     ) -> EntityRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
-        if access_blob is not None and not isinstance(access_blob, AccessBlob):
-            raise TypeError("access_blob must be an AccessBlob")
-        if node_id is not None and access_blob is not None:
-            raise IntegrityError("entity node access blob", {}, None)
+        if node_id is not None and access_tags:
+            raise IntegrityError("entity node access tags", {}, None)
         async with self._engine.begin() as conn:
             await conn.execute(
                 insert(_entities).values(
@@ -247,44 +299,43 @@ class GraphSQLAlchemyStore:
                     created_at=now,
                 )
             )
-            if node_id is None:
-                access_blob_result = await conn.execute(
-                    insert(_access_blobs).values(
-                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
-                    )
-                )
+            if node_id is None and access_tags:
+                tag_ids = await _resolve_tag_ids(conn, access_tags)
                 await conn.execute(
-                    insert(_entity_access_blobs).values(
-                        entity_id=id_,
-                        access_blob_id=access_blob_result.inserted_primary_key[0],
-                    )
+                    insert(_entity_access_tags),
+                    [{"entity_id": id_, "tag_id": tag_id} for tag_id in tag_ids],
                 )
-            row = await self._entity_row(conn, id_)
-        return self._to_entity(row)
+            record = await self._entity_record(conn, id_)
+        return record
 
     async def get_entity(self, id: str) -> Optional[EntityRecord]:
         async with self._engine.connect() as conn:
-            row = await self._entity_row(conn, id)
-        return self._to_entity(row) if row else None
+            return await self._entity_record(conn, id)
 
-    async def get_node_access_blob(self, node_id: int) -> Optional[AccessBlob]:
+    async def get_node_access_tags(self, node_id: int) -> Optional[AccessTags]:
         """
-        Look up a catalog node's access_blob, for resolving the effective
+        Look up a catalog node's access tags, for resolving the effective
         access control of an entity that points to it (node_id is set).
+        Returns None if the node does not exist.
         """
         async with self._engine.connect() as conn:
-            row = (
-                await conn.execute(
-                    select(_access_blobs)
-                    .join(
-                        _node_access_blobs,
-                        _access_blobs.c.id == _node_access_blobs.c.access_blob_id,
-                    )
-                    .join(_nodes, _node_access_blobs.c.node_id == _nodes.c.id)
-                    .where(_nodes.c.id == node_id)
-                )
+            exists = (
+                await conn.execute(select(_nodes.c.id).where(_nodes.c.id == node_id))
             ).one_or_none()
-        return _access_blob_from_association(row) if row else None
+            if exists is None:
+                return None
+            rows = (
+                await conn.execute(
+                    select(_access_tags.c.name)
+                    .select_from(_node_access_tags)
+                    .join(
+                        _access_tags,
+                        _access_tags.c.id == _node_access_tags.c.tag_id,
+                    )
+                    .where(_node_access_tags.c.node_id == node_id)
+                )
+            ).all()
+        return AccessTags(row.name for row in rows)
 
     async def list_entities(
         self,
@@ -292,49 +343,22 @@ class GraphSQLAlchemyStore:
         node_id: Optional[int] = None,
         limit: int = 100,
         offset: int = 0,
-        access_filters: Optional[list[AccessBlobFilter]] = None,
+        access_filters: Optional[list[AccessTagsFilter]] = None,
     ) -> list[EntityRecord]:
-        entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
-        node_access_blobs_value = _access_blobs.alias("node_access_blobs_value")
-        stmt = self._entity_statement(
-            entity_access_blobs_value=entity_access_blobs_value
-        ).order_by(_entities.c.created_at)
+        stmt = select(_entities).order_by(_entities.c.created_at)
         if entity_type is not None:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
         if node_id is not None:
             stmt = stmt.where(_entities.c.node_id == node_id)
         if access_filters:
-            dialect_name = self._engine.url.get_dialect().name
-            stmt = (
-                stmt.outerjoin(
-                    _node_access_blobs,
-                    _entities.c.node_id == _node_access_blobs.c.node_id,
-                )
-                .outerjoin(
-                    node_access_blobs_value,
-                    _node_access_blobs.c.access_blob_id == node_access_blobs_value.c.id,
-                )
-                .where(
-                    or_(
-                        and_(
-                            _entities.c.node_id.is_(None),
-                            _access_blob_association_filters_condition(
-                                dialect_name, entity_access_blobs_value, access_filters
-                            ),
-                        ),
-                        and_(
-                            _entities.c.node_id.isnot(None),
-                            _access_blob_association_filters_condition(
-                                dialect_name, node_access_blobs_value, access_filters
-                            ),
-                        ),
-                    )
-                )
+            stmt = stmt.where(
+                _access_filters_condition(_entity_access_condition, access_filters)
             )
         stmt = stmt.limit(limit).offset(offset)
         async with self._engine.connect() as conn:
             rows = (await conn.execute(stmt)).all()
-        return [self._to_entity(r) for r in rows]
+            tags_by_id = await self._entity_tags(conn, [row.id for row in rows])
+        return [self._to_entity(row, tags_by_id.get(row.id)) for row in rows]
 
     async def delete_entity(self, id: str) -> bool:
         async with self._engine.begin() as conn:
@@ -348,7 +372,7 @@ class GraphSQLAlchemyStore:
         node_id: object = UNSET,
         uri: object = UNSET,
         entity_type: Optional[str] = None,
-        access_blob: object = UNSET,
+        access_tags: object = UNSET,
     ) -> Optional[EntityRecord]:
         values: dict = {}
         if name is not None:
@@ -359,84 +383,46 @@ class GraphSQLAlchemyStore:
             values["uri"] = uri
         if entity_type is not None:
             values["entity_type"] = entity_type
-        if access_blob is not UNSET:
-            if access_blob is not None and not isinstance(access_blob, AccessBlob):
-                raise TypeError("access_blob must be an AccessBlob")
         async with self._engine.begin() as conn:
-            existing = await self._entity_row(conn, id)
+            existing = await self._entity_record(conn, id)
             if existing is None:
                 return None
             effective_node_id = node_id if node_id is not UNSET else existing.node_id
-            if (
-                access_blob is not UNSET
-                and effective_node_id is not None
-                and access_blob is not None
-            ):
-                raise IntegrityError("entity node access blob", {}, None)
+            if access_tags is not UNSET and effective_node_id is not None and access_tags:
+                raise IntegrityError("entity node access tags", {}, None)
             if existing.node_id is None and effective_node_id is not None:
+                # Becoming node-backed: shed own tags first, so the
+                # entities.node_id trigger sees no remaining associations.
                 await conn.execute(
-                    delete(_entity_access_blobs).where(
-                        _entity_access_blobs.c.entity_id == id
+                    delete(_entity_access_tags).where(
+                        _entity_access_tags.c.entity_id == id
                     )
                 )
             if values:
                 await conn.execute(
                     update(_entities).where(_entities.c.id == id).values(**values)
                 )
-            if access_blob is not UNSET:
-                if access_blob is None:
+            if access_tags is not UNSET:
+                if access_tags is None:
                     if effective_node_id is None:
                         raise IntegrityError(
-                            "Refusing to clear access_blob on a standalone entity "
+                            "Refusing to clear access tags on a standalone entity "
                             "(no node_id): it would leave the entity without access "
-                            "control. Provide an AccessBlob or set node_id.",
+                            "control. Provide a list of tags or set node_id.",
                             {},
                             None,
                         )
                     await conn.execute(
-                        delete(_entity_access_blobs).where(
-                            _entity_access_blobs.c.entity_id == id
+                        delete(_entity_access_tags).where(
+                            _entity_access_tags.c.entity_id == id
                         )
                     )
-                elif existing.access_blob_id is None:
-                    access_blob_result = await conn.execute(
-                        insert(_access_blobs).values(**_access_blob_values(access_blob))
+                elif effective_node_id is None:
+                    await self._set_tags(
+                        conn, _entity_access_tags, "entity_id", id, access_tags
                     )
-                    await conn.execute(
-                        insert(_entity_access_blobs).values(
-                            entity_id=id,
-                            access_blob_id=access_blob_result.inserted_primary_key[0],
-                        )
-                    )
-                else:
-                    await conn.execute(
-                        update(_access_blobs)
-                        .where(
-                            _access_blobs.c.id
-                            == select(_entity_access_blobs.c.access_blob_id)
-                            .where(_entity_access_blobs.c.entity_id == id)
-                            .scalar_subquery()
-                        )
-                        .values(**_access_blob_values(access_blob))
-                    )
-            if (
-                existing.node_id is not None
-                and effective_node_id is None
-                and access_blob is UNSET
-            ):
-                access_blob_result = await conn.execute(
-                    insert(_access_blobs).values(
-                        **_access_blob_values(AccessBlob(tags=[]))
-                    )
-                )
-                await conn.execute(
-                    insert(_entity_access_blobs).values(
-                        entity_id=id,
-                        access_blob_id=access_blob_result.inserted_primary_key[0],
-                    )
-                )
-            row = await self._entity_row(conn, id)
-        return self._to_entity(row) if row else None
+            record = await self._entity_record(conn, id)
+        return record
 
     async def create_link(
         self,
@@ -444,12 +430,10 @@ class GraphSQLAlchemyStore:
         predicate: str,
         object_id: str,
         properties: Optional[dict] = None,
-        access_blob: Optional[AccessBlob] = None,
+        access_tags: Optional[Iterable[str]] = None,
     ) -> LinkRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
-        if access_blob is not None and not isinstance(access_blob, AccessBlob):
-            raise TypeError("access_blob must be an AccessBlob")
         # The subject_id/object_id foreign keys reference entities.id, so the
         # database rejects a link to a nonexistent entity (SQLite enforces this
         # too: the shared pool sets PRAGMA foreign_keys=ON). Insert directly and
@@ -467,31 +451,13 @@ class GraphSQLAlchemyStore:
                         created_at=now,
                     )
                 )
-                access_blob_result = await conn.execute(
-                    insert(_access_blobs).values(
-                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
-                    )
-                )
-                await conn.execute(
-                    insert(_link_access_blobs).values(
-                        link_id=id_,
-                        access_blob_id=access_blob_result.inserted_primary_key[0],
-                    )
-                )
-                row = (
+                if access_tags:
+                    tag_ids = await _resolve_tag_ids(conn, access_tags)
                     await conn.execute(
-                        select(_links, _access_blobs)
-                        .join(
-                            _link_access_blobs,
-                            _links.c.id == _link_access_blobs.c.link_id,
-                        )
-                        .join(
-                            _access_blobs,
-                            _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
-                        )
-                        .where(_links.c.id == id_)
+                        insert(_link_access_tags),
+                        [{"link_id": id_, "tag_id": tag_id} for tag_id in tag_ids],
                     )
-                ).one()
+                record = await self._link_record(conn, id_)
         except IntegrityError as exc:
             # A foreign-key violation means one of the endpoints is missing.
             # Resolve which one only on this failure path so the success path
@@ -501,25 +467,11 @@ class GraphSQLAlchemyStore:
             if not await self.get_entity(object_id):
                 raise ValueError(f"Object entity '{object_id}' not found") from exc
             raise
-        return self._to_link(row)
+        return record
 
     async def get_link(self, id: str) -> Optional[LinkRecord]:
         async with self._engine.connect() as conn:
-            row = (
-                await conn.execute(
-                    select(_links, _access_blobs)
-                    .join(
-                        _link_access_blobs,
-                        _links.c.id == _link_access_blobs.c.link_id,
-                    )
-                    .join(
-                        _access_blobs,
-                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
-                    )
-                    .where(_links.c.id == id)
-                )
-            ).one_or_none()
-        return self._to_link(row) if row else None
+            return await self._link_record(conn, id)
 
     async def find_links(
         self,
@@ -528,17 +480,9 @@ class GraphSQLAlchemyStore:
         object_id: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
-        access_filters: Optional[list[AccessBlobFilter]] = None,
+        access_filters: Optional[list[AccessTagsFilter]] = None,
     ) -> list[LinkRecord]:
-        stmt = (
-            select(_links, _access_blobs)
-            .join(_link_access_blobs, _links.c.id == _link_access_blobs.c.link_id)
-            .join(
-                _access_blobs,
-                _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
-            )
-            .order_by(_links.c.created_at)
-        )
+        stmt = select(_links).order_by(_links.c.created_at)
         if subject_id is not None:
             stmt = stmt.where(_links.c.subject_id == subject_id)
         if predicate is not None:
@@ -546,16 +490,14 @@ class GraphSQLAlchemyStore:
         if object_id is not None:
             stmt = stmt.where(_links.c.object_id == object_id)
         if access_filters:
-            dialect_name = self._engine.url.get_dialect().name
             stmt = stmt.where(
-                _access_blob_association_filters_condition(
-                    dialect_name, _access_blobs, access_filters
-                )
+                _access_filters_condition(_link_access_condition, access_filters)
             )
         stmt = stmt.limit(limit).offset(offset)
         async with self._engine.connect() as conn:
             rows = (await conn.execute(stmt)).all()
-        return [self._to_link(r) for r in rows]
+            tags_by_id = await self._link_tags(conn, [row.id for row in rows])
+        return [self._to_link(row, tags_by_id.get(row.id)) for row in rows]
 
     async def delete_link(self, id: str) -> bool:
         async with self._engine.begin() as conn:
@@ -566,7 +508,7 @@ class GraphSQLAlchemyStore:
         self,
         id: str,
         predicate: object = UNSET,
-        access_blob: object = UNSET,
+        access_tags: object = UNSET,
     ) -> Optional[LinkRecord]:
         values: dict = {}
         if predicate is not UNSET:
@@ -576,34 +518,12 @@ class GraphSQLAlchemyStore:
                 await conn.execute(
                     update(_links).where(_links.c.id == id).values(**values)
                 )
-            if access_blob is not UNSET:
-                if access_blob is not None and not isinstance(access_blob, AccessBlob):
-                    raise TypeError("access_blob must be an AccessBlob")
-                await conn.execute(
-                    update(_access_blobs)
-                    .where(
-                        _access_blobs.c.id
-                        == select(_link_access_blobs.c.access_blob_id)
-                        .where(_link_access_blobs.c.link_id == id)
-                        .scalar_subquery()
-                    )
-                    .values(**_access_blob_values(access_blob or AccessBlob(tags=[])))
+            if access_tags is not UNSET:
+                await self._set_tags(
+                    conn, _link_access_tags, "link_id", id, access_tags or []
                 )
-            row = (
-                await conn.execute(
-                    select(_links, _access_blobs)
-                    .join(
-                        _link_access_blobs,
-                        _links.c.id == _link_access_blobs.c.link_id,
-                    )
-                    .join(
-                        _access_blobs,
-                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
-                    )
-                    .where(_links.c.id == id)
-                )
-            ).one_or_none()
-        return self._to_link(row) if row else None
+            record = await self._link_record(conn, id)
+        return record
 
     async def upsert_namespace(self, prefix: str, uri: str) -> None:
         if not prefix:

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -270,7 +270,9 @@ class GraphSQLAlchemyStore:
         """Replace the tag associations of an entity or link."""
         tag_ids = await _resolve_tag_ids(conn, tag_names)
         await conn.execute(
-            delete(assoc_table).where(getattr(assoc_table.c, assoc_id_column_name) == id)
+            delete(assoc_table).where(
+                getattr(assoc_table.c, assoc_id_column_name) == id
+            )
         )
         if tag_ids:
             await conn.execute(
@@ -393,7 +395,11 @@ class GraphSQLAlchemyStore:
             if existing is None:
                 return None
             effective_node_id = node_id if node_id is not UNSET else existing.node_id
-            if access_tags is not UNSET and effective_node_id is not None and access_tags:
+            if (
+                access_tags is not UNSET
+                and effective_node_id is not None
+                and access_tags
+            ):
                 raise IntegrityError("entity node access tags", {}, None)
             if existing.node_id is None and effective_node_id is not None:
                 # Becoming node-backed: shed own tags first, so the

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -32,17 +32,20 @@ from sqlalchemy import (
     type_coerce,
     update,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TEXT
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.sql.expression import cast as sql_cast
 
-from ..catalog.orm import AccessBlob, Node, NodeAccessBlob
+from ..catalog.orm import AccessBlob as AccessBlobORM
+from ..catalog.orm import Node, NodeAccessBlob
 from ..queries import AccessBlobFilter
 from ..server.connection_pool import get_database_engine
 from ..server.settings import DatabaseSettings
+from ..type_aliases import AccessBlob
 from ..utils import UnsupportedQueryType
 from .orm import entities as _entities
+from .orm import entity_access_blobs as _entity_access_blobs
 from .orm import link_access_blobs as _link_access_blobs
 from .orm import links as _links
 from .orm import namespaces as _namespaces
@@ -51,7 +54,7 @@ UNSET = object()
 
 # The catalog ``nodes`` table, used to resolve entities.node_id by catalog path.
 _nodes = Node.__table__
-_access_blobs = AccessBlob.__table__
+_access_blobs = AccessBlobORM.__table__
 _node_access_blobs = NodeAccessBlob.__table__
 
 # ---------------------------------------------------------------------------
@@ -69,7 +72,7 @@ class EntityRecord(BaseModel):
     uri: Optional[str]
     properties: dict
     # None when node_id is set: access control is delegated to the node.
-    access_blob: Optional[dict] = None
+    access_blob: Optional[AccessBlob] = None
     created_at: datetime
 
 
@@ -81,63 +84,8 @@ class LinkRecord(BaseModel):
     predicate: str
     object_id: str
     properties: dict
-    access_blob: dict
+    access_blob: AccessBlob
     created_at: datetime
-
-
-def _json_access_blob_condition(
-    dialect_name: str, access_blob_column, query: AccessBlobFilter
-):
-    """
-    Translate one AccessBlobFilter into a SQL condition on a JSON
-    access_blob column, mirroring tiled.catalog.adapter.access_blob_filter
-    so that pagination (LIMIT/OFFSET) is applied to already-filtered rows
-    instead of filtering a page after the fact.
-    """
-    if not (query.user_id or query.tags):
-        # Results cannot possibly match an empty value or list,
-        # so put a False condition in the list ensuring that
-        # there are no rows returned.
-        return false()
-    if dialect_name == "sqlite":
-        access_tags_json = func.json_each(access_blob_column["tags"]).table_valued(
-            "value"
-        )
-        condition = (
-            select(1)
-            .select_from(access_tags_json)
-            .where(access_tags_json.c.value.in_(query.tags))
-            .exists()
-        )
-        if query.user_id is not None:
-            user_match = (
-                func.json_extract(func.json_quote(access_blob_column["user"]), "$")
-                == query.user_id
-            )
-            condition = or_(condition, user_match)
-    elif dialect_name == "postgresql":
-        access_blob_jsonb = type_coerce(access_blob_column, JSONB)
-        condition = access_blob_jsonb["tags"].has_any(sql_cast(query.tags, ARRAY(TEXT)))
-        if query.user_id is not None:
-            user_match = access_blob_jsonb["user"].astext == query.user_id
-            condition = or_(condition, user_match)
-    else:
-        raise UnsupportedQueryType("access_blob_filter")
-    return condition
-
-
-def _json_access_filters_condition(
-    dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
-):
-    condition = _json_access_blob_condition(
-        dialect_name, access_blob_column, queries[0]
-    )
-    for query in queries[1:]:
-        condition = and_(
-            condition,
-            _json_access_blob_condition(dialect_name, access_blob_column, query),
-        )
-    return condition
 
 
 def _access_blob_association_condition(
@@ -182,17 +130,16 @@ def _access_blob_association_filters_condition(
     return condition
 
 
-def _access_blob_from_association(row) -> dict:
-    if row.kind == "user":
-        return {"user": row.username}
-    return {"tags": row.tags or []}
+def _access_blob_from_association(row) -> AccessBlob:
+    return AccessBlob(username=row.username, tags=row.tags)
 
 
-def _access_blob_values(access_blob: Optional[dict]) -> dict:
-    access_blob = access_blob or {}
-    if "user" in access_blob:
-        return {"kind": "user", "username": access_blob["user"], "tags": None}
-    return {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
+def _access_blob_values(access_blob: AccessBlob) -> dict:
+    if not isinstance(access_blob, AccessBlob):
+        raise TypeError("access_blob must be an AccessBlob")
+    if access_blob.username is not None:
+        return {"kind": "user", "username": access_blob.username, "tags": None}
+    return {"kind": "tags", "username": None, "tags": access_blob.tags or []}
 
 
 class GraphSQLAlchemyStore:
@@ -226,9 +173,12 @@ class GraphSQLAlchemyStore:
             name=row.name,
             uri=row.uri,
             properties=row.properties or {},
-            # Preserve None as-is (rather than coercing to {}): None means
-            # access control is delegated to the node (node_id is set).
-            access_blob=row.access_blob,
+            # No association means access control is delegated to node_id.
+            access_blob=(
+                AccessBlob(username=row.access_blob_username, tags=row.access_blob_tags)
+                if row.access_blob_id is not None
+                else None
+            ),
             created_at=row.created_at,
         )
 
@@ -244,6 +194,32 @@ class GraphSQLAlchemyStore:
             created_at=row.created_at,
         )
 
+    @staticmethod
+    def _entity_statement(id: Optional[str] = None, entity_access_blobs_value=None):
+        if entity_access_blobs_value is None:
+            entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
+        stmt = (
+            select(
+                _entities,
+                entity_access_blobs_value.c.id.label("access_blob_id"),
+                entity_access_blobs_value.c.username.label("access_blob_username"),
+                entity_access_blobs_value.c.tags.label("access_blob_tags"),
+            )
+            .outerjoin(
+                _entity_access_blobs, _entities.c.id == _entity_access_blobs.c.entity_id
+            )
+            .outerjoin(
+                entity_access_blobs_value,
+                _entity_access_blobs.c.access_blob_id == entity_access_blobs_value.c.id,
+            )
+        )
+        if id is not None:
+            stmt = stmt.where(_entities.c.id == id)
+        return stmt
+
+    async def _entity_row(self, conn, id: str):
+        return (await conn.execute(self._entity_statement(id))).one_or_none()
+
     async def create_entity(
         self,
         entity_type: str,
@@ -251,10 +227,14 @@ class GraphSQLAlchemyStore:
         node_id: Optional[int] = None,
         uri: Optional[str] = None,
         properties: Optional[dict] = None,
-        access_blob: Optional[dict] = None,
+        access_blob: Optional[AccessBlob] = None,
     ) -> EntityRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
+        if access_blob is not None and not isinstance(access_blob, AccessBlob):
+            raise TypeError("access_blob must be an AccessBlob")
+        if node_id is not None and access_blob is not None:
+            raise IntegrityError("entity node access blob", {}, None)
         async with self._engine.begin() as conn:
             await conn.execute(
                 insert(_entities).values(
@@ -264,25 +244,30 @@ class GraphSQLAlchemyStore:
                     name=name,
                     uri=uri,
                     properties=properties or {},
-                    # Not coerced to {}: passing None here (as the caller
-                    # must when node_id is set) stores SQL NULL.
-                    access_blob=access_blob,
                     created_at=now,
                 )
             )
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id_))
-            ).one()
+            if node_id is None:
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(
+                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
+                    )
+                )
+                await conn.execute(
+                    insert(_entity_access_blobs).values(
+                        entity_id=id_,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
+            row = await self._entity_row(conn, id_)
         return self._to_entity(row)
 
     async def get_entity(self, id: str) -> Optional[EntityRecord]:
         async with self._engine.connect() as conn:
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id))
-            ).one_or_none()
+            row = await self._entity_row(conn, id)
         return self._to_entity(row) if row else None
 
-    async def get_node_access_blob(self, node_id: int) -> Optional[dict]:
+    async def get_node_access_blob(self, node_id: int) -> Optional[AccessBlob]:
         """
         Look up a catalog node's access_blob, for resolving the effective
         access control of an entity that points to it (node_id is set).
@@ -309,7 +294,11 @@ class GraphSQLAlchemyStore:
         offset: int = 0,
         access_filters: Optional[list[AccessBlobFilter]] = None,
     ) -> list[EntityRecord]:
-        stmt = select(_entities).order_by(_entities.c.created_at)
+        entity_access_blobs_value = _access_blobs.alias("entity_access_blobs_value")
+        node_access_blobs_value = _access_blobs.alias("node_access_blobs_value")
+        stmt = self._entity_statement(
+            entity_access_blobs_value=entity_access_blobs_value
+        ).order_by(_entities.c.created_at)
         if entity_type is not None:
             stmt = stmt.where(_entities.c.entity_type == entity_type)
         if node_id is not None:
@@ -322,21 +311,21 @@ class GraphSQLAlchemyStore:
                     _entities.c.node_id == _node_access_blobs.c.node_id,
                 )
                 .outerjoin(
-                    _access_blobs,
-                    _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    node_access_blobs_value,
+                    _node_access_blobs.c.access_blob_id == node_access_blobs_value.c.id,
                 )
                 .where(
                     or_(
                         and_(
                             _entities.c.node_id.is_(None),
-                            _json_access_filters_condition(
-                                dialect_name, _entities.c.access_blob, access_filters
+                            _access_blob_association_filters_condition(
+                                dialect_name, entity_access_blobs_value, access_filters
                             ),
                         ),
                         and_(
                             _entities.c.node_id.isnot(None),
                             _access_blob_association_filters_condition(
-                                dialect_name, _access_blobs, access_filters
+                                dialect_name, node_access_blobs_value, access_filters
                             ),
                         ),
                     )
@@ -371,15 +360,74 @@ class GraphSQLAlchemyStore:
         if entity_type is not None:
             values["entity_type"] = entity_type
         if access_blob is not UNSET:
-            values["access_blob"] = access_blob
+            if access_blob is not None and not isinstance(access_blob, AccessBlob):
+                raise TypeError("access_blob must be an AccessBlob")
         async with self._engine.begin() as conn:
+            existing = await self._entity_row(conn, id)
+            if existing is None:
+                return None
+            effective_node_id = node_id if node_id is not UNSET else existing.node_id
+            if (
+                access_blob is not UNSET
+                and effective_node_id is not None
+                and access_blob is not None
+            ):
+                raise IntegrityError("entity node access blob", {}, None)
+            if existing.node_id is None and effective_node_id is not None:
+                await conn.execute(
+                    delete(_entity_access_blobs).where(
+                        _entity_access_blobs.c.entity_id == id
+                    )
+                )
             if values:
                 await conn.execute(
                     update(_entities).where(_entities.c.id == id).values(**values)
                 )
-            row = (
-                await conn.execute(select(_entities).where(_entities.c.id == id))
-            ).one_or_none()
+            if access_blob is not UNSET:
+                if access_blob is None:
+                    await conn.execute(
+                        delete(_entity_access_blobs).where(
+                            _entity_access_blobs.c.entity_id == id
+                        )
+                    )
+                elif existing.access_blob_id is None:
+                    access_blob_result = await conn.execute(
+                        insert(_access_blobs).values(**_access_blob_values(access_blob))
+                    )
+                    await conn.execute(
+                        insert(_entity_access_blobs).values(
+                            entity_id=id,
+                            access_blob_id=access_blob_result.inserted_primary_key[0],
+                        )
+                    )
+                else:
+                    await conn.execute(
+                        update(_access_blobs)
+                        .where(
+                            _access_blobs.c.id
+                            == select(_entity_access_blobs.c.access_blob_id)
+                            .where(_entity_access_blobs.c.entity_id == id)
+                            .scalar_subquery()
+                        )
+                        .values(**_access_blob_values(access_blob))
+                    )
+            if (
+                existing.node_id is not None
+                and effective_node_id is None
+                and access_blob is UNSET
+            ):
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(
+                        **_access_blob_values(AccessBlob(tags=[]))
+                    )
+                )
+                await conn.execute(
+                    insert(_entity_access_blobs).values(
+                        entity_id=id,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
+            row = await self._entity_row(conn, id)
         return self._to_entity(row) if row else None
 
     async def create_link(
@@ -388,10 +436,12 @@ class GraphSQLAlchemyStore:
         predicate: str,
         object_id: str,
         properties: Optional[dict] = None,
-        access_blob: Optional[dict] = None,
+        access_blob: Optional[AccessBlob] = None,
     ) -> LinkRecord:
         id_ = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
+        if access_blob is not None and not isinstance(access_blob, AccessBlob):
+            raise TypeError("access_blob must be an AccessBlob")
         # The subject_id/object_id foreign keys reference entities.id, so the
         # database rejects a link to a nonexistent entity (SQLite enforces this
         # too: the shared pool sets PRAGMA foreign_keys=ON). Insert directly and
@@ -410,7 +460,9 @@ class GraphSQLAlchemyStore:
                     )
                 )
                 access_blob_result = await conn.execute(
-                    insert(_access_blobs).values(**_access_blob_values(access_blob))
+                    insert(_access_blobs).values(
+                        **_access_blob_values(access_blob or AccessBlob(tags=[]))
+                    )
                 )
                 await conn.execute(
                     insert(_link_access_blobs).values(
@@ -517,6 +569,8 @@ class GraphSQLAlchemyStore:
                     update(_links).where(_links.c.id == id).values(**values)
                 )
             if access_blob is not UNSET:
+                if access_blob is not None and not isinstance(access_blob, AccessBlob):
+                    raise TypeError("access_blob must be an AccessBlob")
                 await conn.execute(
                     update(_access_blobs)
                     .where(
@@ -525,7 +579,7 @@ class GraphSQLAlchemyStore:
                         .where(_link_access_blobs.c.link_id == id)
                         .scalar_subquery()
                     )
-                    .values(**_access_blob_values(access_blob))
+                    .values(**_access_blob_values(access_blob or AccessBlob(tags=[])))
                 )
             row = (
                 await conn.execute(

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -22,8 +22,8 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
     JSON,
+    String,
     and_,
-    case,
     delete,
     false,
     func,
@@ -38,12 +38,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.sql.expression import cast as sql_cast
 
-from ..catalog.orm import Node
+from ..catalog.orm import AccessBlob, Node, NodeAccessBlob
 from ..queries import AccessBlobFilter
 from ..server.connection_pool import get_database_engine
 from ..server.settings import DatabaseSettings
 from ..utils import UnsupportedQueryType
 from .orm import entities as _entities
+from .orm import link_access_blobs as _link_access_blobs
 from .orm import links as _links
 from .orm import namespaces as _namespaces
 
@@ -51,6 +52,8 @@ UNSET = object()
 
 # The catalog ``nodes`` table, used to resolve entities.node_id by catalog path.
 _nodes = Node.__table__
+_access_blobs = AccessBlob.__table__
+_node_access_blobs = NodeAccessBlob.__table__
 
 # ---------------------------------------------------------------------------
 # Data records
@@ -83,7 +86,7 @@ class LinkRecord(BaseModel):
     created_at: datetime
 
 
-def _access_blob_condition(
+def _json_access_blob_condition(
     dialect_name: str, access_blob_column, query: AccessBlobFilter
 ):
     """
@@ -124,15 +127,65 @@ def _access_blob_condition(
     return condition
 
 
-def _access_filters_condition(
+def _json_access_filters_condition(
     dialect_name: str, access_blob_column, queries: list[AccessBlobFilter]
 ):
-    condition = _access_blob_condition(dialect_name, access_blob_column, queries[0])
+    condition = _json_access_blob_condition(dialect_name, access_blob_column, queries[0])
     for query in queries[1:]:
         condition = and_(
-            condition, _access_blob_condition(dialect_name, access_blob_column, query)
+            condition, _json_access_blob_condition(dialect_name, access_blob_column, query)
         )
     return condition
+
+
+def _access_blob_association_condition(dialect_name: str, table, query: AccessBlobFilter):
+    if not (query.user_id or query.tags):
+        return false()
+    tags_match = false()
+    if query.tags:
+        if dialect_name == "sqlite":
+            tags = func.json_each(table.c.tags).table_valued("value")
+            tags_match = and_(
+                table.c.kind == "tags",
+                select(1).select_from(tags).where(tags.c.value.in_(query.tags)).exists(),
+            )
+        elif dialect_name == "postgresql":
+            tags_match = and_(
+                table.c.kind == "tags",
+                type_coerce(table.c.tags, ARRAY(String())).overlap(
+                    sql_cast(query.tags, ARRAY(String()))
+                ),
+            )
+        else:
+            raise UnsupportedQueryType("access_blob_filter")
+    user_match = false()
+    if query.user_id is not None:
+        user_match = and_(table.c.kind == "user", table.c.username == query.user_id)
+    return or_(tags_match, user_match)
+
+
+def _access_blob_association_filters_condition(
+    dialect_name: str, table, queries: list[AccessBlobFilter]
+):
+    condition = _access_blob_association_condition(dialect_name, table, queries[0])
+    for query in queries[1:]:
+        condition = and_(
+            condition, _access_blob_association_condition(dialect_name, table, query)
+        )
+    return condition
+
+
+def _access_blob_from_association(row) -> dict:
+    if row.kind == "user":
+        return {"user": row.username}
+    return {"tags": row.tags or []}
+
+
+def _access_blob_values(access_blob: Optional[dict]) -> dict:
+    access_blob = access_blob or {}
+    if "user" in access_blob:
+        return {"kind": "user", "username": access_blob["user"], "tags": None}
+    return {"kind": "tags", "username": None, "tags": access_blob.get("tags", [])}
 
 
 class GraphSQLAlchemyStore:
@@ -180,7 +233,7 @@ class GraphSQLAlchemyStore:
             predicate=row.predicate,
             object_id=row.object_id,
             properties=row.properties or {},
-            access_blob=row.access_blob or {},
+            access_blob=_access_blob_from_association(row),
             created_at=row.created_at,
         )
 
@@ -230,10 +283,16 @@ class GraphSQLAlchemyStore:
         async with self._engine.connect() as conn:
             row = (
                 await conn.execute(
-                    select(_nodes.c.access_blob).where(_nodes.c.id == node_id)
+                    select(_access_blobs)
+                    .join(
+                        _node_access_blobs,
+                        _access_blobs.c.id == _node_access_blobs.c.access_blob_id,
+                    )
+                    .join(_nodes, _node_access_blobs.c.node_id == _nodes.c.id)
+                    .where(_nodes.c.id == node_id)
                 )
             ).one_or_none()
-        return row.access_blob if row else None
+        return _access_blob_from_association(row) if row else None
 
     async def list_entities(
         self,
@@ -250,18 +309,25 @@ class GraphSQLAlchemyStore:
             stmt = stmt.where(_entities.c.node_id == node_id)
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
-            # An entity's effective access_blob is its node's access_blob
-            # when node_id is set, else its own access_blob.
-            effective_access_blob = type_coerce(
-                case(
-                    (_entities.c.node_id.isnot(None), _nodes.c.access_blob),
-                    else_=_entities.c.access_blob,
-                ),
-                JSON,
-            )
-            stmt = stmt.outerjoin(_nodes, _entities.c.node_id == _nodes.c.id).where(
-                _access_filters_condition(
-                    dialect_name, effective_access_blob, access_filters
+            stmt = stmt.outerjoin(
+                _node_access_blobs, _entities.c.node_id == _node_access_blobs.c.node_id
+            ).outerjoin(
+                _access_blobs,
+                _node_access_blobs.c.access_blob_id == _access_blobs.c.id,
+            ).where(
+                or_(
+                    and_(
+                        _entities.c.node_id.is_(None),
+                        _json_access_filters_condition(
+                            dialect_name, _entities.c.access_blob, access_filters
+                        ),
+                    ),
+                    and_(
+                        _entities.c.node_id.isnot(None),
+                        _access_blob_association_filters_condition(
+                            dialect_name, _access_blobs, access_filters
+                        ),
+                    ),
                 )
             )
         stmt = stmt.limit(limit).offset(offset)
@@ -328,12 +394,31 @@ class GraphSQLAlchemyStore:
                         predicate=predicate,
                         object_id=object_id,
                         properties=properties or {},
-                        access_blob=access_blob or {},
                         created_at=now,
                     )
                 )
+                access_blob_result = await conn.execute(
+                    insert(_access_blobs).values(**_access_blob_values(access_blob))
+                )
+                await conn.execute(
+                    insert(_link_access_blobs).values(
+                        link_id=id_,
+                        access_blob_id=access_blob_result.inserted_primary_key[0],
+                    )
+                )
                 row = (
-                    await conn.execute(select(_links).where(_links.c.id == id_))
+                    await conn.execute(
+                        select(_links, _access_blobs)
+                        .join(
+                            _link_access_blobs,
+                            _links.c.id == _link_access_blobs.c.link_id,
+                        )
+                        .join(
+                            _access_blobs,
+                            _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                        )
+                        .where(_links.c.id == id_)
+                    )
                 ).one()
         except IntegrityError as exc:
             # A foreign-key violation means one of the endpoints is missing.
@@ -349,7 +434,18 @@ class GraphSQLAlchemyStore:
     async def get_link(self, id: str) -> Optional[LinkRecord]:
         async with self._engine.connect() as conn:
             row = (
-                await conn.execute(select(_links).where(_links.c.id == id))
+                await conn.execute(
+                    select(_links, _access_blobs)
+                    .join(
+                        _link_access_blobs,
+                        _links.c.id == _link_access_blobs.c.link_id,
+                    )
+                    .join(
+                        _access_blobs,
+                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    )
+                    .where(_links.c.id == id)
+                )
             ).one_or_none()
         return self._to_link(row) if row else None
 
@@ -362,7 +458,15 @@ class GraphSQLAlchemyStore:
         offset: int = 0,
         access_filters: Optional[list[AccessBlobFilter]] = None,
     ) -> list[LinkRecord]:
-        stmt = select(_links).order_by(_links.c.created_at)
+        stmt = (
+            select(_links, _access_blobs)
+            .join(_link_access_blobs, _links.c.id == _link_access_blobs.c.link_id)
+            .join(
+                _access_blobs,
+                _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+            )
+            .order_by(_links.c.created_at)
+        )
         if subject_id is not None:
             stmt = stmt.where(_links.c.subject_id == subject_id)
         if predicate is not None:
@@ -372,8 +476,8 @@ class GraphSQLAlchemyStore:
         if access_filters:
             dialect_name = self._engine.url.get_dialect().name
             stmt = stmt.where(
-                _access_filters_condition(
-                    dialect_name, _links.c.access_blob, access_filters
+                _access_blob_association_filters_condition(
+                    dialect_name, _access_blobs, access_filters
                 )
             )
         stmt = stmt.limit(limit).offset(offset)
@@ -395,15 +499,35 @@ class GraphSQLAlchemyStore:
         values: dict = {}
         if predicate is not UNSET:
             values["predicate"] = predicate
-        if access_blob is not UNSET:
-            values["access_blob"] = access_blob
         async with self._engine.begin() as conn:
             if values:
                 await conn.execute(
                     update(_links).where(_links.c.id == id).values(**values)
                 )
+            if access_blob is not UNSET:
+                await conn.execute(
+                    update(_access_blobs)
+                    .where(
+                        _access_blobs.c.id
+                        == select(_link_access_blobs.c.access_blob_id)
+                        .where(_link_access_blobs.c.link_id == id)
+                        .scalar_subquery()
+                    )
+                    .values(**_access_blob_values(access_blob))
+                )
             row = (
-                await conn.execute(select(_links).where(_links.c.id == id))
+                await conn.execute(
+                    select(_links, _access_blobs)
+                    .join(
+                        _link_access_blobs,
+                        _links.c.id == _link_access_blobs.c.link_id,
+                    )
+                    .join(
+                        _access_blobs,
+                        _link_access_blobs.c.access_blob_id == _access_blobs.c.id,
+                    )
+                    .where(_links.c.id == id)
+                )
             ).one_or_none()
         return self._to_link(row) if row else None
 

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -80,7 +80,9 @@ class LinkRecord(BaseModel):
     created_at: datetime
 
 
-def _access_tags_match_condition(assoc_table, assoc_id_column, owner_column, tags):
+def _access_tags_match_condition(
+    assoc_table, assoc_id_column, owner_column, access_tag_names
+):
     """
     Rows tagged with at least one of the given access tags.
     EXISTS is used (vs IN) as it is much more preformant in SQLite,
@@ -91,7 +93,7 @@ def _access_tags_match_condition(assoc_table, assoc_id_column, owner_column, tag
         .select_from(assoc_table)
         .join(_access_tags, _access_tags.c.id == assoc_table.c.tag_id)
         .where(assoc_id_column == owner_column)
-        .where(_access_tags.c.name.in_(tags))
+        .where(_access_tags.c.name.in_(access_tag_names))
         .exists()
     )
 
@@ -141,17 +143,17 @@ def _access_filters_condition(condition_builder, queries: list[AccessTagsFilter]
     return condition
 
 
-async def _resolve_tag_ids(conn, tag_names: Iterable[str]) -> list[int]:
+async def _resolve_access_tag_ids(conn, access_tag_names: Iterable[str]) -> list[int]:
     """
-    Resolve tag names to access_tags ids. An association cannot reference a
-    tag that has no row, so unknown names raise. Normally the access policy
-    has already validated the tags; this fires only for requests that
-    bypassed the policy or raced a tag-definition resync.
+    Resolve access tag names to access_tags ids. An association cannot
+    reference a tag that has no row, so unknown names raise. Normally the
+    access policy has already validated the tags; this fires only for requests
+    that bypassed the policy or raced a tag-definition resync.
 
     Principal tags are slightly different: these need to exist at write,
     possibly before the tags compiler has been able to create them.
     """
-    names = set(tag_names)
+    names = set(access_tag_names)
     if not names:
         return []
     await register_principal_tag_rows(conn, names)
@@ -193,7 +195,7 @@ class GraphSQLAlchemyStore:
         return cls(engine, owns_engine=False)
 
     @staticmethod
-    def _to_entity(row, tags: Optional[frozenset[str]]) -> EntityRecord:
+    def _to_entity(row, access_tags: Optional[frozenset[str]]) -> EntityRecord:
         return EntityRecord(
             id=row.id,
             node_id=row.node_id,
@@ -202,25 +204,27 @@ class GraphSQLAlchemyStore:
             uri=row.uri,
             properties=row.properties or {},
             # None means access control is delegated to node_id.
-            access_tags=None if row.node_id is not None else (tags or frozenset()),
+            access_tags=(
+                None if row.node_id is not None else (access_tags or frozenset())
+            ),
             created_at=row.created_at,
         )
 
     @staticmethod
-    def _to_link(row, tags: Optional[frozenset[str]]) -> LinkRecord:
+    def _to_link(row, access_tags: Optional[frozenset[str]]) -> LinkRecord:
         return LinkRecord(
             id=row.id,
             subject_id=row.subject_id,
             predicate=row.predicate,
             object_id=row.object_id,
             properties=row.properties or {},
-            access_tags=tags or frozenset(),
+            access_tags=access_tags or frozenset(),
             created_at=row.created_at,
         )
 
     @staticmethod
-    async def _tags_by_id(conn, assoc_table, assoc_id_column, ids: list):
-        """Map entity/link id -> frozenset of tag names, one query per page."""
+    async def _access_tags_by_id(conn, assoc_table, assoc_id_column, ids: list):
+        """Map entity/link id -> frozenset of access tag names, one query per page."""
         if not ids:
             return {}
         rows = (
@@ -231,18 +235,18 @@ class GraphSQLAlchemyStore:
                 .where(assoc_id_column.in_(ids))
             )
         ).all()
-        tags_by_id: dict = {}
+        access_tags_by_id: dict = {}
         for assoc_id, name in rows:
-            tags_by_id.setdefault(assoc_id, set()).add(name)
-        return {key: frozenset(value) for key, value in tags_by_id.items()}
+            access_tags_by_id.setdefault(assoc_id, set()).add(name)
+        return {key: frozenset(value) for key, value in access_tags_by_id.items()}
 
-    async def _entity_tags(self, conn, ids: list[str]):
-        return await self._tags_by_id(
+    async def _entity_access_tags_by_id(self, conn, ids: list[str]):
+        return await self._access_tags_by_id(
             conn, _entity_access_tags, _entity_access_tags.c.entity_id, ids
         )
 
-    async def _link_tags(self, conn, ids: list[str]):
-        return await self._tags_by_id(
+    async def _link_access_tags_by_id(self, conn, ids: list[str]):
+        return await self._access_tags_by_id(
             conn, _link_access_tags, _link_access_tags.c.link_id, ids
         )
 
@@ -252,8 +256,8 @@ class GraphSQLAlchemyStore:
         ).one_or_none()
         if row is None:
             return None
-        tags = (await self._entity_tags(conn, [id])).get(id)
-        return self._to_entity(row, tags)
+        access_tags = (await self._entity_access_tags_by_id(conn, [id])).get(id)
+        return self._to_entity(row, access_tags)
 
     async def _link_record(self, conn, id: str) -> Optional[LinkRecord]:
         row = (
@@ -261,23 +265,26 @@ class GraphSQLAlchemyStore:
         ).one_or_none()
         if row is None:
             return None
-        tags = (await self._link_tags(conn, [id])).get(id)
-        return self._to_link(row, tags)
+        access_tags = (await self._link_access_tags_by_id(conn, [id])).get(id)
+        return self._to_link(row, access_tags)
 
-    async def _set_tags(
-        self, conn, assoc_table, assoc_id_column_name: str, id: str, tag_names
+    async def _set_access_tags(
+        self, conn, assoc_table, assoc_id_column_name: str, id: str, access_tag_names
     ) -> None:
-        """Replace the tag associations of an entity or link."""
-        tag_ids = await _resolve_tag_ids(conn, tag_names)
+        """Replace the access tag associations of an entity or link."""
+        access_tag_ids = await _resolve_access_tag_ids(conn, access_tag_names)
         await conn.execute(
             delete(assoc_table).where(
                 getattr(assoc_table.c, assoc_id_column_name) == id
             )
         )
-        if tag_ids:
+        if access_tag_ids:
             await conn.execute(
                 insert(assoc_table),
-                [{assoc_id_column_name: id, "tag_id": tag_id} for tag_id in tag_ids],
+                [
+                    {assoc_id_column_name: id, "tag_id": access_tag_id}
+                    for access_tag_id in access_tag_ids
+                ],
             )
 
     async def create_entity(
@@ -306,10 +313,13 @@ class GraphSQLAlchemyStore:
                 )
             )
             if node_id is None and access_tags:
-                tag_ids = await _resolve_tag_ids(conn, access_tags)
+                access_tag_ids = await _resolve_access_tag_ids(conn, access_tags)
                 await conn.execute(
                     insert(_entity_access_tags),
-                    [{"entity_id": id_, "tag_id": tag_id} for tag_id in tag_ids],
+                    [
+                        {"entity_id": id_, "tag_id": access_tag_id}
+                        for access_tag_id in access_tag_ids
+                    ],
                 )
             record = await self._entity_record(conn, id_)
         return record
@@ -364,8 +374,10 @@ class GraphSQLAlchemyStore:
         stmt = stmt.limit(limit).offset(offset)
         async with self._engine.connect() as conn:
             rows = (await conn.execute(stmt)).all()
-            tags_by_id = await self._entity_tags(conn, [row.id for row in rows])
-        return [self._to_entity(row, tags_by_id.get(row.id)) for row in rows]
+            access_tags_by_id = await self._entity_access_tags_by_id(
+                conn, [row.id for row in rows]
+            )
+        return [self._to_entity(row, access_tags_by_id.get(row.id)) for row in rows]
 
     async def delete_entity(self, id: str) -> bool:
         async with self._engine.begin() as conn:
@@ -429,7 +441,7 @@ class GraphSQLAlchemyStore:
                         )
                     )
                 elif effective_node_id is None:
-                    await self._set_tags(
+                    await self._set_access_tags(
                         conn, _entity_access_tags, "entity_id", id, access_tags
                     )
             record = await self._entity_record(conn, id)
@@ -463,10 +475,13 @@ class GraphSQLAlchemyStore:
                     )
                 )
                 if access_tags:
-                    tag_ids = await _resolve_tag_ids(conn, access_tags)
+                    access_tag_ids = await _resolve_access_tag_ids(conn, access_tags)
                     await conn.execute(
                         insert(_link_access_tags),
-                        [{"link_id": id_, "tag_id": tag_id} for tag_id in tag_ids],
+                        [
+                            {"link_id": id_, "tag_id": access_tag_id}
+                            for access_tag_id in access_tag_ids
+                        ],
                     )
                 record = await self._link_record(conn, id_)
         except IntegrityError as exc:
@@ -507,8 +522,10 @@ class GraphSQLAlchemyStore:
         stmt = stmt.limit(limit).offset(offset)
         async with self._engine.connect() as conn:
             rows = (await conn.execute(stmt)).all()
-            tags_by_id = await self._link_tags(conn, [row.id for row in rows])
-        return [self._to_link(row, tags_by_id.get(row.id)) for row in rows]
+            access_tags_by_id = await self._link_access_tags_by_id(
+                conn, [row.id for row in rows]
+            )
+        return [self._to_link(row, access_tags_by_id.get(row.id)) for row in rows]
 
     async def delete_link(self, id: str) -> bool:
         async with self._engine.begin() as conn:
@@ -530,7 +547,7 @@ class GraphSQLAlchemyStore:
                     update(_links).where(_links.c.id == id).values(**values)
                 )
             if access_tags is not UNSET:
-                await self._set_tags(
+                await self._set_access_tags(
                     conn, _link_access_tags, "link_id", id, access_tags or []
                 )
             record = await self._link_record(conn, id)

--- a/tiled/graph/store.py
+++ b/tiled/graph/store.py
@@ -385,6 +385,14 @@ class GraphSQLAlchemyStore:
                 )
             if access_blob is not UNSET:
                 if access_blob is None:
+                    if effective_node_id is None:
+                        raise IntegrityError(
+                            "Refusing to clear access_blob on a standalone entity "
+                            "(no node_id): it would leave the entity without access "
+                            "control. Provide an AccessBlob or set node_id.",
+                            {},
+                            None,
+                        )
                     await conn.execute(
                         delete(_entity_access_blobs).where(
                             _entity_access_blobs.c.entity_id == id

--- a/tiled/queries.py
+++ b/tiled/queries.py
@@ -8,7 +8,7 @@ The are encoded into and decoded from URL query parameters.
 import enum
 import json
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, List
 
 from .query_registration import register
 from .structures.core import StructureFamily as StructureFamilyEnum
@@ -512,46 +512,40 @@ def SpecQuery(spec):
     return SpecsQuery([spec])
 
 
-@register(name="access_blob_filter")
+@register(name="access_tags_filter")
 @dataclass
-class AccessBlobFilter:
+class AccessTagsFilter:
     """
-    Perform a query against the access_blob with two conditions.
-    1. Query for a user id (i.e. username) match against the "user" field
-    2. Query for if any tag in a list of tags is present in the "tags" field
-    The values for these conditions are independent.
+    Perform a query against node access tags.
+    Match nodes that carry at least one tag in the given list of tags.
 
     Parameters
     ----------
-    user_id : str
-        e.g. "bill", "amanda"
-    tags : List[JSONSerializable]
+    tags : List[str]
         e.g. ["tag_for_bill", "amanda_only"]
 
 
     Examples
     --------
 
-    Search for user "bill", as well as tags in ["tag_for_bill", "useful_data"]
+    Search for tags in ["tag_for_bill", "useful_data"]
 
-    >>> c.search(AccessBlobFilter("bill", ["tag_for_bill", "useful_data"]))
+    >>> c.search(AccessTagsFilter(["tag_for_bill", "useful_data"]))
     """
 
-    user_id: Optional[str]
     tags: List[str]
 
+    def __post_init__(self):
+        if isinstance(self.tags, str):
+            raise TypeError("tags must be a list not a str")
+        self.tags = list(self.tags)
+
     def encode(self):
-        return {
-            "user_id": self.user_id,
-            "tags": self.tags,
-        }
+        return {"tags": json.dumps(self.tags)}
 
     @classmethod
-    def decode(cls, *, user_id, tags):
-        return cls(
-            user_id=user_id,
-            tags=tags,
-        )
+    def decode(cls, *, tags):
+        return cls(tags=json.loads(tags))
 
 
 @register(name="structure_family")

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -749,6 +749,21 @@ def build_app(
                 await app.state.access_policy.access_tags_parser.connect(
                     access_tags_catalog_context.database_settings
                 )
+                # The scopes in the catalog database (written there by the
+                # access tags compiler) should be a subset of the scopes that
+                # the server's access policy is configured with.
+                defined_scopes = (
+                    await app.state.access_policy.access_tags_parser.get_defined_scopes()
+                )
+                unknown_scopes = defined_scopes - set(app.state.access_policy.scopes)
+                if unknown_scopes:
+                    logger.warning(
+                        f"The catalog database contains scopes that the access "
+                        f"policy is not configured with: {sorted(unknown_scopes)}. "
+                        f"This suggests the access tags were compiled with a "
+                        f"different scope list than the access policy's. Tag "
+                        f"grants holding these scopes may be restricted."
+                    )
 
             async def purge_expired_sessions_and_api_keys():
                 PURGE_INTERVAL = 600  # seconds

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -48,11 +48,7 @@ from ..config import (
     construct_build_app_kwargs,
     parse_configs,
 )
-# TODO(access-tags): The graph (splash-links) feature has not yet been
-# converted to the access_tags schema, so its modules do not currently
-# import. Restore this import (and the include_router call below) once
-# tiled.graph is converted:
-#     from ..graph.router import create_router as get_links_router
+from ..graph.router import create_router as get_links_router
 from ..media_type_registration import (
     CompressionRegistry,
     SerializationRegistry,
@@ -439,13 +435,11 @@ def build_app(
     # table), so it is only available when serving a catalog-backed tree.
     # Note this is independent of `database:` config, which configures the
     # unrelated authn/session database.
-    # TODO(access-tags): Re-enable once tiled.graph is converted to the
-    # access_tags schema (see import above).
-    # catalog_context = getattr(tree, "context", None)
-    # if catalog_context is not None:
-    #     app.include_router(
-    #         get_links_router(lambda: catalog_context.database_settings)
-    #     )
+    catalog_context = getattr(tree, "context", None)
+    if catalog_context is not None:
+        app.include_router(
+            get_links_router(lambda: catalog_context.database_settings)
+        )
 
     # The Tree and Authenticator have the opportunity to add custom routes to
     # the server here. (Just for example, a Tree of BlueskyRuns uses this

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -738,7 +738,17 @@ def build_app(
             if app.state.access_policy is not None and hasattr(
                 app.state.access_policy, "access_tags_parser"
             ):
-                await app.state.access_policy.access_tags_parser.connect()
+                # Access tag definitions live in the catalog database, so the
+                # parser connects with the catalog's own database settings.
+                access_tags_catalog_context = getattr(tree, "context", None)
+                if access_tags_catalog_context is None:
+                    raise ValueError(
+                        "This access policy reads access tags from the catalog "
+                        "database, so it requires a catalog-backed tree."
+                    )
+                await app.state.access_policy.access_tags_parser.connect(
+                    access_tags_catalog_context.database_settings
+                )
 
             async def purge_expired_sessions_and_api_keys():
                 PURGE_INTERVAL = 600  # seconds

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -118,6 +118,31 @@ def custom_openapi(app):
     return app.openapi_schema
 
 
+def _find_catalog_context(tree):
+    """
+    Find a catalog database context within the served tree.
+
+    The access tags parser needs the catalog's database settings (the URI) to
+    read tag definitions. The served tree may be a single catalog adapter, or a
+    MapAdapter nesting several catalog mounts (e.g. /foo, /bar mounted from the
+    same catalog database). Walk the tree and return the first catalog context
+    found (any one suffices: access tags are a single shared namespace written
+    to one catalog database).
+
+    Returns the context, or None if the tree contains no catalog adapter.
+    """
+    context = getattr(tree, "context", None)
+    if context is not None:
+        return context
+    values = getattr(tree, "values", None)
+    if callable(values):
+        for child in values():
+            found = _find_catalog_context(child)
+            if found is not None:
+                return found
+    return None
+
+
 def build_app(
     tree,
     authentication: Optional[Authentication] = None,
@@ -740,7 +765,7 @@ def build_app(
             ):
                 # Access tag definitions live in the catalog database, so the
                 # parser connects with the catalog's own database settings.
-                access_tags_catalog_context = getattr(tree, "context", None)
+                access_tags_catalog_context = _find_catalog_context(tree)
                 if access_tags_catalog_context is None:
                     raise ValueError(
                         "This access policy reads access tags from the catalog "

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -48,7 +48,11 @@ from ..config import (
     construct_build_app_kwargs,
     parse_configs,
 )
-from ..graph.router import create_router as get_links_router
+# TODO(access-tags): The graph (splash-links) feature has not yet been
+# converted to the access_tags schema, so its modules do not currently
+# import. Restore this import (and the include_router call below) once
+# tiled.graph is converted:
+#     from ..graph.router import create_router as get_links_router
 from ..media_type_registration import (
     CompressionRegistry,
     SerializationRegistry,
@@ -435,9 +439,13 @@ def build_app(
     # table), so it is only available when serving a catalog-backed tree.
     # Note this is independent of `database:` config, which configures the
     # unrelated authn/session database.
-    catalog_context = getattr(tree, "context", None)
-    if catalog_context is not None:
-        app.include_router(get_links_router(lambda: catalog_context.database_settings))
+    # TODO(access-tags): Re-enable once tiled.graph is converted to the
+    # access_tags schema (see import above).
+    # catalog_context = getattr(tree, "context", None)
+    # if catalog_context is not None:
+    #     app.include_router(
+    #         get_links_router(lambda: catalog_context.database_settings)
+    #     )
 
     # The Tree and Authenticator have the opportunity to add custom routes to
     # the server here. (Just for example, a Tree of BlueskyRuns uses this

--- a/tiled/server/app.py
+++ b/tiled/server/app.py
@@ -462,9 +462,7 @@ def build_app(
     # unrelated authn/session database.
     catalog_context = getattr(tree, "context", None)
     if catalog_context is not None:
-        app.include_router(
-            get_links_router(lambda: catalog_context.database_settings)
-        )
+        app.include_router(get_links_router(lambda: catalog_context.database_settings))
 
     # The Tree and Authenticator have the opportunity to add custom routes to
     # the server here. (Just for example, a Tree of BlueskyRuns uses this

--- a/tiled/server/authentication.py
+++ b/tiled/server/authentication.py
@@ -53,6 +53,7 @@ with warnings.catch_warnings():
 
 from pydantic import BaseModel
 
+from ..access_control.protocols import AccessTags
 from ..authn_database import orm
 from ..authn_database.core import (
     create_service,
@@ -64,7 +65,6 @@ from ..authn_database.core import (
     lookup_valid_pending_session_by_user_code,
     lookup_valid_session,
 )
-from ..type_aliases import AccessTags
 from ..utils import SHARE_TILED_PATH, SingleUserPrincipal
 from . import schemas
 from .connection_pool import get_database_session_factory
@@ -259,7 +259,7 @@ async def get_access_tags_from_api_key(
         return None
     else:
         if (access_tags := api_key_orm.access_tags) is not None:
-            access_tags = set(access_tags)
+            access_tags = AccessTags(access_tags)
         return access_tags
 
 

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -496,7 +496,14 @@ async def construct_resource(
         else:
             attributes["metadata"] = entry.metadata()
     if schemas.EntryFields.access_blob in fields and hasattr(entry, "access_blob"):
-        attributes["access_blob"] = entry.access_blob
+        if entry.access_blob is None:
+            attributes["access_blob"] = {}
+        elif entry.access_blob.username is not None:
+            attributes["access_blob"] = {"user": entry.access_blob.username}
+        elif entry.access_blob.tags is not None:
+            attributes["access_blob"] = {"tags": entry.access_blob.tags}
+        else:
+            attributes["access_blob"] = {}
     if schemas.EntryFields.specs in fields:
         attributes["specs"] = []
         for spec in getattr(entry, "specs", []):

--- a/tiled/server/core.py
+++ b/tiled/server/core.py
@@ -495,15 +495,13 @@ async def construct_resource(
             }
         else:
             attributes["metadata"] = entry.metadata()
-    if schemas.EntryFields.access_blob in fields and hasattr(entry, "access_blob"):
-        if entry.access_blob is None:
-            attributes["access_blob"] = {}
-        elif entry.access_blob.username is not None:
-            attributes["access_blob"] = {"user": entry.access_blob.username}
-        elif entry.access_blob.tags is not None:
-            attributes["access_blob"] = {"tags": entry.access_blob.tags}
-        else:
-            attributes["access_blob"] = {}
+    if schemas.EntryFields.access_tags in fields and hasattr(entry, "access_tags"):
+        access_tags = entry.access_tags
+        # Serialize the AccessTags frozenset in a deterministic order so that
+        # clients see a stable list (e.g. for building JSON patches).
+        attributes["access_tags"] = (
+            sorted(access_tags) if access_tags is not None else None
+        )
     if schemas.EntryFields.specs in fields:
         attributes["specs"] = []
         for spec in getattr(entry, "specs", []):

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -10,8 +10,7 @@ from starlette.status import (
     HTTP_410_GONE,
 )
 
-from ..access_control.protocols import AccessPolicy
-from ..access_control.protocols import AccessTags
+from ..access_control.protocols import AccessPolicy, AccessTags
 from ..adapters.protocols import AnyAdapter
 from ..ndslice import NDBlock, NDSlice
 from ..structures.core import StructureFamily

--- a/tiled/server/dependencies.py
+++ b/tiled/server/dependencies.py
@@ -11,10 +11,11 @@ from starlette.status import (
 )
 
 from ..access_control.protocols import AccessPolicy
+from ..access_control.protocols import AccessTags
 from ..adapters.protocols import AnyAdapter
 from ..ndslice import NDBlock, NDSlice
 from ..structures.core import StructureFamily
-from ..type_aliases import AccessTags, Scopes
+from ..type_aliases import Scopes
 from ..utils import BrokenLink
 from .core import NoEntry
 from .schemas import Principal

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -128,11 +128,18 @@ ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 def _access_blob_from_payload(access_blob):
     if access_blob == {}:
         return None
-    if "user" in access_blob:
+    if "user" in access_blob and set(access_blob) == {"user"}:
         return AccessBlob(username=access_blob["user"])
-    if "tags" in access_blob:
+    if "tags" in access_blob and set(access_blob) == {"tags"}:
         return AccessBlob(tags=access_blob["tags"])
-    return AccessBlob(tags=[])
+    raise HTTPException(
+        status_code=HTTP_400_BAD_REQUEST,
+        detail=(
+            'access_blob must be either {"user": <username>} or '
+            '{"tags": [<tag>, ...]}. '
+            f"Received {access_blob!r}"
+        ),
+    )
 
 
 def _access_blob_to_payload(access_blob):
@@ -2426,8 +2433,11 @@ def get_router(
             entry_access_blob_copy = deepcopy(
                 _access_blob_to_payload(entry.access_blob)
             )
+            # Per RFC 7386, merging a non-object patch REPLACES the target, so
+            # the no-op default for an omitted access_blob must be {} (merge
+            # with an empty object leaves the target unchanged), never [].
             access_blob = _access_blob_from_payload(
-                apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
+                apply_merge_patch(entry_access_blob_copy, (body.access_blob or {}))
             )
         else:
             raise HTTPException(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -126,7 +126,7 @@ ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 
 
 def _access_blob_from_payload(access_blob):
-    if access_blob is None:
+    if access_blob == {}:
         return None
     if "user" in access_blob:
         return AccessBlob(username=access_blob["user"])
@@ -2423,7 +2423,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            entry_access_blob_copy = deepcopy(
+                _access_blob_to_payload(entry.access_blob)
+            )
             access_blob = _access_blob_from_payload(
                 apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
@@ -2466,7 +2468,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2546,7 +2550,9 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
+            access_blob_modified = not access_blob_matches(
+                access_blob, entry.access_blob
+            )
             access_blob = entry.access_blob
 
         await entry.replace_metadata(

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -54,8 +54,14 @@ from ..links import links_for_node
 from ..ndslice import NDBlock, NDSlice
 from ..stream_messages import ArrayPatch
 from ..structures.core import Spec, StructureFamily
-from ..type_aliases import AccessTags, Scopes
-from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
+from ..type_aliases import AccessBlob, AccessTags, Scopes
+from ..utils import (
+    BrokenLink,
+    access_blob_matches,
+    ensure_awaitable,
+    patch_mimetypes,
+    path_from_uri,
+)
 from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from ._backcompat import (
@@ -117,6 +123,26 @@ T = TypeVar("T")
 # actually present on disk (a streaming append in progress), the client is told
 # to retry after this many seconds.
 ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
+
+
+def _access_blob_from_payload(access_blob):
+    if access_blob is None:
+        return None
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    if "tags" in access_blob:
+        return AccessBlob(tags=access_blob["tags"])
+    return AccessBlob(tags=[])
+
+
+def _access_blob_to_payload(access_blob):
+    if access_blob is None:
+        return {}
+    if access_blob.username is not None:
+        return {"user": access_blob.username}
+    if access_blob.tags is not None:
+        return {"tags": access_blob.tags}
+    return {}
 
 
 def _patch_route_signature(
@@ -1890,7 +1916,7 @@ def get_router(
             body.metadata,
             body.structure_family,
             body.specs,
-            body.access_blob,
+            _access_blob_from_payload(body.access_blob),
         )
         if structure_family == StructureFamily.container:
             structure = None
@@ -1917,7 +1943,10 @@ def get_router(
                     access_blob_modified,
                     access_blob,
                 ) = await request.app.state.access_policy.init_node(
-                    principal, authn_access_tags, authn_scopes, access_blob=access_blob
+                    principal,
+                    authn_access_tags,
+                    authn_scopes,
+                    access_blob=access_blob,
                 )
             except ValueError as e:
                 raise HTTPException(
@@ -1925,8 +1954,8 @@ def get_router(
                     detail=f"Access policy rejects the provided access blob.\n{e}",
                 )
         else:
-            access_blob_modified = access_blob != {}
-            access_blob = {}
+            access_blob_modified = access_blob is not None
+            access_blob = AccessBlob(tags=[])
 
         node = await entry.create_node(
             metadata=body.metadata,
@@ -1953,7 +1982,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
 
         return json_or_msgpack(request, response_data)
 
@@ -2377,7 +2406,11 @@ def get_router(
         if body.content_type == patch_mimetypes.JSON_PATCH:
             metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
             specs = apply_json_patch((entry.specs or []), (body.specs or []))
-            access_blob = apply_json_patch(entry.access_blob, (body.access_blob or []))
+            access_blob = _access_blob_from_payload(
+                apply_json_patch(
+                    _access_blob_to_payload(entry.access_blob), (body.access_blob or [])
+                )
+            )
         elif body.content_type == patch_mimetypes.MERGE_PATCH:
             metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
             # body.specs = [] clears specs, as per json merge patch specification
@@ -2390,9 +2423,9 @@ def get_router(
             # access policy from sanity checking the access blob.
             # make a copy so we can compare the node against the
             # proposed new access blob.
-            entry_access_blob_copy = deepcopy(entry.access_blob)
-            access_blob = apply_merge_patch(
-                entry_access_blob_copy, (body.access_blob or [])
+            entry_access_blob_copy = deepcopy(_access_blob_to_payload(entry.access_blob))
+            access_blob = _access_blob_from_payload(
+                apply_merge_patch(entry_access_blob_copy, (body.access_blob or []))
             )
         else:
             raise HTTPException(
@@ -2433,7 +2466,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2447,7 +2480,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
@@ -2485,7 +2518,11 @@ def get_router(
         metadata, specs, access_blob = (
             body.metadata if body.metadata is not None else entry.metadata(),
             body.specs if body.specs is not None else entry.specs,
-            body.access_blob if body.access_blob is not None else entry.access_blob,
+            (
+                _access_blob_from_payload(body.access_blob)
+                if body.access_blob is not None
+                else entry.access_blob
+            ),
         )
 
         metadata_modified, metadata = await validate_specs(
@@ -2509,7 +2546,7 @@ def get_router(
                 )
         else:
             # Cannot modify the access blob if there is no access policy
-            access_blob_modified = access_blob != entry.access_blob
+            access_blob_modified = not access_blob_matches(access_blob, entry.access_blob)
             access_blob = entry.access_blob
 
         await entry.replace_metadata(
@@ -2523,7 +2560,7 @@ def get_router(
         if metadata_modified:
             response_data["metadata"] = metadata
         if access_blob_modified:
-            response_data["access_blob"] = access_blob
+            response_data["access_blob"] = _access_blob_to_payload(access_blob)
         return json_or_msgpack(request, response_data)
 
     @router.get("/revisions/{path:path}")

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -55,12 +55,7 @@ from ..ndslice import NDBlock, NDSlice
 from ..stream_messages import ArrayPatch
 from ..structures.core import Spec, StructureFamily
 from ..type_aliases import Scopes
-from ..utils import (
-    BrokenLink,
-    ensure_awaitable,
-    patch_mimetypes,
-    path_from_uri,
-)
+from ..utils import BrokenLink, ensure_awaitable, patch_mimetypes, path_from_uri
 from ..validation_registration import ValidationError, ValidationRegistry
 from . import schemas
 from ._backcompat import (

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -124,33 +124,6 @@ T = TypeVar("T")
 ARRAY_RETRY_AFTER_SECONDS = int(os.getenv("TILED_ARRAY_RETRY_AFTER", "1"))
 
 
-def _access_blob_from_payload(access_blob):
-    if access_blob == {}:
-        return None
-    if "user" in access_blob and set(access_blob) == {"user"}:
-        return AccessBlob(username=access_blob["user"])
-    if "tags" in access_blob and set(access_blob) == {"tags"}:
-        return AccessBlob(tags=access_blob["tags"])
-    raise HTTPException(
-        status_code=HTTP_400_BAD_REQUEST,
-        detail=(
-            'access_blob must be either {"user": <username>} or '
-            '{"tags": [<tag>, ...]}. '
-            f"Received {access_blob!r}"
-        ),
-    )
-
-
-def _access_blob_to_payload(access_blob):
-    if access_blob is None:
-        return {}
-    if access_blob.username is not None:
-        return {"user": access_blob.username}
-    if access_blob.tags is not None:
-        return {"tags": access_blob.tags}
-    return {}
-
-
 def _patch_route_signature(
     query_registry: QueryRegistry,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -152,6 +152,26 @@ def _access_blob_to_payload(access_blob):
     return {}
 
 
+def _access_blob_from_payload(access_blob):
+    if access_blob is None:
+        return None
+    if "user" in access_blob:
+        return AccessBlob(username=access_blob["user"])
+    if "tags" in access_blob:
+        return AccessBlob(tags=access_blob["tags"])
+    return AccessBlob(tags=[])
+
+
+def _access_blob_to_payload(access_blob):
+    if access_blob is None:
+        return {}
+    if access_blob.username is not None:
+        return {"user": access_blob.username}
+    if access_blob.tags is not None:
+        return {"tags": access_blob.tags}
+    return {}
+
+
 def _patch_route_signature(
     query_registry: QueryRegistry,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -153,7 +153,7 @@ def _access_blob_to_payload(access_blob):
 
 
 def _access_blob_from_payload(access_blob):
-    if access_blob is None:
+    if access_blob == {}:
         return None
     if "user" in access_blob:
         return AccessBlob(username=access_blob["user"])

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -3,7 +3,6 @@ import dataclasses
 import inspect
 import os
 import warnings
-from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from functools import cache, partial
 from pathlib import Path
@@ -50,14 +49,14 @@ from tiled.server.protocols import ExternalAuthenticator, InternalAuthenticator
 from tiled.server.schemas import Principal
 
 from .. import __version__
+from ..access_control.protocols import AccessTags
 from ..links import links_for_node
 from ..ndslice import NDBlock, NDSlice
 from ..stream_messages import ArrayPatch
 from ..structures.core import Spec, StructureFamily
-from ..type_aliases import AccessBlob, AccessTags, Scopes
+from ..type_aliases import Scopes
 from ..utils import (
     BrokenLink,
-    access_blob_matches,
     ensure_awaitable,
     patch_mimetypes,
     path_from_uri,
@@ -140,26 +139,6 @@ def _access_blob_from_payload(access_blob):
             f"Received {access_blob!r}"
         ),
     )
-
-
-def _access_blob_to_payload(access_blob):
-    if access_blob is None:
-        return {}
-    if access_blob.username is not None:
-        return {"user": access_blob.username}
-    if access_blob.tags is not None:
-        return {"tags": access_blob.tags}
-    return {}
-
-
-def _access_blob_from_payload(access_blob):
-    if access_blob == {}:
-        return None
-    if "user" in access_blob:
-        return AccessBlob(username=access_blob["user"])
-    if "tags" in access_blob:
-        return AccessBlob(tags=access_blob["tags"])
-    return AccessBlob(tags=[])
 
 
 def _access_blob_to_payload(access_blob):
@@ -1939,11 +1918,11 @@ def get_router(
         authn_access_tags: Optional[AccessTags],
         authn_scopes: Scopes,
     ):
-        metadata, structure_family, specs, access_blob = (
+        metadata, structure_family, specs, access_tags = (
             body.metadata,
             body.structure_family,
             body.specs,
-            _access_blob_from_payload(body.access_blob),
+            AccessTags(body.access_tags) if body.access_tags is not None else None,
         )
         if structure_family == StructureFamily.container:
             structure = None
@@ -1967,22 +1946,19 @@ def get_router(
         ):
             try:
                 (
-                    access_blob_modified,
-                    access_blob,
+                    access_tags_modified,
+                    access_tags,
                 ) = await request.app.state.access_policy.init_node(
-                    principal,
-                    authn_access_tags,
-                    authn_scopes,
-                    access_blob=access_blob,
+                    principal, authn_access_tags, authn_scopes, access_tags=access_tags
                 )
             except ValueError as e:
                 raise HTTPException(
                     status_code=HTTP_403_FORBIDDEN,
-                    detail=f"Access policy rejects the provided access blob.\n{e}",
+                    detail=f"Access policy rejects the provided access tags.\n{e}",
                 )
         else:
-            access_blob_modified = access_blob is not None
-            access_blob = AccessBlob(tags=[])
+            access_tags_modified = access_tags != AccessTags()
+            access_tags = AccessTags()
 
         node = await entry.create_node(
             metadata=body.metadata,
@@ -1990,7 +1966,7 @@ def get_router(
             key=key,
             specs=body.specs,
             data_sources=body.data_sources,
-            access_blob=access_blob,
+            access_tags=access_tags,
         )
         links = links_for_node(
             structure_family, structure, get_base_url(request), path + f"/{node.key}"
@@ -2008,8 +1984,10 @@ def get_router(
         }
         if metadata_modified:
             response_data["metadata"] = metadata
-        if access_blob_modified:
-            response_data["access_blob"] = _access_blob_to_payload(access_blob)
+        if access_tags_modified:
+            response_data["access_tags"] = (
+                sorted(access_tags) if access_tags is not None else None
+            )
 
         return json_or_msgpack(request, response_data)
 
@@ -2433,10 +2411,10 @@ def get_router(
         if body.content_type == patch_mimetypes.JSON_PATCH:
             metadata = apply_json_patch(entry.metadata(), (body.metadata or []))
             specs = apply_json_patch((entry.specs or []), (body.specs or []))
-            access_blob = _access_blob_from_payload(
-                apply_json_patch(
-                    _access_blob_to_payload(entry.access_blob), (body.access_blob or [])
-                )
+            # Patch against the same deterministic (sorted) list that the
+            # server serves, so that index-based patch operations are stable.
+            access_tags = apply_json_patch(
+                sorted(entry.access_tags), (body.access_tags or [])
             )
         elif body.content_type == patch_mimetypes.MERGE_PATCH:
             metadata = apply_merge_patch(entry.metadata(), (body.metadata or {}))
@@ -2445,24 +2423,27 @@ def get_router(
             current_specs = entry.specs or []
             target_specs = current_specs if body.specs is None else body.specs
             specs = apply_merge_patch(current_specs, target_specs)
-            # json_merge_patch applies merge in-place, which would
-            # otherwise modify the in-memory node and prevent the
-            # access policy from sanity checking the access blob.
-            # make a copy so we can compare the node against the
-            # proposed new access blob.
-            entry_access_blob_copy = deepcopy(
-                _access_blob_to_payload(entry.access_blob)
-            )
-            # Per RFC 7386, merging a non-object patch REPLACES the target, so
-            # the no-op default for an omitted access_blob must be {} (merge
-            # with an empty object leaves the target unchanged), never [].
-            access_blob = _access_blob_from_payload(
-                apply_merge_patch(entry_access_blob_copy, (body.access_blob or {}))
+            # sorted() makes a mutable copy, protecting the in-memory node
+            # from in-place modification by json_merge_patch so that the
+            # access policy can compare the node against the proposed tags.
+            access_tags = apply_merge_patch(
+                sorted(entry.access_tags), (body.access_tags or [])
             )
         else:
             raise HTTPException(
                 status_code=HTTP_406_NOT_ACCEPTABLE,
                 detail=f"valid content types: {', '.join(patch_mimetypes)}",
+            )
+        # A patch is unconstrained by the request schema, so validate that it
+        # produced a flat list of tag names, and normalize to AccessTags.
+        if isinstance(access_tags, list) and all(
+            isinstance(tag, str) for tag in access_tags
+        ):
+            access_tags = AccessTags(access_tags)
+        else:
+            raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="access_tags patch must produce a list of strings",
             )
 
         # Manually validate limits that bypass pydantic validation via patch
@@ -2488,33 +2469,33 @@ def get_router(
             policy, "modify_node"
         ):
             try:
-                (access_blob_modified, access_blob) = await policy.modify_node(
-                    entry, principal, authn_access_tags, authn_scopes, access_blob
+                (access_tags_modified, access_tags) = await policy.modify_node(
+                    entry, principal, authn_access_tags, authn_scopes, access_tags
                 )
             except ValueError as e:
                 raise HTTPException(
                     status_code=HTTP_403_FORBIDDEN,
-                    detail=f"Access policy rejects the provided access blob.\n{e}",
+                    detail=f"Access policy rejects the provided access tags.\n{e}",
                 )
         else:
-            # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(
-                access_blob, entry.access_blob
-            )
-            access_blob = entry.access_blob
+            # Cannot modify the access tags if there is no access policy
+            access_tags_modified = access_tags != entry.access_tags
+            access_tags = entry.access_tags
 
         await entry.replace_metadata(
             metadata=metadata,
             specs=specs,
-            access_blob=access_blob,
+            access_tags=access_tags,
             drop_revision=drop_revision,
         )
 
         response_data = {"id": entry.node.key}
         if metadata_modified:
             response_data["metadata"] = metadata
-        if access_blob_modified:
-            response_data["access_blob"] = _access_blob_to_payload(access_blob)
+        if access_tags_modified:
+            response_data["access_tags"] = (
+                sorted(access_tags) if access_tags is not None else None
+            )
         return json_or_msgpack(request, response_data)
 
     @router.put("/metadata/{path:path}", response_model=schemas.PutMetadataResponse)
@@ -2549,14 +2530,12 @@ def get_router(
                 detail="This node does not support update of metadata.",
             )
 
-        metadata, specs, access_blob = (
+        metadata, specs, access_tags = (
             body.metadata if body.metadata is not None else entry.metadata(),
             body.specs if body.specs is not None else entry.specs,
-            (
-                _access_blob_from_payload(body.access_blob)
-                if body.access_blob is not None
-                else entry.access_blob
-            ),
+            AccessTags(body.access_tags)
+            if body.access_tags is not None
+            else entry.access_tags,
         )
 
         metadata_modified, metadata = await validate_specs(
@@ -2570,33 +2549,33 @@ def get_router(
             policy, "modify_node"
         ):
             try:
-                (access_blob_modified, access_blob) = await policy.modify_node(
-                    entry, principal, authn_access_tags, authn_scopes, access_blob
+                (access_tags_modified, access_tags) = await policy.modify_node(
+                    entry, principal, authn_access_tags, authn_scopes, access_tags
                 )
             except ValueError as e:
                 raise HTTPException(
                     status_code=HTTP_403_FORBIDDEN,
-                    detail=f"Access policy rejects the provided access blob.\n{e}",
+                    detail=f"Access policy rejects the provided access tags.\n{e}",
                 )
         else:
-            # Cannot modify the access blob if there is no access policy
-            access_blob_modified = not access_blob_matches(
-                access_blob, entry.access_blob
-            )
-            access_blob = entry.access_blob
+            # Cannot modify the access tags if there is no access policy
+            access_tags_modified = access_tags != entry.access_tags
+            access_tags = entry.access_tags
 
         await entry.replace_metadata(
             metadata=metadata,
             specs=specs,
-            access_blob=access_blob,
+            access_tags=access_tags,
             drop_revision=drop_revision,
         )
 
         response_data = {"id": entry.node.key}
         if metadata_modified:
             response_data["metadata"] = metadata
-        if access_blob_modified:
-            response_data["access_blob"] = _access_blob_to_payload(access_blob)
+        if access_tags_modified:
+            response_data["access_tags"] = (
+                sorted(access_tags) if access_tags is not None else None
+            )
         return json_or_msgpack(request, response_data)
 
     @router.get("/revisions/{path:path}")

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -152,7 +152,6 @@ class Revision(pydantic.BaseModel):
     revision_number: int
     metadata: dict
     specs: Specs
-    access_blob: dict
     time_updated: datetime
 
     @classmethod
@@ -163,7 +162,6 @@ class Revision(pydantic.BaseModel):
             revision_number=orm.revision_number,
             metadata=orm.metadata_,
             specs=orm.specs,
-            access_blob=orm.access_blob,
             time_updated=orm.time_updated,
         )
 

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -89,7 +89,7 @@ class EntryFields(str, enum.Enum):
     specs = "specs"
     data_sources = "data_sources"
     none = ""
-    access_blob = "access_blob"
+    access_tags = "access_tags"
 
 
 class NodeStructure(pydantic.BaseModel):
@@ -223,7 +223,7 @@ class NodeAttributes(pydantic.BaseModel):
             TableStructure,
         ]
     ] = None
-    access_blob: Optional[Dict] = None  # free-form, access_policy-specified dict
+    access_tags: Optional[List[str]] = None  # list of tags that control access to this node
 
     sorting: Optional[List[SortingItem]] = None
     data_sources: Optional[List[DataSource]] = None
@@ -472,7 +472,7 @@ class PostMetadataRequest(pydantic.BaseModel):
     metadata: Dict = {}
     data_sources: List[DataSource] = []
     specs: Specs = []
-    access_blob: Optional[Dict] = {}
+    access_tags: Optional[List[str]] = []
 
     # Wait for fix https://github.com/pydantic/pydantic/issues/3957
     # to do this with `unique_items` parameters to `pydantic.constr`.
@@ -507,7 +507,7 @@ class PostMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):
     links: Union[ArrayLinks, DataFrameLinks, SparseLinks]
     metadata: Dict
     data_sources: List[DataSource]
-    access_blob: Dict
+    access_tags: List[str]
 
 
 class PutMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):
@@ -516,7 +516,7 @@ class PutMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):
     # May be None if not altered
     metadata: Optional[Dict] = None
     data_sources: Optional[List[DataSource]] = None
-    access_blob: Optional[Dict] = None
+    access_tags: Optional[List[str]] = None
 
 
 class DistinctValueInfo(pydantic.BaseModel):
@@ -534,7 +534,7 @@ class PutMetadataRequest(pydantic.BaseModel):
     # These fields are optional because None means "no changes; do not update".
     metadata: Optional[Dict] = None
     specs: Optional[Specs] = None
-    access_blob: Optional[Dict] = None
+    access_tags: Optional[List[str]] = None
 
     # Wait for fix https://github.com/pydantic/pydantic/issues/3957
     # to do this with `unique_items` parameters to `pydantic.constr`.
@@ -585,10 +585,10 @@ class PatchMetadataRequest(HyphenizedBaseModel):
     )
 
     # These fields are optional because None means "no changes; do not update".
-    # Dict for merge-patch:
+    # List for merge-patch:
     # Define an alias to override parent class alias generator
-    access_blob: Optional[Union[List[JSONPatchAny], Dict]] = Field(
-        alias="access_blob", default=None
+    access_tags: Optional[Union[List[JSONPatchAny], List[str]]] = Field(
+        alias="access_tags", default=None
     )
 
     @pydantic.field_validator("specs")
@@ -616,7 +616,7 @@ class PatchMetadataResponse(pydantic.BaseModel, Generic[ResourceLinksT]):
     # May be None if not altered
     metadata: Optional[Dict]
     data_sources: Optional[List[DataSource]]
-    access_blob: Optional[Dict]
+    access_tags: Optional[List[str]]
 
 
 SearchResponse = Response[

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -472,7 +472,7 @@ class PostMetadataRequest(pydantic.BaseModel):
     metadata: Dict = {}
     data_sources: List[DataSource] = []
     specs: Specs = []
-    access_tags: Optional[List[str]] = []
+    access_tags: Optional[List[str]] = None
 
     # Wait for fix https://github.com/pydantic/pydantic/issues/3957
     # to do this with `unique_items` parameters to `pydantic.constr`.

--- a/tiled/server/schemas.py
+++ b/tiled/server/schemas.py
@@ -223,7 +223,9 @@ class NodeAttributes(pydantic.BaseModel):
             TableStructure,
         ]
     ] = None
-    access_tags: Optional[List[str]] = None  # list of tags that control access to this node
+    access_tags: Optional[
+        List[str]
+    ] = None  # list of tags that control access to this node
 
     sorting: Optional[List[SortingItem]] = None
     data_sources: Optional[List[DataSource]] = None

--- a/tiled/server/utils.py
+++ b/tiled/server/utils.py
@@ -7,10 +7,10 @@ from fastapi import Request, WebSocket
 from starlette.types import Scope
 
 from ..access_control.access_policies import NO_ACCESS
-from ..access_control.protocols import AccessPolicy
+from ..access_control.protocols import AccessPolicy, AccessTags
 from ..adapters.mapping import MapAdapter
 from ..server.schemas import Principal
-from ..type_aliases import AccessTags, Scopes
+from ..type_aliases import Scopes
 
 EMPTY_NODE = MapAdapter({})
 API_KEY_COOKIE_NAME = "tiled_api_key"

--- a/tiled/server/webhook_router.py
+++ b/tiled/server/webhook_router.py
@@ -23,9 +23,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
 from sqlalchemy import select
 from starlette.status import HTTP_404_NOT_FOUND
 
+from ..access_control.protocols import AccessTags
 from ..catalog import orm
 from ..config import WebhooksConfig
-from ..type_aliases import AccessTags, Scopes
+from ..type_aliases import Scopes
 from .authentication import (
     check_scopes,
     get_current_access_tags,

--- a/tiled/server/zarr.py
+++ b/tiled/server/zarr.py
@@ -15,9 +15,10 @@ from starlette.status import (
     HTTP_503_SERVICE_UNAVAILABLE,
 )
 
+from ..access_control.protocols import AccessTags
 from ..adapters.utils import DataNotReadyError, ShapeMismatchError
 from ..structures.core import StructureFamily
-from ..type_aliases import AccessTags, Scopes
+from ..type_aliases import Scopes
 from ..utils import ensure_awaitable
 from .authentication import (
     get_current_access_tags,

--- a/tiled/stream_messages.py
+++ b/tiled/stream_messages.py
@@ -65,7 +65,7 @@ class ChildCreated(Update):
     specs: list[Spec]
     metadata: dict
     data_sources: list[DataSource]
-    access_blob: dict
+    access_tags: list[str]
 
 
 class ChildMetadataUpdated(Update):

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 
 from pydantic import AfterValidator
 
@@ -31,7 +32,13 @@ JSON = Mapping[str, JSON_ITEM]
 Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
-AccessBlob = Mapping[str, Any]
+
+@dataclass(frozen=True)
+class AccessBlob:
+    username: str | None = None
+    tags: list[str] | None = None
+
+
 AccessTags = Set[str]
 Chunks = Tuple[Tuple[int, ...], ...]
 
@@ -52,6 +59,7 @@ EntryPointString = Annotated[
 
 
 __all__ = [
+    "AccessBlob",
     "AppTask",
     "EllipsisType",
     "JSON",

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -33,6 +33,7 @@ Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
 
+
 @dataclass(frozen=True)
 class AccessBlob:
     username: str | None = None

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -1,5 +1,4 @@
 import sys
-from dataclasses import dataclass
 
 from pydantic import AfterValidator
 
@@ -32,17 +31,10 @@ JSON = Mapping[str, JSON_ITEM]
 Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
-AccessTags = Set[str]
 Chunks = Tuple[Tuple[int, ...], ...]
 
 AppTask = Callable[[], Coroutine[None, None, Any]]
 """Async function to be run as part of the app's lifecycle"""
-
-
-@dataclass(frozen=True)
-class AccessBlob:
-    username: str | None = None
-    tags: list[str] | None = None
 
 
 class TaskMap(TypedDict):
@@ -58,7 +50,6 @@ EntryPointString = Annotated[
 
 
 __all__ = [
-    "AccessBlob",
     "AppTask",
     "EllipsisType",
     "JSON",

--- a/tiled/type_aliases.py
+++ b/tiled/type_aliases.py
@@ -32,19 +32,17 @@ JSON = Mapping[str, JSON_ITEM]
 Scopes = Set[str]
 Query = Any  # for now...
 Filters = List[Query]
+AccessTags = Set[str]
+Chunks = Tuple[Tuple[int, ...], ...]
+
+AppTask = Callable[[], Coroutine[None, None, Any]]
+"""Async function to be run as part of the app's lifecycle"""
 
 
 @dataclass(frozen=True)
 class AccessBlob:
     username: str | None = None
     tags: list[str] | None = None
-
-
-AccessTags = Set[str]
-Chunks = Tuple[Tuple[int, ...], ...]
-
-AppTask = Callable[[], Coroutine[None, None, Any]]
-"""Async function to be run as part of the app's lifecycle"""
 
 
 class TaskMap(TypedDict):

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -511,6 +511,12 @@ def import_object(colon_separated_string, accept_live_object=True):
         )
 
 
+def access_blob_matches(left, right) -> bool:
+    if left is None or right is None:
+        return left is right
+    return (left.username, left.tags) == (right.username, right.tags)
+
+
 def modules_available(*module_names):
     for module_name in module_names:
         if not importlib.util.find_spec(module_name):

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -511,12 +511,6 @@ def import_object(colon_separated_string, accept_live_object=True):
         )
 
 
-def access_blob_matches(left, right) -> bool:
-    if left is None or right is None:
-        return left is right
-    return (left.username, left.tags) == (right.username, right.tags)
-
-
 def modules_available(*module_names):
     for module_name in module_names:
         if not importlib.util.find_spec(module_name):

--- a/web-frontend/src/routes/browse.test.tsx
+++ b/web-frontend/src/routes/browse.test.tsx
@@ -71,7 +71,7 @@ const MockItem = (
         metadata: {} as { [key: string]: any },
         structure: {} as any,
         sorting: [] as { key: string; direction: 1 | -1 }[],
-        access_tags: [] as string[]
+        access_tags: [] as string[],
         data_sources: null as any,
         count: undefined as number | undefined,
       },

--- a/web-frontend/src/routes/browse.test.tsx
+++ b/web-frontend/src/routes/browse.test.tsx
@@ -71,7 +71,7 @@ const MockItem = (
         metadata: {} as { [key: string]: any },
         structure: {} as any,
         sorting: [] as { key: string; direction: 1 | -1 }[],
-        access_blob: null as any,
+        access_tags: [] as string[]
         data_sources: null as any,
         count: undefined as number | undefined,
       },


### PR DESCRIPTION
This PR is stacked on top of #1423 and will close #1414. It converts the `access_blob` associations (from the prior PR) into `access_tags` associations. In total, it takes `access_blob` out of `Nodes`, moves `AccessTags` into their own tables, and is a significant change to the AuthZ mechanics.

Overall, the changes are expected to be a significant performance improvement. In our testing, some operations which previously timed out (took greater than 60 seconds) have come down to only a few seconds (for example, catalog `repr` as a user with broad access). Other operations went from seconds to 100's of milliseconds (such as `len(catalog)` for some users).

Though the vast majority of tests have shown good improvement, it is possible that there is _some_ regression in speed in select cases. One case we see is in waiting for a non-existent catalog entry to return a 404 (perhaps 2x slower). However, this new implementation clears the way to build upon and make additional improvements after monitoring query statistics.

### Summary
- The `access_blob` column has been removed from the Nodes table, and has been formalized more strictly to be replaced by `access_tags`.
- Node to Tag associations now live in a separate table, instead of as a Nodes column.
- The `AccessTagsCompiler` now points at the catalog database, instead of the sidecar SQLite database.
- The catalog will now hold the table of all access tags and the association table of all grants, as well as of tag owners.
- The compiler now create "principal tags" (or "user tags") for each Tiled user. This replaces the "user-owned access blob". Note: in order to compile these tags, the compiler needs a connection to the AuthN database.
- Entity-Tag and Link-Tag association tables also exist, as graphs use the same table of access tags for access control.

### Some additional detail
- The new server is still back-compatible with clients that speak in terms of `access_blob`. 
- The `TagBasedAccessPolicy` now gives implicit grants to users equal to their principal tag.
- Tags which are removed from the tag definitions/config, but which are associated with a node, will not be deleted by the tag compiler. Instead, these are left with all grants removed. This prevents unrecoverable erasure of access control information, especially in the case of a transient failure.
- `access_tags` are no longer stored in metadata revisions when changed
- The `AccessTagsParser`, and the `AccessTagsCompiler` now work on both SQLite and Postgres
- The `AccessTagsParser` no longer needs to be given a database URI - it finds it from the server tree
- The access policy is now allowed to have fewer scopes than catalog DB knows, by intersection. Enables, for example, switching to a read-only policy.
- Various other improvements and bug fixes

### Note about catalog database migraitons
This PR contains 3 database migrations: first moving to an intermediate step where `access_blob` was itself moved into an association table, second converting the blob to tags, and third adding a `parent_id` column to the Node-Tag association table. **It is intended that a full migration be done, not stopping at any intermediate step.**

Additionally, the old metadata index is dropped in this PR. Instead, #1521 creates an improved index. One should therefore be sure to also apply this migration.

### Checklist
- [x] Add a Changelog entry
- [x] Add the ticket number which this PR closes to the comment section
